### PR TITLE
feat(evolve): add GEPA harness orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The root export is the core package. The other packages use subpath exports:
 import { EventLog } from "flamecast-core"
 import { createAgent, inference } from "flamecast-core/harness"
 import { InMemoryRuntime } from "flamecast-core/runtime-in-memory"
-import { candidate, rollout } from "flamecast-core/evolve"
+import { candidate, gepa, rollout } from "flamecast-core/evolve"
 ```
 
 ## Quick Start
@@ -79,7 +79,7 @@ if (result.kind === "completed") console.log(result.output)
 - `AgentProgram` records module provenance and compiled behavior. Source-controlled candidates can supply an explicit program id such as a commit SHA.
 - `agent.branch(log)` and `agent.fork()` create independent in-memory continuations.
 - `Router` and `agentNativeTool()` enable multi-agent systems without imposing a planner or topology.
-- `flamecast-core/evolve` supplies generic candidate, observation, rollout, scoring, and Pareto utilities. Search algorithms remain external.
+- `flamecast-core/evolve` supplies candidates, observations, rollouts, scoring, Pareto utilities, and a GEPA search loop. Callers provide mutation and evaluation policy.
 
 ## Public Imports
 
@@ -87,7 +87,7 @@ if (result.kind === "completed") console.log(result.output)
 | --- | --- |
 | `flamecast-core` | Events, event logs, machines, ports, routing, and conformance |
 | `flamecast-core/harness` | Agent programs, modules, rendering, inference providers, native tools, budgets, contracts, and compaction |
-| `flamecast-core/evolve` | Algorithm-neutral candidates, finite observations, forked rollouts, scoring, and Pareto selection |
+| `flamecast-core/evolve` | Candidates, finite observations, forked rollouts, scoring, Pareto selection, and GEPA search |
 | `flamecast-core/runtime-in-memory` | Complete runtime for process-local sessions |
 
 The internal workspaces are private. The root package exposes them through Git-installable subpaths and is not published to npm.

--- a/docs/evolution.md
+++ b/docs/evolution.md
@@ -1,8 +1,8 @@
 # Evolution
 
-Evolution changes the code that constructs an agent. A candidate may rewrite module options, add a module, replace a machine, change orchestration, select another provider, or generate a new source file.
+Evolution changes the code that constructs an agent. A candidate can change modules, machines, orchestration, providers, and source files.
 
-The framework supplies evaluation mechanics. It does not supply a proposer, mutation language, population model, or benchmark policy.
+The framework supplies evaluation mechanics and a GEPA search loop. The caller supplies each mutation, evaluation metric, dataset, and budget.
 
 ## Candidate Values
 
@@ -63,13 +63,45 @@ Changes to static instructions or tool descriptions usually diverge early. Chang
 
 `scoreOf`, `spendOf`, and `verdictsOf` project evaluation facts from logs. Evaluators decide how those values are produced and combined.
 
-`paretoArchive()` is an optional algorithm-neutral utility for retaining candidates that trade off across tasks. It is not the package's search strategy.
+`paretoArchive()` is an algorithm-neutral utility. It retains candidates that trade off across tasks.
 
-## Search Algorithms
+## GEPA Search
 
-GEPA-style prompt search, source-rewriting agents, evolutionary program synthesis, self-play, and co-evolving populations can all consume the same candidate and rollout interfaces.
+`gepa()` implements the reflective-mutation loop from [GEPA](https://arxiv.org/abs/2507.19457). Its mutation unit is a complete `Candidate<Value>`.
 
-The field changes quickly, so algorithm policy remains outside the framework. Relevant examples include [GEPA](https://arxiv.org/abs/2507.19457), [code-writing harness optimization](https://www.cmpnd.ai/blog/let-the-model-write-the-code.html), and [PopuLoRA](https://vmax.ai/roger-creus/populora-co-evolving-llm-populations-for-reasoning-self-play).
+```ts
+const search = gepa({
+  seed: baseline,
+  feedbackExamples,
+  paretoExamples,
+  minibatchSize: 3,
+  maxMetricCalls: 150,
+  evaluate: (entry, example) => evaluateHarness(entry.value, example),
+  mutate: ({ parent, trials }) => rewriteHarness(parent, trials)
+})
+```
+
+The evaluator returns a numeric score and an arbitrary trajectory. The trajectory can contain logs, grader feedback, compiler output, or other evidence.
+
+The mutation reads the parent and its feedback trials. It can replace the complete harness, including its modules, tools, machines, providers, and orchestration.
+
+The loop uses these steps:
+
+1. It scores the seed on every Pareto example.
+2. It finds the best candidates for each Pareto example.
+3. It removes dominated leaders and samples by the number of examples that each candidate leads.
+4. It evaluates the selected parent on a random feedback minibatch.
+5. It asks `mutate` for a new candidate and evaluates that candidate on the same minibatch.
+6. It accepts a candidate when its average minibatch score is higher than its parent's score.
+7. It scores each accepted candidate on every Pareto example.
+
+The result contains the full population, the final frontier, iteration records, and the candidate with the highest Pareto average. GEPA records the selected parent on proposals that omit `parent`.
+
+`maxMetricCalls` counts candidate-example evaluations. The loop starts an iteration when the remaining budget can score an accepted child on the full Pareto set.
+
+The mutation can return `undefined` for an invalid construction. This permits compilation and runtime validation before candidate evaluation.
+
+The generic candidate and rollout interfaces also support source-rewriting search, evolutionary program synthesis, self-play, and co-evolving populations. Related examples include [code-writing harness optimization](https://www.cmpnd.ai/blog/let-the-model-write-the-code.html) and [PopuLoRA](https://vmax.ai/roger-creus/populora-co-evolving-llm-populations-for-reasoning-self-play).
 
 ## Early Rejection
 

--- a/packages/evolve/src/gepa.test.ts
+++ b/packages/evolve/src/gepa.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { candidate } from "./candidate"
+import { gepa, type GepaEvaluation } from "./gepa"
+
+interface Harness {
+  readonly scores: Readonly<Record<string, number>>
+  readonly source: string
+}
+
+const example = (id: string) => ({ id, value: id })
+
+const evaluate = (evaluated: { readonly value: Harness }, task: { readonly id: string }) =>
+  Effect.succeed({
+    score: evaluated.value.scores[task.id] ?? 0,
+    trajectory: `${evaluated.value.source}:${task.id}`
+  })
+
+describe("the GEPA loop", () => {
+  test("returns the seed after its required Pareto evaluation", async () => {
+    const seed = candidate("seed", { source: "seed.ts", scores: { p1: 0.4, p2: 0.8 } })
+    const result = await Effect.runPromise(
+      gepa({
+        seed,
+        feedbackExamples: [example("f1")],
+        paretoExamples: [example("p1"), example("p2")],
+        minibatchSize: 1,
+        maxMetricCalls: 2,
+        evaluate,
+        mutate: () => Effect.succeed(undefined)
+      })
+    )
+
+    expect(result.best.candidate).toBe(seed)
+    expect(result.best.scores).toEqual({ p1: 0.4, p2: 0.8 })
+    expect(result.best.average).toBeCloseTo(0.6, 10)
+    expect(result.metricCalls).toBe(2)
+    expect(result.iterations).toEqual([])
+  })
+
+  test("accepts strict improvements and records whole-harness lineage", async () => {
+    const seed = candidate("seed", {
+      source: "seed.ts",
+      scores: { f1: 0.2, p1: 0.4, p2: 0.4 }
+    })
+    const result = await Effect.runPromise(
+      gepa({
+        seed,
+        feedbackExamples: [example("f1")],
+        paretoExamples: [example("p1"), example("p2")],
+        minibatchSize: 1,
+        maxMetricCalls: 10,
+        random: () => 0,
+        evaluate,
+        mutate: ({ iteration, parent, trials }) => {
+          expect(trials[0]?.evaluation.trajectory).toBe(`${parent.value.source}:f1`)
+          return Effect.succeed(
+            iteration === 0
+              ? candidate("better", {
+                  source: "better.ts",
+                  scores: { f1: 0.8, p1: 0.7, p2: 0.9 }
+                })
+              : candidate("worse", {
+                  source: "worse.ts",
+                  scores: { f1: 0.1, p1: 1, p2: 1 }
+                })
+          )
+        }
+      })
+    )
+
+    expect(result.population.map((entry) => entry.candidate.id)).toEqual(["seed", "better"])
+    expect(result.population[1]?.candidate.parent).toBe("seed")
+    expect(result.best.candidate.id).toBe("better")
+    expect(result.iterations).toEqual([
+      {
+        iteration: 0,
+        parent: "seed",
+        batch: ["f1"],
+        parentAverage: 0.2,
+        proposal: "better",
+        proposalAverage: 0.8,
+        accepted: true
+      },
+      {
+        iteration: 1,
+        parent: "better",
+        batch: ["f1"],
+        parentAverage: 0.8,
+        proposal: "worse",
+        proposalAverage: 0.1,
+        accepted: false
+      }
+    ])
+    expect(result.metricCalls).toBe(8)
+  })
+
+  test("samples from instance-wise leaders with their leadership frequency", async () => {
+    const parents: Array<string> = []
+    const seed = candidate("left", {
+      source: "left.ts",
+      scores: { feedback: 0, left: 1, middle: 1, right: 0 }
+    })
+    const random = [0, 0, 0.6, 0]
+    const result = await Effect.runPromise(
+      gepa({
+        seed,
+        feedbackExamples: [example("feedback")],
+        paretoExamples: [example("left"), example("middle"), example("right")],
+        minibatchSize: 1,
+        maxMetricCalls: 13,
+        random: () => random.shift() ?? 0,
+        evaluate,
+        mutate: ({ iteration, parent }) => {
+          parents.push(parent.id)
+          return Effect.succeed(
+            iteration === 0
+              ? candidate("right", {
+                  source: "right.ts",
+                  scores: { feedback: 1, left: 0, middle: 0, right: 1 }
+                })
+              : candidate("discarded", {
+                  source: "discarded.ts",
+                  scores: { feedback: -1, left: 1, middle: 1, right: 1 }
+                })
+          )
+        }
+      })
+    )
+
+    expect(parents).toEqual(["left", "left"])
+    expect(result.front.map((entry) => entry.candidate.id)).toEqual(["left", "right"])
+    expect(result.metricCalls).toBe(10)
+  })
+
+  test("passes evaluator-specific feedback to the mutation", async () => {
+    interface FeedbackEvaluation extends GepaEvaluation<string> {
+      readonly reason: string
+    }
+
+    const seen: Array<FeedbackEvaluation> = []
+    const seed: Harness = { source: "seed.ts", scores: { f1: 0, p1: 0 } }
+    await Effect.runPromise(
+      gepa({
+        seed: candidate("seed", seed),
+        feedbackExamples: [example("f1")],
+        paretoExamples: [example("p1")],
+        minibatchSize: 1,
+        maxMetricCalls: 4,
+        evaluate: (evaluated, task) =>
+          Effect.succeed({
+            score: evaluated.value.scores[task.id] ?? 0,
+            trajectory: `${evaluated.id}:${task.id}`,
+            reason: "the harness chose the wrong tool"
+          }),
+        mutate: ({ trials }) => {
+          seen.push(...trials.map((trial) => trial.evaluation))
+          return Effect.succeed(undefined)
+        }
+      })
+    )
+
+    expect(seen).toEqual([
+      {
+        score: 0,
+        trajectory: "seed:f1",
+        reason: "the harness chose the wrong tool"
+      }
+    ])
+  })
+
+  test("requires mutations to preserve the selected parent", async () => {
+    const run = Effect.runPromise(
+      gepa({
+        seed: candidate("seed", { source: "seed.ts", scores: { f1: 0, p1: 0 } }),
+        feedbackExamples: [example("f1")],
+        paretoExamples: [example("p1")],
+        minibatchSize: 1,
+        maxMetricCalls: 4,
+        evaluate,
+        mutate: () =>
+          Effect.succeed(
+            candidate(
+              "child",
+              { source: "child.ts", scores: { f1: 1, p1: 1 } },
+              { parent: "someone-else" }
+            )
+          )
+      })
+    )
+
+    expect(run).rejects.toThrow('GEPA proposal "child" names parent "someone-else" instead of "seed"')
+  })
+})

--- a/packages/evolve/src/gepa.ts
+++ b/packages/evolve/src/gepa.ts
@@ -1,0 +1,340 @@
+import { Effect } from "effect"
+import { candidate, type Candidate } from "./candidate"
+import type { Scores } from "./pareto"
+
+export interface GepaExample<Value> {
+  readonly id: string
+  readonly value: Value
+}
+
+export interface GepaEvaluation<Trajectory = unknown> {
+  readonly score: number
+  readonly trajectory: Trajectory
+}
+
+export interface GepaTrial<Example, Evaluation extends GepaEvaluation> {
+  readonly example: GepaExample<Example>
+  readonly evaluation: Evaluation
+}
+
+export interface GepaMutationContext<Value, Example, Evaluation extends GepaEvaluation> {
+  readonly iteration: number
+  readonly parent: Candidate<Value>
+  readonly trials: ReadonlyArray<GepaTrial<Example, Evaluation>>
+}
+
+export interface GepaPopulationEntry<Value> {
+  readonly candidate: Candidate<Value>
+  readonly scores: Scores
+  readonly average: number
+}
+
+export interface GepaIteration {
+  readonly iteration: number
+  readonly parent: string
+  readonly batch: ReadonlyArray<string>
+  readonly parentAverage: number
+  readonly proposal?: string
+  readonly proposalAverage?: number
+  readonly accepted: boolean
+}
+
+export interface GepaResult<Value> {
+  readonly best: GepaPopulationEntry<Value>
+  readonly population: ReadonlyArray<GepaPopulationEntry<Value>>
+  readonly front: ReadonlyArray<GepaPopulationEntry<Value>>
+  readonly iterations: ReadonlyArray<GepaIteration>
+  readonly metricCalls: number
+}
+
+export interface GepaOptions<
+  Value,
+  Example,
+  Evaluation extends GepaEvaluation,
+  EvaluationError = never,
+  EvaluationRequirements = never,
+  MutationError = never,
+  MutationRequirements = never
+> {
+  readonly seed: Candidate<Value>
+  readonly feedbackExamples: ReadonlyArray<GepaExample<Example>>
+  readonly paretoExamples: ReadonlyArray<GepaExample<Example>>
+  readonly minibatchSize: number
+  readonly maxMetricCalls: number
+  readonly evaluate: (
+    candidate: Candidate<Value>,
+    example: GepaExample<Example>
+  ) => Effect.Effect<Evaluation, EvaluationError, EvaluationRequirements>
+  readonly mutate: (
+    context: GepaMutationContext<Value, Example, Evaluation>
+  ) => Effect.Effect<Candidate<Value> | undefined, MutationError, MutationRequirements>
+  readonly random?: () => number
+}
+
+const averageOf = (scores: ReadonlyArray<number>): number =>
+  scores.reduce((total, score) => total + score, 0) / scores.length
+
+const dominates = (left: Scores, right: Scores, examples: ReadonlyArray<string>): boolean => {
+  let strictly = false
+  for (const example of examples) {
+    const leftScore = left[example]
+    const rightScore = right[example]
+    if (leftScore === undefined || rightScore === undefined) {
+      throw new Error(`GEPA candidate is missing the Pareto score for example "${example}"`)
+    }
+    if (leftScore < rightScore) return false
+    if (leftScore > rightScore) strictly = true
+  }
+  return strictly
+}
+
+const leadersByExample = <Value>(
+  population: ReadonlyArray<GepaPopulationEntry<Value>>,
+  examples: ReadonlyArray<string>
+) =>
+  examples.map((example) => {
+    const best = population.reduce((highest, entry) => {
+      const score = entry.scores[example]
+      if (score === undefined) {
+        throw new Error(`GEPA candidate is missing the Pareto score for example "${example}"`)
+      }
+      return Math.max(highest, score)
+    }, Number.NEGATIVE_INFINITY)
+    return new Set(
+      population
+        .filter((entry) => entry.scores[example] === best)
+        .map((entry) => entry.candidate.id)
+    )
+  })
+
+const frontOf = <Value>(
+  population: ReadonlyArray<GepaPopulationEntry<Value>>,
+  examples: ReadonlyArray<string>
+) => {
+  const leaders = leadersByExample(population, examples)
+  const leaderIds = new Set(leaders.flatMap((set) => [...set]))
+  const candidates = population.filter((entry) => leaderIds.has(entry.candidate.id))
+  return candidates.filter(
+    (entry) =>
+      !candidates.some(
+        (other) =>
+          other !== entry && dominates(other.scores, entry.scores, examples)
+      )
+  )
+}
+
+const randomIndex = (length: number, random: () => number): number =>
+  Math.max(0, Math.min(length - 1, Math.floor(random() * length)))
+
+const selectParent = <Value>(
+  population: ReadonlyArray<GepaPopulationEntry<Value>>,
+  examples: ReadonlyArray<string>,
+  random: () => number
+) => {
+  const leaders = leadersByExample(population, examples)
+  const front = frontOf(population, examples)
+  const weights = front.map((entry) =>
+    leaders.filter((set) => set.has(entry.candidate.id)).length
+  )
+  const total = weights.reduce((sum, weight) => sum + weight, 0)
+  let draw = randomIndex(total, random)
+  for (const [index, entry] of front.entries()) {
+    draw -= weights[index]!
+    if (draw < 0) return entry
+  }
+  return front.at(-1)!
+}
+
+const sampleBatch = <Value>(
+  examples: ReadonlyArray<GepaExample<Value>>,
+  size: number,
+  random: () => number
+) => {
+  const available = [...examples]
+  const sampled: Array<GepaExample<Value>> = []
+  while (sampled.length < size) {
+    sampled.push(available.splice(randomIndex(available.length, random), 1)[0]!)
+  }
+  return sampled
+}
+
+const validateOptions = <
+  Value,
+  Example,
+  Evaluation extends GepaEvaluation,
+  EvaluationError,
+  EvaluationRequirements,
+  MutationError,
+  MutationRequirements
+>(
+  options: GepaOptions<
+    Value,
+    Example,
+    Evaluation,
+    EvaluationError,
+    EvaluationRequirements,
+    MutationError,
+    MutationRequirements
+  >
+) => {
+  if (options.feedbackExamples.length === 0) {
+    throw new Error("GEPA requires at least one feedback example")
+  }
+  if (options.paretoExamples.length === 0) {
+    throw new Error("GEPA requires at least one Pareto example")
+  }
+  if (
+    !Number.isInteger(options.minibatchSize) ||
+    options.minibatchSize < 1 ||
+    options.minibatchSize > options.feedbackExamples.length
+  ) {
+    throw new Error("GEPA minibatchSize must be a positive integer within the feedback set")
+  }
+  if (
+    !Number.isInteger(options.maxMetricCalls) ||
+    options.maxMetricCalls < options.paretoExamples.length
+  ) {
+    throw new Error("GEPA maxMetricCalls must cover the initial Pareto evaluation")
+  }
+  const ids = new Set<string>()
+  for (const example of options.paretoExamples) {
+    if (ids.has(example.id)) {
+      throw new Error(`GEPA received duplicate Pareto example id "${example.id}"`)
+    }
+    ids.add(example.id)
+  }
+}
+
+const withParent = <Value>(proposal: Candidate<Value>, parent: Candidate<Value>) => {
+  if (proposal.parent !== undefined && proposal.parent !== parent.id) {
+    throw new Error(
+      `GEPA proposal "${proposal.id}" names parent "${proposal.parent}" instead of "${parent.id}"`
+    )
+  }
+  return proposal.parent === undefined
+    ? candidate(proposal.id, proposal.value, {
+        parent: parent.id,
+        ...(proposal.source === undefined ? {} : { source: proposal.source })
+      })
+    : proposal
+}
+
+export const gepa = <
+  Value,
+  Example,
+  Evaluation extends GepaEvaluation,
+  EvaluationError,
+  EvaluationRequirements,
+  MutationError,
+  MutationRequirements
+>(
+  options: GepaOptions<
+    Value,
+    Example,
+    Evaluation,
+    EvaluationError,
+    EvaluationRequirements,
+    MutationError,
+    MutationRequirements
+  >
+) => {
+  validateOptions(options)
+  const random = options.random ?? Math.random
+  return Effect.gen(function* () {
+    let metricCalls = 0
+    const evaluate = (
+      evaluated: Candidate<Value>,
+      examples: ReadonlyArray<GepaExample<Example>>
+    ) =>
+      Effect.gen(function* () {
+        const trials: Array<GepaTrial<Example, Evaluation>> = []
+        for (const example of examples) {
+          const evaluation = yield* options.evaluate(evaluated, example)
+          metricCalls += 1
+          if (!Number.isFinite(evaluation.score)) {
+            throw new Error(
+              `GEPA evaluator returned a non-finite score for example "${example.id}"`
+            )
+          }
+          trials.push({ example, evaluation })
+        }
+        return trials
+      })
+
+    const scoreOnPareto = (evaluated: Candidate<Value>) =>
+      Effect.map(evaluate(evaluated, options.paretoExamples), (trials) => {
+        const scores = Object.fromEntries(
+          trials.map((trial) => [trial.example.id, trial.evaluation.score])
+        )
+        return {
+          candidate: evaluated,
+          scores,
+          average: averageOf(trials.map((trial) => trial.evaluation.score))
+        } satisfies GepaPopulationEntry<Value>
+      })
+
+    const population: Array<GepaPopulationEntry<Value>> = [yield* scoreOnPareto(options.seed)]
+    const iterations: Array<GepaIteration> = []
+    const exampleIds = options.paretoExamples.map((example) => example.id)
+    const callsForAcceptableIteration =
+      options.minibatchSize * 2 + options.paretoExamples.length
+
+    while (metricCalls + callsForAcceptableIteration <= options.maxMetricCalls) {
+      const iteration = iterations.length
+      const parent = selectParent(population, exampleIds, random)
+      const batch = sampleBatch(options.feedbackExamples, options.minibatchSize, random)
+      const parentTrials = yield* evaluate(parent.candidate, batch)
+      const parentAverage = averageOf(
+        parentTrials.map((trial) => trial.evaluation.score)
+      )
+      const proposed = yield* options.mutate({
+        iteration,
+        parent: parent.candidate,
+        trials: parentTrials
+      })
+
+      if (proposed === undefined) {
+        iterations.push({
+          iteration,
+          parent: parent.candidate.id,
+          batch: batch.map((example) => example.id),
+          parentAverage,
+          accepted: false
+        })
+        continue
+      }
+
+      const proposal = withParent(proposed, parent.candidate)
+      if (population.some((entry) => entry.candidate.id === proposal.id)) {
+        throw new Error(`GEPA proposal id "${proposal.id}" already exists in the population`)
+      }
+      const proposalTrials = yield* evaluate(proposal, batch)
+      const proposalAverage = averageOf(
+        proposalTrials.map((trial) => trial.evaluation.score)
+      )
+      const accepted = proposalAverage > parentAverage
+      if (accepted) population.push(yield* scoreOnPareto(proposal))
+      iterations.push({
+        iteration,
+        parent: parent.candidate.id,
+        batch: batch.map((example) => example.id),
+        parentAverage,
+        proposal: proposal.id,
+        proposalAverage,
+        accepted
+      })
+    }
+
+    const best = population.reduce((leader, entry) =>
+      entry.average > leader.average ? entry : leader
+    )
+    const result: GepaResult<Value> = {
+      best,
+      population,
+      front: frontOf(population, exampleIds),
+      iterations,
+      metricCalls
+    }
+    return result
+  })
+}

--- a/packages/evolve/src/index.ts
+++ b/packages/evolve/src/index.ts
@@ -2,10 +2,21 @@
 // its consumers one door. Inside the package, a module imports from the file that defines the
 // symbol.
 //
-// The package holds the mechanics of a harness search and none of its judgment. There is no proposer
-// prompt and no metric here, because neither one is portable across domains.
+// The package holds reusable mechanics and policies for harness search. Callers own proposer prompts
+// and metrics because those decisions belong to their domains.
 
 export { candidate, type Candidate, type CandidateOptions } from "./candidate"
+export {
+  gepa,
+  type GepaEvaluation,
+  type GepaExample,
+  type GepaIteration,
+  type GepaMutationContext,
+  type GepaOptions,
+  type GepaPopulationEntry,
+  type GepaResult,
+  type GepaTrial
+} from "./gepa"
 export {
   modelCallPrefixes,
   observationOf,


### PR DESCRIPTION
## What and why

Add an Effect-native GEPA orchestrator that uses per-example Pareto selection, reflective minibatch mutation, strict acceptance, lineage, and metric-call budgets. This lets evolution replace an entire agent harness while preserving the paper's search loop and exposing evaluation trajectories to mutators.

- [x] `bun run gate` passes locally
- [x] Docs updated if behavior changed
- [x] Tests cover the change