### PR TITLE
feat(evolve): track optimization cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The root export is the core package. The other packages use subpath exports:
 import { EventLog } from "flamecast-core"
 import { createAgent, inference } from "flamecast-core/harness"
 import { InMemoryRuntime } from "flamecast-core/runtime-in-memory"
-import { candidate, gepa, rollout } from "flamecast-core/evolve"
+import { candidate, gepa, populora, rollout } from "flamecast-core/evolve"
 ```
 
 ## Quick Start
@@ -79,7 +79,7 @@ if (result.kind === "completed") console.log(result.output)
 - `AgentProgram` records module provenance and compiled behavior. Source-controlled candidates can supply an explicit program id such as a commit SHA.
 - `agent.branch(log)` and `agent.fork()` create independent in-memory continuations.
 - `Router` and `agentNativeTool()` enable multi-agent systems without imposing a planner or topology.
-- `flamecast-core/evolve` supplies candidates, observations, rollouts, scoring, Pareto utilities, and a GEPA search loop. Callers provide mutation and evaluation policy.
+- `flamecast-core/evolve` supplies candidates, observations, rollouts, scoring, Pareto utilities, and GEPA and PopuLoRA search loops. Callers provide mutation and evaluation policy.
 
 ## Public Imports
 
@@ -87,7 +87,7 @@ if (result.kind === "completed") console.log(result.output)
 | --- | --- |
 | `flamecast-core` | Events, event logs, machines, ports, routing, and conformance |
 | `flamecast-core/harness` | Agent programs, modules, rendering, inference providers, native tools, budgets, contracts, and compaction |
-| `flamecast-core/evolve` | Candidates, finite observations, forked rollouts, scoring, Pareto selection, and GEPA search |
+| `flamecast-core/evolve` | Candidates, finite observations, forked rollouts, scoring, Pareto selection, GEPA search, and PopuLoRA co-evolution |
 | `flamecast-core/runtime-in-memory` | Complete runtime for process-local sessions |
 
 The internal workspaces are private. The root package exposes them through Git-installable subpaths and is not published to npm.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The root export is the core package. The other packages use subpath exports:
 import { EventLog } from "flamecast-core"
 import { createAgent, inference } from "flamecast-core/harness"
 import { InMemoryRuntime } from "flamecast-core/runtime-in-memory"
-import { candidate, rollout } from "flamecast-core/evolve"
+import { candidate, gepa, rollout } from "flamecast-core/evolve"
 ```
 
 ## Quick Start
@@ -79,7 +79,7 @@ if (result.kind === "completed") console.log(result.output)
 - `AgentProgram` records module provenance and compiled behavior. Source-controlled candidates can supply an explicit program id such as a commit SHA.
 - `agent.branch(log)` and `agent.fork()` create independent in-memory continuations.
 - `Router` and `agentNativeTool()` enable multi-agent systems without imposing a planner or topology.
-- `flamecast-core/evolve` supplies generic candidate, observation, rollout, scoring, and Pareto utilities. Search algorithms remain external.
+- `flamecast-core/evolve` supplies candidates, observations, rollouts, scoring, Pareto utilities, and a GEPA search loop. Callers provide mutation and evaluation policy.
 
 ## Public Imports
 
@@ -87,7 +87,7 @@ if (result.kind === "completed") console.log(result.output)
 | --- | --- |
 | `flamecast-core` | Events, event logs, machines, ports, routing, and conformance |
 | `flamecast-core/harness` | Agent programs, modules, rendering, inference providers, native tools, budgets, contracts, and compaction |
-| `flamecast-core/evolve` | Algorithm-neutral candidates, finite observations, forked rollouts, scoring, and Pareto selection |
+| `flamecast-core/evolve` | Candidates, finite observations, forked rollouts, scoring, Pareto selection, and GEPA search |
 | `flamecast-core/runtime-in-memory` | Complete runtime for process-local sessions |
 
 The internal workspaces are private. The root package exposes them through Git-installable subpaths and is not published to npm.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The root export is the core package. The other packages use subpath exports:
 import { EventLog } from "flamecast-core"
 import { createAgent, inference } from "flamecast-core/harness"
 import { InMemoryRuntime } from "flamecast-core/runtime-in-memory"
-import { candidate, gepa, populora, rollout } from "flamecast-core/evolve"
+import { candidate, costed, gepa, populora, rollout } from "flamecast-core/evolve"
 ```
 
 ## Quick Start
@@ -79,7 +79,7 @@ if (result.kind === "completed") console.log(result.output)
 - `AgentProgram` records module provenance and compiled behavior. Source-controlled candidates can supply an explicit program id such as a commit SHA.
 - `agent.branch(log)` and `agent.fork()` create independent in-memory continuations.
 - `Router` and `agentNativeTool()` enable multi-agent systems without imposing a planner or topology.
-- `flamecast-core/evolve` supplies candidates, observations, rollouts, scoring, Pareto utilities, and GEPA and PopuLoRA search loops. Callers provide mutation and evaluation policy.
+- `flamecast-core/evolve` supplies candidates, observations, cost tracking, rollouts, scoring, Pareto utilities, and GEPA and PopuLoRA search loops. Callers provide costed mutation and evaluation policy.
 
 ## Public Imports
 
@@ -87,7 +87,7 @@ if (result.kind === "completed") console.log(result.output)
 | --- | --- |
 | `flamecast-core` | Events, event logs, machines, ports, routing, and conformance |
 | `flamecast-core/harness` | Agent programs, modules, rendering, inference providers, native tools, budgets, contracts, and compaction |
-| `flamecast-core/evolve` | Candidates, finite observations, forked rollouts, scoring, Pareto selection, GEPA search, and PopuLoRA co-evolution |
+| `flamecast-core/evolve` | Candidates, finite observations, costed callbacks, forked rollouts, scoring, Pareto selection, GEPA search, and PopuLoRA co-evolution |
 | `flamecast-core/runtime-in-memory` | Complete runtime for process-local sessions |
 
 The internal workspaces are private. The root package exposes them through Git-installable subpaths and is not published to npm.

--- a/docs/evolution.md
+++ b/docs/evolution.md
@@ -1,8 +1,8 @@
 # Evolution
 
-Evolution changes the code that constructs an agent. A candidate may rewrite module options, add a module, replace a machine, change orchestration, select another provider, or generate a new source file.
+Evolution changes the code that constructs an agent. A candidate can change modules, machines, orchestration, providers, and source files.
 
-The framework supplies evaluation mechanics. It does not supply a proposer, mutation language, population model, or benchmark policy.
+The framework supplies evaluation mechanics and a GEPA search loop. The caller supplies each mutation, evaluation metric, dataset, and budget.
 
 ## Candidate Values
 
@@ -63,13 +63,45 @@ Changes to static instructions or tool descriptions usually diverge early. Chang
 
 `scoreOf`, `spendOf`, and `verdictsOf` project evaluation facts from logs. Evaluators decide how those values are produced and combined.
 
-`paretoArchive()` is an optional algorithm-neutral utility for retaining candidates that trade off across tasks. It is not the package's search strategy.
+`paretoArchive()` is an algorithm-neutral utility. It retains candidates that trade off across tasks.
 
-## Search Algorithms
+## GEPA Search
 
-GEPA-style prompt search, source-rewriting agents, evolutionary program synthesis, self-play, and co-evolving populations can all consume the same candidate and rollout interfaces.
+`gepa()` implements the reflective-mutation loop from [GEPA](https://arxiv.org/abs/2507.19457). Its mutation unit is a complete `Candidate<Value>`.
 
-The field changes quickly, so algorithm policy remains outside the framework. Relevant examples include [GEPA](https://arxiv.org/abs/2507.19457), [code-writing harness optimization](https://www.cmpnd.ai/blog/let-the-model-write-the-code.html), and [PopuLoRA](https://vmax.ai/roger-creus/populora-co-evolving-llm-populations-for-reasoning-self-play).
+```ts
+const search = gepa({
+  seed: baseline,
+  feedbackExamples,
+  paretoExamples,
+  minibatchSize: 3,
+  maxMetricCalls: 150,
+  evaluate: (entry, example) => evaluateHarness(entry.value, example),
+  mutate: ({ parent, trials }) => rewriteHarness(parent, trials)
+})
+```
+
+The evaluator returns a numeric score and an arbitrary trajectory. The trajectory can contain logs, grader feedback, compiler output, or other evidence.
+
+The mutation reads the parent and its feedback trials. It can replace the complete harness, including its modules, tools, machines, providers, and orchestration.
+
+The loop uses these steps:
+
+1. It scores the seed on every Pareto example.
+2. It finds the best candidates for each Pareto example.
+3. It removes dominated leaders and samples by the number of examples that each candidate leads.
+4. It evaluates the selected parent on a random feedback minibatch.
+5. It asks `mutate` for a new candidate and evaluates that candidate on the same minibatch.
+6. It accepts a candidate when its average minibatch score is higher than its parent's score.
+7. It scores each accepted candidate on every Pareto example.
+
+The result contains the full population, the final frontier, iteration records, and the candidate with the highest Pareto average. GEPA records the selected parent on proposals that omit `parent`.
+
+`maxMetricCalls` counts candidate-example evaluations. The loop starts an iteration when the remaining budget can score an accepted child on the full Pareto set.
+
+The mutation can return `undefined` for an invalid construction. This permits compilation and runtime validation before candidate evaluation.
+
+The generic candidate and rollout interfaces also support source-rewriting search, evolutionary program synthesis, self-play, and co-evolving populations. Related examples include [code-writing harness optimization](https://www.cmpnd.ai/blog/let-the-model-write-the-code.html) and [PopuLoRA](https://vmax.ai/roger-creus/populora-co-evolving-llm-populations-for-reasoning-self-play).
 
 ## Early Rejection
 

--- a/docs/evolution.md
+++ b/docs/evolution.md
@@ -55,13 +55,21 @@ const result = await rollout({
 
 The rollout checks the recording's program provenance, compares requests at recorded `ModelCalled` prefixes when the baseline matches, branches the candidate at the first divergence, and settles the live suffix. A provenance mismatch reuses no model calls.
 
-`result.replayed` counts reused model calls. `result.called` counts live candidate calls. `result.log` is the independent branch log.
+`result.replayed` counts reused model calls. `result.called` counts live candidate calls. `result.log` is the independent branch log. `result.cost` contains the cost of the live suffix.
 
 Changes to static instructions or tool descriptions usually diverge early. Changes to truncation can diverge later. Internal code changes that preserve every recorded request can reuse the full recording.
 
 ## Scoring and Selection
 
 `scoreOf`, `spendOf`, and `verdictsOf` project evaluation facts from logs. Evaluators decide how those values are produced and combined.
+
+`evolutionCostOf(...logs)` combines the harness [cost projections](observability.md#cost-projections). Its result contains prompt tokens, completion tokens, provider cost, and work-tool calls.
+
+It counts every supplied event. Pass only live log spans when a recording contains a replayed prefix.
+
+`costed(value, ...logs)` attaches this cost to a callback value. GEPA and PopuLoRA require a `Costed` result from each effectful callback.
+
+Each operation record contains its own cost. Each search result contains the sum for the complete optimization run. Replayed rollout prefixes add zero cost.
 
 `paretoArchive()` is an algorithm-neutral utility. It retains candidates that trade off across tasks.
 
@@ -76,14 +84,22 @@ const search = gepa({
   paretoExamples,
   minibatchSize: 3,
   maxMetricCalls: 150,
-  evaluate: (entry, example) => evaluateHarness(entry.value, example),
-  mutate: ({ parent, trials }) => rewriteHarness(parent, trials)
+  evaluate: (entry, example) =>
+    runEvaluation(entry.value, example).pipe(
+      Effect.map(({ score, log }) =>
+        costed({ score, trajectory: log }, log)
+      )
+    ),
+  mutate: ({ parent, trials }) =>
+    runMutation(parent, trials).pipe(
+      Effect.map(({ proposal, log }) => costed(proposal, log))
+    )
 })
 ```
 
-The evaluator returns a numeric score and an arbitrary trajectory. The trajectory can contain logs, grader feedback, compiler output, or other evidence.
+The evaluator returns a costed evaluation with a numeric score and an arbitrary trajectory. The trajectory can contain logs, grader feedback, compiler output, or other evidence.
 
-The mutation reads the parent and its feedback trials. It can replace the complete harness, including its modules, tools, machines, providers, and orchestration.
+The mutation reads the parent and its feedback trials. It returns a costed candidate and can replace the complete harness.
 
 The loop uses these steps:
 
@@ -95,11 +111,13 @@ The loop uses these steps:
 6. It accepts a candidate when its average minibatch score is higher than its parent's score.
 7. It scores each accepted candidate on every Pareto example.
 
-The result contains the full population, the final frontier, iteration records, and the candidate with the highest Pareto average. GEPA records the selected parent on proposals that omit `parent`.
+The result contains the population, frontier, iteration records, total cost, and candidate with the highest Pareto average. Each iteration contains its combined cost.
+
+GEPA records the selected parent on proposals that omit `parent`. Each population entry records the cost of its Pareto evaluation.
 
 `maxMetricCalls` counts candidate-example evaluations. The loop starts an iteration when the remaining budget can score an accepted child on the full Pareto set.
 
-The mutation can return `undefined` for an invalid construction. This permits compilation and runtime validation before candidate evaluation.
+The mutation can return `costed(undefined, mutationLog)` for an invalid construction. This records the mutation cost and prevents candidate evaluation.
 
 ## PopuLoRA Search
 
@@ -116,12 +134,14 @@ const search = populora({
   cullFraction: 0.25,
   runMatch: ({ teacher, student }) =>
     evaluatePair(teacher.candidate.value, student.candidate.value),
-  evolveTeacher: (context) => rewriteTeacherHarness(context),
-  evolveStudent: (context) => rewriteStudentHarness(context)
+  evolveTeacher: (context) => evolveTeacherHarness(context),
+  evolveStudent: (context) => evolveStudentHarness(context)
 })
 ```
 
-The caller runs teacher generation, student attempts, and verification inside `runMatch`. It returns one `PopuloraTrial` for each generated problem. A trial contains verifier validity, student outcomes, and arbitrary evidence for later evolution. An invalid trial has no student outcomes. A valid trial has at least one outcome.
+The caller runs teacher generation, student attempts, and verification inside `runMatch`. It returns a costed array with one trial for each generated problem.
+
+A trial contains verifier validity, student outcomes, and evidence for later evolution. An invalid trial has no student outcomes. A valid trial has outcomes.
 
 The loop applies the paper's rewards:
 
@@ -141,9 +161,13 @@ Each search step follows these phases:
 5. At each evolution interval, the loop ranks each role by `mu - confidence * sigma`.
 6. The loop replaces the lowest-ranked fraction through a mutation or crossover callback.
 
-A mutation receives one top-ranked parent. A crossover receives two distinct top-ranked parents. Both callbacks receive the replaced member and all matches since the last evolution step. They can rewrite modules, tools, machines, providers, source files, and orchestration.
+A mutation receives one top-ranked parent. A crossover receives two distinct top-ranked parents. Both callbacks receive the replaced member and recent matches.
 
-A callback can return `undefined` when it cannot construct a valid child. A new child starts with the configured initial TrueSkill rating. `PopuloraMember.parents` records every parent, while `Candidate.parent` records the primary parent.
+Each callback returns a costed candidate. The candidate can rewrite modules, tools, machines, providers, source files, and orchestration.
+
+A callback can return a costed `undefined` value when it cannot construct a child. The loop records this cost and keeps the replaced member.
+
+A new child starts with the configured initial TrueSkill rating. `PopuloraMember.parents` records every parent. `Candidate.parent` records the primary parent.
 
 The rating options use standard TrueSkill defaults. These include `mu = 25`, `sigma = 25 / 3`, `beta = 25 / 6`, `tau = 25 / 300`, and a draw probability of `0.1`. The lower-confidence multiplier defaults to `3`. `crossoverRate` defaults to `0.5`.
 

--- a/docs/evolution.md
+++ b/docs/evolution.md
@@ -2,7 +2,7 @@
 
 Evolution changes the code that constructs an agent. A candidate can change modules, machines, orchestration, providers, and source files.
 
-The framework supplies evaluation mechanics and a GEPA search loop. The caller supplies each mutation, evaluation metric, dataset, and budget.
+The framework supplies evaluation mechanics plus GEPA and PopuLoRA search loops. The caller supplies each mutation, evaluation policy, dataset, and budget.
 
 ## Candidate Values
 
@@ -101,7 +101,55 @@ The result contains the full population, the final frontier, iteration records, 
 
 The mutation can return `undefined` for an invalid construction. This permits compilation and runtime validation before candidate evaluation.
 
-The generic candidate and rollout interfaces also support source-rewriting search, evolutionary program synthesis, self-play, and co-evolving populations. Related examples include [code-writing harness optimization](https://www.cmpnd.ai/blog/let-the-model-write-the-code.html) and [PopuLoRA](https://vmax.ai/roger-creus/populora-co-evolving-llm-populations-for-reasoning-self-play).
+## PopuLoRA Search
+
+`populora()` adapts the asymmetric self-play loop from [PopuLoRA](https://arxiv.org/abs/2605.16727v1) to whole-harness evolution. It keeps separate teacher and student populations. Each member is a complete `Candidate<Value>`.
+
+GEPA searches one population against fixed examples. PopuLoRA searches problem-producing and problem-solving harnesses against each other.
+
+```ts
+const search = populora({
+  teachers: teacherSeeds,
+  students: studentSeeds,
+  steps: 200,
+  evolutionInterval: 10,
+  cullFraction: 0.25,
+  runMatch: ({ teacher, student }) =>
+    evaluatePair(teacher.candidate.value, student.candidate.value),
+  evolveTeacher: (context) => rewriteTeacherHarness(context),
+  evolveStudent: (context) => rewriteStudentHarness(context)
+})
+```
+
+The caller runs teacher generation, student attempts, and verification inside `runMatch`. It returns one `PopuloraTrial` for each generated problem. A trial contains verifier validity, student outcomes, and arbitrary evidence for later evolution. An invalid trial has no student outcomes. A valid trial has at least one outcome.
+
+The loop applies the paper's rewards:
+
+- An invalid teacher problem receives `-1`.
+- A valid problem with no correct student outcome receives `0`.
+- Any other valid problem receives `1 - solveRate`.
+- A correct student outcome receives `1`.
+- An incorrect, well-formed outcome receives `-0.5`.
+- A format error receives `-1`.
+
+Each search step follows these phases:
+
+1. TrueSkill estimates the result of each possible teacher and student pairing.
+2. PFSP samples near-balanced pairings with weight `p * (1 - p)`.
+3. `runMatch` generates problems, collects student attempts, and verifies the results.
+4. The aggregate solve rate is compared with its expected value. The result updates both TrueSkill ratings. A match with no valid problem is a student win.
+5. At each evolution interval, the loop ranks each role by `mu - confidence * sigma`.
+6. The loop replaces the lowest-ranked fraction through a mutation or crossover callback.
+
+A mutation receives one top-ranked parent. A crossover receives two distinct top-ranked parents. Both callbacks receive the replaced member and all matches since the last evolution step. They can rewrite modules, tools, machines, providers, source files, and orchestration.
+
+A callback can return `undefined` when it cannot construct a valid child. A new child starts with the configured initial TrueSkill rating. `PopuloraMember.parents` records every parent, while `Candidate.parent` records the primary parent.
+
+The rating options use standard TrueSkill defaults. These include `mu = 25`, `sigma = 25 / 3`, `beta = 25 / 6`, `tau = 25 / 300`, and a draw probability of `0.1`. The lower-confidence multiplier defaults to `3`. `crossoverRate` defaults to `0.5`.
+
+This adaptation uses harness mutation and crossover as the learning operation. It preserves the paper's teacher and student roles, verifier rewards, matchmaking, ratings, and population replacement policy.
+
+The generic candidate and rollout interfaces also support source-rewriting search and evolutionary program synthesis. A related example is [code-writing harness optimization](https://www.cmpnd.ai/blog/let-the-model-write-the-code.html).
 
 ## Early Rejection
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -43,7 +43,7 @@ Native tool calling is one interface policy. A module can instead expose code mo
 
 `budget(options)` projects tool spend, emits the wall event, withdraws spending tools, and optionally exposes a budget-request tool. The default budget and all wall text belong to this module.
 
-Budget control is event driven. A grant or denial can arrive later through replay or routing, which lets parked work resume without a waiting process.
+Budget control is event driven. A grant or denial can arrive later through replay or routing, which lets parked work resume without a waiting process. [Cost projections](observability.md#cost-projections) expose the tool spend.
 
 ## contract
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -72,6 +72,19 @@ Fork reads the bound session and creates the same independent branch shape.
 
 `flamecast-core/evolve` can compare pure observations on a finite corpus and find the first recorded model-call prefix whose request changes. [Evolution](evolution.md) covers the guarantees and limits.
 
+## Cost Projections
+
+```ts
+import { toolCallsOf, usageIn } from "flamecast-core/harness"
+
+const usage = usageIn(log, "m-1")
+const toolCalls = toolCallsOf(log)
+```
+
+`usageIn(log, turn)` sums the prompt tokens, completion tokens, and provider cost for one turn. The values come from its `ModelReturned` events.
+
+`toolCallsOf(log)` counts work-tool calls in any log span. It uses the budget rules, so `answer` and `request-budget` calls have zero tool cost.
+
 ## Telemetry
 
 Core defines a `Sink` port, and the in-memory runtime binds a no-op implementation. No harness path currently emits sink records. External telemetry can project the stored log until a sink-producing module or runtime integration is added.

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -19,7 +19,7 @@ flamecast-core combines ideas from event-sourced systems, typed effect runtimes,
 - [Don't Train the Model, Evolve the Harness](https://huggingface.co/spaces/joelniklaus/harness-optimization) motivates optimizing the code and control structure around a frozen model.
 - [Let the Model Write the Code](https://www.cmpnd.ai/blog/let-the-model-write-the-code.html) motivates source-level candidates instead of a closed parameter table.
 - [GEPA](https://arxiv.org/abs/2507.19457) motivates reflective search and Pareto selection across tasks.
-- [PopuLoRA](https://vmax.ai/roger-creus/populora-co-evolving-llm-populations-for-reasoning-self-play) is an example of a different population-based direction that should fit the same evaluation substrate.
+- [PopuLoRA](https://arxiv.org/abs/2605.16727v1) motivates separate teacher and student populations, TrueSkill-guided PFSP matchmaking, and periodic population replacement.
 
 ## Compaction
 

--- a/packages/evolve/src/cost.test.ts
+++ b/packages/evolve/src/cost.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test"
+import type { Event } from "@flamecast/core"
+import { costed, evolutionCostOf, sumEvolutionCosts, zeroEvolutionCost } from "./cost"
+
+const first: ReadonlyArray<Event> = [
+  {
+    type: "ModelReturned",
+    usage: { promptTokens: 100, completionTokens: 20, costUsd: 0.003 }
+  },
+  { type: "ToolCalled", name: "lookup_invoice" },
+  { type: "ToolCalled", name: "answer" }
+]
+
+const second: ReadonlyArray<Event> = [
+  {
+    type: "ModelReturned",
+    usage: { promptTokens: 50, completionTokens: 10, costUsd: 0.002 }
+  },
+  { type: "ToolCalled", name: "fetch_ledger" },
+  { type: "ToolCalled", name: "request-budget" }
+]
+
+describe("evolution cost", () => {
+  test("projects model usage and work-tool calls from harness logs", () => {
+    expect(evolutionCostOf(first, second)).toEqual({
+      promptTokens: 150,
+      completionTokens: 30,
+      costUsd: 0.005,
+      toolCalls: 2
+    })
+  })
+
+  test("attaches projected cost to a callback value", () => {
+    expect(costed("candidate", first)).toEqual({
+      value: "candidate",
+      cost: {
+        promptTokens: 100,
+        completionTokens: 20,
+        costUsd: 0.003,
+        toolCalls: 1
+      }
+    })
+    expect(costed(undefined).cost).toEqual(zeroEvolutionCost())
+  })
+
+  test("rejects invalid reported cost", () => {
+    expect(() =>
+      sumEvolutionCosts([
+        { promptTokens: -1, completionTokens: 0, costUsd: 0, toolCalls: 0 }
+      ])
+    ).toThrow("evolution cost promptTokens must be a non-negative finite number")
+  })
+
+  test("rejects an overflowing total", () => {
+    expect(() =>
+      sumEvolutionCosts([
+        {
+          promptTokens: Number.MAX_VALUE,
+          completionTokens: 0,
+          costUsd: 0,
+          toolCalls: 0
+        },
+        {
+          promptTokens: Number.MAX_VALUE,
+          completionTokens: 0,
+          costUsd: 0,
+          toolCalls: 0
+        }
+      ])
+    ).toThrow("evolution cost promptTokens must be a non-negative finite number")
+  })
+})

--- a/packages/evolve/src/cost.ts
+++ b/packages/evolve/src/cost.ts
@@ -1,0 +1,58 @@
+import type { Event } from "@flamecast/core"
+import type { Usage } from "@flamecast/harness/infer"
+import { toolCallsOf } from "@flamecast/harness/modules/budget"
+import { spendOf } from "./score"
+
+export interface EvolutionCost extends Usage {
+  readonly toolCalls: number
+}
+
+export interface Costed<Value> {
+  readonly value: Value
+  readonly cost: EvolutionCost
+}
+
+export const zeroEvolutionCost = (): EvolutionCost => ({
+  promptTokens: 0,
+  completionTokens: 0,
+  costUsd: 0,
+  toolCalls: 0
+})
+
+const validateEvolutionCost = (cost: EvolutionCost) => {
+  for (const field of ["promptTokens", "completionTokens", "costUsd", "toolCalls"] as const) {
+    if (!Number.isFinite(cost[field]) || cost[field] < 0) {
+      throw new Error(`evolution cost ${field} must be a non-negative finite number`)
+    }
+  }
+}
+
+export const sumEvolutionCosts = (
+  costs: ReadonlyArray<EvolutionCost>
+): EvolutionCost =>
+  costs.reduce((total, cost) => {
+    validateEvolutionCost(cost)
+    const combined = {
+      promptTokens: total.promptTokens + cost.promptTokens,
+      completionTokens: total.completionTokens + cost.completionTokens,
+      costUsd: total.costUsd + cost.costUsd,
+      toolCalls: total.toolCalls + cost.toolCalls
+    }
+    validateEvolutionCost(combined)
+    return combined
+  }, zeroEvolutionCost())
+
+export const evolutionCostOf = (
+  ...logs: ReadonlyArray<ReadonlyArray<Event>>
+): EvolutionCost =>
+  sumEvolutionCosts(
+    logs.map((log) => ({
+      ...spendOf(log),
+      toolCalls: toolCallsOf(log)
+    }))
+  )
+
+export const costed = <Value>(
+  value: Value,
+  ...logs: ReadonlyArray<ReadonlyArray<Event>>
+): Costed<Value> => ({ value, cost: evolutionCostOf(...logs) })

--- a/packages/evolve/src/gepa.test.ts
+++ b/packages/evolve/src/gepa.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { candidate } from "./candidate"
+import { costed, zeroEvolutionCost } from "./cost"
 import { gepa, type GepaEvaluation } from "./gepa"
 
 interface Harness {
@@ -9,12 +10,23 @@ interface Harness {
 }
 
 const example = (id: string) => ({ id, value: id })
+const free = <Value>(value: Value) => costed(value)
+const priced = <Value>(
+  value: Value,
+  promptTokens: number,
+  completionTokens: number,
+  costUsd: number,
+  toolCalls: number
+) => ({
+  value,
+  cost: { promptTokens, completionTokens, costUsd, toolCalls }
+})
 
 const evaluate = (evaluated: { readonly value: Harness }, task: { readonly id: string }) =>
-  Effect.succeed({
+  Effect.succeed(free({
     score: evaluated.value.scores[task.id] ?? 0,
     trajectory: `${evaluated.value.source}:${task.id}`
-  })
+  }))
 
 describe("the GEPA loop", () => {
   test("returns the seed after its required Pareto evaluation", async () => {
@@ -27,7 +39,7 @@ describe("the GEPA loop", () => {
         minibatchSize: 1,
         maxMetricCalls: 2,
         evaluate,
-        mutate: () => Effect.succeed(undefined)
+        mutate: () => Effect.succeed(free(undefined))
       })
     )
 
@@ -36,10 +48,11 @@ describe("the GEPA loop", () => {
     expect(result.best.average).toBeCloseTo(0.6, 10)
     expect(result.metricCalls).toBe(2)
     expect(result.iterations).toEqual([])
+    expect(result.cost).toEqual(zeroEvolutionCost())
   })
 
   test("accepts strict improvements and records whole-harness lineage", async () => {
-    const seed = candidate("seed", {
+    const seed = candidate<Harness>("seed", {
       source: "seed.ts",
       scores: { f1: 0.2, p1: 0.4, p2: 0.4 }
     })
@@ -54,7 +67,7 @@ describe("the GEPA loop", () => {
         evaluate,
         mutate: ({ iteration, parent, trials }) => {
           expect(trials[0]?.evaluation.trajectory).toBe(`${parent.value.source}:f1`)
-          return Effect.succeed(
+          return Effect.succeed(free(
             iteration === 0
               ? candidate("better", {
                   source: "better.ts",
@@ -64,7 +77,7 @@ describe("the GEPA loop", () => {
                   source: "worse.ts",
                   scores: { f1: 0.1, p1: 1, p2: 1 }
                 })
-          )
+          ))
         }
       })
     )
@@ -80,7 +93,8 @@ describe("the GEPA loop", () => {
         parentAverage: 0.2,
         proposal: "better",
         proposalAverage: 0.8,
-        accepted: true
+        accepted: true,
+        cost: zeroEvolutionCost()
       },
       {
         iteration: 1,
@@ -89,7 +103,8 @@ describe("the GEPA loop", () => {
         parentAverage: 0.8,
         proposal: "worse",
         proposalAverage: 0.1,
-        accepted: false
+        accepted: false,
+        cost: zeroEvolutionCost()
       }
     ])
     expect(result.metricCalls).toBe(8)
@@ -113,7 +128,7 @@ describe("the GEPA loop", () => {
         evaluate,
         mutate: ({ iteration, parent }) => {
           parents.push(parent.id)
-          return Effect.succeed(
+          return Effect.succeed(free(
             iteration === 0
               ? candidate("right", {
                   source: "right.ts",
@@ -123,7 +138,7 @@ describe("the GEPA loop", () => {
                   source: "discarded.ts",
                   scores: { feedback: -1, left: 1, middle: 1, right: 1 }
                 })
-          )
+          ))
         }
       })
     )
@@ -148,14 +163,14 @@ describe("the GEPA loop", () => {
         minibatchSize: 1,
         maxMetricCalls: 4,
         evaluate: (evaluated, task) =>
-          Effect.succeed({
+          Effect.succeed(free({
             score: evaluated.value.scores[task.id] ?? 0,
             trajectory: `${evaluated.id}:${task.id}`,
             reason: "the harness chose the wrong tool"
-          }),
+          })),
         mutate: ({ trials }) => {
           seen.push(...trials.map((trial) => trial.evaluation))
-          return Effect.succeed(undefined)
+          return Effect.succeed(free(undefined))
         }
       })
     )
@@ -169,6 +184,62 @@ describe("the GEPA loop", () => {
     ])
   })
 
+  test("tracks evaluation and mutation cost", async () => {
+    const seed = candidate<Harness>("seed", {
+      source: "seed.ts",
+      scores: { f1: 0.1, p1: 0.1 }
+    })
+    const result = await Effect.runPromise(
+      gepa({
+        seed,
+        feedbackExamples: [example("f1")],
+        paretoExamples: [example("p1")],
+        minibatchSize: 1,
+        maxMetricCalls: 4,
+        evaluate: (evaluated, task) =>
+          Effect.succeed(
+            priced(
+              {
+                score: evaluated.value.scores[task.id] ?? 0,
+                trajectory: `${evaluated.id}:${task.id}`
+              },
+              10,
+              2,
+              0.01,
+              1
+            )
+          ),
+        mutate: () =>
+          Effect.succeed(
+            priced(
+              candidate("better", {
+                source: "better.ts",
+                scores: { f1: 1, p1: 1 }
+              }),
+              5,
+              1,
+              0.005,
+              2
+            )
+          )
+      })
+    )
+
+    expect(result.iterations[0]?.cost).toMatchObject({
+      promptTokens: 35,
+      completionTokens: 7,
+      toolCalls: 5
+    })
+    expect(result.iterations[0]?.cost.costUsd).toBeCloseTo(0.035, 10)
+    expect(result.cost).toMatchObject({
+      promptTokens: 45,
+      completionTokens: 9,
+      toolCalls: 6
+    })
+    expect(result.cost.costUsd).toBeCloseTo(0.045, 10)
+    expect(result.population.map((entry) => entry.cost.toolCalls)).toEqual([1, 1])
+  })
+
   test("requires mutations to preserve the selected parent", async () => {
     const run = Effect.runPromise(
       gepa({
@@ -179,13 +250,13 @@ describe("the GEPA loop", () => {
         maxMetricCalls: 4,
         evaluate,
         mutate: () =>
-          Effect.succeed(
+          Effect.succeed(free(
             candidate(
               "child",
               { source: "child.ts", scores: { f1: 1, p1: 1 } },
               { parent: "someone-else" }
             )
-          )
+          ))
       })
     )
 

--- a/packages/evolve/src/gepa.test.ts
+++ b/packages/evolve/src/gepa.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { candidate } from "./candidate"
+import { gepa, type GepaEvaluation } from "./gepa"
+
+interface Harness {
+  readonly scores: Readonly<Record<string, number>>
+  readonly source: string
+}
+
+const example = (id: string) => ({ id, value: id })
+
+const evaluate = (evaluated: { readonly value: Harness }, task: { readonly id: string }) =>
+  Effect.succeed({
+    score: evaluated.value.scores[task.id] ?? 0,
+    trajectory: `${evaluated.value.source}:${task.id}`
+  })
+
+describe("the GEPA loop", () => {
+  test("returns the seed after its required Pareto evaluation", async () => {
+    const seed = candidate("seed", { source: "seed.ts", scores: { p1: 0.4, p2: 0.8 } })
+    const result = await Effect.runPromise(
+      gepa({
+        seed,
+        feedbackExamples: [example("f1")],
+        paretoExamples: [example("p1"), example("p2")],
+        minibatchSize: 1,
+        maxMetricCalls: 2,
+        evaluate,
+        mutate: () => Effect.succeed(undefined)
+      })
+    )
+
+    expect(result.best.candidate).toBe(seed)
+    expect(result.best.scores).toEqual({ p1: 0.4, p2: 0.8 })
+    expect(result.best.average).toBeCloseTo(0.6, 10)
+    expect(result.metricCalls).toBe(2)
+    expect(result.iterations).toEqual([])
+  })
+
+  test("accepts strict improvements and records whole-harness lineage", async () => {
+    const seed = candidate("seed", {
+      source: "seed.ts",
+      scores: { f1: 0.2, p1: 0.4, p2: 0.4 }
+    })
+    const result = await Effect.runPromise(
+      gepa({
+        seed,
+        feedbackExamples: [example("f1")],
+        paretoExamples: [example("p1"), example("p2")],
+        minibatchSize: 1,
+        maxMetricCalls: 10,
+        random: () => 0,
+        evaluate,
+        mutate: ({ iteration, parent, trials }) => {
+          expect(trials[0]?.evaluation.trajectory).toBe(`${parent.value.source}:f1`)
+          return Effect.succeed(
+            iteration === 0
+              ? candidate("better", {
+                  source: "better.ts",
+                  scores: { f1: 0.8, p1: 0.7, p2: 0.9 }
+                })
+              : candidate("worse", {
+                  source: "worse.ts",
+                  scores: { f1: 0.1, p1: 1, p2: 1 }
+                })
+          )
+        }
+      })
+    )
+
+    expect(result.population.map((entry) => entry.candidate.id)).toEqual(["seed", "better"])
+    expect(result.population[1]?.candidate.parent).toBe("seed")
+    expect(result.best.candidate.id).toBe("better")
+    expect(result.iterations).toEqual([
+      {
+        iteration: 0,
+        parent: "seed",
+        batch: ["f1"],
+        parentAverage: 0.2,
+        proposal: "better",
+        proposalAverage: 0.8,
+        accepted: true
+      },
+      {
+        iteration: 1,
+        parent: "better",
+        batch: ["f1"],
+        parentAverage: 0.8,
+        proposal: "worse",
+        proposalAverage: 0.1,
+        accepted: false
+      }
+    ])
+    expect(result.metricCalls).toBe(8)
+  })
+
+  test("samples from instance-wise leaders with their leadership frequency", async () => {
+    const parents: Array<string> = []
+    const seed = candidate("left", {
+      source: "left.ts",
+      scores: { feedback: 0, left: 1, middle: 1, right: 0 }
+    })
+    const random = [0, 0, 0.6, 0]
+    const result = await Effect.runPromise(
+      gepa({
+        seed,
+        feedbackExamples: [example("feedback")],
+        paretoExamples: [example("left"), example("middle"), example("right")],
+        minibatchSize: 1,
+        maxMetricCalls: 13,
+        random: () => random.shift() ?? 0,
+        evaluate,
+        mutate: ({ iteration, parent }) => {
+          parents.push(parent.id)
+          return Effect.succeed(
+            iteration === 0
+              ? candidate("right", {
+                  source: "right.ts",
+                  scores: { feedback: 1, left: 0, middle: 0, right: 1 }
+                })
+              : candidate("discarded", {
+                  source: "discarded.ts",
+                  scores: { feedback: -1, left: 1, middle: 1, right: 1 }
+                })
+          )
+        }
+      })
+    )
+
+    expect(parents).toEqual(["left", "left"])
+    expect(result.front.map((entry) => entry.candidate.id)).toEqual(["left", "right"])
+    expect(result.metricCalls).toBe(10)
+  })
+
+  test("passes evaluator-specific feedback to the mutation", async () => {
+    interface FeedbackEvaluation extends GepaEvaluation<string> {
+      readonly reason: string
+    }
+
+    const seen: Array<FeedbackEvaluation> = []
+    const seed: Harness = { source: "seed.ts", scores: { f1: 0, p1: 0 } }
+    await Effect.runPromise(
+      gepa({
+        seed: candidate("seed", seed),
+        feedbackExamples: [example("f1")],
+        paretoExamples: [example("p1")],
+        minibatchSize: 1,
+        maxMetricCalls: 4,
+        evaluate: (evaluated, task) =>
+          Effect.succeed({
+            score: evaluated.value.scores[task.id] ?? 0,
+            trajectory: `${evaluated.id}:${task.id}`,
+            reason: "the harness chose the wrong tool"
+          }),
+        mutate: ({ trials }) => {
+          seen.push(...trials.map((trial) => trial.evaluation))
+          return Effect.succeed(undefined)
+        }
+      })
+    )
+
+    expect(seen).toEqual([
+      {
+        score: 0,
+        trajectory: "seed:f1",
+        reason: "the harness chose the wrong tool"
+      }
+    ])
+  })
+
+  test("requires mutations to preserve the selected parent", async () => {
+    const run = Effect.runPromise(
+      gepa({
+        seed: candidate("seed", { source: "seed.ts", scores: { f1: 0, p1: 0 } }),
+        feedbackExamples: [example("f1")],
+        paretoExamples: [example("p1")],
+        minibatchSize: 1,
+        maxMetricCalls: 4,
+        evaluate,
+        mutate: () =>
+          Effect.succeed(
+            candidate(
+              "child",
+              { source: "child.ts", scores: { f1: 1, p1: 1 } },
+              { parent: "someone-else" }
+            )
+          )
+      })
+    )
+
+    expect(run).rejects.toThrow('GEPA proposal "child" names parent "someone-else" instead of "seed"')
+  })
+})

--- a/packages/evolve/src/gepa.ts
+++ b/packages/evolve/src/gepa.ts
@@ -1,5 +1,10 @@
 import { Effect } from "effect"
 import { candidate, type Candidate } from "./candidate"
+import {
+  sumEvolutionCosts,
+  type Costed,
+  type EvolutionCost
+} from "./cost"
 import type { Scores } from "./pareto"
 
 export interface GepaExample<Value> {
@@ -15,6 +20,7 @@ export interface GepaEvaluation<Trajectory = unknown> {
 export interface GepaTrial<Example, Evaluation extends GepaEvaluation> {
   readonly example: GepaExample<Example>
   readonly evaluation: Evaluation
+  readonly cost: EvolutionCost
 }
 
 export interface GepaMutationContext<Value, Example, Evaluation extends GepaEvaluation> {
@@ -27,6 +33,7 @@ export interface GepaPopulationEntry<Value> {
   readonly candidate: Candidate<Value>
   readonly scores: Scores
   readonly average: number
+  readonly cost: EvolutionCost
 }
 
 export interface GepaIteration {
@@ -37,6 +44,7 @@ export interface GepaIteration {
   readonly proposal?: string
   readonly proposalAverage?: number
   readonly accepted: boolean
+  readonly cost: EvolutionCost
 }
 
 export interface GepaResult<Value> {
@@ -45,6 +53,7 @@ export interface GepaResult<Value> {
   readonly front: ReadonlyArray<GepaPopulationEntry<Value>>
   readonly iterations: ReadonlyArray<GepaIteration>
   readonly metricCalls: number
+  readonly cost: EvolutionCost
 }
 
 export interface GepaOptions<
@@ -64,10 +73,14 @@ export interface GepaOptions<
   readonly evaluate: (
     candidate: Candidate<Value>,
     example: GepaExample<Example>
-  ) => Effect.Effect<Evaluation, EvaluationError, EvaluationRequirements>
+  ) => Effect.Effect<Costed<Evaluation>, EvaluationError, EvaluationRequirements>
   readonly mutate: (
     context: GepaMutationContext<Value, Example, Evaluation>
-  ) => Effect.Effect<Candidate<Value> | undefined, MutationError, MutationRequirements>
+  ) => Effect.Effect<
+    Costed<Candidate<Value> | undefined>,
+    MutationError,
+    MutationRequirements
+  >
   readonly random?: () => number
 }
 
@@ -248,32 +261,38 @@ export const gepa = <
     ) =>
       Effect.gen(function* () {
         const trials: Array<GepaTrial<Example, Evaluation>> = []
+        const costs: Array<EvolutionCost> = []
         for (const example of examples) {
-          const evaluation = yield* options.evaluate(evaluated, example)
+          const evaluatedExample = yield* options.evaluate(evaluated, example)
+          const evaluation = evaluatedExample.value
           metricCalls += 1
           if (!Number.isFinite(evaluation.score)) {
             throw new Error(
               `GEPA evaluator returned a non-finite score for example "${example.id}"`
             )
           }
-          trials.push({ example, evaluation })
+          trials.push({ example, evaluation, cost: evaluatedExample.cost })
+          costs.push(evaluatedExample.cost)
         }
-        return trials
+        return { trials, cost: sumEvolutionCosts(costs) }
       })
 
     const scoreOnPareto = (evaluated: Candidate<Value>) =>
-      Effect.map(evaluate(evaluated, options.paretoExamples), (trials) => {
+      Effect.map(evaluate(evaluated, options.paretoExamples), ({ trials, cost }) => {
         const scores = Object.fromEntries(
           trials.map((trial) => [trial.example.id, trial.evaluation.score])
         )
         return {
           candidate: evaluated,
           scores,
-          average: averageOf(trials.map((trial) => trial.evaluation.score))
+          average: averageOf(trials.map((trial) => trial.evaluation.score)),
+          cost
         } satisfies GepaPopulationEntry<Value>
       })
 
-    const population: Array<GepaPopulationEntry<Value>> = [yield* scoreOnPareto(options.seed)]
+    const seed = yield* scoreOnPareto(options.seed)
+    let totalCost = seed.cost
+    const population: Array<GepaPopulationEntry<Value>> = [seed]
     const iterations: Array<GepaIteration> = []
     const exampleIds = options.paretoExamples.map((example) => example.id)
     const callsForAcceptableIteration =
@@ -283,23 +302,29 @@ export const gepa = <
       const iteration = iterations.length
       const parent = selectParent(population, exampleIds, random)
       const batch = sampleBatch(options.feedbackExamples, options.minibatchSize, random)
-      const parentTrials = yield* evaluate(parent.candidate, batch)
+      const parentEvaluation = yield* evaluate(parent.candidate, batch)
+      const parentTrials = parentEvaluation.trials
       const parentAverage = averageOf(
         parentTrials.map((trial) => trial.evaluation.score)
       )
-      const proposed = yield* options.mutate({
+      const mutation = yield* options.mutate({
         iteration,
         parent: parent.candidate,
         trials: parentTrials
       })
+      const proposed = mutation.value
+      const iterationCosts: Array<EvolutionCost> = [parentEvaluation.cost, mutation.cost]
 
       if (proposed === undefined) {
+        const cost = sumEvolutionCosts(iterationCosts)
+        totalCost = sumEvolutionCosts([totalCost, cost])
         iterations.push({
           iteration,
           parent: parent.candidate.id,
           batch: batch.map((example) => example.id),
           parentAverage,
-          accepted: false
+          accepted: false,
+          cost
         })
         continue
       }
@@ -308,12 +333,20 @@ export const gepa = <
       if (population.some((entry) => entry.candidate.id === proposal.id)) {
         throw new Error(`GEPA proposal id "${proposal.id}" already exists in the population`)
       }
-      const proposalTrials = yield* evaluate(proposal, batch)
+      const proposalEvaluation = yield* evaluate(proposal, batch)
+      iterationCosts.push(proposalEvaluation.cost)
+      const proposalTrials = proposalEvaluation.trials
       const proposalAverage = averageOf(
         proposalTrials.map((trial) => trial.evaluation.score)
       )
       const accepted = proposalAverage > parentAverage
-      if (accepted) population.push(yield* scoreOnPareto(proposal))
+      if (accepted) {
+        const entry = yield* scoreOnPareto(proposal)
+        population.push(entry)
+        iterationCosts.push(entry.cost)
+      }
+      const cost = sumEvolutionCosts(iterationCosts)
+      totalCost = sumEvolutionCosts([totalCost, cost])
       iterations.push({
         iteration,
         parent: parent.candidate.id,
@@ -321,7 +354,8 @@ export const gepa = <
         parentAverage,
         proposal: proposal.id,
         proposalAverage,
-        accepted
+        accepted,
+        cost
       })
     }
 
@@ -333,7 +367,8 @@ export const gepa = <
       population,
       front: frontOf(population, exampleIds),
       iterations,
-      metricCalls
+      metricCalls,
+      cost: totalCost
     }
     return result
   })

--- a/packages/evolve/src/gepa.ts
+++ b/packages/evolve/src/gepa.ts
@@ -1,0 +1,340 @@
+import { Effect } from "effect"
+import { candidate, type Candidate } from "./candidate"
+import type { Scores } from "./pareto"
+
+export interface GepaExample<Value> {
+  readonly id: string
+  readonly value: Value
+}
+
+export interface GepaEvaluation<Trajectory = unknown> {
+  readonly score: number
+  readonly trajectory: Trajectory
+}
+
+export interface GepaTrial<Example, Evaluation extends GepaEvaluation> {
+  readonly example: GepaExample<Example>
+  readonly evaluation: Evaluation
+}
+
+export interface GepaMutationContext<Value, Example, Evaluation extends GepaEvaluation> {
+  readonly iteration: number
+  readonly parent: Candidate<Value>
+  readonly trials: ReadonlyArray<GepaTrial<Example, Evaluation>>
+}
+
+export interface GepaPopulationEntry<Value> {
+  readonly candidate: Candidate<Value>
+  readonly scores: Scores
+  readonly average: number
+}
+
+export interface GepaIteration {
+  readonly iteration: number
+  readonly parent: string
+  readonly batch: ReadonlyArray<string>
+  readonly parentAverage: number
+  readonly proposal?: string
+  readonly proposalAverage?: number
+  readonly accepted: boolean
+}
+
+export interface GepaResult<Value> {
+  readonly best: GepaPopulationEntry<Value>
+  readonly population: ReadonlyArray<GepaPopulationEntry<Value>>
+  readonly front: ReadonlyArray<GepaPopulationEntry<Value>>
+  readonly iterations: ReadonlyArray<GepaIteration>
+  readonly metricCalls: number
+}
+
+export interface GepaOptions<
+  Value,
+  Example,
+  Evaluation extends GepaEvaluation,
+  EvaluationError = never,
+  EvaluationRequirements = never,
+  MutationError = never,
+  MutationRequirements = never
+> {
+  readonly seed: Candidate<Value>
+  readonly feedbackExamples: ReadonlyArray<GepaExample<Example>>
+  readonly paretoExamples: ReadonlyArray<GepaExample<Example>>
+  readonly minibatchSize: number
+  readonly maxMetricCalls: number
+  readonly evaluate: (
+    candidate: Candidate<Value>,
+    example: GepaExample<Example>
+  ) => Effect.Effect<Evaluation, EvaluationError, EvaluationRequirements>
+  readonly mutate: (
+    context: GepaMutationContext<Value, Example, Evaluation>
+  ) => Effect.Effect<Candidate<Value> | undefined, MutationError, MutationRequirements>
+  readonly random?: () => number
+}
+
+const averageOf = (scores: ReadonlyArray<number>): number =>
+  scores.reduce((total, score) => total + score, 0) / scores.length
+
+const dominates = (left: Scores, right: Scores, examples: ReadonlyArray<string>): boolean => {
+  let strictly = false
+  for (const example of examples) {
+    const leftScore = left[example]
+    const rightScore = right[example]
+    if (leftScore === undefined || rightScore === undefined) {
+      throw new Error(`GEPA candidate is missing the Pareto score for example "${example}"`)
+    }
+    if (leftScore < rightScore) return false
+    if (leftScore > rightScore) strictly = true
+  }
+  return strictly
+}
+
+const leadersByExample = <Value>(
+  population: ReadonlyArray<GepaPopulationEntry<Value>>,
+  examples: ReadonlyArray<string>
+) =>
+  examples.map((example) => {
+    const best = population.reduce((highest, entry) => {
+      const score = entry.scores[example]
+      if (score === undefined) {
+        throw new Error(`GEPA candidate is missing the Pareto score for example "${example}"`)
+      }
+      return Math.max(highest, score)
+    }, Number.NEGATIVE_INFINITY)
+    return new Set(
+      population
+        .filter((entry) => entry.scores[example] === best)
+        .map((entry) => entry.candidate.id)
+    )
+  })
+
+const frontOf = <Value>(
+  population: ReadonlyArray<GepaPopulationEntry<Value>>,
+  examples: ReadonlyArray<string>
+) => {
+  const leaders = leadersByExample(population, examples)
+  const leaderIds = new Set(leaders.flatMap((set) => [...set]))
+  const candidates = population.filter((entry) => leaderIds.has(entry.candidate.id))
+  return candidates.filter(
+    (entry) =>
+      !candidates.some(
+        (other) =>
+          other !== entry && dominates(other.scores, entry.scores, examples)
+      )
+  )
+}
+
+const randomIndex = (length: number, random: () => number): number =>
+  Math.max(0, Math.min(length - 1, Math.floor(random() * length)))
+
+const selectParent = <Value>(
+  population: ReadonlyArray<GepaPopulationEntry<Value>>,
+  examples: ReadonlyArray<string>,
+  random: () => number
+) => {
+  const leaders = leadersByExample(population, examples)
+  const front = frontOf(population, examples)
+  const weights = front.map((entry) =>
+    leaders.filter((set) => set.has(entry.candidate.id)).length
+  )
+  const total = weights.reduce((sum, weight) => sum + weight, 0)
+  let draw = randomIndex(total, random)
+  for (const [index, entry] of front.entries()) {
+    draw -= weights[index]!
+    if (draw < 0) return entry
+  }
+  return front.at(-1)!
+}
+
+const sampleBatch = <Value>(
+  examples: ReadonlyArray<GepaExample<Value>>,
+  size: number,
+  random: () => number
+) => {
+  const available = [...examples]
+  const sampled: Array<GepaExample<Value>> = []
+  while (sampled.length < size) {
+    sampled.push(available.splice(randomIndex(available.length, random), 1)[0]!)
+  }
+  return sampled
+}
+
+const validateOptions = <
+  Value,
+  Example,
+  Evaluation extends GepaEvaluation,
+  EvaluationError,
+  EvaluationRequirements,
+  MutationError,
+  MutationRequirements
+>(
+  options: GepaOptions<
+    Value,
+    Example,
+    Evaluation,
+    EvaluationError,
+    EvaluationRequirements,
+    MutationError,
+    MutationRequirements
+  >
+) => {
+  if (options.feedbackExamples.length === 0) {
+    throw new Error("GEPA requires at least one feedback example")
+  }
+  if (options.paretoExamples.length === 0) {
+    throw new Error("GEPA requires at least one Pareto example")
+  }
+  if (
+    !Number.isInteger(options.minibatchSize) ||
+    options.minibatchSize < 1 ||
+    options.minibatchSize > options.feedbackExamples.length
+  ) {
+    throw new Error("GEPA minibatchSize must be a positive integer within the feedback set")
+  }
+  if (
+    !Number.isInteger(options.maxMetricCalls) ||
+    options.maxMetricCalls < options.paretoExamples.length
+  ) {
+    throw new Error("GEPA maxMetricCalls must cover the initial Pareto evaluation")
+  }
+  const ids = new Set<string>()
+  for (const example of options.paretoExamples) {
+    if (ids.has(example.id)) {
+      throw new Error(`GEPA received duplicate Pareto example id "${example.id}"`)
+    }
+    ids.add(example.id)
+  }
+}
+
+const withParent = <Value>(proposal: Candidate<Value>, parent: Candidate<Value>) => {
+  if (proposal.parent !== undefined && proposal.parent !== parent.id) {
+    throw new Error(
+      `GEPA proposal "${proposal.id}" names parent "${proposal.parent}" instead of "${parent.id}"`
+    )
+  }
+  return proposal.parent === undefined
+    ? candidate(proposal.id, proposal.value, {
+        parent: parent.id,
+        ...(proposal.source === undefined ? {} : { source: proposal.source })
+      })
+    : proposal
+}
+
+export const gepa = <
+  Value,
+  Example,
+  Evaluation extends GepaEvaluation,
+  EvaluationError,
+  EvaluationRequirements,
+  MutationError,
+  MutationRequirements
+>(
+  options: GepaOptions<
+    Value,
+    Example,
+    Evaluation,
+    EvaluationError,
+    EvaluationRequirements,
+    MutationError,
+    MutationRequirements
+  >
+) => {
+  validateOptions(options)
+  const random = options.random ?? Math.random
+  return Effect.gen(function* () {
+    let metricCalls = 0
+    const evaluate = (
+      evaluated: Candidate<Value>,
+      examples: ReadonlyArray<GepaExample<Example>>
+    ) =>
+      Effect.gen(function* () {
+        const trials: Array<GepaTrial<Example, Evaluation>> = []
+        for (const example of examples) {
+          const evaluation = yield* options.evaluate(evaluated, example)
+          metricCalls += 1
+          if (!Number.isFinite(evaluation.score)) {
+            throw new Error(
+              `GEPA evaluator returned a non-finite score for example "${example.id}"`
+            )
+          }
+          trials.push({ example, evaluation })
+        }
+        return trials
+      })
+
+    const scoreOnPareto = (evaluated: Candidate<Value>) =>
+      Effect.map(evaluate(evaluated, options.paretoExamples), (trials) => {
+        const scores = Object.fromEntries(
+          trials.map((trial) => [trial.example.id, trial.evaluation.score])
+        )
+        return {
+          candidate: evaluated,
+          scores,
+          average: averageOf(trials.map((trial) => trial.evaluation.score))
+        } satisfies GepaPopulationEntry<Value>
+      })
+
+    const population: Array<GepaPopulationEntry<Value>> = [yield* scoreOnPareto(options.seed)]
+    const iterations: Array<GepaIteration> = []
+    const exampleIds = options.paretoExamples.map((example) => example.id)
+    const callsForAcceptableIteration =
+      options.minibatchSize * 2 + options.paretoExamples.length
+
+    while (metricCalls + callsForAcceptableIteration <= options.maxMetricCalls) {
+      const iteration = iterations.length
+      const parent = selectParent(population, exampleIds, random)
+      const batch = sampleBatch(options.feedbackExamples, options.minibatchSize, random)
+      const parentTrials = yield* evaluate(parent.candidate, batch)
+      const parentAverage = averageOf(
+        parentTrials.map((trial) => trial.evaluation.score)
+      )
+      const proposed = yield* options.mutate({
+        iteration,
+        parent: parent.candidate,
+        trials: parentTrials
+      })
+
+      if (proposed === undefined) {
+        iterations.push({
+          iteration,
+          parent: parent.candidate.id,
+          batch: batch.map((example) => example.id),
+          parentAverage,
+          accepted: false
+        })
+        continue
+      }
+
+      const proposal = withParent(proposed, parent.candidate)
+      if (population.some((entry) => entry.candidate.id === proposal.id)) {
+        throw new Error(`GEPA proposal id "${proposal.id}" already exists in the population`)
+      }
+      const proposalTrials = yield* evaluate(proposal, batch)
+      const proposalAverage = averageOf(
+        proposalTrials.map((trial) => trial.evaluation.score)
+      )
+      const accepted = proposalAverage > parentAverage
+      if (accepted) population.push(yield* scoreOnPareto(proposal))
+      iterations.push({
+        iteration,
+        parent: parent.candidate.id,
+        batch: batch.map((example) => example.id),
+        parentAverage,
+        proposal: proposal.id,
+        proposalAverage,
+        accepted
+      })
+    }
+
+    const best = population.reduce((leader, entry) =>
+      entry.average > leader.average ? entry : leader
+    )
+    const result: GepaResult<Value> = {
+      best,
+      population,
+      front: frontOf(population, exampleIds),
+      iterations,
+      metricCalls
+    }
+    return result
+  })
+}

--- a/packages/evolve/src/index.ts
+++ b/packages/evolve/src/index.ts
@@ -24,6 +24,27 @@ export {
   type ProgramObservation
 } from "./observe"
 export {
+  populora,
+  populoraConservativeScore,
+  populoraRewards,
+  populoraWinProbability,
+  type PopuloraEvolution,
+  type PopuloraEvolutionContext,
+  type PopuloraMatch,
+  type PopuloraMatchContext,
+  type PopuloraMatchOutcome,
+  type PopuloraMember,
+  type PopuloraOperator,
+  type PopuloraOptions,
+  type PopuloraRating,
+  type PopuloraRatingOptions,
+  type PopuloraResult,
+  type PopuloraRewards,
+  type PopuloraRole,
+  type PopuloraSolveOutcome,
+  type PopuloraTrial
+} from "./populora"
+export {
   divergence,
   rollout,
   type Divergence,

--- a/packages/evolve/src/index.ts
+++ b/packages/evolve/src/index.ts
@@ -2,10 +2,21 @@
 // its consumers one door. Inside the package, a module imports from the file that defines the
 // symbol.
 //
-// The package holds the mechanics of a harness search and none of its judgment. There is no proposer
-// prompt and no metric here, because neither one is portable across domains.
+// The package holds reusable mechanics and policies for harness search. Callers own proposer prompts
+// and metrics because those decisions belong to their domains.
 
 export { candidate, type Candidate, type CandidateOptions } from "./candidate"
+export {
+  gepa,
+  type GepaEvaluation,
+  type GepaExample,
+  type GepaIteration,
+  type GepaMutationContext,
+  type GepaOptions,
+  type GepaPopulationEntry,
+  type GepaResult,
+  type GepaTrial
+} from "./gepa"
 export {
   modelCallPrefixes,
   observationOf,

--- a/packages/evolve/src/index.ts
+++ b/packages/evolve/src/index.ts
@@ -7,6 +7,14 @@
 
 export { candidate, type Candidate, type CandidateOptions } from "./candidate"
 export {
+  costed,
+  evolutionCostOf,
+  sumEvolutionCosts,
+  zeroEvolutionCost,
+  type Costed,
+  type EvolutionCost
+} from "./cost"
+export {
   gepa,
   type GepaEvaluation,
   type GepaExample,

--- a/packages/evolve/src/populora.test.ts
+++ b/packages/evolve/src/populora.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { candidate } from "./candidate"
+import { costed } from "./cost"
 import {
   populora,
   populoraConservativeScore,
@@ -15,7 +16,18 @@ const trial = <Evidence>(
   evidence: Evidence
 ): PopuloraTrial<Evidence> => ({ valid, outcomes, evidence })
 
-const noEvolution = () => Effect.succeed(undefined)
+const free = <Value>(value: Value) => costed(value)
+const priced = <Value>(
+  value: Value,
+  promptTokens: number,
+  completionTokens: number,
+  costUsd: number,
+  toolCalls: number
+) => ({
+  value,
+  cost: { promptTokens, completionTokens, costUsd, toolCalls }
+})
+const noEvolution = () => Effect.succeed(free(undefined))
 
 describe("PopuLoRA rewards and ratings", () => {
   test("implements the verifier reward equations", () => {
@@ -60,10 +72,10 @@ describe("the PopuLoRA loop", () => {
         evolutionInterval: 10,
         cullFraction: 0.25,
         runMatch: () =>
-          Effect.succeed([
+          Effect.succeed(free([
             trial(false, [], "invalid problem"),
             trial(true, ["correct", "incorrect", "format-error"], "valid problem")
-          ]),
+          ])),
         evolveTeacher: noEvolution,
         evolveStudent: noEvolution
       })
@@ -98,7 +110,7 @@ describe("the PopuLoRA loop", () => {
           role === "student" && id === "mismatch"
             ? { mu: 100, sigma: 1 }
             : { mu: 25, sigma: 1 },
-        runMatch: () => Effect.succeed([trial(true, ["correct"], null)]),
+        runMatch: () => Effect.succeed(free([trial(true, ["correct"], null)])),
         evolveTeacher: noEvolution,
         evolveStudent: noEvolution
       })
@@ -115,7 +127,8 @@ describe("the PopuLoRA loop", () => {
         steps: 1,
         evolutionInterval: 10,
         cullFraction: 0.25,
-        runMatch: () => Effect.succeed([trial(true, ["correct", "incorrect"], null)]),
+        runMatch: () =>
+          Effect.succeed(free([trial(true, ["correct", "incorrect"], null)])),
         evolveTeacher: noEvolution,
         evolveStudent: noEvolution
       })
@@ -136,7 +149,7 @@ describe("the PopuLoRA loop", () => {
         steps: 1,
         evolutionInterval: 10,
         cullFraction: 0.25,
-        runMatch: () => Effect.succeed([trial(true, ["correct"], null)]),
+        runMatch: () => Effect.succeed(free([trial(true, ["correct"], null)])),
         evolveTeacher: noEvolution,
         evolveStudent: noEvolution
       })
@@ -182,9 +195,9 @@ describe("the PopuLoRA loop", () => {
         random: () => 0.5,
         initialRating,
         runMatch: ({ teacher, student }) =>
-          Effect.succeed([
+          Effect.succeed(free([
             trial(true, ["correct"], `${teacher.candidate.id}:${student.candidate.id}`)
-          ]),
+          ])),
         evolveTeacher: (context) => {
           teacherContexts.push({
             replaced: context.replaced.candidate.id,
@@ -192,7 +205,9 @@ describe("the PopuLoRA loop", () => {
             matches: context.matches.length
           })
           expect(context.operator).toBe("crossover")
-          return Effect.succeed(candidate("teacher-child", { role: "teacher", rank: "child" }))
+          return Effect.succeed(
+            free(candidate("teacher-child", { role: "teacher", rank: "child" }))
+          )
         },
         evolveStudent: (context) => {
           studentContexts.push({
@@ -201,7 +216,9 @@ describe("the PopuLoRA loop", () => {
             matches: context.matches.length
           })
           expect(context.operator).toBe("crossover")
-          return Effect.succeed(candidate("student-child", { role: "student", rank: "child" }))
+          return Effect.succeed(
+            free(candidate("student-child", { role: "student", rank: "child" }))
+          )
         }
       })
     )
@@ -240,14 +257,14 @@ describe("the PopuLoRA loop", () => {
         evolutionInterval: 1,
         cullFraction: 1,
         crossoverRate: 1,
-        runMatch: () => Effect.succeed([trial(true, ["correct"], null)]),
+        runMatch: () => Effect.succeed(free([trial(true, ["correct"], null)])),
         evolveTeacher: (context) => {
           operators.push(context.operator)
-          return Effect.succeed(candidate("teacher-child", "teacher-child"))
+          return Effect.succeed(free(candidate("teacher-child", "teacher-child")))
         },
         evolveStudent: (context) => {
           operators.push(context.operator)
-          return Effect.succeed(candidate("student-child", "student-child"))
+          return Effect.succeed(free(candidate("student-child", "student-child")))
         }
       })
     )
@@ -255,6 +272,42 @@ describe("the PopuLoRA loop", () => {
     expect(operators).toEqual(["mutation", "mutation"])
     expect(result.teachers[0]?.parents).toEqual(["teacher"])
     expect(result.students[0]?.parents).toEqual(["student"])
+  })
+
+  test("tracks match and evolution cost", async () => {
+    const result = await Effect.runPromise(
+      populora({
+        teachers: [candidate("teacher", "teacher")],
+        students: [candidate("student", "student")],
+        steps: 1,
+        evolutionInterval: 1,
+        cullFraction: 1,
+        runMatch: () =>
+          Effect.succeed(priced([trial(true, ["correct"], null)], 10, 2, 0.01, 1)),
+        evolveTeacher: () =>
+          Effect.succeed(
+            priced(candidate("teacher-child", "teacher-child"), 5, 1, 0.005, 2)
+          ),
+        evolveStudent: () =>
+          Effect.succeed(
+            priced(candidate("student-child", "student-child"), 7, 1, 0.007, 1)
+          )
+      })
+    )
+
+    expect(result.matches[0]?.cost).toEqual({
+      promptTokens: 10,
+      completionTokens: 2,
+      costUsd: 0.01,
+      toolCalls: 1
+    })
+    expect(result.evolutions.map((entry) => entry.cost.toolCalls)).toEqual([2, 1])
+    expect(result.cost).toEqual({
+      promptTokens: 22,
+      completionTokens: 4,
+      costUsd: 0.022,
+      toolCalls: 4
+    })
   })
 
   test("rejects verifier output that violates a trial invariant", async () => {
@@ -265,7 +318,7 @@ describe("the PopuLoRA loop", () => {
         steps: 1,
         evolutionInterval: 2,
         cullFraction: 0.25,
-        runMatch: () => Effect.succeed([trial(false, ["correct"], null)]),
+        runMatch: () => Effect.succeed(free([trial(false, ["correct"], null)])),
         evolveTeacher: noEvolution,
         evolveStudent: noEvolution
       })

--- a/packages/evolve/src/populora.test.ts
+++ b/packages/evolve/src/populora.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { candidate } from "./candidate"
+import {
+  populora,
+  populoraConservativeScore,
+  populoraRewards,
+  populoraWinProbability,
+  type PopuloraTrial
+} from "./populora"
+
+const trial = <Evidence>(
+  valid: boolean,
+  outcomes: PopuloraTrial<Evidence>["outcomes"],
+  evidence: Evidence
+): PopuloraTrial<Evidence> => ({ valid, outcomes, evidence })
+
+const noEvolution = () => Effect.succeed(undefined)
+
+describe("PopuLoRA rewards and ratings", () => {
+  test("implements the verifier reward equations", () => {
+    const rewards = populoraRewards([
+      trial(false, [], "invalid problem"),
+      trial(true, ["correct", "incorrect", "format-error"], "valid problem")
+    ])
+
+    expect(rewards.teacherReward).toBeCloseTo(-1 / 6, 10)
+    expect(rewards.studentReward).toBeCloseTo(-1 / 6, 10)
+    expect(rewards.solveRate).toBeCloseTo(1 / 3, 10)
+  })
+
+  test("gives an impossible valid problem zero teacher reward", () => {
+    expect(populoraRewards([trial(true, ["incorrect", "format-error"], null)])).toEqual({
+      teacherReward: 0,
+      studentReward: -0.75,
+      solveRate: 0
+    })
+  })
+
+  test("predicts balanced matches and ranks by the lower confidence bound", () => {
+    expect(
+      populoraWinProbability(
+        { mu: 25, sigma: 25 / 3 },
+        { mu: 25, sigma: 25 / 3 }
+      )
+    ).toBeCloseTo(0.5, 6)
+    expect(populoraConservativeScore({ mu: 25, sigma: 5 }, 3)).toBe(10)
+  })
+})
+
+describe("the PopuLoRA loop", () => {
+  test("cross-evaluates matched harnesses and updates their TrueSkill ratings", async () => {
+    const teacher = candidate("teacher", { role: "teacher" })
+    const student = candidate("student", { role: "student" })
+    const result = await Effect.runPromise(
+      populora({
+        teachers: [teacher],
+        students: [student],
+        steps: 1,
+        evolutionInterval: 10,
+        cullFraction: 0.25,
+        runMatch: () =>
+          Effect.succeed([
+            trial(false, [], "invalid problem"),
+            trial(true, ["correct", "incorrect", "format-error"], "valid problem")
+          ]),
+        evolveTeacher: noEvolution,
+        evolveStudent: noEvolution
+      })
+    )
+
+    expect(result.matches).toHaveLength(1)
+    expect(result.matches[0]).toMatchObject({
+      step: 0,
+      teacher: "teacher",
+      student: "student",
+      outcome: "teacher"
+    })
+    expect(result.matches[0]?.teacherReward).toBeCloseTo(-1 / 6, 10)
+    expect(result.matches[0]?.studentReward).toBeCloseTo(-1 / 6, 10)
+    expect(result.matches[0]?.solveRate).toBeCloseTo(1 / 3, 10)
+    expect(result.matches[0]?.trials[1]?.evidence).toBe("valid problem")
+    expect(result.teachers[0]?.rating.mu).toBeCloseTo(29.396, 3)
+    expect(result.students[0]?.rating.mu).toBeCloseTo(20.604, 3)
+    expect(result.teachers[0]?.rating.sigma).toBeLessThan(25 / 3)
+  })
+
+  test("uses PFSP to prefer the near-balanced student", async () => {
+    const result = await Effect.runPromise(
+      populora({
+        teachers: [candidate("teacher", "teacher")],
+        students: [candidate("balanced", "balanced"), candidate("mismatch", "mismatch")],
+        steps: 1,
+        evolutionInterval: 10,
+        cullFraction: 0.25,
+        random: () => 0.99,
+        initialRating: (role, id) =>
+          role === "student" && id === "mismatch"
+            ? { mu: 100, sigma: 1 }
+            : { mu: 25, sigma: 1 },
+        runMatch: () => Effect.succeed([trial(true, ["correct"], null)]),
+        evolveTeacher: noEvolution,
+        evolveStudent: noEvolution
+      })
+    )
+
+    expect(result.matches[0]?.student).toBe("balanced")
+  })
+
+  test("updates uncertainty after an expected draw", async () => {
+    const result = await Effect.runPromise(
+      populora({
+        teachers: [candidate("teacher", "teacher")],
+        students: [candidate("student", "student")],
+        steps: 1,
+        evolutionInterval: 10,
+        cullFraction: 0.25,
+        runMatch: () => Effect.succeed([trial(true, ["correct", "incorrect"], null)]),
+        evolveTeacher: noEvolution,
+        evolveStudent: noEvolution
+      })
+    )
+
+    expect(result.matches[0]?.outcome).toBe("draw")
+    expect(result.teachers[0]?.rating.mu).toBeCloseTo(25, 10)
+    expect(result.students[0]?.rating.mu).toBeCloseTo(25, 10)
+    expect(result.teachers[0]?.rating.sigma).toBeLessThan(25 / 3)
+    expect(result.students[0]?.rating.sigma).toBeLessThan(25 / 3)
+  })
+
+  test("uses a repeated student's latest rating", async () => {
+    const result = await Effect.runPromise(
+      populora({
+        teachers: [candidate("teacher-one", "one"), candidate("teacher-two", "two")],
+        students: [candidate("student", "student")],
+        steps: 1,
+        evolutionInterval: 10,
+        cullFraction: 0.25,
+        runMatch: () => Effect.succeed([trial(true, ["correct"], null)]),
+        evolveTeacher: noEvolution,
+        evolveStudent: noEvolution
+      })
+    )
+
+    expect(result.matches.map((match) => match.student)).toEqual(["student", "student"])
+    expect(result.matches[0]?.expectedStudentSolveRate).toBe(0.5)
+    expect(result.matches[1]?.expectedStudentSolveRate).toBeGreaterThan(0.5)
+  })
+
+  test("replaces the weakest members with whole-harness crossovers", async () => {
+    const teacherContexts: Array<{
+      readonly replaced: string
+      readonly parents: ReadonlyArray<string>
+      readonly matches: number
+    }> = []
+    const studentContexts: typeof teacherContexts = []
+    const seeds = (role: string) =>
+      ["top", "second", "third", "bottom"].map((rank) =>
+        candidate(`${role}-${rank}`, { role, rank })
+      )
+    const initialRating = (_role: string, id: string) => ({
+      mu: id.endsWith("child")
+        ? 25
+        : id.endsWith("top")
+          ? 100
+          : id.endsWith("second")
+            ? 80
+            : id.endsWith("third")
+              ? 60
+              : -100,
+      sigma: id.endsWith("child") ? 25 / 3 : 1
+    })
+
+    const result = await Effect.runPromise(
+      populora({
+        teachers: seeds("teacher"),
+        students: seeds("student"),
+        steps: 1,
+        evolutionInterval: 1,
+        cullFraction: 0.25,
+        crossoverRate: 1,
+        random: () => 0.5,
+        initialRating,
+        runMatch: ({ teacher, student }) =>
+          Effect.succeed([
+            trial(true, ["correct"], `${teacher.candidate.id}:${student.candidate.id}`)
+          ]),
+        evolveTeacher: (context) => {
+          teacherContexts.push({
+            replaced: context.replaced.candidate.id,
+            parents: context.parents.map((entry) => entry.candidate.id),
+            matches: context.matches.length
+          })
+          expect(context.operator).toBe("crossover")
+          return Effect.succeed(candidate("teacher-child", { role: "teacher", rank: "child" }))
+        },
+        evolveStudent: (context) => {
+          studentContexts.push({
+            replaced: context.replaced.candidate.id,
+            parents: context.parents.map((entry) => entry.candidate.id),
+            matches: context.matches.length
+          })
+          expect(context.operator).toBe("crossover")
+          return Effect.succeed(candidate("student-child", { role: "student", rank: "child" }))
+        }
+      })
+    )
+
+    expect(teacherContexts).toEqual([
+      {
+        replaced: "teacher-bottom",
+        parents: ["teacher-second", "teacher-third"],
+        matches: 4
+      }
+    ])
+    expect(studentContexts).toEqual([
+      {
+        replaced: "student-bottom",
+        parents: ["student-second", "student-third"],
+        matches: 4
+      }
+    ])
+    expect(result.teachers.map((entry) => entry.candidate.id)).toContain("teacher-child")
+    expect(result.students.map((entry) => entry.candidate.id)).toContain("student-child")
+    const child = result.teachers.find((entry) => entry.candidate.id === "teacher-child")!
+    expect(child.candidate.parent).toBe("teacher-second")
+    expect(child.parents).toEqual(["teacher-second", "teacher-third"])
+    expect(child.generation).toBe(1)
+    expect(child.rating).toEqual({ mu: 25, sigma: 25 / 3 })
+    expect(result.evolutions).toHaveLength(2)
+  })
+
+  test("uses mutation when a role has one population member", async () => {
+    const operators: Array<string> = []
+    const result = await Effect.runPromise(
+      populora({
+        teachers: [candidate("teacher", "teacher")],
+        students: [candidate("student", "student")],
+        steps: 1,
+        evolutionInterval: 1,
+        cullFraction: 1,
+        crossoverRate: 1,
+        runMatch: () => Effect.succeed([trial(true, ["correct"], null)]),
+        evolveTeacher: (context) => {
+          operators.push(context.operator)
+          return Effect.succeed(candidate("teacher-child", "teacher-child"))
+        },
+        evolveStudent: (context) => {
+          operators.push(context.operator)
+          return Effect.succeed(candidate("student-child", "student-child"))
+        }
+      })
+    )
+
+    expect(operators).toEqual(["mutation", "mutation"])
+    expect(result.teachers[0]?.parents).toEqual(["teacher"])
+    expect(result.students[0]?.parents).toEqual(["student"])
+  })
+
+  test("rejects verifier output that violates a trial invariant", async () => {
+    const run = Effect.runPromise(
+      populora({
+        teachers: [candidate("teacher", "teacher")],
+        students: [candidate("student", "student")],
+        steps: 1,
+        evolutionInterval: 2,
+        cullFraction: 0.25,
+        runMatch: () => Effect.succeed([trial(false, ["correct"], null)]),
+        evolveTeacher: noEvolution,
+        evolveStudent: noEvolution
+      })
+    )
+
+    expect(run).rejects.toThrow("PopuLoRA invalid trials cannot contain student outcomes")
+  })
+})

--- a/packages/evolve/src/populora.ts
+++ b/packages/evolve/src/populora.ts
@@ -1,5 +1,11 @@
 import { Effect } from "effect"
 import { candidate, type Candidate } from "./candidate"
+import {
+  sumEvolutionCosts,
+  zeroEvolutionCost,
+  type Costed,
+  type EvolutionCost
+} from "./cost"
 
 export type PopuloraRole = "teacher" | "student"
 
@@ -55,6 +61,7 @@ export interface PopuloraMatch<Evidence = unknown> extends PopuloraRewards {
   readonly expectedStudentSolveRate: number
   readonly outcome: PopuloraMatchOutcome
   readonly trials: ReadonlyArray<PopuloraTrial<Evidence>>
+  readonly cost: EvolutionCost
 }
 
 export interface PopuloraEvolutionContext<Value, Evidence = unknown> {
@@ -73,6 +80,7 @@ export interface PopuloraEvolution {
   readonly replaced: string
   readonly parents: ReadonlyArray<string>
   readonly child?: string
+  readonly cost: EvolutionCost
 }
 
 export interface PopuloraResult<Teacher, Student, Evidence = unknown> {
@@ -80,6 +88,7 @@ export interface PopuloraResult<Teacher, Student, Evidence = unknown> {
   readonly students: ReadonlyArray<PopuloraMember<Student>>
   readonly matches: ReadonlyArray<PopuloraMatch<Evidence>>
   readonly evolutions: ReadonlyArray<PopuloraEvolution>
+  readonly cost: EvolutionCost
 }
 
 export interface PopuloraOptions<
@@ -101,13 +110,25 @@ export interface PopuloraOptions<
   readonly initialRating?: (role: PopuloraRole, candidateId: string) => PopuloraRating
   readonly runMatch: (
     context: PopuloraMatchContext<Teacher, Student>
-  ) => Effect.Effect<ReadonlyArray<PopuloraTrial<Evidence>>, MatchError, MatchRequirements>
+  ) => Effect.Effect<
+    Costed<ReadonlyArray<PopuloraTrial<Evidence>>>,
+    MatchError,
+    MatchRequirements
+  >
   readonly evolveTeacher: (
     context: PopuloraEvolutionContext<Teacher, Evidence>
-  ) => Effect.Effect<Candidate<Teacher> | undefined, EvolutionError, EvolutionRequirements>
+  ) => Effect.Effect<
+    Costed<Candidate<Teacher> | undefined>,
+    EvolutionError,
+    EvolutionRequirements
+  >
   readonly evolveStudent: (
     context: PopuloraEvolutionContext<Student, Evidence>
-  ) => Effect.Effect<Candidate<Student> | undefined, EvolutionError, EvolutionRequirements>
+  ) => Effect.Effect<
+    Costed<Candidate<Student> | undefined>,
+    EvolutionError,
+    EvolutionRequirements
+  >
   readonly random?: () => number
 }
 
@@ -495,6 +516,7 @@ export const populora = <
     const matches: Array<PopuloraMatch<Evidence>> = []
     const evolutions: Array<PopuloraEvolution> = []
     let recentMatches: Array<PopuloraMatch<Evidence>> = []
+    let totalCost = zeroEvolutionCost()
 
     const updateRating = <Value>(
       population: ReadonlyArray<PopuloraMember<Value>>,
@@ -513,7 +535,7 @@ export const populora = <
       evolve: (
         context: PopuloraEvolutionContext<Value, Evidence>
       ) => Effect.Effect<
-        Candidate<Value> | undefined,
+        Costed<Candidate<Value> | undefined>,
         EvolutionError,
         EvolutionRequirements
       >
@@ -537,6 +559,7 @@ export const populora = <
         const replaced = ranked.slice(ranked.length - cullCount)
         const parentPool = population.length === 1 ? ranked : ranked.slice(0, -cullCount)
         let next = [...population]
+        const costs: Array<EvolutionCost> = []
 
         for (const weak of replaced) {
           const useCrossover = parentPool.length > 1 && random() < crossoverRate
@@ -547,7 +570,7 @@ export const populora = <
             parents.push(remaining[randomIndex(remaining.length, random)]!)
           }
           const operator: PopuloraOperator = useCrossover ? "crossover" : "mutation"
-          const proposed = yield* evolve({
+          const evolved = yield* evolve({
             step,
             role,
             operator,
@@ -555,13 +578,16 @@ export const populora = <
             parents,
             matches: recentMatches
           })
+          const proposed = evolved.value
+          costs.push(evolved.cost)
           if (proposed === undefined) {
             evolutions.push({
               step,
               role,
               operator,
               replaced: weak.candidate.id,
-              parents: parents.map((entry) => entry.candidate.id)
+              parents: parents.map((entry) => entry.candidate.id),
+              cost: evolved.cost
             })
             continue
           }
@@ -583,10 +609,11 @@ export const populora = <
             operator,
             replaced: weak.candidate.id,
             parents: member.parents,
-            child: child.id
+            child: child.id,
+            cost: evolved.cost
           })
         }
-        return next
+        return { population: next, cost: sumEvolutionCosts(costs) }
       })
 
     for (let step = 0; step < options.steps; step += 1) {
@@ -616,7 +643,9 @@ export const populora = <
           teacher.rating,
           ratingOptions.beta
         )
-        const trials = yield* options.runMatch({ step, teacher, student })
+        const evaluatedMatch = yield* options.runMatch({ step, teacher, student })
+        const trials = evaluatedMatch.value
+        totalCost = sumEvolutionCosts([totalCost, evaluatedMatch.cost])
         const rewards = populoraRewards(trials)
         const hasValidTrial = trials.some((trial) => trial.valid)
         const outcome: PopuloraMatchOutcome = !hasValidTrial
@@ -654,6 +683,7 @@ export const populora = <
           expectedStudentSolveRate,
           outcome,
           trials,
+          cost: evaluatedMatch.cost,
           ...rewards
         }
         matches.push(match)
@@ -661,20 +691,27 @@ export const populora = <
       }
 
       if ((step + 1) % options.evolutionInterval === 0) {
-        teachers = yield* evolvePopulation(
+        const teacherEvolution = yield* evolvePopulation(
           step,
           "teacher",
           teachers,
           teacherIds,
           options.evolveTeacher
         )
-        students = yield* evolvePopulation(
+        teachers = teacherEvolution.population
+        const studentEvolution = yield* evolvePopulation(
           step,
           "student",
           students,
           studentIds,
           options.evolveStudent
         )
+        students = studentEvolution.population
+        totalCost = sumEvolutionCosts([
+          totalCost,
+          teacherEvolution.cost,
+          studentEvolution.cost
+        ])
         recentMatches = []
       }
     }
@@ -683,7 +720,8 @@ export const populora = <
       teachers,
       students,
       matches,
-      evolutions
+      evolutions,
+      cost: totalCost
     }
     return result
   })

--- a/packages/evolve/src/populora.ts
+++ b/packages/evolve/src/populora.ts
@@ -1,0 +1,690 @@
+import { Effect } from "effect"
+import { candidate, type Candidate } from "./candidate"
+
+export type PopuloraRole = "teacher" | "student"
+
+export type PopuloraSolveOutcome = "correct" | "incorrect" | "format-error"
+
+export type PopuloraMatchOutcome = "teacher" | "student" | "draw"
+
+export type PopuloraOperator = "mutation" | "crossover"
+
+export interface PopuloraRating {
+  readonly mu: number
+  readonly sigma: number
+}
+
+export interface PopuloraRatingOptions {
+  readonly initialMu: number
+  readonly initialSigma: number
+  readonly beta: number
+  readonly tau: number
+  readonly drawProbability: number
+  readonly confidence: number
+}
+
+export interface PopuloraTrial<Evidence = unknown> {
+  readonly valid: boolean
+  readonly outcomes: ReadonlyArray<PopuloraSolveOutcome>
+  readonly evidence: Evidence
+}
+
+export interface PopuloraRewards {
+  readonly teacherReward: number
+  readonly studentReward: number
+  readonly solveRate: number
+}
+
+export interface PopuloraMember<Value> {
+  readonly candidate: Candidate<Value>
+  readonly rating: PopuloraRating
+  readonly generation: number
+  readonly parents: ReadonlyArray<string>
+}
+
+export interface PopuloraMatchContext<Teacher, Student> {
+  readonly step: number
+  readonly teacher: PopuloraMember<Teacher>
+  readonly student: PopuloraMember<Student>
+}
+
+export interface PopuloraMatch<Evidence = unknown> extends PopuloraRewards {
+  readonly step: number
+  readonly teacher: string
+  readonly student: string
+  readonly expectedStudentSolveRate: number
+  readonly outcome: PopuloraMatchOutcome
+  readonly trials: ReadonlyArray<PopuloraTrial<Evidence>>
+}
+
+export interface PopuloraEvolutionContext<Value, Evidence = unknown> {
+  readonly step: number
+  readonly role: PopuloraRole
+  readonly operator: PopuloraOperator
+  readonly replaced: PopuloraMember<Value>
+  readonly parents: ReadonlyArray<PopuloraMember<Value>>
+  readonly matches: ReadonlyArray<PopuloraMatch<Evidence>>
+}
+
+export interface PopuloraEvolution {
+  readonly step: number
+  readonly role: PopuloraRole
+  readonly operator: PopuloraOperator
+  readonly replaced: string
+  readonly parents: ReadonlyArray<string>
+  readonly child?: string
+}
+
+export interface PopuloraResult<Teacher, Student, Evidence = unknown> {
+  readonly teachers: ReadonlyArray<PopuloraMember<Teacher>>
+  readonly students: ReadonlyArray<PopuloraMember<Student>>
+  readonly matches: ReadonlyArray<PopuloraMatch<Evidence>>
+  readonly evolutions: ReadonlyArray<PopuloraEvolution>
+}
+
+export interface PopuloraOptions<
+  Teacher,
+  Student,
+  Evidence,
+  MatchError = never,
+  MatchRequirements = never,
+  EvolutionError = never,
+  EvolutionRequirements = never
+> {
+  readonly teachers: ReadonlyArray<Candidate<Teacher>>
+  readonly students: ReadonlyArray<Candidate<Student>>
+  readonly steps: number
+  readonly evolutionInterval: number
+  readonly cullFraction: number
+  readonly crossoverRate?: number
+  readonly rating?: Partial<PopuloraRatingOptions>
+  readonly initialRating?: (role: PopuloraRole, candidateId: string) => PopuloraRating
+  readonly runMatch: (
+    context: PopuloraMatchContext<Teacher, Student>
+  ) => Effect.Effect<ReadonlyArray<PopuloraTrial<Evidence>>, MatchError, MatchRequirements>
+  readonly evolveTeacher: (
+    context: PopuloraEvolutionContext<Teacher, Evidence>
+  ) => Effect.Effect<Candidate<Teacher> | undefined, EvolutionError, EvolutionRequirements>
+  readonly evolveStudent: (
+    context: PopuloraEvolutionContext<Student, Evidence>
+  ) => Effect.Effect<Candidate<Student> | undefined, EvolutionError, EvolutionRequirements>
+  readonly random?: () => number
+}
+
+const DEFAULT_RATING: PopuloraRatingOptions = {
+  initialMu: 25,
+  initialSigma: 25 / 3,
+  beta: 25 / 6,
+  tau: 25 / 300,
+  drawProbability: 0.1,
+  confidence: 3
+}
+
+const normalPdf = (value: number): number =>
+  Math.exp(-(value * value) / 2) / Math.sqrt(2 * Math.PI)
+
+const normalCdf = (value: number): number => {
+  if (value === 0) return 0.5
+  const absolute = Math.abs(value)
+  const scale = 1 / (1 + 0.2316419 * absolute)
+  const tail =
+    normalPdf(absolute) *
+    scale *
+    (0.31938153 +
+      scale *
+        (-0.356563782 +
+          scale * (1.781477937 + scale * (-1.821255978 + scale * 1.330274429))))
+  return value >= 0 ? 1 - tail : tail
+}
+
+const inverseNormalCdf = (probability: number): number => {
+  const lower = 0.02425
+  const upper = 1 - lower
+  if (probability < lower) {
+    const value = Math.sqrt(-2 * Math.log(probability))
+    return (
+      (((((-0.007784894002430293 * value - 0.3223964580411365) * value -
+        2.400758277161838) *
+        value -
+        2.549732539343734) *
+        value +
+        4.374664141464968) *
+        value +
+        2.938163982698783) /
+      ((((0.007784695709041462 * value + 0.3224671290700398) * value +
+        2.445134137142996) *
+        value +
+        3.754408661907416) *
+        value +
+        1)
+    )
+  }
+  if (probability > upper) return -inverseNormalCdf(1 - probability)
+  const value = probability - 0.5
+  const square = value * value
+  return (
+    (((((-39.69683028665376 * square + 220.9460984245205) * square -
+      275.9285104469687) *
+      square +
+      138.357751867269) *
+      square -
+      30.66479806614716) *
+      square +
+      2.506628277459239) *
+    value /
+    (((((-54.47609879822406 * square + 161.5858368580409) * square -
+      155.6989798598866) *
+      square +
+      66.80131188771972) *
+      square -
+      13.28068155288572) *
+      square +
+      1)
+  )
+}
+
+const validateRating = (rating: PopuloraRating, label: string) => {
+  if (!Number.isFinite(rating.mu) || !Number.isFinite(rating.sigma) || rating.sigma <= 0) {
+    throw new Error(`PopuLoRA ${label} rating must have a finite mu and a positive sigma`)
+  }
+}
+
+export const populoraWinProbability = (
+  player: PopuloraRating,
+  opponent: PopuloraRating,
+  beta = DEFAULT_RATING.beta
+): number => {
+  validateRating(player, "player")
+  validateRating(opponent, "opponent")
+  if (!Number.isFinite(beta) || beta <= 0) {
+    throw new Error("PopuLoRA beta must be a positive finite number")
+  }
+  const scale = Math.sqrt(
+    player.sigma ** 2 + opponent.sigma ** 2 + 2 * beta ** 2
+  )
+  return normalCdf((player.mu - opponent.mu) / scale)
+}
+
+export const populoraConservativeScore = (
+  rating: PopuloraRating,
+  confidence = DEFAULT_RATING.confidence
+): number => {
+  validateRating(rating, "candidate")
+  if (!Number.isFinite(confidence) || confidence < 0) {
+    throw new Error("PopuLoRA confidence must be a non-negative finite number")
+  }
+  return rating.mu - confidence * rating.sigma
+}
+
+const rateWinner = (
+  winner: PopuloraRating,
+  loser: PopuloraRating,
+  options: PopuloraRatingOptions
+): readonly [PopuloraRating, PopuloraRating] => {
+  const winnerVariance = winner.sigma ** 2 + options.tau ** 2
+  const loserVariance = loser.sigma ** 2 + options.tau ** 2
+  const scale = Math.sqrt(winnerVariance + loserVariance + 2 * options.beta ** 2)
+  const distance = (winner.mu - loser.mu) / scale
+  const margin =
+    (inverseNormalCdf((options.drawProbability + 1) / 2) *
+      Math.sqrt(2) *
+      options.beta) /
+    scale
+  const adjustedDistance = distance - margin
+  const correction =
+    normalPdf(adjustedDistance) / Math.max(normalCdf(adjustedDistance), 1e-12)
+  const shrink = correction * (correction + adjustedDistance)
+  return [
+    {
+      mu: winner.mu + (winnerVariance / scale) * correction,
+      sigma: Math.sqrt(
+        Math.max(1e-12, winnerVariance * (1 - (winnerVariance / scale ** 2) * shrink))
+      )
+    },
+    {
+      mu: loser.mu - (loserVariance / scale) * correction,
+      sigma: Math.sqrt(
+        Math.max(1e-12, loserVariance * (1 - (loserVariance / scale ** 2) * shrink))
+      )
+    }
+  ]
+}
+
+const rateDraw = (
+  left: PopuloraRating,
+  right: PopuloraRating,
+  options: PopuloraRatingOptions
+): readonly [PopuloraRating, PopuloraRating] => {
+  const leftVariance = left.sigma ** 2 + options.tau ** 2
+  const rightVariance = right.sigma ** 2 + options.tau ** 2
+  const scale = Math.sqrt(leftVariance + rightVariance + 2 * options.beta ** 2)
+  const distance = (left.mu - right.mu) / scale
+  const margin =
+    (inverseNormalCdf((options.drawProbability + 1) / 2) *
+      Math.sqrt(2) *
+      options.beta) /
+    scale
+  const upper = margin - Math.abs(distance)
+  const lower = -margin - Math.abs(distance)
+  const denominator = Math.max(normalCdf(upper) - normalCdf(lower), 1e-12)
+  const baseCorrection = (normalPdf(lower) - normalPdf(upper)) / denominator
+  const correction = distance < 0 ? -baseCorrection : baseCorrection
+  const shrink =
+    correction ** 2 +
+    (upper * normalPdf(upper) - lower * normalPdf(lower)) / denominator
+  return [
+    {
+      mu: left.mu + (leftVariance / scale) * correction,
+      sigma: Math.sqrt(
+        Math.max(1e-12, leftVariance * (1 - (leftVariance / scale ** 2) * shrink))
+      )
+    },
+    {
+      mu: right.mu - (rightVariance / scale) * correction,
+      sigma: Math.sqrt(
+        Math.max(1e-12, rightVariance * (1 - (rightVariance / scale ** 2) * shrink))
+      )
+    }
+  ]
+}
+
+export const populoraRewards = <Evidence>(
+  trials: ReadonlyArray<PopuloraTrial<Evidence>>
+): PopuloraRewards => {
+  if (trials.length === 0) throw new Error("PopuLoRA runMatch must return at least one trial")
+  const teacherRewards: Array<number> = []
+  const studentRewards: Array<number> = []
+  let correct = 0
+  let attempts = 0
+  for (const trial of trials) {
+    if (!trial.valid) {
+      if (trial.outcomes.length > 0) {
+        throw new Error("PopuLoRA invalid trials cannot contain student outcomes")
+      }
+      teacherRewards.push(-1)
+      continue
+    }
+    if (trial.outcomes.length === 0) {
+      throw new Error("PopuLoRA valid trials require at least one student outcome")
+    }
+    const solved = trial.outcomes.filter((outcome) => outcome === "correct").length
+    const solveRate = solved / trial.outcomes.length
+    teacherRewards.push(solveRate === 0 ? 0 : 1 - solveRate)
+    for (const outcome of trial.outcomes) {
+      if (outcome === "correct") {
+        studentRewards.push(1)
+        correct += 1
+      } else if (outcome === "incorrect") {
+        studentRewards.push(-0.5)
+      } else if (outcome === "format-error") {
+        studentRewards.push(-1)
+      } else {
+        throw new Error(`PopuLoRA received unknown student outcome "${String(outcome)}"`)
+      }
+      attempts += 1
+    }
+  }
+  const average = (values: ReadonlyArray<number>) =>
+    values.length === 0 ? 0 : values.reduce((sum, value) => sum + value, 0) / values.length
+  return {
+    teacherReward: average(teacherRewards),
+    studentReward: average(studentRewards),
+    solveRate: attempts === 0 ? 0 : correct / attempts
+  }
+}
+
+const randomIndex = (length: number, random: () => number): number =>
+  Math.max(0, Math.min(length - 1, Math.floor(random() * length)))
+
+const weightedIndex = (weights: ReadonlyArray<number>, random: () => number): number => {
+  const total = weights.reduce((sum, weight) => sum + weight, 0)
+  if (total <= 0) return randomIndex(weights.length, random)
+  let draw = Math.max(0, Math.min(total, random() * total))
+  for (const [index, weight] of weights.entries()) {
+    draw -= weight
+    if (draw <= 0) return index
+  }
+  return weights.length - 1
+}
+
+const ratingOptionsOf = (rating: Partial<PopuloraRatingOptions> | undefined) => ({
+  ...DEFAULT_RATING,
+  ...rating
+})
+
+const validateOptions = <
+  Teacher,
+  Student,
+  Evidence,
+  MatchError,
+  MatchRequirements,
+  EvolutionError,
+  EvolutionRequirements
+>(
+  options: PopuloraOptions<
+    Teacher,
+    Student,
+    Evidence,
+    MatchError,
+    MatchRequirements,
+    EvolutionError,
+    EvolutionRequirements
+  >,
+  rating: PopuloraRatingOptions
+) => {
+  if (options.teachers.length === 0 || options.students.length === 0) {
+    throw new Error("PopuLoRA requires at least one teacher and one student")
+  }
+  if (!Number.isInteger(options.steps) || options.steps < 0) {
+    throw new Error("PopuLoRA steps must be a non-negative integer")
+  }
+  if (!Number.isInteger(options.evolutionInterval) || options.evolutionInterval < 1) {
+    throw new Error("PopuLoRA evolutionInterval must be a positive integer")
+  }
+  if (
+    !Number.isFinite(options.cullFraction) ||
+    options.cullFraction <= 0 ||
+    options.cullFraction > 1
+  ) {
+    throw new Error("PopuLoRA cullFraction must be more than zero and at most one")
+  }
+  const crossoverRate = options.crossoverRate ?? 0.5
+  if (!Number.isFinite(crossoverRate) || crossoverRate < 0 || crossoverRate > 1) {
+    throw new Error("PopuLoRA crossoverRate must be between zero and one")
+  }
+  for (const name of [
+    "initialMu",
+    "initialSigma",
+    "beta",
+    "tau",
+    "drawProbability",
+    "confidence"
+  ] as const) {
+    if (!Number.isFinite(rating[name])) {
+      throw new Error(`PopuLoRA rating ${name} must be finite`)
+    }
+  }
+  if (rating.initialSigma <= 0 || rating.beta <= 0) {
+    throw new Error("PopuLoRA initialSigma and beta must be positive")
+  }
+  if (rating.tau < 0 || rating.confidence < 0) {
+    throw new Error("PopuLoRA tau and confidence must be non-negative")
+  }
+  if (rating.drawProbability < 0 || rating.drawProbability >= 1) {
+    throw new Error("PopuLoRA drawProbability must be at least zero and less than one")
+  }
+  for (const [role, values] of [
+    ["teacher", options.teachers],
+    ["student", options.students]
+  ] as const) {
+    const ids = new Set<string>()
+    for (const value of values) {
+      if (ids.has(value.id)) {
+        throw new Error(`PopuLoRA received duplicate ${role} id "${value.id}"`)
+      }
+      ids.add(value.id)
+    }
+  }
+}
+
+const normalizeChild = <Value>(
+  proposal: Candidate<Value>,
+  parents: ReadonlyArray<PopuloraMember<Value>>
+) => {
+  const primary = parents[0]!.candidate
+  if (proposal.parent !== undefined && proposal.parent !== primary.id) {
+    throw new Error(
+      `PopuLoRA child "${proposal.id}" names parent "${proposal.parent}" instead of "${primary.id}"`
+    )
+  }
+  return proposal.parent === undefined
+    ? candidate(proposal.id, proposal.value, {
+        parent: primary.id,
+        ...(proposal.source === undefined ? {} : { source: proposal.source })
+      })
+    : proposal
+}
+
+export const populora = <
+  Teacher,
+  Student,
+  Evidence,
+  MatchError,
+  MatchRequirements,
+  EvolutionError,
+  EvolutionRequirements
+>(
+  options: PopuloraOptions<
+    Teacher,
+    Student,
+    Evidence,
+    MatchError,
+    MatchRequirements,
+    EvolutionError,
+    EvolutionRequirements
+  >
+) => {
+  const ratingOptions = ratingOptionsOf(options.rating)
+  validateOptions(options, ratingOptions)
+  const random = options.random ?? Math.random
+  const crossoverRate = options.crossoverRate ?? 0.5
+  const initialRating = (role: PopuloraRole, candidateId: string) => {
+    const rating = options.initialRating?.(role, candidateId) ?? {
+      mu: ratingOptions.initialMu,
+      sigma: ratingOptions.initialSigma
+    }
+    validateRating(rating, `${role} "${candidateId}"`)
+    return rating
+  }
+
+  return Effect.gen(function* () {
+    let teachers: Array<PopuloraMember<Teacher>> = options.teachers.map((entry) => ({
+      candidate: entry,
+      rating: initialRating("teacher", entry.id),
+      generation: 0,
+      parents: []
+    }))
+    let students: Array<PopuloraMember<Student>> = options.students.map((entry) => ({
+      candidate: entry,
+      rating: initialRating("student", entry.id),
+      generation: 0,
+      parents: []
+    }))
+    const teacherIds = new Set(teachers.map((entry) => entry.candidate.id))
+    const studentIds = new Set(students.map((entry) => entry.candidate.id))
+    const matches: Array<PopuloraMatch<Evidence>> = []
+    const evolutions: Array<PopuloraEvolution> = []
+    let recentMatches: Array<PopuloraMatch<Evidence>> = []
+
+    const updateRating = <Value>(
+      population: ReadonlyArray<PopuloraMember<Value>>,
+      candidateId: string,
+      rating: PopuloraRating
+    ) =>
+      population.map((entry) =>
+        entry.candidate.id === candidateId ? { ...entry, rating } : entry
+      )
+
+    const evolvePopulation = <Value>(
+      step: number,
+      role: PopuloraRole,
+      population: ReadonlyArray<PopuloraMember<Value>>,
+      knownIds: Set<string>,
+      evolve: (
+        context: PopuloraEvolutionContext<Value, Evidence>
+      ) => Effect.Effect<
+        Candidate<Value> | undefined,
+        EvolutionError,
+        EvolutionRequirements
+      >
+    ) =>
+      Effect.gen(function* () {
+        const ranked = [...population].sort((left, right) => {
+          const difference =
+            populoraConservativeScore(right.rating, ratingOptions.confidence) -
+            populoraConservativeScore(left.rating, ratingOptions.confidence)
+          return difference === 0
+            ? left.candidate.id.localeCompare(right.candidate.id)
+            : difference
+        })
+        const cullCount =
+          population.length === 1
+            ? 1
+            : Math.min(
+                population.length - 1,
+                Math.max(1, Math.floor(population.length * options.cullFraction))
+              )
+        const replaced = ranked.slice(ranked.length - cullCount)
+        const parentPool = population.length === 1 ? ranked : ranked.slice(0, -cullCount)
+        let next = [...population]
+
+        for (const weak of replaced) {
+          const useCrossover = parentPool.length > 1 && random() < crossoverRate
+          const first = parentPool[randomIndex(parentPool.length, random)]!
+          const parents: Array<PopuloraMember<Value>> = [first]
+          if (useCrossover) {
+            const remaining = parentPool.filter((entry) => entry !== first)
+            parents.push(remaining[randomIndex(remaining.length, random)]!)
+          }
+          const operator: PopuloraOperator = useCrossover ? "crossover" : "mutation"
+          const proposed = yield* evolve({
+            step,
+            role,
+            operator,
+            replaced: weak,
+            parents,
+            matches: recentMatches
+          })
+          if (proposed === undefined) {
+            evolutions.push({
+              step,
+              role,
+              operator,
+              replaced: weak.candidate.id,
+              parents: parents.map((entry) => entry.candidate.id)
+            })
+            continue
+          }
+          const child = normalizeChild(proposed, parents)
+          if (knownIds.has(child.id)) {
+            throw new Error(`PopuLoRA ${role} id "${child.id}" already exists in its lineage`)
+          }
+          knownIds.add(child.id)
+          const member: PopuloraMember<Value> = {
+            candidate: child,
+            rating: initialRating(role, child.id),
+            generation: Math.max(...parents.map((entry) => entry.generation)) + 1,
+            parents: parents.map((entry) => entry.candidate.id)
+          }
+          next = next.map((entry) => (entry === weak ? member : entry))
+          evolutions.push({
+            step,
+            role,
+            operator,
+            replaced: weak.candidate.id,
+            parents: member.parents,
+            child: child.id
+          })
+        }
+        return next
+      })
+
+    for (let step = 0; step < options.steps; step += 1) {
+      let available = [...students]
+      const pairings = teachers.map((teacher) => {
+        if (available.length === 0) available = [...students]
+        const weights = available.map((student) => {
+          const expected = populoraWinProbability(
+            student.rating,
+            teacher.rating,
+            ratingOptions.beta
+          )
+          return expected * (1 - expected)
+        })
+        const selected = available.splice(weightedIndex(weights, random), 1)[0]!
+        return {
+          teacher: teacher.candidate.id,
+          student: selected.candidate.id
+        }
+      })
+
+      for (const pairing of pairings) {
+        const teacher = teachers.find((entry) => entry.candidate.id === pairing.teacher)!
+        const student = students.find((entry) => entry.candidate.id === pairing.student)!
+        const expectedStudentSolveRate = populoraWinProbability(
+          student.rating,
+          teacher.rating,
+          ratingOptions.beta
+        )
+        const trials = yield* options.runMatch({ step, teacher, student })
+        const rewards = populoraRewards(trials)
+        const hasValidTrial = trials.some((trial) => trial.valid)
+        const outcome: PopuloraMatchOutcome = !hasValidTrial
+          ? "student"
+          : Math.abs(rewards.solveRate - expectedStudentSolveRate) <= Number.EPSILON
+            ? "draw"
+            : rewards.solveRate > expectedStudentSolveRate
+              ? "student"
+              : "teacher"
+        if (outcome === "draw") {
+          const [nextTeacher, nextStudent] = rateDraw(
+            teacher.rating,
+            student.rating,
+            ratingOptions
+          )
+          teachers = updateRating(teachers, teacher.candidate.id, nextTeacher)
+          students = updateRating(students, student.candidate.id, nextStudent)
+        } else {
+          const [winner, loser] =
+            outcome === "student"
+              ? rateWinner(student.rating, teacher.rating, ratingOptions)
+              : rateWinner(teacher.rating, student.rating, ratingOptions)
+          if (outcome === "student") {
+            students = updateRating(students, student.candidate.id, winner)
+            teachers = updateRating(teachers, teacher.candidate.id, loser)
+          } else {
+            teachers = updateRating(teachers, teacher.candidate.id, winner)
+            students = updateRating(students, student.candidate.id, loser)
+          }
+        }
+        const match: PopuloraMatch<Evidence> = {
+          step,
+          teacher: teacher.candidate.id,
+          student: student.candidate.id,
+          expectedStudentSolveRate,
+          outcome,
+          trials,
+          ...rewards
+        }
+        matches.push(match)
+        recentMatches.push(match)
+      }
+
+      if ((step + 1) % options.evolutionInterval === 0) {
+        teachers = yield* evolvePopulation(
+          step,
+          "teacher",
+          teachers,
+          teacherIds,
+          options.evolveTeacher
+        )
+        students = yield* evolvePopulation(
+          step,
+          "student",
+          students,
+          studentIds,
+          options.evolveStudent
+        )
+        recentMatches = []
+      }
+    }
+
+    const result: PopuloraResult<Teacher, Student, Evidence> = {
+      teachers,
+      students,
+      matches,
+      evolutions
+    }
+    return result
+  })
+}

--- a/packages/evolve/src/rollout.test.ts
+++ b/packages/evolve/src/rollout.test.ts
@@ -148,6 +148,12 @@ describe("forked rollouts", () => {
     expect(result.replayed).toBe(3)
     expect(result.called).toBe(0)
     expect(result.usage).toEqual({ promptTokens: 0, completionTokens: 0, costUsd: 0 })
+    expect(result.cost).toEqual({
+      promptTokens: 0,
+      completionTokens: 0,
+      costUsd: 0,
+      toolCalls: 0
+    })
     expect(result.log).toEqual(recorded)
   })
 
@@ -160,6 +166,7 @@ describe("forked rollouts", () => {
     expect(result.called).toBe(3)
     expect(model.seen[0]?.system).toBe("Answer in one sentence.")
     expect(result.usage.costUsd).toBeCloseTo(0.0123, 6)
+    expect(result.cost.toolCalls).toBe(2)
     expect(types(result.log)).toEqual(types(recorded))
   })
 
@@ -240,6 +247,7 @@ describe("forked rollouts", () => {
       replayed: 0,
       called: 0,
       usage: { promptTokens: 0, completionTokens: 0, costUsd: 0 },
+      cost: { promptTokens: 0, completionTokens: 0, costUsd: 0, toolCalls: 0 },
       log: []
     })
   })

--- a/packages/evolve/src/rollout.ts
+++ b/packages/evolve/src/rollout.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect"
 import type { Event } from "@flamecast/core"
 import { canonicalValue, type Agent, type AgentServices, type Usage } from "@flamecast/harness"
-import { spendOf } from "./score"
+import { evolutionCostOf, type EvolutionCost } from "./cost"
 
 export interface RolloutOptions<Baseline, Candidate> {
   readonly baseline: Agent<Baseline>
@@ -13,6 +13,7 @@ export interface RolloutResult {
   readonly replayed: number
   readonly called: number
   readonly usage: Usage
+  readonly cost: EvolutionCost
   readonly log: ReadonlyArray<Event>
 }
 
@@ -62,10 +63,16 @@ export const rollout = <Baseline, Candidate>(
       yield* branch.replay([])
       const settled = yield* branch.log
       const tail = settled.slice(seeded)
+      const cost = evolutionCostOf(tail)
       return {
         replayed: aligned.replayed,
         called: tail.filter((event) => event.type === "ModelCalled").length,
-        usage: spendOf(tail),
+        usage: {
+          promptTokens: cost.promptTokens,
+          completionTokens: cost.completionTokens,
+          costUsd: cost.costUsd
+        },
+        cost,
         log: settled
       }
     })

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -86,6 +86,7 @@ export {
   budget,
   canRequestBudget,
   escalatableOf,
+  toolCallsOf,
   usedOf,
   type BudgetOptions,
   type BudgetPhase

--- a/packages/harness/src/modules/budget.test.ts
+++ b/packages/harness/src/modules/budget.test.ts
@@ -7,7 +7,14 @@ import { inferWith, type Action, type ModelRequest, type NativeTool } from "../i
 import { keyOf } from "../keys"
 import { createAgent } from "../module"
 import { defaultPack } from "../pack"
-import { budgetOf, budgetPhase, budgetSpent, canRequestBudget, usedOf } from "./budget"
+import {
+  budgetOf,
+  budgetPhase,
+  budgetSpent,
+  canRequestBudget,
+  toolCallsOf,
+  usedOf
+} from "./budget"
 
 const usage = { promptTokens: 10, completionTokens: 2, costUsd: 0.0001 }
 
@@ -73,6 +80,18 @@ describe("the budget projections", () => {
   test("only work draws the budget down", () => {
     const log = [head(), called("c-1"), called("c-2", "answer"), called("c-3", "request-budget")]
     expect(usedOf(log)).toBe(1)
+  })
+
+  test("work can be counted across turns", () => {
+    const log: ReadonlyArray<Event> = [
+      head(),
+      called("c-1"),
+      { type: "TurnCompleted", turn: "m-1", output: "done", at: 3 },
+      { type: "MessageReceived", id: "m-2", text: "next", at: 4 },
+      { type: "ToolCalled", turn: "m-2", callId: "c-2", name: "lookup_invoice", arguments: {}, at: 5 },
+      { type: "ToolCalled", turn: "m-2", callId: "c-3", name: "answer", arguments: {}, at: 6 }
+    ]
+    expect(toolCallsOf(log)).toBe(2)
   })
 
   test("the phase is scoped to the turn, so an earlier wall does not leak", () => {

--- a/packages/harness/src/modules/budget.ts
+++ b/packages/harness/src/modules/budget.ts
@@ -32,11 +32,14 @@ export const budgetOf = (
   )
 }
 
-// The tool calls the turn has spent. The exits are not work, so they never draw the budget down.
-export const usedOf = (log: ReadonlyArray<Event>): number =>
-  turnView(log).filter(
+// The work-tool calls in any log span. The exits are not work, so they never draw the budget down.
+export const toolCallsOf = (log: ReadonlyArray<Event>): number =>
+  log.filter(
     (event) => event.type === "ToolCalled" && !EXITS.has(String(event.name ?? ""))
   ).length
+
+// The tool calls the current turn has spent.
+export const usedOf = (log: ReadonlyArray<Event>): number => toolCallsOf(turnView(log))
 
 // Whether the turn head permits escalation at its budget wall.
 export const escalatableOf = (log: ReadonlyArray<Event>): boolean =>


### PR DESCRIPTION
## What and why

Track model token usage, provider spend, and work-tool calls throughout every evolution optimization so callers can inspect operation and total costs. GEPA, PopuLoRA, and rollouts now use harness log projections, and invalid reported costs fail early.

- [x] `bun run gate` passes locally
- [x] Docs updated if behavior changed
- [x] Tests cover the change