### PR TITLE
feat(harness): subagent delegation with session host and derived cost trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ if (result.kind === "completed") console.log(result.output)
 - Static instructions form the cache-friendly system prefix. Conditional nudges are appended near the request tail by default.
 - `AgentProgram` records module provenance and compiled behavior. Source-controlled candidates can supply an explicit program id such as a commit SHA.
 - `agent.branch(log)` and `agent.fork()` create independent in-memory continuations.
-- `Router` and `agentNativeTool()` enable multi-agent systems without imposing a planner or topology.
+- `callAgent()`, `subagentTool()`, and `host()` enable multi-agent systems without imposing a planner or topology. Origin and usage cross the session boundary, so provenance and cost trees are derived from logs.
 - `flamecast-core/evolve` supplies candidates, observations, cost tracking, rollouts, scoring, Pareto utilities, and GEPA and PopuLoRA search loops. Callers provide costed mutation and evaluation policy.
 
 ## Public Imports

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ flowchart TD
   B --> M[Modules]
   A --> E[Events]
   A --> R[Runtimes]
+  A --> Or[Orchestration]
   A --> O[Observability]
   O --> V[Evolution]
   P[Prior art] --> A
@@ -22,8 +23,9 @@ flowchart TD
 4. [Modules](modules.md) documents composition and the built-in module catalog.
 5. [Events](events.md) owns the event alphabet and dedup rules.
 6. [Runtimes](runtimes.md) owns the platform port contract and binding status.
-7. [Observability](observability.md) covers reading, rendering, replaying, and forking logs.
-8. [Evolution](evolution.md) covers code candidates, finite equivalence, evaluation, and search integration.
-9. [Prior art](prior-art.md) records the external systems and research that informed the design.
+7. [Orchestration](orchestration.md) covers delegation, the session host, and swarm inspection.
+8. [Observability](observability.md) covers reading, rendering, replaying, and forking logs.
+9. [Evolution](evolution.md) covers code candidates, finite equivalence, evaluation, and search integration.
+10. [Prior art](prior-art.md) records the external systems and research that informed the design.
 
 The repository [README](../README.md) is the package-level entry point.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,12 +65,12 @@ Pure construction services use Effect `Context` directly. Effectful capabilities
 
 The framework exposes routing primitives and leaves topology in user code or model behavior.
 
-- `Router.call(address, event)` performs a synchronous, acyclic sub-call and returns the terminal event.
-- `Router.deliver(address, event)` sends asynchronous work.
-- `agentNativeTool()` wraps `Router.call` as a provider-native tool, so compatible models can delegate through the same surface they already understand.
-- `InboundMessage.replyTo` lets a completed turn route its answer to another session.
+- `Router.call(address, event)` performs a synchronous sub-call and returns the terminal event. `Router.deliver(address, event)` sends asynchronous work.
+- `callAgent(address, message)` is delegation as an awaitable value, and `subagentTool()` is the same call as a provider-native tool.
+- `host({ programs })` resolves addresses to programs, creates or resumes sessions, and guards cycles and depth.
+- `InboundMessage.origin` names the sender, replies carry usage, and `InboundMessage.replyTo` routes a completed turn's answer to another session.
 
-These primitives support supervisors, peer groups, recursive calls, RLM-style decomposition, and generated orchestration modules. The framework does not install a planner, role taxonomy, or fixed conversation protocol.
+These primitives support supervisors, peer groups, recursive calls, RLM-style decomposition, and generated orchestration modules. The framework does not install a planner, role taxonomy, or fixed conversation protocol. [Orchestration](orchestration.md) covers the design.
 
 ## Invariants
 

--- a/docs/building-an-agent.md
+++ b/docs/building-an-agent.md
@@ -167,20 +167,38 @@ Leaving out `tenantSource` fails tuple type-checking and runtime validation.
 ## Delegate to Another Agent
 
 ```ts
-import { agentNativeTool, defaultPack } from "flamecast-core/harness"
-
-const askResearcher = agentNativeTool({
-  name: "ask_researcher",
-  description: "Ask the research agent for supporting evidence.",
-  address: "agent:research"
-})
+import { createAgent, defaultPack, host, subagentTool } from "flamecast-core/harness"
 
 const supervisor = createAgent({
-  modules: defaultPack({ nativeTools: [askResearcher] })
+  modules: defaultPack({
+    nativeTools: [
+      subagentTool({
+        name: "ask_researcher",
+        description: "Ask the research agent for supporting evidence.",
+        address: "agent:research"
+      })
+    ]
+  })
 })
+
+const h = host({
+  programs: {
+    "agent:supervisor": supervisor,
+    "agent:research": researcher
+  }
+})
+
+const terminal = await Effect.runPromise(h.call("agent:supervisor", { id: "m-1", text: "go" }))
 ```
 
-The runtime decides how `agent:research` resolves. For long-running work, send through `Router.deliver` and set `replyTo` on the inbound message.
+Each program picks its own model through its `inference` module. The tool result carries the
+child's output and inclusive usage, and the child's log records who asked through `origin`.
+
+Code can delegate without a model in the loop through `callAgent(address, message)`, and several
+concurrent calls joined by `await` are a fan-out. For long-running work, send through
+`Router.deliver` and set `replyTo` on the inbound message; the reply arrives as a new message
+stamped with `origin`, `outcome`, and `usage`. [Orchestration](orchestration.md) covers the
+design.
 
 ## Test Inference
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -11,6 +11,8 @@ Common fields include:
 - `callId` for provider or tool intent identity
 - `at` for recorded time
 - `program` for the program that accepted the inbound message
+- `origin` for the session, turn, and call that sent a cross-session message
+- `usage` on a cross-session reply for the sender's inclusive spend
 
 Unknown fields and event types survive reads and folds.
 
@@ -45,6 +47,10 @@ This lets providers reuse `call_1` in later turns without the store confusing se
 | compaction | `CompactionFired`, `CompactionCompleted` |
 
 Modules declare the event types they own. `agent.program.events` is the sorted union. `undeclaredEvents(program, log)` reports rows outside that declared alphabet.
+
+Cross-session delegation adds no event types. A delegation is a `ToolCalled` and `ToolReturned`
+in the parent log and a `MessageReceived` plus a terminal in the child log, tied together by
+`origin`. [Orchestration](orchestration.md#the-boundary-contract) covers the fields that cross.
 
 ## Custom Events
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -37,7 +37,7 @@ Vercel AI Gateway is the default provider. The gateway reads `AI_GATEWAY_API_KEY
 
 Native tool calling is one interface policy. A module can instead expose code mode, MCP, textual commands, one generic RPC operation, or another protocol. Those alternatives can use their own request projection and machines without changing the event-log or module primitives.
 
-`agentNativeTool(options)` adapts `Router.call` to `NativeTool<Router>`. It is the default synchronous multi-agent adapter for providers that support native calls.
+`subagentTool(options)` adapts `callAgent` to a `NativeTool`, so a model delegates to another agent through the same surface it already understands. [Orchestration](orchestration.md) covers the delegation surface.
 
 ## budget
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -75,16 +75,28 @@ Fork reads the bound session and creates the same independent branch shape.
 ## Cost Projections
 
 ```ts
-import { toolCallsOf, usageIn } from "flamecast-core/harness"
+import { toolCallsOf, treeUsageIn, usageIn } from "flamecast-core/harness"
 
 const usage = usageIn(log, "m-1")
+const total = treeUsageIn(log, "m-1")
 const toolCalls = toolCallsOf(log)
 ```
 
 `usageIn(log, turn)` sums the prompt tokens, completion tokens, and provider cost for one turn. The values come from its `ModelReturned` events.
+
+`treeUsageIn(log, turn)` adds the usage every sub-agent result reported, and a child reports its
+own tree usage, so the sum covers the whole delegation tree from one log.
 
 `toolCallsOf(log)` counts work-tool calls in any log span. It uses the budget rules, so `answer` and `request-budget` calls have zero tool cost.
 
 ## Telemetry
 
 Core defines a `Sink` port, and the in-memory runtime binds a no-op implementation. No harness path currently emits sink records. External telemetry can project the stored log until a sink-producing module or runtime integration is added.
+
+## Across Sessions
+
+A swarm is a set of session logs. The [host](orchestration.md#session-host) exposes them:
+`h.sessions` lists the addresses it serves and `h.log(address)` reads one session's evidence.
+Each inbound head's `origin` names the session, turn, and call that sent it, so the delegation
+tree is a projection over the set of logs, and every single-session view on this page applies per
+session.

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -1,0 +1,139 @@
+# Orchestration
+
+A multi-agent system in this framework is sessions delegating to sessions. The framework ships
+three small pieces: one awaitable delegation function with a code face and a model face, a session
+host that resolves addresses to programs, and two carried facts from which provenance and cost are
+derived. Topology, retries, and gathering stay in user code.
+
+## Why This Shape
+
+Multi-agent patterns churned through 2025 and 2026, and the field's most credible practitioners
+each reversed their public position within a year.
+[Prior art](prior-art.md#multi-agent-evidence) records the evidence. The patterns that survived
+production share four substrate properties:
+
+1. Every stage leaves an auditable artifact.
+2. Information crosses an agent boundary as a small declared artifact, and a collaborator that
+   adds no new signal makes the system worse.
+3. Writes have one owner.
+4. Failures are observable across the whole system, with provenance per claim.
+
+The event log and the single writer already guarantee 1 and 3. Delegation adds 2 and 4 as
+properties of the crossing itself. The framework ships no supervisor, swarm, or debate primitive,
+because those are the parts that keep changing; they compose from the pieces below in a few lines
+of user code.
+
+A second premise: model capability keeps compounding, so orchestration authority that a model
+handles poorly today it may handle well within months. Every capability here therefore has two
+faces over the same events, and moving authority between them is configuration.
+
+## One Function, Two Faces
+
+`callAgent(address, message)` is delegation as a value: it routes one `MessageReceived` through
+`Router.call` and returns a `SubagentResult` with the child's output or error and the child's
+inclusive usage.
+
+- The code face awaits it. A machine, a workflow, or a code-mode sandbox writes fan-out and
+  gathering as ordinary code: run several calls concurrently and the join is the language's own
+  `await`, with deadlines and retries as ordinary combinators around it.
+- The model face is `subagentTool(options)`, the same call wrapped as a provider-native tool. The
+  model sees an ordinary tool whose result carries the child's answer and spend.
+
+Both faces send the same event and read the same reply, so a run driven by generated code and a
+run driven by tool calls leave the same evidence in the logs.
+
+## The Boundary Contract
+
+Exactly two facts cross the boundary, one in each direction.
+
+- Outward, the message carries `origin`: the sending session, and, when sent while serving a turn,
+  the turn and tool call that asked. The child's inbound head records it.
+- Homeward, the result carries the child's inclusive usage: its own model spend plus everything
+  its own delegations reported. The parent's `ToolReturned` records it.
+
+Neither side reads the other's log. From these two fields, the delegation tree, ancestry, blast
+radius, and tree cost are all derived by projections; nothing else needs to be carried, stored, or
+kept consistent. `treeUsageIn(log, turn)` folds one turn's total spend including every agent it
+called. [Events](events.md) lists the fields; [Observability](observability.md#cost-projections)
+covers the projections.
+
+The asynchronous door follows the same contract. A turn whose head names `replyTo` delivers its
+outcome as a new `MessageReceived` at that address, stamped with `origin`, `outcome`, and `usage`.
+
+## Session Host
+
+`host({ programs })` is the in-process map from an address to a running session. It removes the
+route glue a multi-session application otherwise writes by hand.
+
+```ts
+import { host } from "flamecast-core/harness"
+
+const h = host({
+  programs: {
+    "agent:supervisor": supervisor,
+    "agent:verify": verifier,
+    "researcher/*": (address) => researcherFor(address)
+  }
+})
+
+const terminal = await Effect.runPromise(h.call("agent:supervisor", { id: "m-1", text: "go" }))
+```
+
+- A registry maps an exact address, or a `prefix/*` pattern, to a program or a factory. A spawned
+  session keeps one program for its lifetime.
+- The host creates a session's store and writer lease on first delivery, settles the program's
+  machines under that session's services, and answers with the terminal event stamped with tree
+  usage.
+- `h.route` plugs into any runtime's `route` option, and `h.log` and `h.sessions` expose the
+  swarm's evidence for inspection.
+
+The host is also where swarm safety lives, because it sees every crossing. It walks the derived
+origin chain and refuses a delegation cycle or a delegation past `maxDepth` with a failed turn
+instead of a deadlock or a runaway. A durable runtime replaces this host wholesale: on such a
+platform an address names a durable object or a cell, and hosting is the platform's job.
+[Runtimes](runtimes.md) owns binding status.
+
+## Model Heterogeneity
+
+The model is a property of the child's program, never of the delegation. Each program's
+`inference` module selects its own provider, so a supervisor on one model delegating to workers on
+another is just two entries in the registry. A registry factory can pick the model from the
+address, and provider selection can be a function of the child's own log.
+
+## Widening Model Authority
+
+How much orchestration the model drives is configuration:
+
+1. Fixed peers: `subagentTool` entries with fixed addresses. The model chooses when to ask, never
+   whom.
+2. Spawns: a `prefix/*` registry entry lets the model open fresh sessions under a namespace the
+   application chose.
+3. Generated orchestration: a code-execution module exposes `callAgent` inside the sandbox, and
+   the model writes the fan-out, joins, and retries as code.
+
+All three leave the same events, so widening authority as models improve changes configuration and
+prompt, never architecture. An orchestration module is source, so
+[evolution](evolution.md) can search it like any other candidate.
+
+## What Stays in User Code
+
+The framework ships no planner, role taxonomy, debate protocol, or peer mesh. The evidence shows
+role splits losing context at each handoff, debate matching self-consistency at equal budget, and
+unstructured meshes amplifying one injected error system-wide. The surviving patterns are short
+compositions:
+
+- A verifier is a `subagentTool` whose message is a projected artifact, answered by a fresh
+  session with no parent history.
+- Research fan-out is several `callAgent` calls joined by the language, or several tool calls if
+  the model drives.
+- Map, reduce, and manage is a workflow machine calling `callAgent` deterministically.
+- A retry is a new call with a new id; the child's dedup absorbs a redelivered one.
+
+## Invariants
+
+1. A message that crosses sessions names its origin.
+2. A parent observes a child only through its reply.
+3. The host refuses cycles and bounds depth from derived ancestry, so recursion ends in a failed
+   turn instead of a deadlock.
+4. Usage folds up the delegation tree.
+5. A crossing leaves committed events in both logs, so a swarm replays session by session.

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -21,6 +21,17 @@ flamecast-core combines ideas from event-sourced systems, typed effect runtimes,
 - [GEPA](https://arxiv.org/abs/2507.19457) motivates reflective search and Pareto selection across tasks.
 - [PopuLoRA](https://arxiv.org/abs/2605.16727v1) motivates separate teacher and student populations, TrueSkill-guided PFSP matchmaking, and periodic population replacement.
 
+## Multi-Agent Evidence
+
+These sources motivate the delegation design in [Orchestration](orchestration.md).
+
+- [Anthropic's guidance on multi-agent systems](https://claude.com/blog/building-multi-agent-systems-when-and-how-to-use-them) motivates splitting work by context boundary and the clean-context verification subagent.
+- [Cognition's production report](https://cognition.com/blog/multi-agents-working) motivates single-threaded writes and manager-to-child delegation. Their earlier [Don't Build Multi-Agents](https://cognition.com/blog/dont-build-multi-agents) argued the opposite a year before, which motivates shipping primitives instead of patterns.
+- [MAST](https://arxiv.org/abs/2503.13657) catalogs fourteen failure modes across seven frameworks and shows most failures are design failures.
+- [Reliability limits of delegated planning](https://arxiv.org/abs/2603.26993) proves a delegation chain that adds no new information loses to one centralized decision maker.
+- [From Spark to Fire](https://arxiv.org/abs/2603.04474) shows one error injected at a hub reaching every downstream agent, which motivates origin fields and provenance projections.
+- [MANTA](https://arxiv.org/abs/2607.28527) motivates trace auditing and treating topology as a searchable artifact.
+
 ## Compaction
 
 - [Morph](https://www.morphllm.com/) supplies the optional remote compaction path. The framework records checkpoints in the log and retains a deterministic local fallback.

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -38,16 +38,23 @@ the lifetime of the layer and disappears with the process.
 
 `runtime-cf` and `runtime-celld` are design targets and have no package in the repository.
 
-- A Cloudflare binding can map sessions to Durable Objects, alarms, R2, and worker routing.
+- `runtime-cf` is the durable reference target. It can map a session to a Durable Object, wakes
+  to alarms, spill to R2, and routing to worker calls, with `wrangler` serving the local
+  development loop. On that platform the address itself names the session's host, so it replaces
+  the in-process [session host](orchestration.md#session-host) wholesale.
 - A celld binding can map each session to a self-hosted cell with a local database and distributed lease.
 
 Durable read APIs, session listing, and cross-process replay depend on one of those bindings being implemented.
 
 ## Router Semantics
 
-`Router.call` waits for a terminal event and is suited to quick acyclic sub-calls. Cycles can deadlock when sessions each hold their writer lock.
+`Router.call` waits for a terminal event and returns it to the caller, which is what an awaited
+delegation needs. `Router.deliver` is the asynchronous door: the receiving session appends the
+event and settles independently, and a later reply can target the caller through `replyTo`.
 
-`Router.deliver` is the asynchronous door. The receiving session appends the event and settles independently. A later reply can target the caller through `replyTo`.
+A call cycle would deadlock on writer leases, so the harness [host](orchestration.md#session-host)
+refuses cycles and bounds depth before running the target. A runtime without the host owes its
+own guard or its route functions must stay acyclic.
 
 ## Implementing a Runtime
 

--- a/packages/harness/src/host.test.ts
+++ b/packages/harness/src/host.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { Router, type Event } from "@flamecast/core"
+import { customInference, type Action, type ModelRequest } from "./infer"
+import { host } from "./host"
+import { createAgent, type MessageOrigin } from "./module"
+import { inference } from "./modules/inference"
+import { nativeTools } from "./modules/native-tools"
+import { callAgent, subagentTool, type SubagentResult } from "./subagent"
+import { treeUsageIn } from "./turns"
+
+const scripted = (model: string, react: (request: ModelRequest) => Action) =>
+  customInference(async (request) => react(request), { id: model, model })
+
+const toolAnswered = (request: ModelRequest) =>
+  request.messages.some((message) => message.role === "tool")
+
+describe("host", () => {
+  test("delegation crosses sessions with origin out and tree usage home", async () => {
+    const supervisor = createAgent({
+      modules: [
+        inference({
+          provider: scripted("opus", (request) =>
+            toolAnswered(request)
+              ? { kind: "complete", output: "verified" }
+              : { kind: "call", callId: "c-1", name: "ask_verify", arguments: { message: "check" } }
+          )
+        }),
+        nativeTools([
+          subagentTool({
+            name: "ask_verify",
+            description: "Ask the verifier.",
+            address: "agent:verify"
+          })
+        ])
+      ]
+    })
+    const verifier = createAgent({
+      modules: [
+        inference({
+          provider: scripted("haiku", () => ({
+            kind: "complete",
+            output: "looks correct",
+            usage: { promptTokens: 5, completionTokens: 7, costUsd: 0.01 }
+          }))
+        })
+      ]
+    })
+    const h = host({ programs: { "agent:supervisor": supervisor, "agent:verify": verifier } })
+
+    const terminal = await Effect.runPromise(h.call("agent:supervisor", { id: "m-1", text: "go" }))
+    expect(terminal).toMatchObject({
+      type: "TurnCompleted",
+      output: "verified",
+      usage: { promptTokens: 5, completionTokens: 7, costUsd: 0.01 }
+    })
+
+    const childLog = await Effect.runPromise(h.log("agent:verify"))
+    const head = childLog.find((event) => event.type === "MessageReceived")
+    expect(head?.origin).toEqual({ session: "agent:supervisor", turn: "m-1", call: "c-1" })
+    expect(String(head?.id)).toBe("ask_verify:m-1:c-1")
+
+    const parentLog = await Effect.runPromise(h.log("agent:supervisor"))
+    const returned = parentLog.find((event) => event.type === "ToolReturned")?.result as
+      | SubagentResult
+      | undefined
+    expect(returned?.usage.costUsd).toBe(0.01)
+    expect(treeUsageIn(parentLog, "m-1")).toEqual({
+      promptTokens: 5,
+      completionTokens: 7,
+      costUsd: 0.01
+    })
+  })
+
+  test("a redelivered message opens no second turn", async () => {
+    const echo = createAgent({
+      modules: [
+        inference({ provider: scripted("haiku", () => ({ kind: "complete", output: "once" })) })
+      ]
+    })
+    const h = host({ programs: { "agent:echo": echo } })
+    const first = await Effect.runPromise(h.call("agent:echo", { id: "m-1", text: "hi" }))
+    const before = (await Effect.runPromise(h.log("agent:echo"))).length
+    const second = await Effect.runPromise(h.call("agent:echo", { id: "m-1", text: "hi" }))
+    const after = (await Effect.runPromise(h.log("agent:echo"))).length
+    expect(first).toMatchObject({ type: "TurnCompleted", output: "once" })
+    expect(second).toMatchObject({ type: "TurnCompleted", output: "once" })
+    expect(after).toBe(before)
+  })
+
+  test("a delegation cycle fails fast instead of deadlocking", async () => {
+    const bouncer = (name: string, other: string) =>
+      createAgent({
+        modules: [
+          inference({
+            provider: scripted(name, (request) =>
+              toolAnswered(request)
+                ? { kind: "complete", output: `${name} done` }
+                : { kind: "call", callId: "c-1", name: "bounce", arguments: { message: "back" } }
+            )
+          }),
+          nativeTools([
+            subagentTool({ name: "bounce", description: "Bounce.", address: other })
+          ])
+        ]
+      })
+    const h = host({
+      programs: {
+        "agent:a": bouncer("a", "agent:b"),
+        "agent:b": bouncer("b", "agent:a")
+      }
+    })
+    const terminal = await Effect.runPromise(h.call("agent:a", { id: "m-1", text: "go" }))
+    expect(terminal).toMatchObject({ type: "TurnCompleted", output: "a done" })
+    const bLog = await Effect.runPromise(h.log("agent:b"))
+    const bounced = bLog.find((event) => event.type === "ToolReturned")?.result as
+      | SubagentResult
+      | undefined
+    expect(String(bounced?.error)).toContain("delegation cycle")
+  })
+
+  test("recursion stops at the depth bound, derived from origins", async () => {
+    const h = host({
+      maxDepth: 3,
+      programs: {
+        "loop/*": (address) => {
+          const depth = Number(address.split("/")[1])
+          return createAgent({
+            modules: [
+              inference({
+                provider: scripted(`loop-${depth}`, (request) =>
+                  toolAnswered(request)
+                    ? { kind: "complete", output: `stopped at ${depth}` }
+                    : { kind: "call", callId: "c-1", name: "deeper", arguments: { message: "go" } }
+                )
+              }),
+              nativeTools([
+                subagentTool({
+                  name: "deeper",
+                  description: "Go one level deeper.",
+                  address: `loop/${depth + 1}`
+                })
+              ])
+            ]
+          })
+        }
+      }
+    })
+    const terminal = await Effect.runPromise(h.call("loop/0", { id: "l-0", text: "go" }))
+    expect(terminal.type).toBe("TurnCompleted")
+    const sessions = await Effect.runPromise(h.sessions)
+    expect(sessions).toContain("loop/2")
+    expect(sessions).not.toContain("loop/3")
+    const deepest = await Effect.runPromise(h.log("loop/2"))
+    const refused = deepest.find((event) => event.type === "ToolReturned")?.result as
+      | SubagentResult
+      | undefined
+    expect(String(refused?.error)).toContain("delegation depth")
+  })
+
+  test("fan-out is plain code: two calls, two sessions, one join", async () => {
+    const h = host({
+      programs: {
+        "researcher/*": (address) =>
+          createAgent({
+            modules: [
+              inference({
+                provider: scripted(`worker-${address}`, () => ({
+                  kind: "complete",
+                  output: `${address} done`,
+                  usage: { promptTokens: 1, completionTokens: 1, costUsd: 0.001 }
+                }))
+              })
+            ]
+          })
+      }
+    })
+    const hostRouter = {
+      deliver: (address: string, event: Event) => Effect.asVoid(h.route(address, event)),
+      call: h.route
+    }
+    const gathered = await Promise.all([
+      Effect.runPromise(
+        Effect.provideService(callAgent("researcher/1", { id: "r-1", text: "alpha" }), Router, hostRouter)
+      ),
+      Effect.runPromise(
+        Effect.provideService(callAgent("researcher/2", { id: "r-2", text: "beta" }), Router, hostRouter)
+      )
+    ])
+    expect(gathered.map((result) => result.output)).toEqual([
+      "researcher/1 done",
+      "researcher/2 done"
+    ])
+    expect(await Effect.runPromise(h.sessions)).toEqual(["researcher/1", "researcher/2"])
+  })
+
+  test("the async door replies with origin and usage attached", async () => {
+    const worker = createAgent({
+      modules: [
+        inference({
+          provider: scripted("worker", () => ({
+            kind: "complete",
+            output: "background result",
+            usage: { promptTokens: 3, completionTokens: 4, costUsd: 0.005 }
+          }))
+        })
+      ]
+    })
+    const collector = createAgent({
+      modules: [
+        inference({ provider: scripted("collector", () => ({ kind: "complete", output: "ack" })) })
+      ]
+    })
+    const h = host({ programs: { "agent:worker": worker, "agent:collector": collector } })
+    await Effect.runPromise(
+      h.call("agent:worker", { id: "j-1", text: "work in the background", replyTo: "agent:collector" })
+    )
+    const inbox = await Effect.runPromise(h.log("agent:collector"))
+    const reply = inbox.find((event) => event.type === "MessageReceived")
+    expect(String(reply?.id)).toBe("reply:j-1")
+    expect(String(reply?.text)).toBe("background result")
+    const from = reply?.origin as MessageOrigin | undefined
+    expect(from?.session).toBe("agent:worker")
+    expect(reply?.usage).toMatchObject({ promptTokens: 3, completionTokens: 4, costUsd: 0.005 })
+  })
+
+  test("an unknown address is a failed turn, never a hang", async () => {
+    const h = host({ programs: {} })
+    const terminal = await Effect.runPromise(h.call("agent:ghost", { id: "m-1", text: "hi" }))
+    expect(terminal.type).toBe("TurnFailed")
+    expect(String(terminal.error)).toContain('no program at "agent:ghost"')
+  })
+})

--- a/packages/harness/src/host.ts
+++ b/packages/harness/src/host.ts
@@ -1,0 +1,218 @@
+import { Effect, Semaphore } from "effect"
+import {
+  EventLog,
+  Router,
+  Self,
+  Wake,
+  Writer,
+  type Event,
+  type EventLogStore
+} from "@flamecast/core"
+import { usageOf } from "./infer"
+import {
+  privateLog,
+  type Agent,
+  type AgentServices,
+  type InboundMessage,
+  type MessageOrigin,
+  type TurnResult
+} from "./module"
+import { treeUsageIn } from "./turns"
+
+// The in-process session host: the map from an address to a running session. It owns one store and
+// one writer lease per address, creates a session on first delivery, and settles the program's
+// machines under that session's services. It is what a `route` function had to hand-write before,
+// and it is the whole registry a swarm needs: no roles, no topology, just names bound to programs.
+//
+// The host is also where swarm-level safety lives, because it sees every crossing. It walks the
+// derived origin chain to refuse a delegation cycle and to bound recursion depth, and it stamps the
+// terminal it returns with the child's inclusive tree usage, so cost folds up to the caller without
+// the caller reading the child's log.
+//
+// A durable runtime replaces this host wholesale: on such a platform the address already names a
+// durable object or a cell, and hosting is the platform's job. This one exists so a swarm runs in
+// one process with nothing bound but a `route`.
+
+// A program the host can serve: its requirements are the session services the host provides.
+export type HostedAgent = Agent<AgentServices, any>
+
+export interface HostOptions {
+  readonly programs: Readonly<
+    Record<string, HostedAgent | ((address: string) => HostedAgent)>
+  >
+  // The recursion bound. The chain is derived by walking heads through their origins, so the cap
+  // needs no carried counter and an application cannot forget to decrement it.
+  readonly maxDepth?: number
+}
+
+export interface Host {
+  readonly route: (address: string, event: Event) => Effect.Effect<Event>
+  readonly call: (address: string, message: InboundMessage) => Effect.Effect<Event>
+  readonly log: (address: string) => Effect.Effect<ReadonlyArray<Event>>
+  readonly sessions: Effect.Effect<ReadonlyArray<string>>
+}
+
+const DEFAULT_MAX_DEPTH = 8
+
+const messageOf = (event: Event): InboundMessage => ({
+  id: String(event.id ?? ""),
+  text: String(event.text ?? ""),
+  ...(event.output === undefined ? {} : { output: event.output }),
+  ...(typeof event.budget === "number" ? { budget: event.budget } : {}),
+  ...(event.escalatable === undefined ? {} : { escalatable: event.escalatable === true }),
+  ...(event.replyTo === undefined ? {} : { replyTo: String(event.replyTo) }),
+  ...(event.origin === undefined ? {} : { origin: event.origin as MessageOrigin }),
+  ...(event.outcome === "completed" || event.outcome === "failed"
+    ? { outcome: event.outcome }
+    : {}),
+  ...(event.usage === undefined ? {} : { usage: usageOf(event.usage) })
+})
+
+export const host = (options: HostOptions): Host => {
+  const maxDepth = options.maxDepth ?? DEFAULT_MAX_DEPTH
+  const stores = new Map<string, EventLogStore>()
+  const leases = new Map<string, Semaphore.Semaphore>()
+  const agents = new Map<string, HostedAgent>()
+
+  const storeOf = (address: string): EventLogStore => {
+    const held = stores.get(address)
+    if (held !== undefined) return held
+    const fresh = privateLog([])
+    stores.set(address, fresh)
+    return fresh
+  }
+
+  const leaseOf = (address: string): Semaphore.Semaphore => {
+    const held = leases.get(address)
+    if (held !== undefined) return held
+    const fresh = Semaphore.makeUnsafe(1)
+    leases.set(address, fresh)
+    return fresh
+  }
+
+  // Exact address first, then the longest `prefix/*` pattern. A factory builds the program once
+  // per address, so a spawned session keeps one program identity for its lifetime.
+  const programOf = (address: string): HostedAgent | undefined => {
+    const built = agents.get(address)
+    if (built !== undefined) return built
+    const exact = options.programs[address]
+    const entry =
+      exact ??
+      Object.entries(options.programs)
+        .filter(([key]) => key.endsWith("/*") && address.startsWith(key.slice(0, -1)))
+        .sort(([a], [b]) => b.length - a.length)[0]?.[1]
+    if (entry === undefined) return undefined
+    const agent = typeof entry === "function" ? entry(address) : entry
+    agents.set(address, agent)
+    return agent
+  }
+
+  // The ancestry of a delegation, derived: each origin names a session and the turn that sent,
+  // and that turn's head names its own origin. The walk stays inside this host's stores; a hop
+  // into a session the host does not hold ends the chain with what is known.
+  const ancestry = (origin: MessageOrigin | undefined) =>
+    Effect.gen(function* () {
+      const chain: Array<string> = []
+      let cursor = origin
+      while (cursor !== undefined && chain.length <= maxDepth) {
+        const current = cursor
+        chain.push(current.session)
+        const store = stores.get(current.session)
+        if (store === undefined) break
+        const rows: ReadonlyArray<Event> = yield* store.read
+        const head = rows.find(
+          (event) => event.type === "MessageReceived" && String(event.id ?? "") === current.turn
+        )
+        cursor = head?.origin as MessageOrigin | undefined
+      }
+      return chain
+    })
+
+  const failed = (event: Event, error: string): Event => ({
+    type: "TurnFailed",
+    turn: String(event.id ?? ""),
+    error
+  })
+
+  const routerValue = {
+    deliver: (address: string, event: Event) => Effect.asVoid(route(address, event)),
+    call: (address: string, event: Event) => route(address, event)
+  }
+
+  const terminalOf = (result: TurnResult, log: ReadonlyArray<Event>): Event => {
+    const usage = treeUsageIn(log, result.turn)
+    switch (result.kind) {
+      case "completed":
+        return { type: "TurnCompleted", turn: result.turn, output: result.output, usage }
+      case "failed":
+        return { type: "TurnFailed", turn: result.turn, error: result.error, usage }
+      case "parked":
+        // The event that parked the turn is the event that ended the settle. A caller that wants
+        // to grant the ask can deliver the grant and call again; `callAgent` reads it as an error.
+        return {
+          type: "BudgetRequested",
+          turn: result.turn,
+          callId: result.callId,
+          reason: result.reason,
+          amount: result.amount,
+          usage
+        }
+      case "open":
+        return { type: "TurnFailed", turn: result.turn, error: "the turn settled without a terminal", usage }
+    }
+  }
+
+  const route = (address: string, event: Event): Effect.Effect<Event> =>
+    Effect.gen(function* () {
+      const agent = programOf(address)
+      if (agent === undefined) return failed(event, `the host has no program at "${address}"`)
+      const origin = event.origin as MessageOrigin | undefined
+      if (origin !== undefined) {
+        const chain = yield* ancestry(origin)
+        if (chain.includes(address)) {
+          return failed(event, `delegation cycle: "${address}" is already serving this request`)
+        }
+        if (chain.length >= maxDepth) {
+          return failed(event, `delegation depth reached the host bound of ${maxDepth}`)
+        }
+      }
+      const store = storeOf(address)
+      const provided = <A>(work: Effect.Effect<A, never, AgentServices>) =>
+        work.pipe(
+          Effect.provideService(EventLog, store),
+          Effect.provideService(Self, address),
+          Effect.provideService(Writer, {
+            hold: (session, held) => leaseOf(session).withPermits(1)(held)
+          }),
+          Effect.provideService(Wake, {
+            armIfSooner: () => Effect.void,
+            owed: Effect.succeed([])
+          }),
+          Effect.provideService(Router, routerValue)
+        )
+      // A message is a turn. Any other event is a delivery the session absorbs: append and settle,
+      // then report the last turn's boundary, which is how a grant resumes a parked session.
+      const result =
+        event.type === "MessageReceived"
+          ? yield* provided(agent.turn(messageOf(event)))
+          : yield* provided(agent.replay([event]))
+      return terminalOf(result, yield* store.read)
+    })
+
+  return {
+    route,
+    call: (address, message) =>
+      route(address, {
+        type: "MessageReceived",
+        id: message.id,
+        text: message.text,
+        ...(message.output === undefined ? {} : { output: message.output }),
+        ...(message.budget === undefined ? {} : { budget: message.budget }),
+        ...(message.escalatable === undefined ? {} : { escalatable: message.escalatable }),
+        ...(message.replyTo === undefined ? {} : { replyTo: message.replyTo }),
+        ...(message.origin === undefined ? {} : { origin: message.origin })
+      }),
+    log: (address) => storeOf(address).read,
+    sessions: Effect.sync(() => [...stores.keys()])
+  }
+}

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -40,17 +40,28 @@ export {
   type AnyModule,
   type BranchOptions,
   type InboundMessage,
+  type MessageOrigin,
   type Module,
   type ModulePart,
   type TurnOutcome,
   type TurnResult
 } from "./module"
+export {
+  callAgent,
+  subagentResultOf,
+  subagentTool,
+  type CallAgentMessage,
+  type SubagentResult,
+  type SubagentToolOptions
+} from "./subagent"
+export { host, type Host, type HostOptions, type HostedAgent } from "./host"
 export { defaultPack, type DefaultPackOptions } from "./pack"
 export { modelRequest, nativeToolSurface, renderMessages, systemPrompt } from "./render"
 export {
   replyView,
   servedLog,
   transcript,
+  treeUsageIn,
   turnHead,
   turnOf,
   turnView,
@@ -74,11 +85,7 @@ export {
   inference,
   type InferenceOptions
 } from "./modules/inference"
-export {
-  agentNativeTool,
-  nativeTools,
-  type AgentNativeToolOptions
-} from "./modules/native-tools"
+export { nativeTools } from "./modules/native-tools"
 export {
   budgetOf,
   budgetPhase,

--- a/packages/harness/src/module.ts
+++ b/packages/harness/src/module.ts
@@ -124,6 +124,16 @@ type ValidModules<Modules extends readonly unknown[]> =
       : { readonly duplicateModuleIds: DuplicateModuleIds<Modules> }
     : { readonly missingModuleDependencies: ServiceKey<MissingDependencies<Modules>> }
 
+// Where a cross-session message came from: the sending session, and, when the send happened while
+// serving a turn, the turn and the tool call that asked. It is the one carried provenance fact.
+// Everything else about a swarm, the delegation tree, ancestry, blast radius, is derived by
+// walking logs through these fields.
+export interface MessageOrigin {
+  readonly session: string
+  readonly turn?: string
+  readonly call?: string
+}
+
 export interface InboundMessage {
   readonly id: string
   readonly text: string
@@ -131,6 +141,11 @@ export interface InboundMessage {
   readonly budget?: number
   readonly escalatable?: boolean
   readonly replyTo?: string
+  readonly origin?: MessageOrigin
+  // A reply from another session states how that session's turn ended and what it spent. Both
+  // ride the message so the receiver attributes and costs the exchange from its own log alone.
+  readonly outcome?: "completed" | "failed"
+  readonly usage?: Usage
 }
 
 export type TurnOutcome = CallResult | { readonly kind: "open" }
@@ -174,7 +189,7 @@ export const undeclaredEvents = (
     .filter((type) => !program.events.includes(type))
     .sort()
 
-const privateLog = (seed: ReadonlyArray<Event>): EventLogStore => {
+export const privateLog = (seed: ReadonlyArray<Event>): EventLogStore => {
   const rows: Array<Event> = []
   const keys = new Set<string>()
   const put = (events: ReadonlyArray<Event>) => {
@@ -203,6 +218,9 @@ const headOf = (message: InboundMessage, program: AgentProgram<unknown, any>, at
   ...(message.budget === undefined ? {} : { budget: message.budget }),
   ...(message.escalatable === undefined ? {} : { escalatable: message.escalatable }),
   ...(message.replyTo === undefined ? {} : { replyTo: message.replyTo }),
+  ...(message.origin === undefined ? {} : { origin: message.origin }),
+  ...(message.outcome === undefined ? {} : { outcome: message.outcome }),
+  ...(message.usage === undefined ? {} : { usage: message.usage }),
   at
 })
 

--- a/packages/harness/src/modules/inference.ts
+++ b/packages/harness/src/modules/inference.ts
@@ -1,5 +1,5 @@
 import { Clock, Context, Effect, Option } from "effect"
-import { EventLog, Router, erase, machine, type Event, type Machine } from "@flamecast/core"
+import { EventLog, Router, Self, erase, machine, type Event, type Machine } from "@flamecast/core"
 import {
   Infer,
   selectedInference,
@@ -12,7 +12,7 @@ import { defineModule } from "../module"
 import type { Projection } from "../projection"
 import type { RenderPlan } from "../program"
 import { modelRequest } from "../render"
-import { replyView, turnView } from "../turns"
+import { replyView, treeUsageIn, turnView } from "../turns"
 import { vercelGatewayInference } from "../providers/vercel-gateway"
 
 const BASE_SYSTEM =
@@ -127,7 +127,7 @@ const inferMachine = (
     }
   })
 
-const replyMachine = machine<Router>({
+const replyMachine = machine<Router | Self>({
   id: "reply",
   view: replyView,
   initial: "idle",
@@ -152,11 +152,16 @@ const replyMachine = machine<Router>({
           if (head.replyTo === undefined) return [{ type: "ReplyDelivered", turn, at }]
           const to = String(head.replyTo)
           const failed = terminal.type === "TurnFailed"
+          const session = yield* Self
+          // The reply names its origin and carries this turn's inclusive usage, so the receiver
+          // can attribute and cost the exchange without reading this session's log.
           yield* (yield* Router).deliver(to, {
             type: "MessageReceived",
             id: `reply:${turn}`,
             text: failed ? `error: ${String(terminal.error ?? "")}` : String(terminal.output ?? ""),
             outcome: failed ? "failed" : "completed",
+            origin: { session, turn },
+            usage: treeUsageIn(log, turn),
             at
           })
           return [{ type: "ReplyDelivered", turn, to, at }]

--- a/packages/harness/src/modules/native-tools.ts
+++ b/packages/harness/src/modules/native-tools.ts
@@ -1,10 +1,8 @@
 import { Cause, Clock, Effect, Exit } from "effect"
-import { Router, erase, machine, type Event } from "@flamecast/core"
+import { erase, machine, type Event } from "@flamecast/core"
 import { EXITS } from "../exits"
-import type { NativeTool, NativeToolContext } from "../infer"
+import type { NativeTool } from "../infer"
 import { defineModule } from "../module"
-import { canonicalValue } from "../program"
-import { sha256 } from "../sha256"
 import { turnView } from "../turns"
 import { budgetSpent } from "./budget"
 
@@ -100,45 +98,3 @@ export const nativeTools = <R = never>(list: ReadonlyArray<NativeTool<R>>) => {
   })
 }
 
-export interface AgentNativeToolOptions {
-  readonly name: string
-  readonly description: string
-  readonly address: string
-  readonly inputSchema?: unknown
-  readonly message?: (input: unknown) => string
-  readonly callId?: (input: unknown, context?: NativeToolContext) => string
-}
-
-export const agentNativeTool = (options: AgentNativeToolOptions): NativeTool<Router> => ({
-  spec: {
-    name: options.name,
-    description: options.description,
-    inputSchema:
-      options.inputSchema ?? {
-        type: "object",
-        properties: { message: { type: "string" } },
-        required: ["message"],
-        additionalProperties: false
-      }
-  },
-  run: (input, context) =>
-    Effect.gen(function* () {
-      const router = yield* Router
-      const message =
-        options.message?.(input) ??
-        String((input as { readonly message?: unknown } | undefined)?.message ?? input)
-      const callId =
-        options.callId?.(input, context) ??
-        (context === undefined
-          ? `${options.name}:${sha256(canonicalValue(input)).slice(0, 16)}`
-          : `${options.name}:${context.turn}:${context.callId}`)
-      const terminal = yield* router.call(options.address, {
-        type: "MessageReceived",
-        id: callId,
-        text: message
-      })
-      return terminal.type === "TurnCompleted"
-        ? terminal.output
-        : { error: String(terminal.error ?? `sub-agent ended with ${terminal.type}`) }
-    })
-})

--- a/packages/harness/src/subagent.test.ts
+++ b/packages/harness/src/subagent.test.ts
@@ -2,44 +2,51 @@ import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import type { Event } from "@flamecast/core"
 import { InMemoryRuntime } from "@flamecast/runtime-in-memory"
-import { keyOf } from "../keys"
-import { agentNativeTool } from "./native-tools"
+import { keyOf } from "./keys"
+import { subagentTool } from "./subagent"
 
-describe("agentNativeTool", () => {
-  test("turns a routed agent into an ordinary tool", async () => {
+describe("subagentTool", () => {
+  test("turns a routed agent into an ordinary tool and stamps the origin", async () => {
     const routed: Array<{ readonly address: string; readonly event: Event }> = []
-    const delegate = agentNativeTool({
+    const delegate = subagentTool({
       name: "ask_researcher",
       description: "Ask the research agent.",
       address: "agent:research"
     })
     const result = await Effect.runPromise(
       Effect.provide(
-        delegate.run({ message: "Find the refund policy." }),
+        delegate.run({ message: "Find the refund policy." }, { turn: "m-1", callId: "c-1" }),
         InMemoryRuntime({
           keyOf,
+          session: "agent:supervisor",
           route: (address, event) => {
             routed.push({ address, event })
             return Effect.succeed({
               type: "TurnCompleted",
               turn: String(event.id ?? ""),
-              output: "Refunds are allowed within 30 days."
+              output: "Refunds are allowed within 30 days.",
+              usage: { promptTokens: 5, completionTokens: 7, costUsd: 0.01 }
             })
           }
         })
       )
     )
-    expect(result).toBe("Refunds are allowed within 30 days.")
+    expect(result).toMatchObject({
+      agent: "agent:research",
+      output: "Refunds are allowed within 30 days.",
+      usage: { promptTokens: 5, completionTokens: 7, costUsd: 0.01 }
+    })
     expect(routed[0]?.address).toBe("agent:research")
     expect(routed[0]?.event).toMatchObject({
       type: "MessageReceived",
-      text: "Find the refund policy."
+      text: "Find the refund policy.",
+      origin: { session: "agent:supervisor", turn: "m-1", call: "c-1" }
     })
   })
 
-  test("uses a deterministic call id for the same input", async () => {
+  test("uses a deterministic child turn id for the same input", async () => {
     const ids: Array<string> = []
-    const delegate = agentNativeTool({
+    const delegate = subagentTool({
       name: "ask_researcher",
       description: "Ask the research agent.",
       address: "agent:research"
@@ -56,9 +63,9 @@ describe("agentNativeTool", () => {
     expect(ids[0]).toBe(ids[1])
   })
 
-  test("names routed work by the parent turn and provider call", async () => {
+  test("names the child turn by the parent turn and provider call", async () => {
     const ids: Array<string> = []
-    const delegate = agentNativeTool({
+    const delegate = subagentTool({
       name: "ask_researcher",
       description: "Ask the research agent.",
       address: "agent:research"
@@ -77,5 +84,31 @@ describe("agentNativeTool", () => {
       Effect.provide(delegate.run({ message: "same" }, { turn: "m-2", callId: "c-1" }), layer)
     )
     expect(ids).toEqual(["ask_researcher:m-1:c-1", "ask_researcher:m-2:c-1"])
+  })
+
+  test("a failed child turn is an error value with the child's spend", async () => {
+    const delegate = subagentTool({
+      name: "ask_researcher",
+      description: "Ask the research agent.",
+      address: "agent:research"
+    })
+    const result = await Effect.runPromise(
+      Effect.provide(
+        delegate.run({ message: "hard question" }),
+        InMemoryRuntime({
+          keyOf,
+          route: () =>
+            Effect.succeed({
+              type: "TurnFailed",
+              error: "the model attempt died 3 times in a row",
+              usage: { promptTokens: 9, completionTokens: 0, costUsd: 0.02 }
+            })
+        })
+      )
+    )
+    expect(result).toMatchObject({
+      error: "the model attempt died 3 times in a row",
+      usage: { promptTokens: 9, completionTokens: 0, costUsd: 0.02 }
+    })
   })
 })

--- a/packages/harness/src/subagent.ts
+++ b/packages/harness/src/subagent.ts
@@ -1,0 +1,112 @@
+import { Effect } from "effect"
+import { Router, Self, type Event } from "@flamecast/core"
+import { usageOf, type NativeTool, type NativeToolContext, type Usage } from "./infer"
+import type { MessageOrigin } from "./module"
+import { canonicalValue } from "./program"
+import { sha256 } from "./sha256"
+
+// Delegation as one awaitable function with two faces. `callAgent` is the code face: a machine, a
+// workflow, or a code-mode sandbox awaits it, and `Effect.all` over several calls is fan-out with
+// the join written in ordinary code. `subagentTool` is the model face: the same call wrapped as a
+// provider-native tool. Both faces send the same event and read the same reply, so moving
+// orchestration authority between code and model changes configuration, never architecture.
+//
+// The boundary carries exactly two facts. Outward, `origin` names who asked. Homeward, the result
+// carries the child's inclusive usage. Provenance trees and cost trees are derived from those two
+// fields; nothing else crosses, and neither side reads the other's log.
+
+export interface SubagentResult {
+  readonly agent: string
+  readonly turn: string
+  readonly output?: string
+  readonly error?: string
+  readonly usage: Usage
+}
+
+export interface CallAgentMessage {
+  readonly id: string
+  readonly text: string
+  readonly origin?: MessageOrigin
+  readonly budget?: number
+  readonly escalatable?: boolean
+}
+
+// The terminal event of a routed call, read as a result. `TurnCompleted` carries the output;
+// anything else reads as an error that names the event, so a parked or failed child is a value the
+// caller can act on rather than a defect.
+export const subagentResultOf = (address: string, terminal: Event, fallbackTurn: string): SubagentResult => {
+  const turn = String(terminal.turn ?? fallbackTurn)
+  const usage = usageOf(terminal.usage)
+  if (terminal.type === "TurnCompleted") {
+    return { agent: address, turn, output: String(terminal.output ?? ""), usage }
+  }
+  const reason =
+    terminal.error !== undefined
+      ? String(terminal.error)
+      : `the agent ended with ${terminal.type}`
+  return { agent: address, turn, error: reason, usage }
+}
+
+export const callAgent = (
+  address: string,
+  message: CallAgentMessage
+): Effect.Effect<SubagentResult, never, Router> =>
+  Effect.gen(function* () {
+    const router = yield* Router
+    const terminal = yield* router.call(address, {
+      type: "MessageReceived",
+      id: message.id,
+      text: message.text,
+      ...(message.origin === undefined ? {} : { origin: message.origin }),
+      ...(message.budget === undefined ? {} : { budget: message.budget }),
+      ...(message.escalatable === undefined ? {} : { escalatable: message.escalatable })
+    })
+    return subagentResultOf(address, terminal, message.id)
+  })
+
+export interface SubagentToolOptions {
+  readonly name: string
+  readonly description: string
+  readonly address: string
+  readonly inputSchema?: unknown
+  readonly budget?: number
+  readonly message?: (input: unknown) => string
+  readonly callId?: (input: unknown, context?: NativeToolContext) => string
+}
+
+export const subagentTool = (options: SubagentToolOptions): NativeTool<Router | Self> => ({
+  spec: {
+    name: options.name,
+    description: options.description,
+    inputSchema:
+      options.inputSchema ?? {
+        type: "object",
+        properties: { message: { type: "string" } },
+        required: ["message"],
+        additionalProperties: false
+      }
+  },
+  run: (input, context) =>
+    Effect.gen(function* () {
+      const session = yield* Self
+      const message =
+        options.message?.(input) ??
+        String((input as { readonly message?: unknown } | undefined)?.message ?? input)
+      // The child turn id is derived from the parent turn and provider call, so a re-dispatched
+      // tool call re-sends the same message and the child's dedup absorbs it.
+      const id =
+        options.callId?.(input, context) ??
+        (context === undefined
+          ? `${options.name}:${sha256(canonicalValue(input)).slice(0, 16)}`
+          : `${options.name}:${context.turn}:${context.callId}`)
+      return yield* callAgent(options.address, {
+        id,
+        text: message,
+        ...(options.budget === undefined ? {} : { budget: options.budget }),
+        origin: {
+          session,
+          ...(context === undefined ? {} : { turn: context.turn, call: context.callId })
+        }
+      })
+    })
+})

--- a/packages/harness/src/turns.ts
+++ b/packages/harness/src/turns.ts
@@ -76,19 +76,42 @@ export const servedLog = (log: ReadonlyArray<Event>): ReadonlyArray<Event> => {
   return out
 }
 
+const summed = (parts: ReadonlyArray<Usage>): Usage =>
+  parts.reduce(
+    (total, one) => ({
+      promptTokens: total.promptTokens + one.promptTokens,
+      completionTokens: total.completionTokens + one.completionTokens,
+      costUsd: total.costUsd + one.costUsd
+    }),
+    { promptTokens: 0, completionTokens: 0, costUsd: 0 }
+  )
+
 // What one turn spent on the model.
 export const usageIn = (log: ReadonlyArray<Event>, turn: string): Usage =>
-  log
-    .filter((event) => event.type === "ModelReturned" && stampOf(event) === turn)
-    .map((event) => usageOf(event.usage))
-    .reduce(
-      (total, one) => ({
-        promptTokens: total.promptTokens + one.promptTokens,
-        completionTokens: total.completionTokens + one.completionTokens,
-        costUsd: total.costUsd + one.costUsd
-      }),
-      { promptTokens: 0, completionTokens: 0, costUsd: 0 }
-    )
+  summed(
+    log
+      .filter((event) => event.type === "ModelReturned" && stampOf(event) === turn)
+      .map((event) => usageOf(event.usage))
+  )
+
+// A tool result that came back from another agent: it names the agent and carries usage.
+const subagentUsage = (event: Event): Usage | undefined => {
+  if (event.type !== "ToolReturned") return undefined
+  const result = event.result as { readonly agent?: unknown; readonly usage?: unknown } | undefined
+  if (typeof result?.agent !== "string" || result.usage === undefined) return undefined
+  return usageOf(result.usage)
+}
+
+// What one turn spent including every agent it called. A sub-agent result reports the child's own
+// tree usage, so the sum is inclusive over the whole delegation tree without reading child logs.
+export const treeUsageIn = (log: ReadonlyArray<Event>, turn: string): Usage =>
+  summed([
+    usageIn(log, turn),
+    ...log
+      .filter((event) => stampOf(event) === turn)
+      .map(subagentUsage)
+      .filter((usage): usage is Usage => usage !== undefined)
+  ])
 
 const quoted = (value: unknown): string => `"${String(value ?? "")}"`
 


### PR DESCRIPTION
## What and why

Multi-agent support becomes three small pieces: delegation as one awaitable function with a code face and a model face, an in-process session host that resolves addresses to programs, and two carried facts (origin outward, inclusive usage homeward) from which provenance and cost trees are derived. Topology stays in user code, per the evidence recorded in docs/prior-art.md.

- `callAgent(address, message)` is the code face: awaited delegation, so fan-out and joins are ordinary code and the same function is what a future code-mode sandbox exposes.
- `subagentTool(options)` is the model face: the same call as a provider-native tool. It replaces `agentNativeTool` and stamps `origin` on the child head; its result carries the child's inclusive usage.
- `host({ programs })` maps exact addresses and `prefix/*` patterns to programs or factories, creates or resumes a session per address, settles under that session's services, and returns terminals stamped with tree usage. It walks derived origin chains to refuse delegation cycles and depth overruns with a failed turn instead of a deadlock.
- `treeUsageIn(log, turn)` folds a turn's spend including everything its sub-agents reported; replies through `replyTo` now carry `origin`, `outcome`, and `usage`.
- Docs: new docs/orchestration.md, and architecture, building-an-agent, events, modules, observability, runtimes, prior-art updated in the same change. Planned durable binding is `runtime-cf` with wrangler as the local loop.

- [x] `bun run gate` passes locally
- [x] Docs updated if behavior changed
- [x] Tests cover the change

Verified: host tests cover cross-session origin and usage, dedup of redelivered messages, cycle refusal, depth bounds, wildcard spawn fan-out joined by `Promise.all`, async replies, and unknown addresses. Full gate (lint, typecheck, all package tests, package smoke, knip) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)