### PR TITLE
docs(swarm): walkthrough for building multiple agents

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ flowchart TD
   A --> R[Runtimes]
   A --> Or[Orchestration]
   Or --> Cm[Code mode]
+  Cm --> Sw[Building a swarm]
   A --> O[Observability]
   O --> V[Evolution]
   P[Prior art] --> A
@@ -26,8 +27,9 @@ flowchart TD
 6. [Runtimes](runtimes.md) owns the platform port contract and binding status.
 7. [Orchestration](orchestration.md) covers delegation, the session host, and swarm inspection.
 8. [Code mode](codemode.md) covers capabilities, the sandbox port, and scripts that delegate.
-9. [Observability](observability.md) covers reading, rendering, replaying, and forking logs.
-10. [Evolution](evolution.md) covers code candidates, finite equivalence, evaluation, and search integration.
-11. [Prior art](prior-art.md) records the external systems and research that informed the design.
+9. [Building a swarm](building-a-swarm.md) walks through multiple agents, spawning, and model-written fan-out.
+10. [Observability](observability.md) covers reading, rendering, replaying, and forking logs.
+11. [Evolution](evolution.md) covers code candidates, finite equivalence, evaluation, and search integration.
+12. [Prior art](prior-art.md) records the external systems and research that informed the design.
 
 The repository [README](../README.md) is the package-level entry point.

--- a/docs/building-a-swarm.md
+++ b/docs/building-a-swarm.md
@@ -1,0 +1,183 @@
+# Building a Swarm
+
+This guide builds a multi-agent system in one process: a lead agent, a verifier peer, spawned workers, fan-out from code, and a script the model writes. Every step runs on the in-memory pieces, and a durable runtime takes the same agents unchanged.
+
+`packages/codemode/src/guide.test.ts` runs this walkthrough, so the snippets stay honest.
+
+## Programs, Then Addresses
+
+A [program](concepts.md#program) is compiled behavior and a [session](concepts.md#session) is a running conversation, so building a swarm is two separate decisions. First construct the programs, one per kind of agent. Then give the [host](orchestration.md#session-host) a registry that says which addresses run which program.
+
+Each program picks its own model through its `inference` module, so a swarm mixes models by construction.
+
+```ts
+import { Effect } from "effect"
+import {
+  createAgent,
+  defaultPack,
+  host,
+  inference,
+  subagentTool,
+  vercelGatewayInference
+} from "flamecast-core/harness"
+
+const lead = createAgent({
+  modules: defaultPack({
+    inference: { provider: vercelGatewayInference({ model: "anthropic/claude-opus-4.5" }) },
+    nativeTools: [
+      subagentTool({
+        name: "verify",
+        description: "Ask the verifier to check an answer before returning it.",
+        address: "agent:verify"
+      })
+    ]
+  })
+})
+
+const verifier = createAgent({
+  modules: [
+    inference({
+      provider: vercelGatewayInference({ model: "anthropic/claude-haiku-4.5" }),
+      system: "Check the claim you are given. Answer with the defects you find, or 'correct'."
+    })
+  ]
+})
+```
+
+The verifier program carries no tools and no history. A delegation sends it one message, so it reads the claim with a clean context, which is what makes a verifier worth running.
+
+## Host and Run
+
+```ts
+const h = host({
+  programs: {
+    "agent:lead": lead,
+    "agent:verify": verifier
+  }
+})
+
+const terminal = await Effect.runPromise(h.call("agent:lead", { id: "m-1", text: "..." }))
+```
+
+`h.call` appends the message, settles the lead's machines, and returns the terminal event. When the lead calls its `verify` tool, the host creates the `agent:verify` session on first delivery, runs it under its own log and writer lease, and hands the answer back as an ordinary tool result.
+
+## Read the Evidence
+
+Every crossing leaves derived evidence, so a swarm is debugged from its logs.
+
+```ts
+import { treeUsageIn } from "flamecast-core/harness"
+
+const childLog = await Effect.runPromise(h.log("agent:verify"))
+const head = childLog.find((event) => event.type === "MessageReceived")
+// head.origin names the lead session, the turn, and the tool call that asked.
+
+const leadLog = await Effect.runPromise(h.log("agent:lead"))
+const total = treeUsageIn(leadLog, "m-1")
+// total covers the lead's own model calls plus everything the verifier reported.
+```
+
+## Spawn Workers by Address
+
+A `prefix/*` registry entry is a family of agents. The factory receives the concrete address, so it can vary the model, the instruction, or anything else by name. A session appears when its address is first used, and the factory runs once per address.
+
+```ts
+const h = host({
+  programs: {
+    "agent:lead": lead,
+    "worker/*": (address) =>
+      createAgent({
+        modules: [inference({ provider: modelFor(address), system: instructionFor(address) })]
+      })
+  }
+})
+```
+
+## Fan Out From Code
+
+`callAgent` is delegation as a value, so a deterministic workflow drives workers with no model in the loop. Concurrent calls join on `Promise.all`, and each worker runs under its own writer lease, so the fan-out is parallel.
+
+```ts
+import { Router } from "flamecast-core"
+import { callAgent } from "flamecast-core/harness"
+
+const router = {
+  deliver: (address, event) => Effect.asVoid(h.route(address, event)),
+  call: h.route
+}
+
+const ask = (address: string, id: string, text: string) =>
+  Effect.runPromise(Effect.provideService(callAgent(address, { id, text }), Router, router))
+
+const answers = await Promise.all([
+  ask("worker/1", "r-1", "summarize the first half"),
+  ask("worker/2", "r-2", "summarize the second half")
+])
+```
+
+## Let the Model Write the Fan-Out
+
+[Code mode](codemode.md) moves the same shape inside a model-written script. The lead gets one `execute` tool, the script reaches the `agents` capability, and `allow` bounds the addresses it may open.
+
+```ts
+import { Context } from "effect"
+import { agents, codemode, inProcessSandbox, Sandbox } from "flamecast-core/codemode"
+
+const execute = codemode({ capabilities: [agents({ allow: ["worker/*"] })] })
+
+const lead = createAgent({ modules: defaultPack({ nativeTools: [execute] }) })
+
+const h = host({
+  programs: { "agent:lead": lead, "worker/*": workerFor },
+  services: Context.make(Sandbox, inProcessSandbox())
+})
+```
+
+A script the model writes then reads like the code above it:
+
+```js
+const answers = await Promise.all([
+  agents.call("worker/1", "summarize the first half"),
+  agents.call("worker/2", "summarize the second half")
+])
+return answers.map((one) => one.output).join("\n")
+```
+
+## Give the Script Your Own Tools
+
+A capability is a named object injected across the sandbox boundary, so any application surface becomes a tool the script calls by name. The capability list is the whole import surface of the sandbox, and the harness developer owns it.
+
+```ts
+import { capability } from "flamecast-core/codemode"
+
+const notes = capability({
+  name: "notes",
+  summary: "Shared notes for this run.",
+  methods: [
+    {
+      name: "save",
+      signature: "save(key, text): Promise<void>",
+      description: "Keep one note under a key.",
+      run: (args) => Effect.sync(() => void store.set(String(args[0]), String(args[1])))
+    }
+  ]
+})
+
+const execute = codemode({ capabilities: [notes, agents({ allow: ["worker/*"] })] })
+```
+
+One script can now delegate, combine the answers, and record where they landed, in a single model call.
+
+## Long-Running Work
+
+`replyTo` is the asynchronous door. The lead delivers work and finishes its turn, and the worker's answer arrives later as a new inbound message stamped with `origin`, `outcome`, and `usage`. [Orchestration](orchestration.md#the-boundary-contract) covers the contract.
+
+```ts
+await Effect.runPromise(
+  h.call("worker/9", { id: "j-1", text: "index the archive", replyTo: "agent:lead" })
+)
+```
+
+## Move It to a Durable Runtime
+
+The host is the in-process binding of address resolution, and everything above it is runtime-neutral. On a durable platform an address names a durable object or a cell, hosting is the platform's job, and the programs, capabilities, and projections move unchanged. [Runtimes](runtimes.md) owns binding status.

--- a/docs/building-an-agent.md
+++ b/docs/building-an-agent.md
@@ -225,4 +225,4 @@ await Effect.runPromise(Effect.provide(alternative.replay([]), runtime))
 
 Use `agent.fork({ at })` when the source log is already bound to the current runtime.
 
-Module details are in [Modules](modules.md).
+Module details are in [Modules](modules.md). [Building a swarm](building-a-swarm.md) continues into multiple agents.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -61,6 +61,20 @@ Modules own their configuration and can contribute machines or projections. Modu
 
 `identity` contributes behavior-affecting configuration to the default program id. [Program Identity](evolution.md#program-identity) explains the identity rules.
 
+## Program
+
+A program is compiled agent behavior: the machines, render plan, projections, and identity that `createAgent` builds from a module tuple.
+
+A program is a value with no state of its own, the way an executable on disk is a value with no memory of its own. Its `turn` effect asks for a log, an address, and the other [ports](#port) through Effect requirements, so one program value can serve any number of independent conversations.
+
+The word names the compiled agent, never source that a model writes. A model-written orchestration in [code mode](codemode.md) is a script, and the program is what offered the tool that runs it.
+
+## Session
+
+A session is one running conversation: one address, one event log, one writer lease. A program runs in a session the way an executable runs as a process, and the same program can run in many sessions at once without any shared state.
+
+Behavior comes from the program and identity comes from the session. A [host](orchestration.md#session-host) or a runtime marries the two by resolving an address to a program and providing that session's log and services.
+
 ## Service
 
 An Effect service names a typed construction dependency. A module provides service implementations in an Effect `Context`.

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -11,6 +11,7 @@ flamecast-core combines ideas from event-sourced systems, typed effect runtimes,
 ## Extensible Harnesses
 
 - [Pi](https://pi.dev/) demonstrates a small coding-agent core with extension-first behavior, session trees, and explicit context handling. flamecast-core shares the preference for minimal primitives while using typed module dependencies and event-sourced machines.
+- [flamecast's package system](https://github.com/clavia-inc/flamecast) demonstrates SDKs injected by name into a code sandbox, so arbitrary tools reach the model as callable objects. Codemode [capabilities](codemode.md#writing-a-capability) keep that injection and leave out the catalog, install lifecycle, and discovery machinery.
 - [Anthropic's multi-agent research system](https://www.anthropic.com/research/multiagent-systems) demonstrates parallel delegation and coordinator-worker patterns.
 - [Recursive language model harnesses](https://alexzhang13.github.io/blog/2026/harness/) motivate leaving orchestration open to generated code and runtime routing.
 

--- a/packages/codemode/src/guide.test.ts
+++ b/packages/codemode/src/guide.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "bun:test"
+import { Context, Effect } from "effect"
+import { Router, type Event } from "@flamecast/core"
+import {
+  callAgent,
+  createAgent,
+  customInference,
+  defaultPack,
+  host,
+  treeUsageIn,
+  type Action,
+  type ModelRequest
+} from "@flamecast/harness"
+import { inference } from "@flamecast/harness/modules/inference"
+import { subagentTool } from "@flamecast/harness/subagent"
+import { agents } from "./capabilities/agents"
+import { capability } from "./capability"
+import { codemode } from "./tool"
+import { inProcessSandbox, Sandbox } from "./sandbox"
+
+// The walkthrough in docs/building-a-swarm.md, run. Each test is one section of the guide, with a
+// scripted provider standing in for the gateway, so an edit that breaks a snippet breaks here. The
+// guide imports from "flamecast-core/*" and this file from "@flamecast/*", because the guide
+// addresses an installer of the published package and this file lives in the workspace.
+
+const scripted = (model: string, react: (request: ModelRequest) => Action) =>
+  customInference(async (request) => react(request), { id: model, model })
+
+const toolAnswered = (request: ModelRequest) =>
+  request.messages.some((message) => message.role === "tool")
+
+const spent = { promptTokens: 2, completionTokens: 3, costUsd: 0.002 }
+
+const worker = (address: string) =>
+  createAgent({
+    modules: [
+      inference({
+        provider: scripted(address, () => ({
+          kind: "complete",
+          output: `${address} done`,
+          usage: spent
+        }))
+      })
+    ]
+  })
+
+describe("building a swarm, as the guide tells it", () => {
+  test("a verifier peer answers with a clean context and the evidence folds home", async () => {
+    const lead = createAgent({
+      modules: defaultPack({
+        inference: {
+          provider: scripted("lead", (request) =>
+            toolAnswered(request)
+              ? { kind: "complete", output: "checked" }
+              : { kind: "call", callId: "c-1", name: "verify", arguments: { message: "claim" } }
+          )
+        },
+        nativeTools: [
+          subagentTool({
+            name: "verify",
+            description: "Ask the verifier to check an answer before returning it.",
+            address: "agent:verify"
+          })
+        ]
+      })
+    })
+    const verifier = createAgent({
+      modules: [
+        inference({
+          provider: scripted("verifier", () => ({ kind: "complete", output: "correct", usage: spent }))
+        })
+      ]
+    })
+    const h = host({ programs: { "agent:lead": lead, "agent:verify": verifier } })
+
+    const terminal = await Effect.runPromise(h.call("agent:lead", { id: "m-1", text: "go" }))
+    expect(terminal).toMatchObject({ type: "TurnCompleted", output: "checked" })
+
+    const childLog = await Effect.runPromise(h.log("agent:verify"))
+    const head = childLog.find((event) => event.type === "MessageReceived")
+    expect(head?.origin).toMatchObject({ session: "agent:lead", turn: "m-1", call: "c-1" })
+
+    const leadLog = await Effect.runPromise(h.log("agent:lead"))
+    expect(treeUsageIn(leadLog, "m-1")).toEqual(spent)
+  })
+
+  test("workers spawn by address and fan out from code on Promise.all", async () => {
+    const h = host({ programs: { "worker/*": worker } })
+    const router = {
+      deliver: (address: string, event: Event) => Effect.asVoid(h.route(address, event)),
+      call: h.route
+    }
+    const ask = (address: string, id: string, text: string) =>
+      Effect.runPromise(Effect.provideService(callAgent(address, { id, text }), Router, router))
+
+    const answers = await Promise.all([
+      ask("worker/1", "r-1", "summarize the first half"),
+      ask("worker/2", "r-2", "summarize the second half")
+    ])
+    expect(answers.map((one) => one.output)).toEqual(["worker/1 done", "worker/2 done"])
+    expect(await Effect.runPromise(h.sessions)).toEqual(["worker/1", "worker/2"])
+  })
+
+  test("the model writes the fan-out and reaches the application's own capability", async () => {
+    const store = new Map<string, string>()
+    const notes = capability({
+      name: "notes",
+      summary: "Shared notes for this run.",
+      methods: [
+        {
+          name: "save",
+          signature: "save(key, text): Promise<void>",
+          description: "Keep one note under a key.",
+          run: (args) => Effect.sync(() => void store.set(String(args[0]), String(args[1])))
+        }
+      ]
+    })
+    const execute = codemode({ capabilities: [notes, agents({ allow: ["worker/*"] })] })
+    const lead = createAgent({
+      modules: defaultPack({
+        inference: {
+          provider: scripted("lead", (request) =>
+            toolAnswered(request)
+              ? { kind: "complete", output: "gathered" }
+              : {
+                  kind: "call",
+                  callId: "c-1",
+                  name: "execute",
+                  arguments: {
+                    source: `
+                      const answers = await Promise.all([
+                        agents.call("worker/1", "summarize the first half"),
+                        agents.call("worker/2", "summarize the second half")
+                      ])
+                      const joined = answers.map((one) => one.output).join("\\n")
+                      await notes.save("summary", joined)
+                      return joined
+                    `
+                  }
+                }
+          )
+        },
+        nativeTools: [execute]
+      })
+    })
+    const h = host({
+      programs: { "agent:lead": lead, "worker/*": worker },
+      services: Context.make(Sandbox, inProcessSandbox())
+    })
+
+    const terminal = await Effect.runPromise(h.call("agent:lead", { id: "m-1", text: "go" }))
+    expect(terminal).toMatchObject({ type: "TurnCompleted", output: "gathered" })
+    expect(store.get("summary")).toBe("worker/1 done\nworker/2 done")
+
+    // One model-written script, two delegations, and the spend folds up the tree regardless.
+    const leadLog = await Effect.runPromise(h.log("agent:lead"))
+    expect(treeUsageIn(leadLog, "m-1").costUsd).toBeCloseTo(0.004, 6)
+  })
+
+  test("replyTo delivers the answer later as an attributed inbound message", async () => {
+    const lead = createAgent({
+      modules: [
+        inference({ provider: scripted("lead", () => ({ kind: "complete", output: "ack" })) })
+      ]
+    })
+    const h = host({ programs: { "agent:lead": lead, "worker/*": worker } })
+    await Effect.runPromise(
+      h.call("worker/9", { id: "j-1", text: "index the archive", replyTo: "agent:lead" })
+    )
+    const inbox = await Effect.runPromise(h.log("agent:lead"))
+    const reply = inbox.find((event) => event.type === "MessageReceived")
+    expect(reply).toMatchObject({
+      id: "reply:j-1",
+      text: "worker/9 done",
+      outcome: "completed",
+      usage: spent
+    })
+    expect(reply?.origin).toMatchObject({ session: "worker/9" })
+  })
+})

--- a/tools/docs-lint.ts
+++ b/tools/docs-lint.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises"
+import { readdir, readFile } from "node:fs/promises"
 import { join } from "node:path"
 
 // The markdown gate. The house rules for prose are as mechanical as the ones for code, so they are
@@ -13,24 +13,15 @@ import { join } from "node:path"
 
 const root = join(import.meta.dir, "..")
 
+// Every page in docs/ is found rather than listed, so a new page cannot escape the check.
+const pages = (await readdir(join(root, "docs"))).filter((name) => name.endsWith(".md"))
 const files = [
   "README.md",
   "AGENTS.md",
   "CLAUDE.md",
   "CONTRIBUTING.md",
   ".github/PULL_REQUEST_TEMPLATE.md",
-  "docs/README.md",
-  "docs/architecture.md",
-  "docs/building-an-agent.md",
-  "docs/codemode.md",
-  "docs/concepts.md",
-  "docs/events.md",
-  "docs/evolution.md",
-  "docs/modules.md",
-  "docs/observability.md",
-  "docs/orchestration.md",
-  "docs/prior-art.md",
-  "docs/runtimes.md"
+  ...pages.map((name) => `docs/${name}`)
 ]
 
 interface Problem {


### PR DESCRIPTION
## What and why

The docs explain the primitives one at a time and no page shows a developer the whole path, so this adds the walkthrough: from two programs and a registry to spawned workers, fan-out from code, model-written scripts, and application tools across the sandbox boundary.

- `docs/building-a-swarm.md` walks the path in eight steps, each with the code a developer writes. `packages/codemode/src/guide.test.ts` runs the walkthrough with scripted providers, so an edit that breaks a snippet breaks the gate.
- `docs/concepts.md` defines Program and Session. A program is compiled behavior with no state, the way an executable on disk has no memory, and a session is one address, one log, one writer lease, the way a process runs an executable. The entry states that a model-written code-mode script is never called a program.
- `tools/docs-lint.ts` discovers pages in `docs/` instead of listing them, since the new page was not in the hard-coded list and would have silently escaped the prose gate.
- `docs/prior-art.md` records the flamecast package system that codemode capabilities descend from: SDKs injected by name into a code sandbox, with the catalog and install machinery left out.

- [x] `bun run gate` passes locally
- [x] Docs updated if behavior changed
- [x] Tests cover the change

Verified: the guide test covers the verifier peer with origin and tree cost, spawn plus `Promise.all` fan-out, a model-written script reaching a custom capability with spend folding home, and `replyTo` with an attributed reply. Full gate is green, and the prose linter passes 18 markdown files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)