### PR TITLE
feat(core): check machine state names at both tiers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ flowchart TD
   A --> R[Runtimes]
   A --> Or[Orchestration]
   Or --> Cm[Code mode]
+  Cm --> Sw[Building a swarm]
   A --> O[Observability]
   O --> V[Evolution]
   P[Prior art] --> A
@@ -26,8 +27,9 @@ flowchart TD
 6. [Runtimes](runtimes.md) owns the platform port contract and binding status.
 7. [Orchestration](orchestration.md) covers delegation, the session host, and swarm inspection.
 8. [Code mode](codemode.md) covers capabilities, the sandbox port, and scripts that delegate.
-9. [Observability](observability.md) covers reading, rendering, replaying, and forking logs.
-10. [Evolution](evolution.md) covers code candidates, finite equivalence, evaluation, and search integration.
-11. [Prior art](prior-art.md) records the external systems and research that informed the design.
+9. [Building a swarm](building-a-swarm.md) walks through multiple agents, spawning, and model-written fan-out.
+10. [Observability](observability.md) covers reading, rendering, replaying, and forking logs.
+11. [Evolution](evolution.md) covers code candidates, finite equivalence, evaluation, and search integration.
+12. [Prior art](prior-art.md) records the external systems and research that informed the design.
 
 The repository [README](../README.md) is the package-level entry point.

--- a/docs/building-a-swarm.md
+++ b/docs/building-a-swarm.md
@@ -1,0 +1,183 @@
+# Building a Swarm
+
+This guide builds a multi-agent system in one process: a lead agent, a verifier peer, spawned workers, fan-out from code, and a script the model writes. Every step runs on the in-memory pieces, and a durable runtime takes the same agents unchanged.
+
+`packages/codemode/src/guide.test.ts` runs this walkthrough, so the snippets stay honest.
+
+## Programs, Then Addresses
+
+A [program](concepts.md#program) is compiled behavior and a [session](concepts.md#session) is a running conversation, so building a swarm is two separate decisions. First construct the programs, one per kind of agent. Then give the [host](orchestration.md#session-host) a registry that says which addresses run which program.
+
+Each program picks its own model through its `inference` module, so a swarm mixes models by construction.
+
+```ts
+import { Effect } from "effect"
+import {
+  createAgent,
+  defaultPack,
+  host,
+  inference,
+  subagentTool,
+  vercelGatewayInference
+} from "flamecast-core/harness"
+
+const lead = createAgent({
+  modules: defaultPack({
+    inference: { provider: vercelGatewayInference({ model: "anthropic/claude-opus-4.5" }) },
+    nativeTools: [
+      subagentTool({
+        name: "verify",
+        description: "Ask the verifier to check an answer before returning it.",
+        address: "agent:verify"
+      })
+    ]
+  })
+})
+
+const verifier = createAgent({
+  modules: [
+    inference({
+      provider: vercelGatewayInference({ model: "anthropic/claude-haiku-4.5" }),
+      system: "Check the claim you are given. Answer with the defects you find, or 'correct'."
+    })
+  ]
+})
+```
+
+The verifier program carries no tools and no history. A delegation sends it one message, so it reads the claim with a clean context, which is what makes a verifier worth running.
+
+## Host and Run
+
+```ts
+const h = host({
+  programs: {
+    "agent:lead": lead,
+    "agent:verify": verifier
+  }
+})
+
+const terminal = await Effect.runPromise(h.call("agent:lead", { id: "m-1", text: "..." }))
+```
+
+`h.call` appends the message, settles the lead's machines, and returns the terminal event. When the lead calls its `verify` tool, the host creates the `agent:verify` session on first delivery, runs it under its own log and writer lease, and hands the answer back as an ordinary tool result.
+
+## Read the Evidence
+
+Every crossing leaves derived evidence, so a swarm is debugged from its logs.
+
+```ts
+import { treeUsageIn } from "flamecast-core/harness"
+
+const childLog = await Effect.runPromise(h.log("agent:verify"))
+const head = childLog.find((event) => event.type === "MessageReceived")
+// head.origin names the lead session, the turn, and the tool call that asked.
+
+const leadLog = await Effect.runPromise(h.log("agent:lead"))
+const total = treeUsageIn(leadLog, "m-1")
+// total covers the lead's own model calls plus everything the verifier reported.
+```
+
+## Spawn Workers by Address
+
+A `prefix/*` registry entry is a family of agents. The factory receives the concrete address, so it can vary the model, the instruction, or anything else by name. A session appears when its address is first used, and the factory runs once per address.
+
+```ts
+const h = host({
+  programs: {
+    "agent:lead": lead,
+    "worker/*": (address) =>
+      createAgent({
+        modules: [inference({ provider: modelFor(address), system: instructionFor(address) })]
+      })
+  }
+})
+```
+
+## Fan Out From Code
+
+`callAgent` is delegation as a value, so a deterministic workflow drives workers with no model in the loop. Concurrent calls join on `Promise.all`, and each worker runs under its own writer lease, so the fan-out is parallel.
+
+```ts
+import { Router } from "flamecast-core"
+import { callAgent } from "flamecast-core/harness"
+
+const router = {
+  deliver: (address, event) => Effect.asVoid(h.route(address, event)),
+  call: h.route
+}
+
+const ask = (address: string, id: string, text: string) =>
+  Effect.runPromise(Effect.provideService(callAgent(address, { id, text }), Router, router))
+
+const answers = await Promise.all([
+  ask("worker/1", "r-1", "summarize the first half"),
+  ask("worker/2", "r-2", "summarize the second half")
+])
+```
+
+## Let the Model Write the Fan-Out
+
+[Code mode](codemode.md) moves the same shape inside a model-written script. The lead gets one `execute` tool, the script reaches the `agents` capability, and `allow` bounds the addresses it may open.
+
+```ts
+import { Context } from "effect"
+import { agents, codemode, inProcessSandbox, Sandbox } from "flamecast-core/codemode"
+
+const execute = codemode({ capabilities: [agents({ allow: ["worker/*"] })] })
+
+const lead = createAgent({ modules: defaultPack({ nativeTools: [execute] }) })
+
+const h = host({
+  programs: { "agent:lead": lead, "worker/*": workerFor },
+  services: Context.make(Sandbox, inProcessSandbox())
+})
+```
+
+A script the model writes then reads like the code above it:
+
+```js
+const answers = await Promise.all([
+  agents.call("worker/1", "summarize the first half"),
+  agents.call("worker/2", "summarize the second half")
+])
+return answers.map((one) => one.output).join("\n")
+```
+
+## Give the Script Your Own Tools
+
+A capability is a named object injected across the sandbox boundary, so any application surface becomes a tool the script calls by name. The capability list is the whole import surface of the sandbox, and the harness developer owns it.
+
+```ts
+import { capability } from "flamecast-core/codemode"
+
+const notes = capability({
+  name: "notes",
+  summary: "Shared notes for this run.",
+  methods: [
+    {
+      name: "save",
+      signature: "save(key, text): Promise<void>",
+      description: "Keep one note under a key.",
+      run: (args) => Effect.sync(() => void store.set(String(args[0]), String(args[1])))
+    }
+  ]
+})
+
+const execute = codemode({ capabilities: [notes, agents({ allow: ["worker/*"] })] })
+```
+
+One script can now delegate, combine the answers, and record where they landed, in a single model call.
+
+## Long-Running Work
+
+`replyTo` is the asynchronous door. The lead delivers work and finishes its turn, and the worker's answer arrives later as a new inbound message stamped with `origin`, `outcome`, and `usage`. [Orchestration](orchestration.md#the-boundary-contract) covers the contract.
+
+```ts
+await Effect.runPromise(
+  h.call("worker/9", { id: "j-1", text: "index the archive", replyTo: "agent:lead" })
+)
+```
+
+## Move It to a Durable Runtime
+
+The host is the in-process binding of address resolution, and everything above it is runtime-neutral. On a durable platform an address names a durable object or a cell, hosting is the platform's job, and the programs, capabilities, and projections move unchanged. [Runtimes](runtimes.md) owns binding status.

--- a/docs/building-an-agent.md
+++ b/docs/building-an-agent.md
@@ -225,4 +225,4 @@ await Effect.runPromise(Effect.provide(alternative.replay([]), runtime))
 
 Use `agent.fork({ at })` when the source log is already bound to the current runtime.
 
-Module details are in [Modules](modules.md).
+Module details are in [Modules](modules.md). [Building a swarm](building-a-swarm.md) continues into multiple agents.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -61,6 +61,20 @@ Modules own their configuration and can contribute machines or projections. Modu
 
 `identity` contributes behavior-affecting configuration to the default program id. [Program Identity](evolution.md#program-identity) explains the identity rules.
 
+## Program
+
+A program is compiled agent behavior: the machines, render plan, projections, and identity that `createAgent` builds from a module tuple.
+
+A program is a value with no state of its own, the way an executable on disk is a value with no memory of its own. Its `turn` effect asks for a log, an address, and the other [ports](#port) through Effect requirements, so one program value can serve any number of independent conversations.
+
+The word names the compiled agent, never source that a model writes. A model-written orchestration in [code mode](codemode.md) is a script, and the program is what offered the tool that runs it.
+
+## Session
+
+A session is one running conversation: one address, one event log, one writer lease. A program runs in a session the way an executable runs as a process, and the same program can run in many sessions at once without any shared state.
+
+Behavior comes from the program and identity comes from the session. A [host](orchestration.md#session-host) or a runtime marries the two by resolving an address to a program and providing that session's log and services.
+
 ## Service
 
 An Effect service names a typed construction dependency. A module provides service implementations in an Effect `Context`.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -40,6 +40,8 @@ Each state can define one work slot:
 
 `settle` repeatedly folds and runs ready work until the machine rests. `settleAll` reaches a fixpoint across a group of machines.
 
+State names are checked in two tiers, because a transition to a state that does not exist is silent otherwise: the fold lands on a name with no definition, later events fall through the tolerant read, and `settle` reads a missing state as resting. For a machine written by hand, the state names are inferred from the keys of the states record, so an undeclared `initial` or `target` fails to compile. For a machine that arrives as generated source, `machine()` repeats both checks over the values and throws at construction, before any log exists.
+
 Use a machine when behavior must append facts, wait for events, or perform effects. A pure projection that changes a request does not need a machine.
 
 ## Module

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -11,6 +11,7 @@ flamecast-core combines ideas from event-sourced systems, typed effect runtimes,
 ## Extensible Harnesses
 
 - [Pi](https://pi.dev/) demonstrates a small coding-agent core with extension-first behavior, session trees, and explicit context handling. flamecast-core shares the preference for minimal primitives while using typed module dependencies and event-sourced machines.
+- [flamecast's package system](https://github.com/clavia-inc/flamecast) demonstrates SDKs injected by name into a code sandbox, so arbitrary tools reach the model as callable objects. Codemode [capabilities](codemode.md#writing-a-capability) keep that injection and leave out the catalog, install lifecycle, and discovery machinery.
 - [Anthropic's multi-agent research system](https://www.anthropic.com/research/multiagent-systems) demonstrates parallel delegation and coordinator-worker patterns.
 - [Recursive language model harnesses](https://alexzhang13.github.io/blog/2026/harness/) motivate leaving orchestration open to generated code and runtime routing.
 

--- a/packages/codemode/src/guide.test.ts
+++ b/packages/codemode/src/guide.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "bun:test"
+import { Context, Effect } from "effect"
+import { Router, type Event } from "@flamecast/core"
+import {
+  callAgent,
+  createAgent,
+  customInference,
+  defaultPack,
+  host,
+  treeUsageIn,
+  type Action,
+  type ModelRequest
+} from "@flamecast/harness"
+import { inference } from "@flamecast/harness/modules/inference"
+import { subagentTool } from "@flamecast/harness/subagent"
+import { agents } from "./capabilities/agents"
+import { capability } from "./capability"
+import { codemode } from "./tool"
+import { inProcessSandbox, Sandbox } from "./sandbox"
+
+// The walkthrough in docs/building-a-swarm.md, run. Each test is one section of the guide, with a
+// scripted provider standing in for the gateway, so an edit that breaks a snippet breaks here. The
+// guide imports from "flamecast-core/*" and this file from "@flamecast/*", because the guide
+// addresses an installer of the published package and this file lives in the workspace.
+
+const scripted = (model: string, react: (request: ModelRequest) => Action) =>
+  customInference(async (request) => react(request), { id: model, model })
+
+const toolAnswered = (request: ModelRequest) =>
+  request.messages.some((message) => message.role === "tool")
+
+const spent = { promptTokens: 2, completionTokens: 3, costUsd: 0.002 }
+
+const worker = (address: string) =>
+  createAgent({
+    modules: [
+      inference({
+        provider: scripted(address, () => ({
+          kind: "complete",
+          output: `${address} done`,
+          usage: spent
+        }))
+      })
+    ]
+  })
+
+describe("building a swarm, as the guide tells it", () => {
+  test("a verifier peer answers with a clean context and the evidence folds home", async () => {
+    const lead = createAgent({
+      modules: defaultPack({
+        inference: {
+          provider: scripted("lead", (request) =>
+            toolAnswered(request)
+              ? { kind: "complete", output: "checked" }
+              : { kind: "call", callId: "c-1", name: "verify", arguments: { message: "claim" } }
+          )
+        },
+        nativeTools: [
+          subagentTool({
+            name: "verify",
+            description: "Ask the verifier to check an answer before returning it.",
+            address: "agent:verify"
+          })
+        ]
+      })
+    })
+    const verifier = createAgent({
+      modules: [
+        inference({
+          provider: scripted("verifier", () => ({ kind: "complete", output: "correct", usage: spent }))
+        })
+      ]
+    })
+    const h = host({ programs: { "agent:lead": lead, "agent:verify": verifier } })
+
+    const terminal = await Effect.runPromise(h.call("agent:lead", { id: "m-1", text: "go" }))
+    expect(terminal).toMatchObject({ type: "TurnCompleted", output: "checked" })
+
+    const childLog = await Effect.runPromise(h.log("agent:verify"))
+    const head = childLog.find((event) => event.type === "MessageReceived")
+    expect(head?.origin).toMatchObject({ session: "agent:lead", turn: "m-1", call: "c-1" })
+
+    const leadLog = await Effect.runPromise(h.log("agent:lead"))
+    expect(treeUsageIn(leadLog, "m-1")).toEqual(spent)
+  })
+
+  test("workers spawn by address and fan out from code on Promise.all", async () => {
+    const h = host({ programs: { "worker/*": worker } })
+    const router = {
+      deliver: (address: string, event: Event) => Effect.asVoid(h.route(address, event)),
+      call: h.route
+    }
+    const ask = (address: string, id: string, text: string) =>
+      Effect.runPromise(Effect.provideService(callAgent(address, { id, text }), Router, router))
+
+    const answers = await Promise.all([
+      ask("worker/1", "r-1", "summarize the first half"),
+      ask("worker/2", "r-2", "summarize the second half")
+    ])
+    expect(answers.map((one) => one.output)).toEqual(["worker/1 done", "worker/2 done"])
+    expect(await Effect.runPromise(h.sessions)).toEqual(["worker/1", "worker/2"])
+  })
+
+  test("the model writes the fan-out and reaches the application's own capability", async () => {
+    const store = new Map<string, string>()
+    const notes = capability({
+      name: "notes",
+      summary: "Shared notes for this run.",
+      methods: [
+        {
+          name: "save",
+          signature: "save(key, text): Promise<void>",
+          description: "Keep one note under a key.",
+          run: (args) => Effect.sync(() => void store.set(String(args[0]), String(args[1])))
+        }
+      ]
+    })
+    const execute = codemode({ capabilities: [notes, agents({ allow: ["worker/*"] })] })
+    const lead = createAgent({
+      modules: defaultPack({
+        inference: {
+          provider: scripted("lead", (request) =>
+            toolAnswered(request)
+              ? { kind: "complete", output: "gathered" }
+              : {
+                  kind: "call",
+                  callId: "c-1",
+                  name: "execute",
+                  arguments: {
+                    source: `
+                      const answers = await Promise.all([
+                        agents.call("worker/1", "summarize the first half"),
+                        agents.call("worker/2", "summarize the second half")
+                      ])
+                      const joined = answers.map((one) => one.output).join("\\n")
+                      await notes.save("summary", joined)
+                      return joined
+                    `
+                  }
+                }
+          )
+        },
+        nativeTools: [execute]
+      })
+    })
+    const h = host({
+      programs: { "agent:lead": lead, "worker/*": worker },
+      services: Context.make(Sandbox, inProcessSandbox())
+    })
+
+    const terminal = await Effect.runPromise(h.call("agent:lead", { id: "m-1", text: "go" }))
+    expect(terminal).toMatchObject({ type: "TurnCompleted", output: "gathered" })
+    expect(store.get("summary")).toBe("worker/1 done\nworker/2 done")
+
+    // One model-written script, two delegations, and the spend folds up the tree regardless.
+    const leadLog = await Effect.runPromise(h.log("agent:lead"))
+    expect(treeUsageIn(leadLog, "m-1").costUsd).toBeCloseTo(0.004, 6)
+  })
+
+  test("replyTo delivers the answer later as an attributed inbound message", async () => {
+    const lead = createAgent({
+      modules: [
+        inference({ provider: scripted("lead", () => ({ kind: "complete", output: "ack" })) })
+      ]
+    })
+    const h = host({ programs: { "agent:lead": lead, "worker/*": worker } })
+    await Effect.runPromise(
+      h.call("worker/9", { id: "j-1", text: "index the archive", replyTo: "agent:lead" })
+    )
+    const inbox = await Effect.runPromise(h.log("agent:lead"))
+    const reply = inbox.find((event) => event.type === "MessageReceived")
+    expect(reply).toMatchObject({
+      id: "reply:j-1",
+      text: "worker/9 done",
+      outcome: "completed",
+      usage: spent
+    })
+    expect(reply?.origin).toMatchObject({ session: "worker/9" })
+  })
+})

--- a/packages/core/src/machine.test.ts
+++ b/packages/core/src/machine.test.ts
@@ -56,6 +56,52 @@ describe("the malformed machine", () => {
       })
     ).toThrow('machine "both" malformed: the state "a" defines both decide and act')
   })
+
+  // The type tier catches these when a machine is written by hand. The runtime tier is what a
+  // machine that arrives as generated source gets, so both checks run over the values too.
+  test("a transition to an undeclared state is rejected at definition time", () => {
+    const generated = {
+      id: "typo",
+      initial: "idle",
+      states: { idle: { on: { Ping: "wating" } }, waiting: {} }
+    } as unknown as Parameters<typeof machine>[0]
+    expect(() => machine(generated)).toThrow(
+      'machine "typo" malformed: the state "idle" transitions on "Ping" to the undeclared state "wating"'
+    )
+  })
+
+  test("a guarded transition to an undeclared state is rejected the same way", () => {
+    const generated = {
+      id: "guarded",
+      initial: "idle",
+      states: { idle: { on: { Ping: { target: "gone", when: () => true } } } }
+    } as unknown as Parameters<typeof machine>[0]
+    expect(() => machine(generated)).toThrow(
+      'machine "guarded" malformed: the state "idle" transitions on "Ping" to the undeclared state "gone"'
+    )
+  })
+
+  test("an initial state that is not declared is rejected at definition time", () => {
+    const generated = {
+      id: "start",
+      initial: "nowhere",
+      states: { idle: {} }
+    } as unknown as Parameters<typeof machine>[0]
+    expect(() => machine(generated)).toThrow(
+      'machine "start" malformed: the initial state "nowhere" is not declared'
+    )
+  })
+
+  // A typo'd target would otherwise fold to a state with no definition, and `settle` reads a
+  // missing state as resting, so the machine would go silent instead of failing.
+  test("the check is what keeps a typo from resting forever", () => {
+    const sound = machine({
+      id: "sound",
+      initial: "idle",
+      states: { idle: { on: { Ping: "waiting" } }, waiting: {} }
+    })
+    expect(stateOf(sound, [{ type: "Ping" }])).toBe("waiting")
+  })
 })
 
 describe("decide purity", () => {

--- a/packages/core/src/machine.ts
+++ b/packages/core/src/machine.ts
@@ -40,15 +40,18 @@ import type { Event } from "./event"
 // is not assignable to `Machine<R, never>` because context is invariant. Defaulting to `never` lets
 // a plain machine join an agent's list directly, and keeps `erase` for the machines that really do
 // carry a context.
-export type Transition<C = never> =
-  | string
+// `S` is the machine's state names. It defaults to `string`, so a value that only reads a machine
+// stays unconstrained, and the `machine` constructor narrows it to the keys of the states record so
+// a target that names no state fails to compile.
+export type Transition<C = never, S extends string = string> =
+  | S
   | {
-      readonly target: string
+      readonly target: S
       readonly when?: (log: ReadonlyArray<Event>) => boolean
       readonly assign?: (context: C, event: Event) => C
     }
 
-export interface StateDef<R, C = never> {
+export interface StateDef<R, C = never, S extends string = string> {
   // Derive new events from the record. A decide is pure: the log, `now`, and the folded context
   // fully determine its output, so a re-run after a crash rewrites the same events. `now` is the
   // one clock read, taken by the runtime, so the decide itself stays a plain function the
@@ -70,14 +73,14 @@ export interface StateDef<R, C = never> {
   // When event X, go to state T. A guarded transition only fires when its `when` holds, so a state
   // can stay resting and silent until a computed threshold over the log trips. Unknown event types
   // fall through: tolerant reads.
-  readonly on?: Readonly<Record<string, Transition<C>>>
+  readonly on?: Readonly<Record<string, Transition<C, S>>>
 }
 
-export interface Machine<R = never, C = never> {
-  // The machine's stable name, used by conformance failures and program observations.
+export interface Machine<R = never, C = never, S extends string = string> {
+  // The machine's stable name, used by conformance failures and agent observations.
   readonly id: string
-  readonly initial: string
-  readonly states: Readonly<Record<string, StateDef<R, C>>>
+  readonly initial: S
+  readonly states: Readonly<Record<S, StateDef<R, C, S>>>
   // The context an empty view folds to. Context is private to the machine: machines compose over
   // event names on the shared log, never over each other's context.
   readonly context?: C
@@ -102,17 +105,47 @@ export interface Fold<C> {
 // layer that binds it.
 export const erase = <R, C>(m: Machine<R, C>): Machine<R, never> => m as unknown as Machine<R, never>
 
-// The constructor checks the one structural rule: a state decides or acts, never both. Throwing at
-// definition time is honest about the bug; the machine is malformed before any log exists.
-export const machine = <R = never, C = never>(definition: Machine<R, C>): Machine<R, C> => {
-  for (const [name, state] of Object.entries(definition.states)) {
+// The constructor is the definition-time gate, and it checks in two tiers because machines arrive
+// two ways.
+//
+// The TYPE tier serves a machine written by hand. `S` infers from the keys of the states record and
+// every other position is `NoInfer`, so `initial` and every `target` must name a declared state or
+// the call does not compile. That check earns its keep: an undeclared target folds to a state with
+// no definition, every later event falls through the tolerant read, and `settle` sees a missing
+// state as resting, so a typo is a machine that silently never runs again rather than one that
+// fails.
+//
+// The RUNTIME tier serves a machine that arrives as generated source, where no compiler ran. It
+// repeats the same two checks over the values, plus the structural rule that a state decides or
+// acts and never both. Throwing here is honest about the bug: the machine is malformed before any
+// log exists, so an evolution candidate that names a state it does not declare dies at
+// construction instead of resting forever mid-rollout.
+export const machine = <R = never, C = never, const S extends string = string>(definition: {
+  readonly id: string
+  readonly initial: NoInfer<S>
+  readonly states: Readonly<Record<S, StateDef<R, C, NoInfer<S>>>>
+  readonly context?: C
+  readonly view?: (log: ReadonlyArray<Event>) => ReadonlyArray<Event>
+}): Machine<R, C, S> => {
+  const declared = new Set(Object.keys(definition.states))
+  const malformed = (detail: string) => {
+    throw new Error(`machine "${definition.id}" malformed: ${detail}`)
+  }
+  if (!declared.has(definition.initial)) {
+    malformed(`the initial state "${definition.initial}" is not declared`)
+  }
+  for (const [name, state] of Object.entries<StateDef<R, C, S>>(definition.states)) {
     if (state.decide !== undefined && state.act !== undefined) {
-      throw new Error(
-        `machine "${definition.id}" malformed: the state "${name}" defines both decide and act`
-      )
+      malformed(`the state "${name}" defines both decide and act`)
+    }
+    for (const [type, rule] of Object.entries(state.on ?? {})) {
+      const target = typeof rule === "string" ? rule : rule.target
+      if (!declared.has(target)) {
+        malformed(`the state "${name}" transitions on "${type}" to the undeclared state "${target}"`)
+      }
     }
   }
-  return definition
+  return definition as Machine<R, C, S>
 }
 
 const viewOf = <R, C>(m: Machine<R, C>, log: ReadonlyArray<Event>) => m.view?.(log) ?? log

--- a/packages/harness/src/modules/budget.ts
+++ b/packages/harness/src/modules/budget.ts
@@ -126,11 +126,11 @@ const isEscalation = (log: ReadonlyArray<Event>): boolean =>
 // The escalation machine: record the ask, park, and answer the call when the parent decides. No
 // `ToolReturned` follows the ask, so the model loop rests and the turn is durably paused. A parent
 // reads the park through `boundaryOf` and delivers a grant or a denial, which wakes the turn.
-const escalationMachine = machine<never, Partial<Ask>>({
+const escalationMachine = machine({
   id: "escalation",
   view: turnView,
   initial: "idle",
-  context: {},
+  context: {} as Partial<Ask>,
   states: {
     idle: {
       on: {

--- a/packages/harness/src/modules/contract.ts
+++ b/packages/harness/src/modules/contract.ts
@@ -51,11 +51,13 @@ const answerOf = (context: Partial<Answer>): Answer => {
 const isAnswer = (log: ReadonlyArray<Event>): boolean =>
   String(log[log.length - 1]?.name ?? "") === ANSWER
 
-const contractMachine = machine<never, Partial<Answer>>({
+const contractMachine = machine({
   id: "contract",
   view: turnView,
   initial: "idle",
-  context: {},
+  // The context type is annotated on the value, not applied as a type argument, so the state names
+  // stay inferred and a transition to an undeclared state fails to compile.
+  context: {} as Partial<Answer>,
   states: {
     idle: {
       on: {

--- a/packages/harness/src/modules/inference.ts
+++ b/packages/harness/src/modules/inference.ts
@@ -63,7 +63,7 @@ const inferMachine = (
   giveUpAfter: number,
   repairAtMost: number
 ) =>
-  machine<EventLog, { readonly turn: string }>({
+  machine({
     id: "inference",
     initial: "idle",
     context: { turn: "" },
@@ -127,7 +127,7 @@ const inferMachine = (
     }
   })
 
-const replyMachine = machine<Router | Self>({
+const replyMachine = machine({
   id: "reply",
   view: replyView,
   initial: "idle",

--- a/packages/harness/src/modules/native-tools.ts
+++ b/packages/harness/src/modules/native-tools.ts
@@ -30,11 +30,11 @@ const WALL_REFUSAL =
   "you have already gathered."
 
 const nativeToolsMachine = <R>(handlers: ReadonlyMap<string, NativeTool<R>>) =>
-  machine<R, Partial<Call>>({
+  machine({
     id: "native-tools",
     view: turnView,
     initial: "idle",
-    context: {},
+    context: {} as Partial<Call>,
     states: {
       idle: {
         on: {

--- a/tools/docs-lint.ts
+++ b/tools/docs-lint.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises"
+import { readdir, readFile } from "node:fs/promises"
 import { join } from "node:path"
 
 // The markdown gate. The house rules for prose are as mechanical as the ones for code, so they are
@@ -13,24 +13,15 @@ import { join } from "node:path"
 
 const root = join(import.meta.dir, "..")
 
+// Every page in docs/ is found rather than listed, so a new page cannot escape the check.
+const pages = (await readdir(join(root, "docs"))).filter((name) => name.endsWith(".md"))
 const files = [
   "README.md",
   "AGENTS.md",
   "CLAUDE.md",
   "CONTRIBUTING.md",
   ".github/PULL_REQUEST_TEMPLATE.md",
-  "docs/README.md",
-  "docs/architecture.md",
-  "docs/building-an-agent.md",
-  "docs/codemode.md",
-  "docs/concepts.md",
-  "docs/events.md",
-  "docs/evolution.md",
-  "docs/modules.md",
-  "docs/observability.md",
-  "docs/orchestration.md",
-  "docs/prior-art.md",
-  "docs/runtimes.md"
+  ...pages.map((name) => `docs/${name}`)
 ]
 
 interface Problem {


### PR DESCRIPTION
## What and why

Stacked on #7.

A transition to a state that does not exist was silent. The fold lands on a name with no definition, every later event falls through the tolerant read, and `settle` reads a missing state as resting, so a typo produced a machine that never ran again rather than one that failed. Machines are checked in two tiers now, because they arrive two ways.

- The type tier serves a machine written by hand. `S` infers from the keys of the states record and every other position is `NoInfer`, so an undeclared `initial` or `target` fails to compile. TypeScript reports it as `Type '"waitng"' is not assignable to type 'Transition<..., "idle" | "thinking" | "waiting">'. Did you mean '"waiting"'?`
- The runtime tier serves a machine that arrives as generated source, where no compiler ran. `machine()` repeats both checks over the values and throws at construction, next to the existing decide-xor-act rule, so an evolution candidate that names a state it does not declare dies before any log exists.
- Built-in modules annotate their context type on the value (`context: {} as Partial<Call>`) rather than applying it as a type argument. A partial type application makes `S` fall back to its default and drops the check, which I verified by planting a typo at a real call site and watching it compile.

- [x] `bun run gate` passes locally
- [x] Docs updated if behavior changed
- [x] Tests cover the change

Verified: new tests cover a bare transition, a guarded transition, and an initial state naming an undeclared state, plus the sound machine that folds where the typo would have rested. The type tier was verified by planting `"waitng"` in the inference machine, confirming it compiled before this change and fails after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)