### PR TITLE
feat: close the type holes the audit found and reject any

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -10,6 +10,7 @@
     ".claude/**"
   ],
   "rules": {
-    "eslint/require-yield": "off"
+    "eslint/require-yield": "off",
+    "typescript/no-explicit-any": "error"
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ Keep the docs conceptual. Use diagrams, invariants, and links to explain concept
 ## TypeScript
 
 - Use static imports.
+- Do not write `any`. The linter rejects it, and a wildcard that is genuinely unwriteable otherwise carries a comment saying why.
+- Check a mistake at the tier that can catch it. A type catches what a human writes; a construction-time throw catches what generated code writes, and the framework compiles generated modules and machines.
 - Use inferred return types by default. This keeps the code less verbose.
 - Import symbols from their canonical files. Use re-exports only in a package's published `index.ts`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,8 @@ bun run gate
 
 The gate runs lint (oxlint), prose lint (`tools/docs-lint.ts`), typecheck (every package plus root tools), tests (`bun test` per package), and dead-code analysis (knip) in parallel. It must exit 0. Narrow it with `bun run gate --only=typecheck` while iterating. The pre-push hook runs the whole gate.
 
+`any` is a lint error. It defeats the checks the rest of the framework leans on, and every place it looked necessary had an honest type behind it. The one exception is annotated where it sits, with the reason it can not be written any other way.
+
 The prose lint holds markdown to the rules in [AGENTS.md](AGENTS.md) that a code linter cannot see. A paragraph is one line, because hard wrapping bakes one editor's width into the source and makes a one-word change read as a reflowed block. A document states what is true now, so words that narrate the repository's own history belong in the commit and the pull request.
 
 CI runs `bun install --frozen-lockfile` and then the same `bun run gate`. There is no second list of checks to keep in sync, so a green gate locally is a green gate in CI. Commit `bun.lock` with any dependency change.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -61,6 +61,8 @@ interface Module<Id, Services, Requires, R> {
 
 Modules own their configuration and can contribute machines or projections. Module ids are unique. Compilation rejects ambiguous or incomplete compositions.
 
+Compilation checks what a type cannot see, because a module tuple can be generated. A transition on an event no module declares waits forever, a withdrawal that names no offered tool takes nothing away, and a function carried in `identity` hashes to one constant, so two behaviors would share an agent id. Each is rejected where the tuple is known, before any log exists.
+
 `identity` contributes behavior-affecting configuration to the default agent id. [Agent Identity](evolution.md#agent-identity) explains the identity rules.
 
 ## Agent

--- a/docs/events.md
+++ b/docs/events.md
@@ -16,6 +16,8 @@ Common fields include:
 
 Unknown fields and event types survive reads and folds.
 
+The open shape is the right contract for reading, and the wrong one for writing the harness's own events: a misspelled field compiles, and `keyOf` reads `callId` to derive a dedup key, so a `ToolReturned` carrying `calId` derives no key and the store stops absorbing its redeliveries. The constructors in `flamecast-core/harness` name each event's fields, and the built-in modules emit through them. They return a plain `Event`, so every reader keeps its tolerant read.
+
 ## Append-Only Rules
 
 1. An event records a past fact.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -35,6 +35,8 @@ Vercel AI Gateway is the default provider. The gateway reads `AI_GATEWAY_API_KEY
 
 `nativeTools(list)` implements the model provider's native tool-calling interface. It contributes schemas and a dispatch machine. A handler success or failure becomes a `ToolReturned` event, so the model can observe the outcome and replay can reuse it.
 
+`tool(options)` declares a tool's schema and its handler together. The input spec built from `object`, `string`, `array`, and their siblings carries both the JSON Schema the model reads and the TypeScript type the handler receives, so a field the schema does not offer is a compile error rather than an `undefined` read at runtime. Arguments are checked against that schema before the handler runs, and a mismatch returns to the model as an ordinary tool error it can repair.
+
 Native tool calling is one interface policy. MCP, textual commands, one generic RPC operation, or another protocol can use its own request projection and machines without changing the event-log or module primitives. [Code mode](codemode.md) is the policy that ships, in its own package.
 
 `subagentTool(options)` adapts `callAgent` to a `NativeTool`, so a model delegates to another agent through the same surface it already understands. [Orchestration](orchestration.md) covers the delegation surface.

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -41,7 +41,9 @@ It uses arrays, maps, and a semaphore. Agents, routing, wake tracking, spill sto
 
 Serving many sessions is address resolution, so it belongs to the runtime that owns addresses, storage, and leases. `sessions` says who answers where: an exact key names one address, and a `prefix/*` key or a bare `*` names a family and holds a factory that receives the address. A store and a writer lease appear on first delivery, and a session exists once its log holds something, so an address a caller invents costs nothing until it records one.
 
-A registry value is a plain function from an event to a terminal event. `serve` in the harness builds one from an agent, and an application whose sessions are machines rather than agents registers its own. `services` binds what those sessions need beyond the runtime's own ports, for a served session and for a caller alike.
+A registry value is a plain function from an event to a terminal event. `serve` in the harness builds one from an agent, and an application whose sessions are machines rather than agents registers its own. `services` binds what those sessions need beyond the runtime's own ports, for a served session and for a caller alike, and a session that reaches for a service the runtime was not given fails to compile.
+
+Both halves take one argument, so the key's shape is what says which a value is: the type of an exact key is what serves that address, and the type of a pattern key is a function of the address. Getting them the wrong way round would call a factory with an event or a serve with an address, and both die on delivery, so the registry is checked key by key rather than as a union.
 
 ## Planned Bindings
 

--- a/packages/codemode/src/capability.ts
+++ b/packages/codemode/src/capability.ts
@@ -45,10 +45,23 @@ export const capability = <R = never>(value: Capability<R>): Capability<R> => {
   return value
 }
 
+// What rendering a surface reads: the words, and none of the effects behind them. Asking for this
+// rather than for a `Capability` of some requirement lets one list of capabilities with different
+// requirements render together, and says in the type that rendering runs nothing.
+export interface CapabilitySurface {
+  readonly name: string
+  readonly summary: string
+  readonly methods: ReadonlyArray<{
+    readonly name: string
+    readonly signature: string
+    readonly description: string
+  }>
+}
+
 // The surface as the model reads it. Names and signatures are cheap, so they sit in the static
 // instruction where they cache; a capability that needs more explanation carries it in its
 // description and its method descriptions.
-export const surfaceOf = (capabilities: ReadonlyArray<Capability<any>>): string =>
+export const surfaceOf = (capabilities: ReadonlyArray<CapabilitySurface>): string =>
   capabilities
     .map((one) =>
       [

--- a/packages/codemode/src/tool.ts
+++ b/packages/codemode/src/tool.ts
@@ -1,6 +1,11 @@
 import { Effect } from "effect"
 import { usageOf, type NativeTool, type NativeToolContext, type Usage } from "@flamecast/harness/infer"
-import { surfaceOf, type Capability, type CapabilityContext } from "./capability"
+import {
+  surfaceOf,
+  type Capability,
+  type CapabilityContext,
+  type CapabilitySurface
+} from "./capability"
 import { Sandbox } from "./sandbox"
 
 // Code mode: the model writes a script, and the script drives the capabilities the harness offers.
@@ -37,7 +42,7 @@ export interface CodemodeResult {
 
 const DEFAULT_MAX_CALLS = 64
 
-const describe = (capabilities: ReadonlyArray<Capability<any>>, extra?: string) =>
+const describe = (capabilities: ReadonlyArray<CapabilitySurface>, extra?: string) =>
   [
     "Run JavaScript. The body is an async function, so it can await and return.",
     "Return the value the caller needs, and use print(...) for progress.",

--- a/packages/harness/src/alphabet.ts
+++ b/packages/harness/src/alphabet.ts
@@ -1,0 +1,177 @@
+import type { Event } from "@flamecast/core"
+import type { Usage } from "./infer"
+import type { MessageOrigin } from "./module"
+
+// The harness's own events, as constructors. `Event` is open because a reader must survive an
+// event type it never met, and that openness is the right contract at every boundary. It is the
+// wrong contract for the events this package writes itself: a misspelled field on an emission
+// compiles, and the cost is silent. `keyOf` reads `callId` to derive a dedup key, so a
+// `ToolReturned` carrying `calId` derives no key at all, the store stops absorbing its
+// redeliveries, and the guarantee degrades with nothing to see.
+//
+// Each constructor returns a plain `Event`, so nothing downstream changes: the log, the folds, and
+// the projections keep reading an open shape. The type is a gate on the way in, not a new
+// representation.
+//
+// `at` is a parameter rather than a clock read, because a decide is a pure function of the log and
+// the timestamp the runtime hands it.
+
+export interface Stamped {
+  readonly turn: string
+  readonly at: number
+}
+
+export const messageReceived = (fields: {
+  readonly id: string
+  readonly text: string
+  readonly at: number
+  readonly agent?: string
+  readonly output?: unknown
+  readonly budget?: number
+  readonly escalatable?: boolean
+  readonly replyTo?: string
+  readonly origin?: MessageOrigin
+  readonly outcome?: "completed" | "failed"
+  readonly usage?: Usage
+}): Event => ({
+  type: "MessageReceived",
+  id: fields.id,
+  text: fields.text,
+  at: fields.at,
+  ...(fields.agent === undefined ? {} : { agent: fields.agent }),
+  ...(fields.output === undefined ? {} : { output: fields.output }),
+  ...(fields.budget === undefined ? {} : { budget: fields.budget }),
+  ...(fields.escalatable === undefined ? {} : { escalatable: fields.escalatable }),
+  ...(fields.replyTo === undefined ? {} : { replyTo: fields.replyTo }),
+  ...(fields.origin === undefined ? {} : { origin: fields.origin }),
+  ...(fields.outcome === undefined ? {} : { outcome: fields.outcome }),
+  ...(fields.usage === undefined ? {} : { usage: fields.usage })
+})
+
+export const modelCalled = (fields: Stamped & { readonly callId: string }): Event => ({
+  type: "ModelCalled",
+  turn: fields.turn,
+  callId: fields.callId,
+  at: fields.at
+})
+
+export const modelReturned = (
+  fields: Stamped & { readonly callId: string; readonly usage: Usage }
+): Event => ({
+  type: "ModelReturned",
+  turn: fields.turn,
+  callId: fields.callId,
+  usage: fields.usage,
+  at: fields.at
+})
+
+export const textReturned = (fields: Stamped & { readonly text: string }): Event => ({
+  type: "TextReturned",
+  turn: fields.turn,
+  text: fields.text,
+  at: fields.at
+})
+
+export const toolCalled = (
+  fields: Stamped & {
+    readonly callId: string
+    readonly name: string
+    readonly arguments: unknown
+  }
+): Event => ({
+  type: "ToolCalled",
+  turn: fields.turn,
+  callId: fields.callId,
+  name: fields.name,
+  arguments: fields.arguments,
+  at: fields.at
+})
+
+// The dedup key of a tool result is `tr:<turn>/<callId>`, so both fields are required here. A
+// result that carried neither would land twice on a redelivery and the machine would dispatch
+// twice.
+export const toolReturned = (
+  fields: Stamped & {
+    readonly callId: string
+    readonly name: string
+    readonly result: unknown
+    readonly error?: string
+  }
+): Event => ({
+  type: "ToolReturned",
+  turn: fields.turn,
+  callId: fields.callId,
+  name: fields.name,
+  result: fields.result,
+  ...(fields.error === undefined ? {} : { error: fields.error }),
+  at: fields.at
+})
+
+export const turnCompleted = (fields: Stamped & { readonly output: string }): Event => ({
+  type: "TurnCompleted",
+  turn: fields.turn,
+  output: fields.output,
+  at: fields.at
+})
+
+export const turnFailed = (fields: Stamped & { readonly error: string }): Event => ({
+  type: "TurnFailed",
+  turn: fields.turn,
+  error: fields.error,
+  at: fields.at
+})
+
+export const replyDelivered = (fields: Stamped & { readonly to?: string }): Event => ({
+  type: "ReplyDelivered",
+  turn: fields.turn,
+  ...(fields.to === undefined ? {} : { to: fields.to }),
+  at: fields.at
+})
+
+export const answerRejected = (
+  fields: Stamped & { readonly callId: string; readonly error: string }
+): Event => ({
+  type: "AnswerRejected",
+  turn: fields.turn,
+  callId: fields.callId,
+  error: fields.error,
+  at: fields.at
+})
+
+export const budgetExhausted = (
+  fields: Stamped & { readonly budget: number; readonly used: number }
+): Event => ({
+  type: "BudgetExhausted",
+  turn: fields.turn,
+  budget: fields.budget,
+  used: fields.used,
+  at: fields.at
+})
+
+export const budgetRequested = (
+  fields: Stamped & {
+    readonly callId: string
+    readonly reason: string
+    readonly amount: number
+  }
+): Event => ({
+  type: "BudgetRequested",
+  turn: fields.turn,
+  callId: fields.callId,
+  reason: fields.reason,
+  amount: fields.amount,
+  at: fields.at
+})
+
+export const compactionCompleted = (fields: {
+  readonly upTo: number
+  readonly summary: string
+  readonly provider: string
+  readonly at: number
+}): Event => ({
+  type: "CompactionCompleted",
+  upTo: fields.upTo,
+  summary: fields.summary,
+  provider: fields.provider,
+  at: fields.at
+})

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -70,6 +70,37 @@ export {
 export { checkpointOf, estimateTokens, keepUpTo, suffixOf, type Checkpoint } from "./context"
 export { boundaryOf, type CallResult } from "./boundary"
 export { keyOf } from "./keys"
+export {
+  answerRejected,
+  budgetExhausted,
+  budgetRequested,
+  compactionCompleted,
+  messageReceived,
+  modelCalled,
+  modelReturned,
+  replyDelivered,
+  textReturned,
+  toolCalled,
+  toolReturned,
+  turnCompleted,
+  turnFailed,
+  type Stamped
+} from "./alphabet"
+export { tool, type ToolOptions } from "./tool"
+export {
+  array,
+  boolean,
+  integer,
+  literal,
+  number,
+  object,
+  optional,
+  specOf,
+  string,
+  type Input,
+  type Optional,
+  type Spec
+} from "./spec"
 export { answerErrors, repairText } from "./schema"
 export { ANSWER, EXITS, REQUEST_BUDGET } from "./exits"
 export {

--- a/packages/harness/src/module.test.ts
+++ b/packages/harness/src/module.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import { Context, Effect } from "effect"
-import type { Event } from "@flamecast/core"
+import { machine, type Event } from "@flamecast/core"
 import { customInference, type NativeTool } from "./infer"
+import { WITHDRAW_ALL } from "./definition"
 import { createAgent, defineModule, undeclaredEvents } from "./module"
 import { morphCompaction } from "./modules/compaction"
 import { inference, InferenceStateProjection } from "./modules/inference"
@@ -22,6 +23,109 @@ const lookupInvoice: NativeTool = {
   run: () => Effect.succeed({ total: "312.00" })
 }
 
+// The checks that serve a module tuple built by generated code, where no compiler ran. Each one
+// names a mistake that is silent at runtime: a transition that waits forever, a withdrawal that
+// takes nothing away, and an identity that hashes two different behaviors to one agent id.
+// A module written inline inside `createAgent` has no `requires` to read, and the tuple's own
+// element constraint is its contextual type, so inference falls back to the constraint rather than
+// to the empty default. Reading that as "requires every service" rejected a module that requires
+// none, which is the shape a one-off module is most naturally written in.
+describe("a module written inline", () => {
+  test("composes with no requires declared", () => {
+    const agent = createAgent({
+      modules: [defineModule({ id: "inline", setup: () => ({ events: ["Noted"] }) })]
+    })
+    expect(agent.definition.events).toEqual(["Noted"])
+  })
+
+  test("still reports a requirement no module provides", () => {
+    const consumer = defineModule({
+      id: "consumer",
+      requires: [InferenceStateProjection] as const,
+      setup: () => ({})
+    })
+    // @ts-expect-error the tuple provides no InferenceStateProjection
+    expect(() => createAgent({ modules: [consumer] })).toThrow(
+      'module "consumer" requires missing service "flamecast/InferenceStateProjection"'
+    )
+  })
+})
+
+describe("composition checks", () => {
+  const bare = (part: Record<string, unknown>) =>
+    defineModule({ id: "generated", setup: () => part as never })
+
+  test("a transition on an event no module declares is rejected", () => {
+    expect(() =>
+      createAgent({
+        modules: [
+          bare({
+            events: ["Started"],
+            machines: [machine({ id: "m", initial: "idle", states: { idle: { on: { Startd: "go" } }, go: {} } })]
+          })
+        ]
+      })
+    ).toThrow('machine "m" transitions on "Startd" in state "idle", which no module declares')
+  })
+
+  test("an event a module declares and no machine reads is ordinary", () => {
+    const agent = createAgent({
+      modules: [bare({ events: ["Noted"], machines: [] })]
+    })
+    expect(agent.definition.events).toEqual(["Noted"])
+  })
+
+  test("a withdrawal that names no offered tool is rejected", () => {
+    expect(() =>
+      createAgent({
+        modules: [
+          bare({
+            nativeTools: [{ name: "lookup_invoice", description: "d", inputSchema: {} }],
+            nudges: [
+              { id: "n", when: () => true, text: "t", withdrawsNativeTools: ["lookup_invoce"] }
+            ]
+          })
+        ]
+      })
+    ).toThrow('nudge "n" withdraws "lookup_invoce", which no module offers')
+  })
+
+  test("withdrawing everything names no tool, so it is always allowed", () => {
+    const agent = createAgent({
+      modules: [
+        bare({
+          nativeTools: [{ name: "lookup", description: "d", inputSchema: {} }],
+          nudges: [{ id: "n", when: () => true, text: "t", withdrawsNativeTools: [WITHDRAW_ALL] }]
+        })
+      ]
+    })
+    expect(agent.definition.render.nudges).toHaveLength(1)
+  })
+
+  // The agent id hashes identity, and the hash writes any function as one constant, so two modules
+  // whose behavior differs only inside a function would share an id and a rollout would reuse the
+  // wrong recording.
+  test("a function carried in identity is rejected", () => {
+    expect(() =>
+      createAgent({
+        modules: [
+          defineModule({ id: "picky", identity: { pick: (log: unknown) => log }, setup: () => ({}) })
+        ]
+      })
+    ).toThrow('module "picky" carries a function at identity pick')
+  })
+
+  test("a function nested deeper in identity is found too", () => {
+    expect(() =>
+      createAgent({
+        modules: [
+          defineModule({ id: "deep", identity: { a: { b: { c: () => 1 } } }, setup: () => ({}) })
+        ]
+      })
+    ).toThrow('module "deep" carries a function at identity a.b.c')
+  })
+})
+
 describe("the declared alphabet", () => {
   test("gathers every module's events into one sorted list", () => {
     const agent = createAgent({ modules: defaultPack({ nativeTools: [lookupInvoice] }) })
@@ -39,10 +143,13 @@ describe("the declared alphabet", () => {
       undeclaredEvents(agent.definition, [
         { type: "MessageReceived", id: "m-1" },
         { type: "ModelCalled", turn: "m-1" },
+        // The model loop emits this one and waits on its result, so an inference-only agent
+        // declares both halves even though nothing dispatches the call.
+        { type: "ToolCalled", turn: "m-1" },
         { type: "ToolReturned", turn: "m-1" },
         { type: "HandoffAccepted", turn: "m-1" }
       ])
-    ).toEqual(["HandoffAccepted", "ToolReturned"])
+    ).toEqual(["HandoffAccepted"])
   })
 
   test("declares nothing the empty agent can meet", () => {

--- a/packages/harness/src/module.ts
+++ b/packages/harness/src/module.ts
@@ -17,6 +17,7 @@ import { type ModelRequest, type NativeToolSpec, type Usage } from "./infer"
 import { keyOf } from "./keys"
 import { modelRequest } from "./render"
 import {
+  WITHDRAW_ALL,
   agentId,
   type AgentDefinition,
   type Instruction,
@@ -42,9 +43,16 @@ export interface ModulePart<R = never> {
 }
 
 type AnyService = Context.Service.Any
-type RequiredServices<Requires extends readonly AnyService[]> = Context.Service.Identifier<
-  Requires[number]
->
+
+// What a module's declared requirements name. `defineModule` takes `Requires` as a `const`, so a
+// module that declares any is always a literal tuple, and a tuple has a literal `length`. An
+// unbounded array reaches here only when inference had nothing to read and fell back to the
+// constraint, which happens to a module written inline inside `createAgent`, where the tuple's own
+// element constraint is the contextual type. Reading that as "requires every service" would reject
+// a module that declares none, so it reads as what it means: nothing was declared.
+type RequiredServices<Requires extends readonly AnyService[]> = number extends Requires["length"]
+  ? never
+  : Context.Service.Identifier<Requires[number]>
 
 export interface Module<
   Id extends string = string,
@@ -60,7 +68,16 @@ export interface Module<
   readonly setup: (context: Context.Context<RequiredServices<Requires>>) => ModulePart<R>
 }
 
-export type AnyModule = Module<string, never, any, any>
+// A module in a heterogeneous tuple, and the constraint every module tuple is checked against.
+//
+// `Requires` is the one `any` in the framework, and it is load-bearing. It sits in `setup`'s
+// parameter, which is contravariant, so the constraint has to accept a module that requires
+// anything and a module that requires nothing at once. `unknown` and `never` each reject one of
+// those, and a service array narrows `setup` to a context no real module can be called with.
+// A wildcard in a constraint is read by the compiler and never by the code, so nothing here is
+// unsound: `createAgent` recovers each module's real types from the tuple it was given.
+// eslint-disable-next-line typescript/no-explicit-any
+export type AnyModule = Module<string, never, any, unknown>
 
 export const defineModule = <
   const Id extends string,
@@ -209,7 +226,7 @@ export const privateLog = (seed: ReadonlyArray<Event>): EventLogStore => {
   }
 }
 
-const headOf = (message: InboundMessage, definition: AgentDefinition<unknown, any>, at: number): Event => ({
+const headOf = (message: InboundMessage, definition: Pick<AgentDefinition<never>, "id">, at: number): Event => ({
   type: "MessageReceived",
   id: message.id,
   text: message.text,
@@ -321,6 +338,17 @@ const build = <R, Services>(
   }
 }
 
+// Where a function sits inside an identity value, as a path, or undefined when it is all data.
+const functionIn = (value: unknown, path = ""): string | undefined => {
+  if (typeof value === "function") return path === "" ? "" : ` ${path}`
+  if (value === null || typeof value !== "object") return undefined
+  for (const [key, held] of Object.entries(value as Record<string, unknown>)) {
+    const found = functionIn(held, path === "" ? key : `${path}.${key}`)
+    if (found !== undefined) return found
+  }
+  return undefined
+}
+
 const compile = <R, Services>(
   modules: ReadonlyArray<AnyModule>,
   options: { readonly id?: string; readonly parent?: string }
@@ -383,6 +411,19 @@ const compile = <R, Services>(
       resultTruncateAt: 6_000
     } satisfies RenderPlan
   )
+  // Identity is hashed into the agent id, and the hash serializes a function as the constant
+  // "[function]". Two modules whose behavior differs only inside a function would then share an
+  // id, and evolution reads that id as provenance: a rollout would reuse a recording another
+  // agent produced. The value has to be data for the hash to mean anything.
+  for (const module of modules) {
+    const carried = functionIn(module.identity)
+    if (carried !== undefined) {
+      throw new Error(
+        `module "${module.id}" carries a function at identity${carried} and identity is hashed, so it must be data`
+      )
+    }
+  }
+
   const manifests: ReadonlyArray<ModuleManifest> = modules.map((module) => ({
     id: module.id,
     version: module.version ?? "1",
@@ -395,6 +436,40 @@ const compile = <R, Services>(
   for (const machine of machines) {
     if (machineIds.has(machine.id)) throw new Error(`duplicate machine id "${machine.id}"`)
     machineIds.add(machine.id)
+  }
+
+  const declared = new Set(parts.flatMap((part) => part.events ?? []))
+
+  // A transition on an event no module declares waits forever. `machine()` checks that a target
+  // names a declared state, and this is the same check on the other axis of the transition table:
+  // the event names are only meaningful against the alphabet the tuple composes, so the check
+  // belongs here, where the tuple is known, rather than in core, which knows no alphabet.
+  //
+  // The rule is one-directional on purpose. Transitioning on an undeclared event is a typo or a
+  // missing module. Declaring an event nothing transitions on is ordinary: a module records facts
+  // for a projection or for a reader, and no machine has to care.
+  for (const machine of machines) {
+    for (const [state, definition] of Object.entries(machine.states)) {
+      for (const type of Object.keys(definition.on ?? {})) {
+        if (!declared.has(type)) {
+          throw new Error(
+            `machine "${machine.id}" transitions on "${type}" in state "${state}", which no module declares`
+          )
+        }
+      }
+    }
+  }
+
+  // A withdrawal that names no tool is a typo that reads as working: the nudge fires, the surface
+  // is unchanged, and the tool it meant to take away stays in front of the model. Nudges that
+  // compute their tools from the log are exempt, since their names are only known at render time.
+  const offered = new Set(render.nativeTools.map((tool) => tool.name))
+  for (const nudge of render.nudges) {
+    for (const name of nudge.withdrawsNativeTools ?? []) {
+      if (name !== WITHDRAW_ALL && !offered.has(name)) {
+        throw new Error(`nudge "${nudge.id}" withdraws "${name}", which no module offers`)
+      }
+    }
   }
   const projections: Record<string, Projection<unknown>> = {}
   for (const part of parts) {

--- a/packages/harness/src/modules/budget.ts
+++ b/packages/harness/src/modules/budget.ts
@@ -1,6 +1,7 @@
 import { erase, machine, type Event } from "@flamecast/core"
 import { EXITS, REQUEST_BUDGET } from "../exits"
 import type { NativeToolSpec } from "../infer"
+import { budgetExhausted, budgetRequested, toolReturned } from "../alphabet"
 import { defineModule } from "../module"
 import { WITHDRAW_ALL, type Nudge } from "../definition"
 import { turnHead, turnOf, turnView } from "../turns"
@@ -90,13 +91,12 @@ const budgetMachine = (defaultBudget: number) => machine({
     // The one active state: record the wall, then rest.
     exhausted: {
       decide: (log, now) => [
-        {
-          type: "BudgetExhausted",
+        budgetExhausted({
           turn: turnOf(log),
           budget: budgetOf(log, defaultBudget),
           used: usedOf(log),
           at: now
-        }
+        })
       ],
       on: { BudgetExhausted: "spent" }
     },
@@ -154,14 +154,13 @@ const escalationMachine = machine({
       decide: (_log, now, context) => {
         const ask = askOf(context)
         return [
-          {
-            type: "BudgetRequested",
+          budgetRequested({
             turn: ask.turn,
             callId: ask.callId,
             reason: ask.reason,
             amount: ask.amount,
             at: now
-          }
+          })
         ]
       },
       on: { BudgetRequested: "parked" }
@@ -182,14 +181,13 @@ const escalationMachine = machine({
       decide: (_log, now, context) => {
         const ask = askOf(context)
         return [
-          {
-            type: "ToolReturned",
+          toolReturned({
             turn: ask.turn,
             callId: ask.callId,
             name: REQUEST_BUDGET,
             result: { granted: ask.grant ?? 0 },
             at: now
-          }
+          })
         ]
       },
       on: { ToolReturned: "idle" }
@@ -198,8 +196,7 @@ const escalationMachine = machine({
       decide: (_log, now, context) => {
         const ask = askOf(context)
         return [
-          {
-            type: "ToolReturned",
+          toolReturned({
             turn: ask.turn,
             callId: ask.callId,
             name: REQUEST_BUDGET,
@@ -209,7 +206,7 @@ const escalationMachine = machine({
               note: "No more budget. Answer now with your best result."
             },
             at: now
-          }
+          })
         ]
       },
       on: { ToolReturned: "idle" }
@@ -275,7 +272,14 @@ export const budget = (options: BudgetOptions = {}) => {
     version: "2",
     identity: { defaultBudget, wallText, escalateText, requestTool },
     setup: () => ({
-      events: ["BudgetExhausted", "BudgetRequested", "BudgetGranted", "BudgetDenied"],
+      events: [
+        "BudgetExhausted",
+        "BudgetRequested",
+        "BudgetGranted",
+        "BudgetDenied",
+        "ToolCalled",
+        "ToolReturned"
+      ],
       machines: [budgetMachine(defaultBudget), erase(escalationMachine)],
       nudges: [wallNudge, escalateNudge]
     })

--- a/packages/harness/src/modules/compaction.ts
+++ b/packages/harness/src/modules/compaction.ts
@@ -1,6 +1,7 @@
 import { Clock, Context, Effect } from "effect"
 import { machine, type Event } from "@flamecast/core"
 import { checkpointOf, estimateTokens, keepUpTo, suffixOf } from "../context"
+import { compactionCompleted } from "../alphabet"
 import { defineModule } from "../module"
 import { environment } from "../providers/environment"
 import { transcript } from "../turns"
@@ -131,13 +132,12 @@ export const morphCompaction = (options: MorphOptions = {}) => {
                 const span = log.slice(prior.upTo, upTo)
                 if (span.length === 0) {
                   return [
-                    {
-                      type: "CompactionCompleted",
+                    compactionCompleted({
                       upTo: prior.upTo,
                       summary: prior.summary,
                       provider: "fallback",
                       at
-                    }
+                    })
                   ]
                 }
                 const input = [
@@ -148,13 +148,12 @@ export const morphCompaction = (options: MorphOptions = {}) => {
                   .join("\n\n")
                 const compacted = yield* compress(options, input, lastQuestion(log), ratio)
                 return [
-                  {
-                    type: "CompactionCompleted",
+                  compactionCompleted({
                     upTo,
                     summary: compacted.summary,
                     provider: compacted.provider,
                     at
-                  }
+                  })
                 ]
               }),
             on: { CompactionCompleted: "idle" }

--- a/packages/harness/src/modules/contract.ts
+++ b/packages/harness/src/modules/contract.ts
@@ -1,4 +1,5 @@
 import { erase, machine, type Event } from "@flamecast/core"
+import { answerRejected, toolReturned, turnCompleted } from "../alphabet"
 import { ANSWER } from "../exits"
 import type { NativeToolSpec } from "../infer"
 import { defineModule } from "../module"
@@ -82,28 +83,26 @@ const contractMachine = machine({
         const errors = answerErrors(outputSchemaOf(log), answer.arguments)
         if (errors.length === 0) {
           return [
-            {
-              type: "ToolReturned",
+            toolReturned({
               turn,
               callId: answer.callId,
               name: ANSWER,
               result: { accepted: true },
               at: now
-            },
-            { type: "TurnCompleted", turn, output: JSON.stringify(answer.arguments ?? null), at: now }
+            }),
+            turnCompleted({ turn, output: JSON.stringify(answer.arguments ?? null), at: now })
           ]
         }
         return [
-          { type: "AnswerRejected", turn, callId: answer.callId, error: errors.join("; "), at: now },
-          {
-            type: "ToolReturned",
+          answerRejected({ turn, callId: answer.callId, error: errors.join("; "), at: now }),
+          toolReturned({
             turn,
             callId: answer.callId,
             name: ANSWER,
             result: null,
             error: repairText(errors),
             at: now
-          }
+          })
         ]
       },
       on: { ToolReturned: "idle" }
@@ -130,7 +129,7 @@ export const contract = (options: ContractOptions = {}) => {
     version: "2",
     identity: { text, description },
     setup: () => ({
-      events: ["AnswerRejected"],
+      events: ["AnswerRejected", "ToolCalled", "ToolReturned", "TurnCompleted"],
       machines: [erase(contractMachine)],
       nudges: [answerNudge]
     })

--- a/packages/harness/src/modules/inference.ts
+++ b/packages/harness/src/modules/inference.ts
@@ -8,6 +8,16 @@ import {
   type InferenceSelection,
   type InferenceState
 } from "../infer"
+import {
+  messageReceived,
+  modelCalled,
+  modelReturned,
+  replyDelivered,
+  textReturned,
+  toolCalled,
+  turnCompleted,
+  turnFailed
+} from "../alphabet"
 import { defineModule } from "../module"
 import type { Projection } from "../projection"
 import type { RenderPlan } from "../definition"
@@ -45,17 +55,16 @@ const diedAttempts = (view: ReadonlyArray<Event>): number => {
 
 const consequenceOf = (action: Action, turn: string, at: number): Event =>
   action.kind === "call"
-    ? {
-        type: "ToolCalled",
+    ? toolCalled({
         turn,
         callId: action.callId,
         name: action.name,
         arguments: action.arguments,
         at
-      }
+      })
     : action.kind === "complete"
-      ? { type: "TurnCompleted", turn, output: action.output, at }
-      : { type: "TurnFailed", turn, error: action.error, at }
+      ? turnCompleted({ turn, output: action.output, at })
+      : turnFailed({ turn, error: action.error, at })
 
 const inferMachine = (
   render: RenderPlan,
@@ -86,37 +95,35 @@ const inferMachine = (
             const died = diedAttempts(view)
             if (died >= giveUpAfter) {
               return [
-                {
-                  type: "TurnFailed",
+                turnFailed({
                   turn,
                   error: `the model attempt died ${giveUpAfter} times in a row`,
                   at
-                }
+                })
               ]
             }
             const rejections = view.filter((event) => event.type === "AnswerRejected").length
             if (rejections > repairAtMost) {
               return [
-                {
-                  type: "TurnFailed",
+                turnFailed({
                   turn,
                   error: `the answer did not satisfy the declared schema after ${repairAtMost} corrections`,
                   at
-                }
+                })
               ]
             }
             const marks = view.filter((event) => event.type === "ModelCalled").length
             const key = `${turn}/infer/${marks - died}`
             const store = yield* EventLog
-            yield* store.append([{ type: "ModelCalled", turn, callId: key, at }])
+            yield* store.append([modelCalled({ turn, callId: key, at })])
             const override = yield* Effect.serviceOption(Infer)
             const provider = Option.getOrElse(override, () => selectedInference(selection, log))
             const action = yield* provider.react(modelRequest({ render }, log), key)
             const after = yield* Clock.currentTimeMillis
             return [
-              { type: "ModelReturned", turn, callId: key, usage: usageOf(action.usage), at: after },
+              modelReturned({ turn, callId: key, usage: usageOf(action.usage), at: after }),
               ...(action.kind === "call" && action.text !== undefined && action.text !== ""
-                ? [{ type: "TextReturned", turn, text: action.text, at: after }]
+                ? [textReturned({ turn, text: action.text, at: after })]
                 : []),
               consequenceOf(action, turn, after)
             ]
@@ -149,22 +156,24 @@ const replyMachine = machine({
           }
           const turn = String(head.id ?? "")
           const at = yield* Clock.currentTimeMillis
-          if (head.replyTo === undefined) return [{ type: "ReplyDelivered", turn, at }]
+          if (head.replyTo === undefined) return [replyDelivered({ turn, at })]
           const to = String(head.replyTo)
           const failed = terminal.type === "TurnFailed"
           const session = yield* Self
           // The reply names its origin and carries this turn's inclusive usage, so the receiver
           // can attribute and cost the exchange without reading this session's log.
-          yield* (yield* Router).deliver(to, {
-            type: "MessageReceived",
-            id: `reply:${turn}`,
-            text: failed ? `error: ${String(terminal.error ?? "")}` : String(terminal.output ?? ""),
-            outcome: failed ? "failed" : "completed",
-            origin: { session, turn },
-            usage: treeUsageIn(log, turn),
-            at
-          })
-          return [{ type: "ReplyDelivered", turn, to, at }]
+          yield* (yield* Router).deliver(
+            to,
+            messageReceived({
+              id: `reply:${turn}`,
+              text: failed ? `error: ${String(terminal.error ?? "")}` : String(terminal.output ?? ""),
+              outcome: failed ? "failed" : "completed",
+              origin: { session, turn },
+              usage: treeUsageIn(log, turn),
+              at
+            })
+          )
+          return [replyDelivered({ turn, to, at })]
         }),
       on: { ReplyDelivered: "idle" }
     }
@@ -197,11 +206,15 @@ export const inference = (options: InferenceOptions = {}) => {
     },
     services: Context.make(InferenceStateProjection, state),
     setup: () => ({
+      // The model loop emits the tool call and then waits on its result, so both belong here even
+      // though the native-tools module is what dispatches one.
       events: [
         "MessageReceived",
         "ModelCalled",
         "ModelReturned",
         "TextReturned",
+        "ToolCalled",
+        "ToolReturned",
         "TurnCompleted",
         "TurnFailed",
         "ReplyDelivered"
@@ -209,11 +222,13 @@ export const inference = (options: InferenceOptions = {}) => {
       projections: { [InferenceStateProjection.key]: state },
       instructions: [{ id: "inference.system", text: system }],
       render: { messageTruncateAt, resultTruncateAt },
-      machines: (render) =>
-        [
-          erase(inferMachine(render, selection, giveUpAfter, repairAtMost)),
-          replyMachine
-        ] as unknown as ReadonlyArray<Machine<never>>
+      // The requirements are declared rather than cast away. The model loop reaches the log and the
+      // reply machine reaches the router and this session's name, so the module says so and the
+      // agent's own requirement carries it to the runtime.
+      machines: (render): ReadonlyArray<Machine<EventLog | Router | Self, never>> => [
+        erase(inferMachine(render, selection, giveUpAfter, repairAtMost)),
+        erase(replyMachine)
+      ]
     })
   })
 }

--- a/packages/harness/src/modules/native-tools.ts
+++ b/packages/harness/src/modules/native-tools.ts
@@ -1,5 +1,6 @@
 import { Cause, Clock, Effect, Exit } from "effect"
 import { erase, machine, type Event } from "@flamecast/core"
+import { toolReturned } from "../alphabet"
 import { EXITS } from "../exits"
 import type { NativeTool } from "../infer"
 import { defineModule } from "../module"
@@ -54,30 +55,27 @@ const nativeToolsMachine = <R>(handlers: ReadonlyMap<string, NativeTool<R>>) =>
         act: (log, context) =>
           Effect.gen(function* () {
             const call = callOf(context)
-            const answer = (result: unknown, error?: string) => [
-              {
-                type: "ToolReturned",
+            const answer = (result: unknown, error?: string) => (at: number) => [
+              toolReturned({
                 turn: call.turn,
                 callId: call.callId,
                 name: call.name,
                 result,
-                ...(error === undefined ? {} : { error })
-              }
+                ...(error === undefined ? {} : { error }),
+                at
+              })
             ]
             const at = yield* Clock.currentTimeMillis
-            const stamped = (events: ReadonlyArray<Event>) =>
-              events.map((event) => ({ ...event, at }))
-            if (budgetSpent(log)) return stamped(answer(null, WALL_REFUSAL))
+            if (budgetSpent(log)) return answer(null, WALL_REFUSAL)(at)
             const tool = handlers.get(call.name)
-            if (tool === undefined) return stamped(answer(null, `unknown tool: ${call.name}`))
+            if (tool === undefined) return answer(null, `unknown tool: ${call.name}`)(at)
             const outcome = yield* Effect.exit(
               tool.run(call.arguments, { turn: call.turn, callId: call.callId })
             )
-            return stamped(
-              Exit.isSuccess(outcome)
-                ? answer(outcome.value)
-                : answer(null, Cause.pretty(outcome.cause))
-            )
+            const after = yield* Clock.currentTimeMillis
+            return Exit.isSuccess(outcome)
+              ? answer(outcome.value)(after)
+              : answer(null, Cause.pretty(outcome.cause))(after)
           }),
         on: { ToolReturned: "idle" }
       }

--- a/packages/harness/src/serve.ts
+++ b/packages/harness/src/serve.ts
@@ -99,8 +99,8 @@ const ancestry = (origin: MessageOrigin | undefined, maxDepth: number) =>
     return chain
   })
 
-export const serve = <R = never>(
-  agent: Agent<AgentServices | R, any>,
+export const serve = <R = never, Services = unknown>(
+  agent: Agent<AgentServices | R, Services>,
   options: ServeOptions = {}
 ): Serve<R> => {
   const maxDepth = options.maxDepth ?? DEFAULT_MAX_DEPTH

--- a/packages/harness/src/spec.ts
+++ b/packages/harness/src/spec.ts
@@ -1,0 +1,106 @@
+import type { NativeToolSpec } from "./infer"
+
+// A tool's input, declared once. The value carries the JSON Schema the model reads and the
+// TypeScript type the handler receives, so the two can not drift: the schema says `orderId` and
+// the handler reads `input.orderId`, checked by the compiler.
+//
+// Writing them separately is the older shape, and it is still legal: `NativeToolSpec` takes any
+// `inputSchema` and a handler can cast. The cast is where drift lives, and a drifted field reads
+// as `undefined` at runtime rather than failing, so the typed door exists to make the compiler
+// hold both halves at once.
+//
+// The subset is the one a tool input actually uses: strings, numbers, booleans, enums, arrays,
+// objects, and optional fields. It is the same subset `answerErrors` validates, so the schema this
+// builds is checkable at dispatch by the checker that already exists.
+
+declare const carried: unique symbol
+
+export interface Spec<Value> {
+  readonly json: Record<string, unknown>
+  // The type this spec describes. It is never present at runtime; it carries `Value` through
+  // inference so a handler's input type is the schema's type. It is a value position rather than a
+  // parameter position so that a `Spec<string>` is a `Spec<unknown>`, which is what lets one
+  // object shape hold specs of different types.
+  readonly [carried]?: Value
+}
+
+const of = <Value>(json: Record<string, unknown>): Spec<Value> => ({ json })
+
+export const string = (description?: string): Spec<string> =>
+  of({ type: "string", ...(description === undefined ? {} : { description }) })
+
+export const number = (description?: string): Spec<number> =>
+  of({ type: "number", ...(description === undefined ? {} : { description }) })
+
+export const integer = (description?: string): Spec<number> =>
+  of({ type: "integer", ...(description === undefined ? {} : { description }) })
+
+export const boolean = (description?: string): Spec<boolean> =>
+  of({ type: "boolean", ...(description === undefined ? {} : { description }) })
+
+export const literal = <const Values extends ReadonlyArray<string>>(
+  ...values: Values
+): Spec<Values[number]> => of({ type: "string", enum: [...values] })
+
+export const array = <Value>(items: Spec<Value>, description?: string): Spec<ReadonlyArray<Value>> =>
+  of({
+    type: "array",
+    items: items.json,
+    ...(description === undefined ? {} : { description })
+  })
+
+// A field the caller may leave out. The object builder reads it to decide what `required` lists.
+const optionalMark: unique symbol = Symbol.for("flamecast/spec/optional")
+
+export interface Optional<Value> extends Spec<Value | undefined> {
+  readonly [optionalMark]: true
+}
+
+export const optional = <Value>(spec: Spec<Value>): Optional<Value> => ({
+  json: spec.json,
+  [optionalMark]: true
+})
+
+const isOptional = (spec: Spec<unknown>): boolean =>
+  (spec as Partial<Optional<unknown>>)[optionalMark] === true
+
+type Fields<Shape extends Record<string, Spec<unknown>>> = {
+  readonly [Key in keyof Shape as Shape[Key] extends Optional<unknown> ? never : Key]: Carried<
+    Shape[Key]
+  >
+} & {
+  readonly [Key in keyof Shape as Shape[Key] extends Optional<unknown> ? Key : never]?: Carried<
+    Shape[Key]
+  >
+}
+
+type Carried<One> = One extends Optional<infer Value>
+  ? Value
+  : One extends Spec<infer Value>
+    ? Value
+    : never
+
+// An object input. `additionalProperties` is false because a model that invents a field is
+// guessing, and a guess that lands silently is the failure this whole file exists to prevent.
+export const object = <const Shape extends Record<string, Spec<unknown>>>(
+  shape: Shape
+): Spec<{ [Key in keyof Fields<Shape>]: Fields<Shape>[Key] }> => {
+  const required = Object.entries(shape)
+    .filter(([, spec]) => !isOptional(spec))
+    .map(([name]) => name)
+  return of({
+    type: "object",
+    properties: Object.fromEntries(Object.entries(shape).map(([name, spec]) => [name, spec.json])),
+    ...(required.length === 0 ? {} : { required }),
+    additionalProperties: false
+  })
+}
+
+// The type a spec describes, for a caller that wants to name it.
+export type Input<One> = One extends Spec<infer Value> ? Value : never
+
+export const specOf = <Value>(
+  name: string,
+  description: string,
+  input: Spec<Value>
+): NativeToolSpec => ({ name, description, inputSchema: input.json })

--- a/packages/harness/src/tool.test.ts
+++ b/packages/harness/src/tool.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { array, boolean, integer, literal, object, optional, string } from "./spec"
+import { tool } from "./tool"
+
+// One declaration is both halves. These tests pin the schema the model reads and the check that
+// runs before the handler, since the compiler covers the third half in the type tests.
+
+describe("spec", () => {
+  test("an object declares its properties, its required fields, and no others", () => {
+    const input = object({
+      orderId: string("The order to look up."),
+      limit: optional(integer()),
+      tags: array(string()),
+      mode: literal("fast", "thorough"),
+      dryRun: boolean()
+    })
+    expect(input.json).toEqual({
+      type: "object",
+      properties: {
+        orderId: { type: "string", description: "The order to look up." },
+        limit: { type: "integer" },
+        tags: { type: "array", items: { type: "string" } },
+        mode: { type: "string", enum: ["fast", "thorough"] },
+        dryRun: { type: "boolean" }
+      },
+      required: ["orderId", "tags", "mode", "dryRun"],
+      additionalProperties: false
+    })
+  })
+
+  test("an object with only optional fields requires nothing", () => {
+    expect(object({ note: optional(string()) }).json).toEqual({
+      type: "object",
+      properties: { note: { type: "string" } },
+      additionalProperties: false
+    })
+  })
+})
+
+describe("tool", () => {
+  const lookup = tool({
+    name: "lookup_invoice",
+    description: "Look up one invoice by order id.",
+    input: object({ orderId: string(), limit: optional(integer()) }),
+    run: (input) => Effect.succeed({ invoice: `INV-${input.orderId}`, limit: input.limit ?? 10 })
+  })
+
+  test("the schema the model reads is the schema the handler was typed against", () => {
+    expect(lookup.spec).toEqual({
+      name: "lookup_invoice",
+      description: "Look up one invoice by order id.",
+      inputSchema: {
+        type: "object",
+        properties: { orderId: { type: "string" }, limit: { type: "integer" } },
+        required: ["orderId"],
+        additionalProperties: false
+      }
+    })
+  })
+
+  test("conforming arguments reach the handler", async () => {
+    const result = await Effect.runPromise(lookup.run({ orderId: "4182" }))
+    expect(result).toEqual({ invoice: "INV-4182", limit: 10 })
+  })
+
+  // A model can produce a well-formed call whose arguments miss the schema. The handler is typed
+  // against that schema, so running it on those arguments would be reading a lie.
+  test("a missing required field returns an error the model can repair", async () => {
+    const result = await Effect.runPromise(lookup.run({}))
+    expect(String((result as { error: string }).error)).toContain("/orderId: required")
+  })
+
+  test("a field of the wrong type never reaches the handler", async () => {
+    const result = await Effect.runPromise(lookup.run({ orderId: 4182 }))
+    expect(String((result as { error: string }).error)).toContain("expected string, got number")
+  })
+
+  test("an invented field is refused rather than ignored", async () => {
+    const result = await Effect.runPromise(lookup.run({ orderId: "4182", sneaky: true }))
+    expect(String((result as { error: string }).error)).toContain("/sneaky: not allowed here")
+  })
+
+  test("an absent optional field is not an error", async () => {
+    const result = await Effect.runPromise(lookup.run({ orderId: "4182", limit: 3 }))
+    expect(result).toEqual({ invoice: "INV-4182", limit: 3 })
+  })
+})

--- a/packages/harness/src/tool.ts
+++ b/packages/harness/src/tool.ts
@@ -1,0 +1,39 @@
+import { Effect } from "effect"
+import type { NativeTool, NativeToolContext } from "./infer"
+import { answerErrors } from "./schema"
+import type { Spec } from "./spec"
+
+// A tool whose schema and handler are one declaration. The input type the handler receives is the
+// type its own schema describes, so a field the schema does not offer is a compile error rather
+// than an `undefined` the handler reads at runtime.
+//
+// Arguments are checked before the handler runs. A model can produce a well-formed call whose
+// arguments miss the schema, and a handler typed against that schema would then be reading a lie.
+// The check is the one `answerErrors` already performs for the answer tool, so a tool and an
+// answer hold their arguments to the same standard, and a mismatch returns to the model as an
+// ordinary tool error it can repair.
+
+export interface ToolOptions<Value, R> {
+  readonly name: string
+  readonly description: string
+  readonly input: Spec<Value>
+  readonly run: (input: Value, context?: NativeToolContext) => Effect.Effect<unknown, never, R>
+}
+
+export const tool = <Value, R = never>(options: ToolOptions<Value, R>): NativeTool<R> => ({
+  spec: {
+    name: options.name,
+    description: options.description,
+    inputSchema: options.input.json
+  },
+  run: (input, context) =>
+    Effect.suspend(() => {
+      const errors = answerErrors(options.input.json, input)
+      if (errors.length > 0) {
+        return Effect.succeed({
+          error: `the arguments did not match this tool's schema: ${errors.join("; ")}`
+        })
+      }
+      return options.run(input as Value, context)
+    })
+})

--- a/packages/runtime-in-memory/src/runtime.test.ts
+++ b/packages/runtime-in-memory/src/runtime.test.ts
@@ -18,7 +18,7 @@ import {
   type DedupKey,
   type Event
 } from "@flamecast/core"
-import { InMemoryRuntime, type InMemoryOptions } from "./runtime"
+import { InMemoryRuntime, type InMemoryOptions, type SessionPorts } from "./runtime"
 
 // The runtime owes eight ports and six log guarantees. These tests read each guarantee back through
 // the port, because a runtime is trusted for what the core can observe through the seam.
@@ -27,10 +27,16 @@ const ev = (type: string): Event => ({ type })
 
 // The runtime requires a key policy rather than assuming one. These tests run under the core's
 // own, where an event states its own key, and the file says so once here.
-const inRuntime = <A>(
-  program: Effect.Effect<A, never, EventLog | Writer | Wake | Placement | Spill | Sink | Router | Self | Sessions>,
-  { keyOf = dedupKey, ...options }: Omit<InMemoryOptions, "keyOf"> & { readonly keyOf?: DedupKey } = {}
-) => Effect.runPromise(Effect.provide(program, InMemoryRuntime({ ...options, keyOf })))
+const inRuntime = <A, const Keys = Readonly<Record<string, never>>>(
+  program: Effect.Effect<A, never, SessionPorts>,
+  {
+    keyOf = dedupKey,
+    ...options
+  }: Omit<InMemoryOptions<never, Keys>, "keyOf"> & { readonly keyOf?: DedupKey } = {}
+) =>
+  Effect.runPromise(
+    Effect.provide(program, InMemoryRuntime({ ...options, keyOf } as InMemoryOptions<never, Keys>))
+  )
 
 const died = async (program: Effect.Effect<unknown, never, never>) => {
   const exit = await Effect.runPromiseExit(program)

--- a/packages/runtime-in-memory/src/runtime.ts
+++ b/packages/runtime-in-memory/src/runtime.ts
@@ -30,14 +30,47 @@ import { inMemoryEventLog } from "./event-log"
 // What answers at an address: an event goes in, the terminal event comes out. `serve` in the
 // harness turns an agent into one of these, and an application whose sessions are machines rather
 // than agents writes its own function of the same shape.
-export type Serve = (event: Event) => Effect.Effect<Event, never, any>
+//
+// `R` is what the answering session needs beyond the runtime's own ports. It rides the type rather
+// than being erased, so a session that reaches for a service the runtime was not given fails to
+// compile instead of dying on its first delivery.
+export type Serve<R = never> = (
+  event: Event
+) => Effect.Effect<Event, never, SessionPorts | R>
+
+// The ports the runtime binds for every session it serves. A serve function may reach any of them
+// without declaring anything, because the runtime owes them all.
+export type SessionPorts =
+  | EventLog
+  | Writer
+  | Wake
+  | Placement
+  | Spill
+  | Sink
+  | Router
+  | Sessions
+  | Self
+
+// What a family of addresses answers with: the address goes in, and what serves it comes out.
+export type SessionFactory<R = never> = (address: string) => Serve<R>
 
 // Who answers where. An exact key names one address and holds what serves it. A `prefix/*` key, or
-// a bare `*`, names a family and holds a factory that receives the address, so the key's shape says
-// which is which and no marker is needed. The most specific key wins.
-export type SessionRegistry = Readonly<Record<string, Serve | ((address: string) => Serve)>>
+// a bare `*`, names a family and holds a factory that receives the address. The most specific key
+// wins.
+export type SessionRegistry<R = never> = Readonly<
+  Record<string, Serve<R> | SessionFactory<R>>
+>
 
-export interface InMemoryOptions<R = never> {
+// The registry as the caller wrote it, checked key by key. Both halves are one-argument functions,
+// so nothing but the key's shape can say which one a value is meant to be, and a union would let
+// either mistake compile: a factory at an exact key is called with the event as its address, and a
+// serve at a pattern key is called with the address as its event. Both die on delivery. The mapped
+// type reads the key and demands the matching half.
+export type ValidRegistry<Keys, R> = {
+  readonly [Key in keyof Keys]: Key extends `${string}/*` | "*" ? SessionFactory<R> : Serve<R>
+}
+
+export interface InMemoryOptions<R = never, Keys = Readonly<Record<string, never>>> {
   // The dedup key policy the store absorbs redeliveries on, and the one required option.
   //
   // Guarantee 5 of the log port is only real once a policy names the key, and the policy belongs to
@@ -52,13 +85,15 @@ export interface InMemoryOptions<R = never> {
   readonly session?: string
   // The events the primary session starts from. A recorded run seeds the log and a settle resumes it.
   readonly seed?: ReadonlyArray<Event>
-  readonly sessions?: SessionRegistry
+  readonly sessions?: ValidRegistry<Keys, R>
   // What the sessions require beyond the runtime's own ports, such as a sandbox. The runtime binds
   // these for a served session and for a caller alike, so one declaration covers both.
   readonly services?: Context.Context<R>
 }
 
-export const InMemoryRuntime = <R = never>(options: InMemoryOptions<R>) => {
+export const InMemoryRuntime = <R = never, const Keys = Readonly<Record<string, never>>>(
+  options: InMemoryOptions<R, Keys>
+) => {
   const session = options.session ?? "in-memory"
   const registry = options.sessions ?? {}
   const services = options.services ?? (Context.empty() as Context.Context<R>)
@@ -107,20 +142,30 @@ export const InMemoryRuntime = <R = never>(options: InMemoryOptions<R>) => {
   // The resolved behavior for an address, memoized, so a factory runs once per address and a
   // session keeps one behavior for its lifetime. The exact lookup asks for an own property, because
   // a plain object inherits `constructor` and `toString` and a caller can choose the address.
-  const served = new Map<string, Serve>()
-  const serveOf = (address: string): Serve | undefined => {
+  // The registry is typed key by key for the caller. Inside, it is read as the plain record it is.
+  const entries = registry as SessionRegistry<R>
+  const served = new Map<string, Serve<R>>()
+  const serveOf = (address: string): Serve<R> | undefined => {
     const built = served.get(address)
     if (built !== undefined) return built
-    if (Object.hasOwn(registry, address)) {
-      const exact = registry[address] as Serve
+    if (Object.hasOwn(entries, address)) {
+      const exact = entries[address] as Serve<R>
       served.set(address, exact)
       return exact
     }
-    const pattern = Object.entries(registry)
+    const pattern = Object.entries(entries)
       .filter(([key]) => (key === "*" || key.endsWith("/*")) && address.startsWith(key.slice(0, -1)))
       .sort(([a], [b]) => b.length - a.length)[0]
     if (pattern === undefined) return undefined
-    const resolved = (pattern[1] as (address: string) => Serve)(address)
+    // A factory owes a function. A registry written by hand can not get this wrong, because the
+    // key's shape types the value, but a generated one meets no compiler, and returning the wrong
+    // half here would surface as an unreadable defect one call later.
+    const resolved = (pattern[1] as SessionFactory<R>)(address)
+    if (typeof resolved !== "function") {
+      throw new Error(
+        `the registry key "${pattern[0]}" names a family, so it owes a function of the address, and it returned ${typeof resolved}`
+      )
+    }
     served.set(address, resolved)
     return resolved
   }
@@ -192,7 +237,15 @@ export const InMemoryRuntime = <R = never>(options: InMemoryOptions<R>) => {
           error: `no session serves "${address}"`
         })
       }
-      return serve(event).pipe(
+      const answering = serve(event)
+      // The mirror of the factory check: an exact key that holds a factory answers with another
+      // function rather than with the effect of a turn.
+      if (typeof answering === "function") {
+        throw new Error(
+          `the registry key "${address}" names one address, so it owes what serves it, and it answered with a function of the address`
+        )
+      }
+      return answering.pipe(
         Effect.provideService(EventLog, storeOf(address)),
         Effect.provideService(Self, address),
         Effect.provideService(Writer, writer),


### PR DESCRIPTION
## What and why

A framework audit looked for places where a mistake compiles today and then fails silently or late. Eight survived verification, meaning the wrong code was compiled against the workspace and the failure reproduced. Each is now checked at the tier that can catch it: a type for what a human writes, a construction-time throw for what generated code writes, since the framework compiles generated modules and machines.

- **The session registry types both halves by key shape.** A factory at an exact key was called with the event as its address, and a serve at a pattern key with the address as its event. Both compiled and both died on delivery, and addresses are model-chosen under a spawn pattern. A mapped type now reads the key and demands the matching half, with a runtime shape check for a generated registry.
- **`Serve` carries its requirements.** It was `Effect<Event, never, any>`, so a session reaching for a service the runtime was not given compiled and died on its first delivery.
- **A transition on an undeclared event is rejected.** This is the state-name hole from #8 on the other axis of the transition table: the machine simply waits forever. The check found three built-in modules emitting or waiting on events they never declared, so `inference`, `budget`, and `contract` now declare their full alphabets.
- **A withdrawal that names no offered tool is rejected**, and **a function carried in `identity` is rejected**, since the agent id hashes identity and the hash writes every function as one constant, so two behaviors would share an id and a rollout would reuse the wrong recording.
- **`tool(options)` declares a schema and a handler together.** One input spec carries both the JSON Schema the model reads and the TypeScript type the handler receives, so a drifted field is a compile error rather than an `undefined` read. Arguments are checked against that schema before the handler runs, reusing `answerErrors`, so a tool and an answer hold their arguments to one standard.
- **The harness emits its own events through constructors.** A misspelled field compiled, and `keyOf` reads `callId`, so a `ToolReturned` carrying `calId` derived no dedup key and the store quietly stopped absorbing its redeliveries. `Event` stays open at every boundary; this is a gate on the way in.
- **`inference` declares its machines' requirements** instead of casting them to `never`.
- **oxlint rejects `any`.** One wildcard survives, annotated with why: a module tuple's constraint sits in `setup`'s parameter, which is contravariant, and has to accept a module requiring anything and a module requiring nothing at once.

Fixing the type around that wildcard uncovered a live bug this also fixes: **a module written inline inside `createAgent` never typechecked**, because inference read the tuple's element constraint rather than the empty default and concluded the module required every service.

- [x] `bun run gate` passes locally
- [x] Docs updated if behavior changed
- [x] Tests cover the change

Verified: every finding was confirmed by compiling the wrong code before the fix and confirming the error after, including the registry mismatches dying at delivery and `keyOf` returning `undefined` for the misspelled field. New tests cover the composition checks, the inline module, and the spec builder with its dispatch validation. Full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)