### PR TITLE
fix(harness)!: cancel a timed-out request and separate a broken proposer from a declined one

### DIFF
--- a/docs/evolution.md
+++ b/docs/evolution.md
@@ -129,7 +129,7 @@ This buys four things over a bare model call. The proposal arrives through the [
 
 One instruction changes per iteration. Selection walks them in round robin, which is how the paper selects modules, so every instruction receives updates instead of the budget pouring into whichever one the search touched first. `selectTarget` replaces that policy.
 
-A proposer that answers with the instruction it was given has proposed nothing, and a proposer whose turn fails has proposed nothing. Both record their cost and skip the candidate evaluation.
+A proposer that answers with the instruction it was given has proposed nothing. A proposer whose turn never completed is a different fact, and the mutation says which of the two happened.
 
 ## Evolving More Than Prompts
 
@@ -147,6 +147,18 @@ const mutate = reflectiveMutation({
 
 `apply` returns `undefined` when it cannot build a candidate, which is how a generated construction that fails to compile costs a proposal and no evaluations. Each proposal needs an id that no accepted candidate already holds, so an id derived from content carries the iteration as well.
 
+## What a Mutation Answers
+
+A mutation returns one of three things, because they are three different things for the loop to do next.
+
+- `{ kind: "proposed", candidate }` is a candidate to evaluate on the minibatch.
+- `{ kind: "declined", reason }` is the proposer choosing not to propose. The iteration records the reason and the search continues.
+- `{ kind: "failed", error }` is the proposer not running at all. The loop stops, the iteration records the error, and `GepaResult.failure` carries it.
+
+The last one is why the three are separate. A reflection whose transport is down proposes nothing, and so does a reflection that read the trials and judged the instruction already good. Reading the first as the second spends the rest of the budget re-learning that the transport is still down, and reports it as a search that found nothing. A result that carries `failure` was cut short; one that does not ran to its budget.
+
+Cost rides all three, so a run reports what it paid whether or not it got a candidate for it.
+
 ## The Loop
 
 1. It scores the seed on every Pareto example.
@@ -163,7 +175,7 @@ GEPA records the selected parent on proposals that omit `parent`. Each populatio
 
 `maxMetricCalls` counts candidate-example evaluations. The loop starts an iteration when the remaining budget can score an accepted child on the full Pareto set.
 
-The mutation can return `costed(undefined, mutationLog)` for an invalid construction. This records the mutation cost and prevents candidate evaluation.
+A declined mutation records its cost and evaluates no candidate. A failed one does the same and ends the loop.
 
 ## PopuLoRA Search
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -60,6 +60,12 @@ A module says which model answers, and saying that means saying what it accepts,
 
 A gateway that is busy, unwell, or unreachable earns further attempts on a jittered exponential backoff, bounded by `retries`, and one attempt is bounded by `timeout`. Every attempt carries one idempotency key, so a retry after a reply this side never saw is the same call rather than a second one. A refusal earns no retry: a request refused for a bad key is refused the same way every time. A failure that outlives its retries becomes a failed action, which the model loop records as the turn's evidence.
 
+An attempt this side stops waiting for is cancelled. Dropping the wait alone leaves the request running: the model finishes it, the gateway bills for it, and the retry asks for the same completion again, so one turn is paid for twice. `timeout` therefore bounds what the gateway is asked to do rather than only what this side waits for.
+
+`timeout` defaults to ten minutes, which is a guard against a socket that has gone quiet rather than a limit on how long a model may think. A bound inside the range where real answers land discards answers that were on their way, and a reasoning model working for two minutes is inside that range. `headers`, `fetch`, `retries`, and `timeout` are settings of the transport, so every shipped gateway forwards them rather than fixing them.
+
+`openAiChatInference(options)` is the provider those gateways are built from, and it is published. A caller who needs another OpenAI-compatible endpoint, or a header the shipped gateways do not model, writes options rather than a second copy of the request serialization.
+
 A response the gateway stopped at its completion-token limit is a failed action too. The fragment it returns has the shape of an answer, so reading it as one would finish a turn on half a sentence or dispatch a tool call whose arguments stop mid-JSON. The failure carries the usage, because those tokens were spent.
 
 A request estimated past a known context window is refused before it is sent. It cannot succeed, so sending it buys a slow refusal in the gateway's words, and this one names both sizes and the model they belong to. The estimate is characters over four, which runs low against JSON and code, so a refusal means the request is past the window rather than near it.

--- a/packages/evolve/src/gepa.test.ts
+++ b/packages/evolve/src/gepa.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
-import { candidate } from "./candidate"
+import { candidate, type Candidate } from "./candidate"
 import { costed, zeroEvolutionCost } from "./cost"
 import { gepa, type GepaEvaluation } from "./gepa"
 
@@ -10,6 +10,10 @@ interface Harness {
 }
 
 const example = (id: string) => ({ id, value: id })
+// A mutation answers with what to do next, so a test says which of the three it means.
+const proposes = <Value>(built: Candidate<Value>) =>
+  ({ kind: "proposed", candidate: built }) as const
+const nothing = { kind: "declined", reason: "the proposer had nothing better" } as const
 const free = <Value>(value: Value) => costed(value)
 const priced = <Value>(
   value: Value,
@@ -40,7 +44,7 @@ describe("the GEPA loop", () => {
         minibatchSize: 1,
         maxMetricCalls: 2,
         evaluate,
-        mutate: () => Effect.succeed(free(undefined))
+        mutate: () => Effect.succeed(free(nothing))
       })
     )
 
@@ -69,15 +73,17 @@ describe("the GEPA loop", () => {
         mutate: ({ iteration, parent, trials }) => {
           expect(trials[0]?.evaluation.trajectory).toBe(`${parent.value.source}:f1`)
           return Effect.succeed(free(
-            iteration === 0
-              ? candidate("better", {
-                  source: "better.ts",
-                  scores: { f1: 0.8, p1: 0.7, p2: 0.9 }
-                })
-              : candidate("worse", {
-                  source: "worse.ts",
-                  scores: { f1: 0.1, p1: 1, p2: 1 }
-                })
+            proposes(
+              iteration === 0
+                ? candidate("better", {
+                    source: "better.ts",
+                    scores: { f1: 0.8, p1: 0.7, p2: 0.9 }
+                  })
+                : candidate("worse", {
+                    source: "worse.ts",
+                    scores: { f1: 0.1, p1: 1, p2: 1 }
+                  })
+            )
           ))
         }
       })
@@ -130,15 +136,17 @@ describe("the GEPA loop", () => {
         mutate: ({ iteration, parent }) => {
           parents.push(parent.id)
           return Effect.succeed(free(
-            iteration === 0
-              ? candidate("right", {
-                  source: "right.ts",
-                  scores: { feedback: 1, left: 0, middle: 0, right: 1 }
-                })
-              : candidate("discarded", {
-                  source: "discarded.ts",
-                  scores: { feedback: -1, left: 1, middle: 1, right: 1 }
-                })
+            proposes(
+              iteration === 0
+                ? candidate("right", {
+                    source: "right.ts",
+                    scores: { feedback: 1, left: 0, middle: 0, right: 1 }
+                  })
+                : candidate("discarded", {
+                    source: "discarded.ts",
+                    scores: { feedback: -1, left: 1, middle: 1, right: 1 }
+                  })
+            )
           ))
         }
       })
@@ -175,7 +183,7 @@ describe("the GEPA loop", () => {
           })),
         mutate: ({ trials }) => {
           seen.push(...trials.map((trial) => trial.evaluation))
-          return Effect.succeed(free(undefined))
+          return Effect.succeed(free(nothing))
         }
       })
     )
@@ -220,10 +228,12 @@ describe("the GEPA loop", () => {
         mutate: () =>
           Effect.succeed(
             priced(
-              candidate("better", {
-                source: "better.ts",
-                scores: { f1: 1, p1: 1 }
-              }),
+              proposes(
+                candidate("better", {
+                  source: "better.ts",
+                  scores: { f1: 1, p1: 1 }
+                })
+              ),
               5,
               1,
               0.005,
@@ -248,6 +258,63 @@ describe("the GEPA loop", () => {
     expect(result.population.map((entry) => entry.cost.toolCalls)).toEqual([1, 1])
   })
 
+  // A declined proposal and a broken proposer are different facts. The first is the search working
+  // and finding nothing this round. The second is the search unable to run, and every later
+  // iteration would pay a minibatch to discover that again.
+  test("keeps going when a proposer declines", async () => {
+    let mutations = 0
+    const result = await Effect.runPromise(
+      gepa({
+        seed: candidate("seed", { source: "seed.ts", scores: { f1: 0, p1: 0 } }),
+        feedbackExamples: [example("f1")],
+        paretoExamples: [example("p1")],
+        minibatchSize: 1,
+        maxMetricCalls: 7,
+        evaluate,
+        mutate: () => {
+          mutations += 1
+          return Effect.succeed(free(nothing))
+        }
+      })
+    )
+
+    // The loop spends its whole budget rather than stopping, because declining is an answer.
+    expect(mutations).toBe(4)
+    expect(result.failure).toBeUndefined()
+    expect(result.iterations.every((one) => one.declined === "the proposer had nothing better")).toBe(
+      true
+    )
+    expect(result.iterations.every((one) => one.failure === undefined)).toBe(true)
+  })
+
+  test("stops when a proposer reports that it could not run", async () => {
+    let mutations = 0
+    const result = await Effect.runPromise(
+      gepa({
+        seed: candidate("seed", { source: "seed.ts", scores: { f1: 0, p1: 0 } }),
+        feedbackExamples: [example("f1")],
+        paretoExamples: [example("p1")],
+        minibatchSize: 1,
+        maxMetricCalls: 100,
+        evaluate,
+        mutate: () => {
+          mutations += 1
+          return Effect.succeed(
+            free({ kind: "failed", error: "the proposer turn failed: no response" } as const)
+          )
+        }
+      })
+    )
+
+    // One iteration, not the ninety-odd the budget would have allowed.
+    expect(mutations).toBe(1)
+    expect(result.failure).toBe("the proposer turn failed: no response")
+    expect(result.iterations).toHaveLength(1)
+    expect(result.iterations[0]?.failure).toBe("the proposer turn failed: no response")
+    // The parent minibatch and the reflection are still counted, so the run reports what it spent.
+    expect(result.metricCalls).toBe(2)
+  })
+
   test("requires mutations to preserve the selected parent", async () => {
     const run = Effect.runPromise(
       gepa({
@@ -259,10 +326,12 @@ describe("the GEPA loop", () => {
         evaluate,
         mutate: () =>
           Effect.succeed(free(
-            candidate(
-              "child",
-              { source: "child.ts", scores: { f1: 1, p1: 1 } },
-              { parent: "someone-else" }
+            proposes(
+              candidate(
+                "child",
+                { source: "child.ts", scores: { f1: 1, p1: 1 } },
+                { parent: "someone-else" }
+              )
             )
           ))
       })

--- a/packages/evolve/src/gepa.ts
+++ b/packages/evolve/src/gepa.ts
@@ -44,6 +44,31 @@ export interface GepaTrial<Example, Evaluation extends GepaEvaluation> {
   readonly cost: EvolutionCost
 }
 
+// What a mutation answers with. The three cases are three different things to do next, and
+// collapsing them is how a broken proposer reads as a working one.
+//
+// A declined proposal is ordinary: the proposer looked and had nothing better to offer, and the
+// search moves on. A failed one means the proposer itself did not run, so every later iteration
+// would spend a minibatch on the same broken thing. The loop stops on that and says so, which is
+// what a caller needs to retry or to fix the transport rather than to read a wasted budget as a
+// search that found nothing.
+export interface GepaProposed<Value> {
+  readonly kind: "proposed"
+  readonly candidate: Candidate<Value>
+}
+
+export interface GepaDeclined {
+  readonly kind: "declined"
+  readonly reason: string
+}
+
+export interface GepaProposalFailed {
+  readonly kind: "failed"
+  readonly error: string
+}
+
+export type GepaProposal<Value> = GepaProposed<Value> | GepaDeclined | GepaProposalFailed
+
 export interface GepaMutationContext<Value, Example, Evaluation extends GepaEvaluation> {
   readonly iteration: number
   readonly parent: Candidate<Value>
@@ -64,6 +89,10 @@ export interface GepaIteration {
   readonly parentAverage: number
   readonly proposal?: string
   readonly proposalAverage?: number
+  // Why no candidate was evaluated. `declined` is the proposer choosing not to propose. `failure` is
+  // the proposer not running, and it is the last iteration in the result.
+  readonly declined?: string
+  readonly failure?: string
   readonly accepted: boolean
   readonly cost: EvolutionCost
 }
@@ -75,6 +104,9 @@ export interface GepaResult<Value> {
   readonly iterations: ReadonlyArray<GepaIteration>
   readonly metricCalls: number
   readonly cost: EvolutionCost
+  // Why the loop stopped before its budget ran out, when it did. A result carrying this is a search
+  // that was cut short rather than one that finished and found little.
+  readonly failure?: string
 }
 
 export interface GepaOptions<
@@ -98,7 +130,7 @@ export interface GepaOptions<
   readonly mutate: (
     context: GepaMutationContext<Value, Example, Evaluation>
   ) => Effect.Effect<
-    Costed<Candidate<Value> | undefined>,
+    Costed<GepaProposal<Value>>,
     MutationError,
     MutationRequirements
   >
@@ -313,6 +345,7 @@ export const gepa = <
 
     const seed = yield* scoreOnPareto(options.seed)
     let totalCost = seed.cost
+    let failure: string | undefined
     const population: Array<GepaPopulationEntry<Value>> = [seed]
     const iterations: Array<GepaIteration> = []
     const exampleIds = options.paretoExamples.map((example) => example.id)
@@ -336,7 +369,7 @@ export const gepa = <
       const proposed = mutation.value
       const iterationCosts: Array<EvolutionCost> = [parentEvaluation.cost, mutation.cost]
 
-      if (proposed === undefined) {
+      if (proposed.kind !== "proposed") {
         const cost = sumEvolutionCosts(iterationCosts)
         totalCost = sumEvolutionCosts([totalCost, cost])
         iterations.push({
@@ -344,13 +377,22 @@ export const gepa = <
           parent: parent.candidate.id,
           batch: batch.map((example) => example.id),
           parentAverage,
+          ...(proposed.kind === "declined"
+            ? { declined: proposed.reason }
+            : { failure: proposed.error }),
           accepted: false,
           cost
         })
+        // A proposer that did not run will not run on the next iteration either, and each one costs
+        // a minibatch to learn that again. The loop stops and the result says why.
+        if (proposed.kind === "failed") {
+          failure = proposed.error
+          break
+        }
         continue
       }
 
-      const proposal = withParent(proposed, parent.candidate)
+      const proposal = withParent(proposed.candidate, parent.candidate)
       if (population.some((entry) => entry.candidate.id === proposal.id)) {
         throw new Error(`GEPA proposal id "${proposal.id}" already exists in the population`)
       }
@@ -389,7 +431,8 @@ export const gepa = <
       front: frontOf(population, exampleIds),
       iterations,
       metricCalls,
-      cost: totalCost
+      cost: totalCost,
+      ...(failure === undefined ? {} : { failure })
     }
     return result
   })

--- a/packages/evolve/src/index.ts
+++ b/packages/evolve/src/index.ts
@@ -22,6 +22,10 @@ export {
   type GepaMutationContext,
   type GepaOptions,
   type GepaPopulationEntry,
+  type GepaDeclined,
+  type GepaProposal,
+  type GepaProposalFailed,
+  type GepaProposed,
   type GepaResult,
   type GepaTrial
 } from "./gepa"

--- a/packages/evolve/src/reflect.test.ts
+++ b/packages/evolve/src/reflect.test.ts
@@ -12,7 +12,7 @@ import {
 import { InMemoryRuntime } from "@flamecast/runtime-in-memory"
 import { candidate } from "./candidate"
 import { costed } from "./cost"
-import { gepa, type GepaMutationContext } from "./gepa"
+import { gepa, type GepaMutationContext, type GepaProposal } from "./gepa"
 import {
   evaluationOf,
   feedbackOf,
@@ -59,6 +59,14 @@ const run = <A>(
       Layer.merge(InMemoryRuntime({ keyOf, session: "search" }), model)
     )
   )
+
+// A mutation answers with what to do next, so a test says which case it expects before reading it.
+const proposedBy = (proposal: GepaProposal<Prompts>) => {
+  if (proposal.kind !== "proposed") {
+    throw new Error(`expected a proposal, and the mutation answered "${proposal.kind}"`)
+  }
+  return proposal.candidate
+}
 
 const trial = (id: string, value: string, evaluation: {
   readonly score: number
@@ -173,11 +181,11 @@ describe("the reflective mutation", () => {
       model.layer
     )
 
-    expect(result.value?.value).toEqual({
+    expect(proposedBy(result.value).value).toEqual({
       "inference.system": "Answer the billing question. Always state the tax line.",
       tone: "Write in plain English."
     })
-    expect(result.value?.parent).toBe("seed")
+    expect(proposedBy(result.value).parent).toBe("seed")
     // The proposer is an agent, so what it spent is priced from its own log by the same projection
     // that prices an evaluation.
     expect(result.cost).toEqual({
@@ -211,8 +219,8 @@ describe("the reflective mutation", () => {
     const second = await run(mutate(contextOf(prompts, 1, trials)), model.layer)
 
     expect(targets).toEqual(["inference.system", "tone"])
-    expect(first.value?.value["inference.system"]).toBe("first rewrite")
-    expect(second.value?.value.tone).toBe("second rewrite")
+    expect(proposedBy(first.value).value["inference.system"]).toBe("first rewrite")
+    expect(proposedBy(second.value).value.tone).toBe("second rewrite")
   })
 
   test("selects by round robin without being told to", async () => {
@@ -224,8 +232,8 @@ describe("the reflective mutation", () => {
       model.layer
     )
 
-    expect(result.value?.value.tone).toBe("a rewrite of the tone")
-    expect(result.value?.value["inference.system"]).toBe("Answer the billing question.")
+    expect(proposedBy(result.value).value.tone).toBe("a rewrite of the tone")
+    expect(proposedBy(result.value).value["inference.system"]).toBe("Answer the billing question.")
   })
 
   test("reflects with the proposer's own system instruction", async () => {
@@ -238,7 +246,9 @@ describe("the reflective mutation", () => {
       model.layer
     )
 
-    expect(result.value?.value["inference.system"]).toBe("a rewrite from the default proposer")
+    expect(proposedBy(result.value).value["inference.system"]).toBe(
+      "a rewrite from the default proposer"
+    )
     expect(model.seen[0]?.system).toContain("You rewrite the instructions")
   })
 
@@ -251,12 +261,16 @@ describe("the reflective mutation", () => {
       model.layer
     )
 
-    // No candidate, and the reflection is still priced: the loop paid for the thinking.
-    expect(result.value).toBeUndefined()
+    // Declined rather than failed: the proposer ran and chose to leave the instruction alone, so the
+    // search keeps going. The reflection is still priced, because the loop paid for the thinking.
+    expect(result.value.kind).toBe("declined")
     expect(result.cost.completionTokens).toBe(60)
   })
 
-  test("proposes nothing when the proposer turn fails", async () => {
+  // The defect this pins: a proposer that broke answered with the same "nothing" as a proposer that
+  // chose not to propose, so a search whose transport was down read as a search that found nothing
+  // and spent the rest of its budget proving it.
+  test("reports a failure when the proposer turn does not complete", async () => {
     const model = scripted([{ kind: "fail", error: "the provider refused", usage }])
     const mutate = reflectivePrompts({ proposer: proposer({ contextWindow: 200_000 }) })
 
@@ -265,7 +279,10 @@ describe("the reflective mutation", () => {
       model.layer
     )
 
-    expect(result.value).toBeUndefined()
+    expect(result.value.kind).toBe("failed")
+    expect(result.value.kind === "failed" ? result.value.error : "").toContain(
+      "the provider refused"
+    )
     expect(result.cost.promptTokens).toBe(900)
   })
 
@@ -278,7 +295,7 @@ describe("the reflective mutation", () => {
       model.layer
     )
 
-    expect(result.value).toBeUndefined()
+    expect(result.value.kind).toBe("declined")
     expect(model.seen).toEqual([])
   })
 

--- a/packages/evolve/src/reflect.ts
+++ b/packages/evolve/src/reflect.ts
@@ -27,7 +27,7 @@ import type { InferenceSelection, NativeTool } from "@flamecast/harness/infer"
 import type { InferenceOptions } from "@flamecast/harness/modules/inference"
 import { candidate, type Candidate } from "./candidate"
 import { costed } from "./cost"
-import type { GepaEvaluation, GepaMutationContext } from "./gepa"
+import type { GepaEvaluation, GepaMutationContext, GepaProposal } from "./gepa"
 import { scoreOf, verdictsOf } from "./score"
 
 // The paper's feedback function over a Flamework log.
@@ -258,6 +258,24 @@ export interface ReflectiveMutationOptions<
   readonly budget?: number
 }
 
+const proposed = <Value>(built: Candidate<Value>): GepaProposal<Value> => ({
+  kind: "proposed",
+  candidate: built
+})
+
+const declined = (reason: string): GepaProposal<never> => ({ kind: "declined", reason })
+
+const failedProposal = (error: string): GepaProposal<never> => ({ kind: "failed", error })
+
+// Why the reflection turn did not answer, in the words the turn itself recorded.
+const reflectionFailure = (result: TurnResult): string => {
+  if (result.kind === "failed") return `the proposer turn failed: ${result.error}`
+  if (result.kind === "parked") {
+    return `the proposer turn parked asking for more budget: ${result.reason}`
+  }
+  return "the proposer turn did not finish"
+}
+
 // Round robin over the candidate's instructions, which is what the paper selects modules with: every
 // instruction receives updates rather than the search pouring its budget into whichever one it
 // touched first.
@@ -282,9 +300,11 @@ export const reflectiveMutation = <
   return (context: GepaMutationContext<Value, Example, Evaluation>) =>
     Effect.gen(function* () {
       const targets = options.instructionsOf(context.parent.value)
-      if (targets.length === 0) return costed(undefined)
+      if (targets.length === 0) {
+        return costed(declined("the candidate exposes no instruction to rewrite"))
+      }
       const target = select(targets, context)
-      if (target === undefined) return costed(undefined)
+      if (target === undefined) return costed(declined("no instruction was selected to rewrite"))
       const prompt = reflectionPrompt({
         instruction: target,
         trials: context.trials.map((trial) => ({
@@ -308,14 +328,31 @@ export const reflectiveMutation = <
         ...(options.budget === undefined ? {} : { budget: options.budget })
       })
       const log = yield* session.log
-      if (result.kind !== "completed") return costed(undefined, log)
+      // A turn that did not complete is the proposer breaking, which is a different fact from the
+      // proposer declining. The reflection never ran, so reading it as "nothing better to offer"
+      // would spend the rest of the budget re-learning that the transport is down.
+      if (result.kind !== "completed") {
+        return costed(failedProposal(reflectionFailure(result)), log)
+      }
       const rewritten = instructionIn(result.output)
+      if (rewritten === undefined) {
+        return costed(
+          failedProposal("the proposer completed without answering through the contract"),
+          log
+        )
+      }
       // A proposer that answers with the instruction it was given has proposed nothing. Evaluating
       // it would spend a minibatch to learn that a candidate ties itself.
-      if (rewritten === undefined || rewritten.trim() === "" || rewritten === target.text) {
-        return costed(undefined, log)
+      if (rewritten.trim() === "" || rewritten === target.text) {
+        return costed(declined(`the proposer left "${target.id}" as it was`), log)
       }
-      return costed(options.apply({ id: target.id, text: rewritten }, context), log)
+      const built = options.apply({ id: target.id, text: rewritten }, context)
+      return costed(
+        built === undefined
+          ? declined(`the rewritten "${target.id}" did not build a candidate`)
+          : proposed(built),
+        log
+      )
     })
 }
 

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -93,6 +93,14 @@ export {
   cloudflareGatewayInference,
   type CloudflareGatewayInferenceOptions
 } from "./providers/cloudflare-gateway"
+// The OpenAI-compatible provider the shipped gateways are built from. It is published so a caller
+// who needs a different endpoint, or a header the gateways do not model, writes options rather than
+// a second copy of the request serialization.
+export {
+  openAiChatInference,
+  type OpenAiChatOptions,
+  type TransportOptions
+} from "./providers/openai-chat"
 export {
   vercelGatewayInference,
   type VercelGatewayInferenceOptions

--- a/packages/harness/src/providers/cloudflare-gateway.ts
+++ b/packages/harness/src/providers/cloudflare-gateway.ts
@@ -1,7 +1,7 @@
-import { Config, Redacted } from "effect"
+import { Config, Duration, Redacted } from "effect"
 import type { InferenceProvider } from "../infer"
 import { environment, environmentNumber } from "./environment"
-import { openAiChatInference } from "./openai-chat"
+import { openAiChatInference, transport } from "./openai-chat"
 
 export interface CloudflareGatewayInferenceOptions {
   readonly accountId?: string
@@ -14,6 +14,10 @@ export interface CloudflareGatewayInferenceOptions {
   readonly contextWindow?: number
   readonly baseUrl?: string
   readonly fetch?: typeof fetch
+  // The transport settings, forwarded rather than fixed here.
+  readonly headers?: Readonly<Record<string, string>>
+  readonly retries?: number
+  readonly timeout?: Duration.Input
 }
 
 export const cloudflareGatewayInference = (
@@ -49,8 +53,10 @@ export const cloudflareGatewayInference = (
     contextWindow,
     endpoint: `${baseUrl.replace(/\/$/, "")}/${accountId ?? "missing"}/ai/v1/chat/completions`,
     apiKey: apiToken,
-    ...(gatewayId === undefined ? {} : { headers: { "cf-aig-gateway-id": gatewayId } }),
-    ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
+    ...transport(options),
+    ...(gatewayId === undefined
+      ? {}
+      : { headers: { "cf-aig-gateway-id": gatewayId, ...options.headers } }),
     // The account names the endpoint, so its absence is known here rather than at the request.
     ...(accountId === undefined
       ? {

--- a/packages/harness/src/providers/gateway.test.ts
+++ b/packages/harness/src/providers/gateway.test.ts
@@ -334,6 +334,33 @@ describe("Vercel AI Gateway", () => {
     expect(called).toBe(true)
   })
 
+  // The defect this pins: the provider accepted a timeout, a retry count, and headers, and the
+  // gateway that builds it forwarded none of them. A caller in front of a slow model had no way to
+  // move the bound except to reimplement the provider.
+  test("forwards the transport settings a caller states", async () => {
+    const seen: Array<Headers> = []
+    const stub = (async (_url: string, init: RequestInit) => {
+      seen.push(new Headers(init.headers))
+      return await new Promise<Response>(() => {})
+    }) as unknown as typeof fetch
+    const provider = vercelGatewayInference({
+      apiKey: "vercel-key",
+      contextWindow: 200_000,
+      headers: { "x-trace": "abc" },
+      retries: 0,
+      timeout: "10 millis",
+      fetch: stub
+    })
+
+    const action = await Effect.runPromise(provider.react(request, "k"))
+
+    expect(action.kind).toBe("fail")
+    expect(String(action.kind === "fail" ? action.error : "")).toContain("timeout")
+    // One attempt, because the caller asked for no retries.
+    expect(seen).toHaveLength(1)
+    expect(seen[0]?.get("x-trace")).toBe("abc")
+  })
+
   // The key is read from configuration rather than from the machine's environment, so the test
   // supplies the configuration it wants and asks nothing of the machine it runs on.
   test("fails before fetch when no key is configured", async () => {
@@ -417,6 +444,29 @@ describe("Cloudflare AI Gateway", () => {
     )
     expect(calls[0]?.headers.get("authorization")).toBe("Bearer cloudflare-token")
     expect(calls[0]?.headers.get("cf-aig-gateway-id")).toBe("support-gateway")
+  })
+
+  test("forwards the transport settings beside its own gateway header", async () => {
+    const seen: Array<Headers> = []
+    const stub = (async (_url: string, init: RequestInit) => {
+      seen.push(new Headers(init.headers))
+      return await new Promise<Response>(() => {})
+    }) as unknown as typeof fetch
+    const provider = cloudflareGatewayInference({
+      accountId: "account-1",
+      apiToken: "cloudflare-token",
+      gatewayId: "support-gateway",
+      contextWindow: 200_000,
+      headers: { "x-trace": "abc" },
+      retries: 0,
+      timeout: "10 millis",
+      fetch: stub
+    })
+
+    await Effect.runPromise(provider.react(request, "k"))
+
+    expect(seen[0]?.get("x-trace")).toBe("abc")
+    expect(seen[0]?.get("cf-aig-gateway-id")).toBe("support-gateway")
   })
 
   test("reports missing account configuration without a network call", async () => {

--- a/packages/harness/src/providers/openai-chat.ts
+++ b/packages/harness/src/providers/openai-chat.ts
@@ -30,6 +30,23 @@ export interface OpenAiChatOptions {
   readonly timeout?: Duration.Input
 }
 
+// What a gateway forwards rather than fixes. Every gateway built on this provider has the same four,
+// and one that swallowed them would leave a caller reimplementing the whole provider to change one
+// number, which is what a gateway in front of a slow model needs to do.
+export interface TransportOptions {
+  readonly headers?: Readonly<Record<string, string>>
+  readonly fetch?: typeof fetch
+  readonly retries?: number
+  readonly timeout?: Duration.Input
+}
+
+export const transport = (options: TransportOptions) => ({
+  ...(options.headers === undefined ? {} : { headers: options.headers }),
+  ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
+  ...(options.retries === undefined ? {} : { retries: options.retries }),
+  ...(options.timeout === undefined ? {} : { timeout: options.timeout })
+})
+
 interface ChatToolCall {
   readonly id?: unknown
   readonly function?: { readonly name?: unknown; readonly arguments?: unknown }
@@ -178,7 +195,13 @@ const RETRYABLE = new Set([408, 409, 425, 429])
 const isTransient = (status: number) => status >= 500 || RETRYABLE.has(status)
 
 const DEFAULT_RETRIES = 2
-const DEFAULT_TIMEOUT: Duration.Input = "60 seconds"
+
+// How long one attempt may take before this side stops waiting. It is a guard against a socket that
+// has gone quiet, so it sits well outside the range where real answers land: a reasoning model
+// thinking for two minutes is working, and a connection silent for ten is hung. A bound inside that
+// range discards answers that were on their way, which is the failure this number is set to avoid
+// rather than the one it is set to cause. `timeout` moves it.
+const DEFAULT_TIMEOUT: Duration.Input = "10 minutes"
 
 // Waiting longer each time is what makes a retry useful to a gateway that is shedding load, and the
 // jitter is what stops a fleet of agents that failed together from returning together.
@@ -235,7 +258,11 @@ const reacted = (
   if (refusal !== undefined) return Effect.succeed(refusal)
   const attempt = Effect.gen(function* () {
     const response = yield* Effect.tryPromise({
-      try: () =>
+      // The signal is what makes an interruption reach the gateway. Without it, a timed-out attempt
+      // stops being awaited and keeps running: the model finishes, the provider bills for it, and
+      // the retry asks for the same completion again. Every attempt after the first was then paid
+      // for twice for a turn that recorded a failure.
+      try: (signal) =>
         call(options.endpoint, {
           method: "POST",
           headers: {
@@ -246,7 +273,8 @@ const reacted = (
             "idempotency-key": key,
             ...options.headers
           },
-          body
+          body,
+          signal
         }),
       catch: (error) => failed(error instanceof Error ? error.message : String(error))
     })

--- a/packages/harness/src/providers/retry.test.ts
+++ b/packages/harness/src/providers/retry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { Config, Effect, Fiber, Redacted } from "effect"
+import { Config, Duration, Effect, Fiber, Redacted } from "effect"
 import { TestClock } from "effect/testing"
 import type { Action, ModelRequest } from "../infer"
 import { openAiChatInference } from "./openai-chat"
@@ -21,7 +21,10 @@ const answer = JSON.stringify({
   usage: { prompt_tokens: 10, completion_tokens: 4, cost_usd: 0.001 }
 })
 
-const provider = (stub: typeof fetch, options: { readonly retries?: number } = {}) =>
+const provider = (
+  stub: typeof fetch,
+  options: { readonly retries?: number; readonly timeout?: Duration.Input } = {}
+) =>
   openAiChatInference({
     id: "test",
     provider: "test-gateway",
@@ -116,17 +119,50 @@ describe("a refusal", () => {
 })
 
 describe("a silent gateway", () => {
-  test("costs one timeout rather than the turn", async () => {
+  // A gateway that accepts the request and never answers.
+  const silent = () => {
+    const signals: Array<AbortSignal> = []
     let attempts = 0
-    const stub = (async () => {
+    const stub = (async (_url: string, init: RequestInit) => {
       attempts += 1
-      // A gateway that accepts the request and never answers.
+      if (init.signal !== null && init.signal !== undefined) signals.push(init.signal)
       return await new Promise<Response>(() => {})
     }) as unknown as typeof fetch
-    const result = await settled(provider(stub, { retries: 0 }).react(request, "turn/infer/0"))
+    return { signals, stub, attempts: () => attempts }
+  }
+
+  test("costs one timeout rather than the turn", async () => {
+    const gateway = silent()
+    const result = await settled(
+      provider(gateway.stub, { retries: 0, timeout: "2 minutes" }).react(request, "turn/infer/0")
+    )
 
     expect(result).toMatchObject({ kind: "fail" })
     expect(String((result as { error: string }).error)).toContain("timeout")
-    expect(attempts).toBe(1)
+    expect(gateway.attempts()).toBe(1)
+  })
+
+  // The defect this pins: a timed-out attempt that is only stopped being awaited keeps running. The
+  // model finishes, the gateway bills for it, and the retry asks for the same completion again, so
+  // a turn that recorded a failure was paid for two or three times over.
+  test("aborts the request it gave up on", async () => {
+    const gateway = silent()
+    await settled(
+      provider(gateway.stub, { retries: 0, timeout: "2 minutes" }).react(request, "turn/infer/0")
+    )
+
+    expect(gateway.signals).toHaveLength(1)
+    expect(gateway.signals[0]?.aborted).toBe(true)
+  })
+
+  test("takes the timeout the caller states", async () => {
+    const gateway = silent()
+    // Under the default this attempt is still in flight when the clock stops, so a result at all is
+    // the caller's bound being read.
+    const result = await settled(
+      provider(gateway.stub, { retries: 0, timeout: "30 seconds" }).react(request, "turn/infer/0")
+    )
+
+    expect(result).toMatchObject({ kind: "fail" })
   })
 })

--- a/packages/harness/src/providers/vercel-gateway.ts
+++ b/packages/harness/src/providers/vercel-gateway.ts
@@ -1,7 +1,7 @@
-import { Config, Effect, Redacted } from "effect"
+import { Config, Duration, Effect, Redacted } from "effect"
 import type { InferenceProvider } from "../infer"
 import { environment, environmentNumber } from "./environment"
-import { openAiChatInference } from "./openai-chat"
+import { openAiChatInference, transport } from "./openai-chat"
 
 export interface VercelGatewayInferenceOptions {
   readonly apiKey?: string
@@ -11,6 +11,12 @@ export interface VercelGatewayInferenceOptions {
   readonly contextWindow?: number
   readonly baseUrl?: string
   readonly fetch?: typeof fetch
+  // The transport settings, forwarded rather than fixed here. A gateway in front of a reasoning
+  // model answers on a different scale from one in front of a small one, and the caller is the only
+  // one who knows which they have.
+  readonly headers?: Readonly<Record<string, string>>
+  readonly retries?: number
+  readonly timeout?: Duration.Input
 }
 
 // What each model accepts, as the gateway publishes it. The context window belongs to the model, so
@@ -82,7 +88,7 @@ const build = (
     contextWindow,
     endpoint: `${baseUrl}/chat/completions`,
     apiKey,
-    ...(options.fetch === undefined ? {} : { fetch: options.fetch })
+    ...transport(options)
   })
 
 // The key is the one secret here, so it is the one setting read as a `Config`: it is resolved where


### PR DESCRIPTION
## What and why

Three defects reported from a paid GEPA run against pin `91fb8a6`. All three were verified against the source before fixing, and each fix has a test that fails against the previous behavior.

### The transport discarded valid answers and paid for them anyway

A reflection call finishing in seventy seconds was thrown away and billed three times. Three things combined:

- **The bound was `"60 seconds"`**, which sits inside the range where real answers land. A reasoning model working for seventy seconds is working, not hung.
- **Dropping the wait did not stop the request.** `Effect.timeoutOrElse` stops awaiting an attempt. With no signal on the fetch, the request keeps running: the model finishes it, the gateway bills for it, and the retry asks for the same completion again. One turn, paid for three times, every answer discarded.
- **Neither could be moved.** `timeout` and `retries` existed on `OpenAiChatOptions` and no gateway forwarded them, so the only way past sixty seconds was to reimplement the request serialization.

`Effect.tryPromise` now passes its `AbortSignal` to the fetch. `timeout` defaults to ten minutes, which guards a socket that has gone quiet rather than limiting how long a model may think. `headers`, `fetch`, `retries`, and `timeout` are forwarded by both shipped gateways. `openAiChatInference` is published so another OpenAI-compatible endpoint is options rather than a fork.

### A broken proposer read as a working one

`reflectiveMutation` answered `undefined` both when the proposer read the trials and had nothing better to offer, and when the proposer never ran. Those want opposite responses. The first is the search working. The second is the search unable to work, and the loop went on spending a minibatch per iteration to rediscover it, then reported a burned budget as a search that found nothing. The reported run hit exactly this: the reflection turn timed out, and the search proceeded to its holdout with the parent unchanged and no record of why.

A mutation now returns `GepaProposal<Value>`:

- `{ kind: "proposed", candidate }` evaluates on the minibatch.
- `{ kind: "declined", reason }` records the reason and the search continues.
- `{ kind: "failed", error }` stops the loop and lands on `GepaResult.failure`.

A result with no `failure` ran to its budget. One with it was cut short. Cost rides all three, so a run reports what it paid whether or not it got a candidate for it.

## Breaking

`GepaOptions.mutate` returns `Costed<GepaProposal<Value>>` rather than `Costed<Candidate<Value> | undefined>`. A caller returning a candidate wraps it in `{ kind: "proposed", candidate }`; one returning `undefined` picks between `declined` and `failed`.

The transport change alters two defaults: `timeout` moves from sixty seconds to ten minutes, and a timed-out attempt is now cancelled at the gateway instead of left running.

## Verification

`bun run gate` passes. Each new test was checked by reverting the source and rerunning:

- the request a timeout gave up on carries an aborted signal
- a stated timeout is honoured, and a gateway forwards a stated timeout, retry count, and header
- a declining proposer spends the whole budget and records a reason per iteration
- a failing proposer stops the loop after one iteration rather than ninety, and the error reaches `GepaResult.failure`
- the reflective mutation reports `failed` when its turn does not complete and `declined` when it ran and left the instruction alone

- [x] `bun run gate` passes locally
- [x] Docs updated if behavior changed
- [x] Tests cover the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)