### PR TITLE
feat(harness): let a caller state the model's output ceiling

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -62,7 +62,11 @@ A gateway that is busy, unwell, or unreachable earns further attempts on a jitte
 
 An attempt this side stops waiting for is cancelled. Dropping the wait alone leaves the request running: the model finishes it, the gateway bills for it, and the retry asks for the same completion again, so one turn is paid for twice. `timeout` therefore bounds what the gateway is asked to do rather than only what this side waits for.
 
-`timeout` defaults to ten minutes, which is a guard against a socket that has gone quiet rather than a limit on how long a model may think. A bound inside the range where real answers land discards answers that were on their way, and a reasoning model working for two minutes is inside that range. `headers`, `fetch`, `retries`, and `timeout` are settings of the transport, so every shipped gateway forwards them rather than fixing them.
+`timeout` defaults to ten minutes, which is a guard against a socket that has gone quiet rather than a limit on how long a model may think. A bound inside the range where real answers land discards answers that were on their way, and a reasoning model working for two minutes is inside that range.
+
+`maxOutputTokens` is the ceiling on one answer. Absent leaves it to the gateway's own default for the model, which is right until a turn asks for something long: a reflection that rewrites a source file spends its tokens on the file and on the reasoning that produced it, and a default sized for chat stops it mid-file. That stop is the completion-token failure above, so the option that moves it is the one that failure names.
+
+`headers`, `fetch`, `retries`, `timeout`, and `maxOutputTokens` are settings a gateway forwards rather than fixes.
 
 `openAiChatInference(options)` is the provider those gateways are built from, and it is published. A caller who needs another OpenAI-compatible endpoint, or a header the shipped gateways do not model, writes options rather than a second copy of the request serialization.
 

--- a/packages/harness/src/providers/cloudflare-gateway.ts
+++ b/packages/harness/src/providers/cloudflare-gateway.ts
@@ -18,6 +18,7 @@ export interface CloudflareGatewayInferenceOptions {
   readonly headers?: Readonly<Record<string, string>>
   readonly retries?: number
   readonly timeout?: Duration.Input
+  readonly maxOutputTokens?: number
 }
 
 export const cloudflareGatewayInference = (

--- a/packages/harness/src/providers/gateway.test.ts
+++ b/packages/harness/src/providers/gateway.test.ts
@@ -112,6 +112,8 @@ describe("Vercel AI Gateway", () => {
 
     expect(action.kind).toBe("fail")
     expect(String(action.kind === "fail" ? action.error : "")).toContain("completion-token limit")
+    // The message names the option that moves the ceiling, and that option exists.
+    expect(String(action.kind === "fail" ? action.error : "")).toContain("maxOutputTokens")
     // The tokens were spent, so the turn still costs what it cost.
     expect(action.usage).toEqual({ promptTokens: 900, completionTokens: 4096, costUsd: 0.02 })
   })
@@ -332,6 +334,33 @@ describe("Vercel AI Gateway", () => {
 
     expect(await Effect.runPromise(provider.react(request, "k"))).toMatchObject({ kind: "complete" })
     expect(called).toBe(true)
+  })
+
+  // The ceiling on one answer. Without it the gateway's own default for the model decides, and a
+  // default sized for chat cuts off a reflection that has to write out a source file. The provider
+  // that refuses a truncated answer names this option, so the option has to exist.
+  test("sends the output ceiling a caller states, and none when they state none", async () => {
+    const bodies: Array<Record<string, unknown>> = []
+    const stub = (async (_url: string, init: RequestInit) => {
+      bodies.push(JSON.parse(String(init.body)) as Record<string, unknown>)
+      return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
+        status: 200
+      })
+    }) as unknown as typeof fetch
+    const of = (maxOutputTokens?: number) =>
+      vercelGatewayInference({
+        apiKey: "vercel-key",
+        contextWindow: 200_000,
+        fetch: stub,
+        ...(maxOutputTokens === undefined ? {} : { maxOutputTokens })
+      })
+
+    await Effect.runPromise(of(32_000).react(request, "k"))
+    await Effect.runPromise(of().react(request, "k"))
+
+    expect(bodies[0]?.max_tokens).toBe(32_000)
+    // Absent rather than a figure this side chose, so the model's own default decides.
+    expect(bodies[1]).not.toHaveProperty("max_tokens")
   })
 
   // The defect this pins: the provider accepted a timeout, a retry count, and headers, and the

--- a/packages/harness/src/providers/openai-chat.ts
+++ b/packages/harness/src/providers/openai-chat.ts
@@ -18,6 +18,8 @@ export interface OpenAiChatOptions {
   // it builds one.
   readonly contextWindow: number
   readonly endpoint: string
+  // The ceiling on one answer, in completion tokens. See `TransportOptions`.
+  readonly maxOutputTokens?: number
   // The key is a `Config` rather than a string, so it is read where it is used and stays redacted
   // on the way there. A value that never becomes a plain string can not be printed by an error
   // report or a log line that happened to hold the options.
@@ -30,21 +32,27 @@ export interface OpenAiChatOptions {
   readonly timeout?: Duration.Input
 }
 
-// What a gateway forwards rather than fixes. Every gateway built on this provider has the same four,
-// and one that swallowed them would leave a caller reimplementing the whole provider to change one
-// number, which is what a gateway in front of a slow model needs to do.
+// What a gateway forwards rather than fixes. Every gateway built on this provider takes the same
+// settings, and one that swallowed them would leave a caller reimplementing the whole provider to
+// change one number, which is what a gateway in front of a slow model needs to do.
 export interface TransportOptions {
   readonly headers?: Readonly<Record<string, string>>
   readonly fetch?: typeof fetch
   readonly retries?: number
   readonly timeout?: Duration.Input
+  // The ceiling on one answer, in completion tokens. Absent leaves it to the gateway's own default
+  // for the model, which is the right answer until a turn asks for something long: a reflection that
+  // rewrites a source file spends its tokens on the file and on the reasoning that produced it, and
+  // a default sized for chat cuts it off mid-file.
+  readonly maxOutputTokens?: number
 }
 
 export const transport = (options: TransportOptions) => ({
   ...(options.headers === undefined ? {} : { headers: options.headers }),
   ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
   ...(options.retries === undefined ? {} : { retries: options.retries }),
-  ...(options.timeout === undefined ? {} : { timeout: options.timeout })
+  ...(options.timeout === undefined ? {} : { timeout: options.timeout }),
+  ...(options.maxOutputTokens === undefined ? {} : { maxOutputTokens: options.maxOutputTokens })
 })
 
 interface ChatToolCall {
@@ -130,8 +138,8 @@ const actionOf = (body: ChatResponse): Action => {
     return {
       kind: "fail",
       error:
-        "the model stopped at its completion-token limit, so its answer is incomplete. Raise the " +
-        "model's completion-token limit, or ask for a shorter answer.",
+        "the model stopped at its completion-token limit, so its answer is incomplete. Raise " +
+        "maxOutputTokens on the provider, or ask for a shorter answer.",
       usage
     }
   }
@@ -251,6 +259,9 @@ const reacted = (
       ...(request.system === "" ? [] : [{ role: "system", content: request.system }]),
       ...request.messages.map(message)
     ],
+    ...(options.maxOutputTokens === undefined
+      ? {}
+      : { max_tokens: options.maxOutputTokens }),
     ...(request.tools.length === 0 ? {} : { tools: request.tools.map(tool) })
   })
   const failed = (reason: string): Transient => ({ reason })

--- a/packages/harness/src/providers/vercel-gateway.ts
+++ b/packages/harness/src/providers/vercel-gateway.ts
@@ -17,6 +17,7 @@ export interface VercelGatewayInferenceOptions {
   readonly headers?: Readonly<Record<string, string>>
   readonly retries?: number
   readonly timeout?: Duration.Input
+  readonly maxOutputTokens?: number
 }
 
 // What each model accepts, as the gateway publishes it. The context window belongs to the model, so


### PR DESCRIPTION
## What and why

From a paid GEPA run against `ed7c8036` (post-PR-14). A reflection asked to rewrite a source file stopped at exactly 12,000 completion tokens, mid-file. It failed its output schema, was corrected twice into the same wall, and the search ended with no proposal.

The ceiling was one the caller had injected by wrapping `fetch`, because the provider had no option for it and never sent `max_tokens` at all. So the ceiling in force was whatever the gateway defaulted to for the model, and nothing in the framework could move it.

That gap sat directly under the truncation failure added in #13. That failure tells the caller to raise the model's completion-token limit, and the framework offered no way to do it, so the only route was the same `fetch` wrapper #14 was meant to make deletable. The fix was incomplete without this.

- `maxOutputTokens` sets `max_tokens` on the request, and both shipped gateways forward it.
- Absent sends nothing, so the gateway's own default for the model decides rather than a figure written into the framework.
- The completion-token failure names the option that moves it.

## Verification

`bun run gate` passes. Both new assertions fail against the previous behavior, checked by reverting the source and rerunning:

- a stated ceiling reaches the request body as `max_tokens`
- an unstated one leaves `max_tokens` off the body entirely
- the truncation message names `maxOutputTokens`

- [x] `bun run gate` passes locally
- [x] Docs updated if behavior changed
- [x] Tests cover the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)