### PR TITLE
fix: read limits from the model, and fail where a guess would have been quiet

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,6 +72,18 @@ The framework exposes routing primitives and leaves topology in user code or mod
 
 These primitives support supervisors, peer groups, recursive calls, RLM-style decomposition, and generated orchestration modules. The framework does not install a planner, role taxonomy, or fixed conversation protocol. [Orchestration](orchestration.md) covers the design.
 
+## Visible Failure
+
+Work that can not be done correctly fails, and the failure says what to change. The framework repairs no request by guessing, and it decides nothing on an application's behalf that the application is entitled to decide.
+
+A figure the framework can not know is asked for. The context window belongs to the model, so a provider is built with one or built by reading the gateway's catalog, and a provider with neither fails to construct. A number invented here would be wrong for every model it was never measured against, and it would be wrong silently.
+
+A decision that belongs to a deployment stays with the deployment. Which upstream provider serves a model changes cost, latency, and where data travels, so no provider here states a routing preference. When a route breaks a rule the harness depends on, the turn fails and names the option that reaches a route which holds it.
+
+A result shaped like an answer is checked before it is read as one. An answer stopped at its token ceiling is a fragment, and a turn that accepted it would finish on half a sentence. A tool call whose recorded arguments will not parse would reach the tool with none of what the model asked for.
+
+The failure worth this much care is the quiet one. A gateway that receives a request stripped of its Gemini thought signature answers it anyway, by substituting the sentinel that turns the provider's validation off. The turn succeeds, the model answers without the reasoning it already paid for, and nothing in the reply says so. [inference](modules.md#inference) covers what Flamework carries so that substitution never applies, and `bun run smoke:live` is what checks it against live models, because a stub can not.
+
 ## Invariants
 
 1. The event log is append-only.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -66,6 +66,8 @@ An attempt this side stops waiting for is cancelled. Dropping the wait alone lea
 
 `maxOutputTokens` is the ceiling on one answer. Absent leaves it to the gateway's own default for the model. A long generated artifact can exceed a default sized for chat and stop partway through. That stop is the completion-token failure above, so the option that moves it is the one that failure names.
 
+The Messages API refuses a request that states no ceiling, so a provider for it always sends one. The gateway's catalog publishes the ceiling each model accepts, and a provider built from the catalog sends that figure, which is how a model that can write 128,000 tokens is allowed to. A provider built from a stated context window makes no catalog request, so what is left is the lowest ceiling any Claude model accepts. State `maxOutputTokens` to raise it, and a turn that reaches it says so.
+
 `headers`, `fetch`, `retries`, `timeout`, and `maxOutputTokens` are settings a gateway forwards rather than fixes.
 
 `openAiChatInference(options)` is the provider those gateways are built from, and it is published. A caller who needs another OpenAI-compatible endpoint, or a header the shipped gateways do not model, writes options rather than a second copy of the request serialization.

--- a/packages/harness/src/providers/anthropic-messages.test.ts
+++ b/packages/harness/src/providers/anthropic-messages.test.ts
@@ -174,6 +174,97 @@ describe("an Anthropic model on the Vercel gateway", () => {
     expect(calls[1]).not.toHaveProperty("output_config")
   })
 
+  // The ceiling belongs to the model, and the catalog publishes it. Holding every model to the one
+  // figure that is safe for all of them would cut a long answer short on the models that could have
+  // finished it, and nothing in the reply would say the ceiling was this side's choice.
+  test("takes the output ceiling the catalog publishes for the model", async () => {
+    const bodies: Array<Record<string, unknown>> = []
+    const stub = (async (url: string, init: RequestInit) => {
+      if (String(url).endsWith("/models")) {
+        return new Response(
+          JSON.stringify({
+            object: "list",
+            data: [
+              { id: "anthropic/claude-opus-5", context_window: 1_000_000, max_tokens: 128_000 }
+            ]
+          }),
+          { status: 200 }
+        )
+      }
+      bodies.push(JSON.parse(String(init.body)) as Record<string, unknown>)
+      return new Response(
+        JSON.stringify({ content: [{ type: "text", text: "ok" }], stop_reason: "end_turn" }),
+        { status: 200 }
+      )
+    }) as unknown as typeof fetch
+
+    const built = await Effect.runPromise(
+      vercelGatewayInference({
+        apiKey: "vercel-key",
+        model: "anthropic/claude-opus-5",
+        baseUrl: "https://anthropic-catalog.invalid/v1",
+        fetch: stub
+      })
+    )
+    await Effect.runPromise(built.react(request, "k"))
+
+    expect(bodies[0]?.max_tokens).toBe(128_000)
+  })
+
+  // A caller who states the window has said they know the model's limits, and this call asks the
+  // gateway nothing. What is left is the lowest ceiling any Claude model accepts, because a figure
+  // above what the model allows is refused on every request rather than on a long one.
+  test("falls back to a ceiling every model accepts, and takes the caller's over it", async () => {
+    const bodies: Array<Record<string, unknown>> = []
+    const stub = (async (_url: string, init: RequestInit) => {
+      bodies.push(JSON.parse(String(init.body)) as Record<string, unknown>)
+      return new Response(
+        JSON.stringify({ content: [{ type: "text", text: "ok" }], stop_reason: "end_turn" }),
+        { status: 200 }
+      )
+    }) as unknown as typeof fetch
+
+    await Effect.runPromise(provider(stub).react(request, "k"))
+    await Effect.runPromise(provider(stub, { maxOutputTokens: 64_000 }).react(request, "k"))
+
+    expect(bodies[0]?.max_tokens).toBe(8192)
+    expect(bodies[1]?.max_tokens).toBe(64_000)
+  })
+
+  // This API takes a call's input as a value rather than as the string the other format uses. A
+  // recorded string that will not parse is a broken record, and calling the tool with an empty
+  // input in its place would answer a question the model never asked.
+  test("refuses to replay a tool call whose recorded arguments are not JSON", async () => {
+    let called = false
+    const stub = (async () => {
+      called = true
+      return new Response("{}", { status: 200 })
+    }) as unknown as typeof fetch
+
+    const action = await Effect.runPromise(
+      provider(stub).react(
+        {
+          ...request,
+          messages: [
+            { role: "user", content: "Find order 4182." },
+            {
+              role: "assistant",
+              content: null,
+              toolCalls: [{ id: "c-1", name: "lookup_invoice", arguments: '{"orderId":"41' }]
+            },
+            { role: "tool", toolCallId: "c-1", content: "{}" }
+          ]
+        },
+        "k"
+      )
+    )
+
+    expect(action.kind).toBe("fail")
+    expect(String(action.kind === "fail" ? action.error : "")).toContain("lookup_invoice")
+    expect(String(action.kind === "fail" ? action.error : "")).toContain("not JSON")
+    expect(called).toBe(false)
+  })
+
   test("refuses an answer stopped at the output-token limit", async () => {
     const action = await Effect.runPromise(
       provider(

--- a/packages/harness/src/providers/anthropic-messages.ts
+++ b/packages/harness/src/providers/anthropic-messages.ts
@@ -24,9 +24,11 @@ export interface AnthropicMessagesOptions {
   // folds that read it agree in every process.
   readonly contextWindow: number
   readonly endpoint: string
-  // The ceiling on one answer. This API requires it, so absent means the default below rather than
-  // the model's own, which is the one way this surface differs from the OpenAI-compatible one.
-  readonly maxOutputTokens?: number
+  // The ceiling on one answer, which this API requires in every request. It is required here for the
+  // same reason the context window is: the number belongs to the model, and a figure invented here
+  // would be wrong for every model it was not measured against. A ceiling set low enough to be safe
+  // everywhere cuts a long answer short on the models that could have finished it.
+  readonly maxOutputTokens: number
   // The key is a `Config` rather than a string, so it is read where it is used and stays redacted on
   // the way there.
   readonly apiKey?: Config.Config<Redacted.Redacted<string>>
@@ -43,11 +45,6 @@ export interface AnthropicMessagesOptions {
   // API takes routing options here, so this file holds no vendor's routing vocabulary.
   readonly body?: Readonly<Record<string, unknown>>
 }
-
-// This API requires a ceiling, so one is chosen. It is low enough for every current Claude model to
-// accept and high enough for an ordinary answer. A turn that needs a long artifact raises it, and a
-// turn that hits it fails loudly rather than returning a fragment.
-const DEFAULT_MAX_OUTPUT_TOKENS = 8192
 
 interface ContentBlock {
   readonly type?: unknown
@@ -99,11 +96,17 @@ const carriedBlocks = (
   return Array.isArray(blocks) ? blocks : []
 }
 
+// This API takes a tool call's input as a value rather than as the string the OpenAI-compatible
+// format uses, so the recorded arguments are read back here. A string that will not parse is a
+// broken record: sending an empty object in its place would call the tool with none of what the
+// model asked for, and the tool would answer the wrong question with no sign anything was lost.
+const BAD_ARGUMENTS = Symbol("arguments that are not JSON")
+
 const parsedArguments = (value: string): unknown => {
   try {
     return JSON.parse(value) as unknown
   } catch {
-    return {}
+    return BAD_ARGUMENTS
   }
 }
 
@@ -163,11 +166,19 @@ const joined = (entries: ReadonlyArray<Entry>): ReadonlyArray<Entry> =>
     return all
   }, [])
 
-const messagesOf = (request: ModelRequest) =>
-  joined(request.messages.flatMap((one) => {
+const messagesOf = (request: ModelRequest) => {
+  const entries = request.messages.flatMap((one) => {
     const entry = entryOf(one)
     return entry === undefined ? [] : [entry]
-  }))
+  })
+  const broken = entries
+    .flatMap((entry) => entry.content)
+    .find((block) => (block as { readonly input?: unknown }).input === BAD_ARGUMENTS)
+  if (broken !== undefined) {
+    return { name: String((broken as { readonly name?: unknown }).name ?? "") }
+  }
+  return { messages: joined(entries) }
+}
 
 const usageOf = (usage: MessagesResponse["usage"]): Usage => {
   const count = (value: unknown) => (typeof value === "number" ? value : 0)
@@ -277,11 +288,21 @@ const reacted = (
   key: string,
   secret: string
 ) => {
+  const converted = messagesOf(request)
+  if (converted.messages === undefined) {
+    return Effect.succeed({
+      kind: "fail",
+      error:
+        `the recorded arguments for the ${converted.name} call are not JSON, so this turn can not ` +
+        "be replayed. The log holds what the model asked for, and sending an empty input in its " +
+        "place would call the tool with none of it."
+    } satisfies Action)
+  }
   const body = JSON.stringify({
     model: options.model,
-    max_tokens: options.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
+    max_tokens: options.maxOutputTokens,
     ...(request.system === "" ? {} : { system: request.system }),
-    messages: messagesOf(request),
+    messages: converted.messages,
     ...(request.tools.length === 0
       ? {}
       : {

--- a/packages/harness/src/providers/vercel-gateway.ts
+++ b/packages/harness/src/providers/vercel-gateway.ts
@@ -36,17 +36,25 @@ export interface VercelGatewayInferenceOptions {
 // One catalog per gateway per process, shared by every provider built against it, because the
 // answer is the same for all of them and none of it is a secret. A read that fails is dropped from
 // the table so the next construction tries again rather than inheriting one bad morning.
-const catalogs = new Map<string, Promise<ReadonlyMap<string, number>>>()
+// The catalog publishes an output ceiling beside the window, and the Messages API requires one in
+// every request, so it is read from the model for the same reason the window is.
+interface Limits {
+  readonly contextWindow: number
+  readonly maxOutputTokens?: number
+}
+
+const catalogs = new Map<string, Promise<ReadonlyMap<string, Limits>>>()
 
 interface CatalogEntry {
   readonly id?: unknown
   readonly context_window?: unknown
+  readonly max_tokens?: unknown
 }
 
 const readCatalog = async (
   baseUrl: string,
   call: typeof fetch
-): Promise<ReadonlyMap<string, number>> => {
+): Promise<ReadonlyMap<string, Limits>> => {
   const response = await call(`${baseUrl}/models`)
   if (!response.ok) {
     throw new Error(`the gateway model catalog returned HTTP ${response.status}`)
@@ -55,13 +63,23 @@ const readCatalog = async (
   return new Map(
     (body.data ?? []).flatMap((entry) =>
       typeof entry.id === "string" && typeof entry.context_window === "number"
-        ? ([[entry.id, entry.context_window]] as ReadonlyArray<readonly [string, number]>)
+        ? ([
+            [
+              entry.id,
+              {
+                contextWindow: entry.context_window,
+                ...(typeof entry.max_tokens === "number"
+                  ? { maxOutputTokens: entry.max_tokens }
+                  : {})
+              }
+            ]
+          ] as ReadonlyArray<readonly [string, Limits]>)
         : []
     )
   )
 }
 
-const catalogOf = (baseUrl: string, call: typeof fetch): Promise<ReadonlyMap<string, number>> => {
+const catalogOf = (baseUrl: string, call: typeof fetch): Promise<ReadonlyMap<string, Limits>> => {
   const held = catalogs.get(baseUrl)
   if (held !== undefined) return held
   const reading = readCatalog(baseUrl, call).catch((error: unknown) => {
@@ -91,36 +109,51 @@ const settings = (options: VercelGatewayInferenceOptions) => {
 // built for it.
 const isAnthropic = (model: string) => model.startsWith("anthropic/")
 
+// The Messages API refuses a request that states no ceiling on the answer, so one is always sent.
+// The model publishes its own, and this is what is left when nobody asked the catalog: a caller who
+// states the context window has said they know the model's limits, and this call makes no network
+// request to check. It is the lowest ceiling any Claude model accepts, because a figure above what
+// the model allows is refused on every request rather than on a long one. A turn that reaches it
+// fails and names `maxOutputTokens`, so a ceiling too low for the work says so.
+const SAFE_OUTPUT_TOKENS = 8192
+
 const build = (
   options: VercelGatewayInferenceOptions,
   model: string,
   baseUrl: string,
   apiKey: Config.Config<Redacted.Redacted<string>>,
-  contextWindow: number
-): InferenceProvider =>
-  isAnthropic(model)
-    ? anthropicMessagesInference({
-        id: `vercel-ai-gateway:${model}`,
-        provider: "vercel-ai-gateway",
-        model,
-        contextWindow,
-        endpoint: `${baseUrl}/messages`,
-        apiKey,
-        ...transport(options),
-        ...(options.effort === undefined ? {} : { effort: options.effort }),
-        ...(options.routes === undefined
-          ? {}
-          : { body: { providerOptions: { gateway: { only: options.routes } } } })
-      })
-    : openAiChatInference({
-        id: `vercel-ai-gateway:${model}`,
-        provider: "vercel-ai-gateway",
-        model,
-        contextWindow,
-        endpoint: `${baseUrl}/chat/completions`,
-        apiKey,
-        ...transport(options)
-      })
+  contextWindow: number,
+  publishedOutputTokens?: number
+): InferenceProvider => {
+  if (isAnthropic(model)) {
+    return anthropicMessagesInference({
+      id: `vercel-ai-gateway:${model}`,
+      provider: "vercel-ai-gateway",
+      model,
+      contextWindow,
+      endpoint: `${baseUrl}/messages`,
+      apiKey,
+      ...transport(options),
+      // The caller's ceiling, then the model's own, then the floor below. The published figure is
+      // why a model that can write 128,000 tokens is allowed to, rather than being held to the one
+      // number that would have been safe for every model at once.
+      maxOutputTokens: options.maxOutputTokens ?? publishedOutputTokens ?? SAFE_OUTPUT_TOKENS,
+      ...(options.effort === undefined ? {} : { effort: options.effort }),
+      ...(options.routes === undefined
+        ? {}
+        : { body: { providerOptions: { gateway: { only: options.routes } } } })
+    })
+  }
+  return openAiChatInference({
+    id: `vercel-ai-gateway:${model}`,
+    provider: "vercel-ai-gateway",
+    model,
+    contextWindow,
+    endpoint: `${baseUrl}/chat/completions`,
+    apiKey,
+    ...transport(options)
+  })
+}
 
 // The key is the one secret here, so it is the one setting read as a `Config`: it is resolved where
 // it is used and stays redacted until the request carries it. The model is read at construction
@@ -162,6 +195,20 @@ export function vercelGatewayInference(
         )
       )
     }
-    return build(options, model, baseUrl, apiKey, published)
+    // A construction that can not settle a required figure throws, and this one runs inside an
+    // effect, so the throw becomes the effect's failure rather than a defect the caller can not
+    // catch beside the other construction failures here.
+    return yield* Effect.try({
+      try: () =>
+        build(
+          options,
+          model,
+          baseUrl,
+          apiKey,
+          published.contextWindow,
+          published.maxOutputTokens
+        ),
+      catch: (error) => (error instanceof Error ? error : new Error(String(error)))
+    })
   })
 }


### PR DESCRIPTION
Follow-up to #17, which introduced the Anthropic Messages provider this patches.

## The principle

Work that can not be done correctly fails, and the failure says what to change. The framework repairs no request by guessing, and it decides nothing on an application's behalf that the application is entitled to decide. `docs/architecture.md` now states this beside the invariants, with the gateway's sentinel substitution as the example of what it exists to avoid.

## Three places the code fell short of it

**An invented answer ceiling.** The Messages API refuses a request that states no ceiling, and the provider sent a figure it made up. Opus 5 accepts 128,000 output tokens, so the invented 8,192 held every answer to a sixteenth of what the model can write, and only a truncated turn would ever have revealed it. The gateway catalog publishes `max_tokens` beside `context_window`, so the ceiling is now read from the model the same way the window is.

```
anthropic/claude-opus-5      context_window 1000000   max_tokens 128000
google/gemini-3.1-pro-preview context_window 1000000   max_tokens 64000
```

A caller who states `contextWindow` asks the catalog nothing, so that path keeps the lowest ceiling any Claude model accepts and names `maxOutputTokens` as the way to raise it. Requiring the figure there instead was tried and rejected: it fails 39 tests that build an ordinary agent, because the default model is an Anthropic one, and a required option on the simplest documented path is its own gotcha.

**A tool call replayed with nothing in it.** The Messages API takes a call's input as a value rather than as the string the OpenAI-compatible format uses, so recorded arguments are parsed on the way back. A string that would not parse became an empty object, which calls the tool with none of what the model asked for and answers the wrong question with no sign anything was lost. It now fails and names the call.

**Routing chosen for the application.** Removed in #17 after review. Where a request runs changes cost, latency, and where data travels, so no provider here states a preference.

## Checks

The gate passes: 193 tests, type checks, lint, documentation checks, dependency analysis, and package installation smoke tests. The catalog figures above were read from the live gateway.
