### PR TITLE
feat: journal model backoff so a restart can wait out a queue

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@ sequenceDiagram
   Agent-->>Caller: TurnResult
 ```
 
-The runtime holds the session writer lock around a turn or replay. Every machine folds the same log and tolerates events owned by other modules. Quiescence is a full pass that appends nothing.
+The runtime holds the session writer lock around a turn or replay. Every machine folds the same log and tolerates events owned by other modules. Quiescence is a full pass that appends nothing. A transient model failure appends `ModelDeferred` and rests; the runtime's alarm wakes the session at `notBefore` and the loop retries with the same key.
 
 ## Static Prefix and Dynamic Tail
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -100,4 +100,4 @@ Services connect modules during construction. A projection can be exposed as a s
 
 ## Port
 
-A port is an effectful capability required by a machine, such as event storage, exclusive writing, routing, or session inspection. A runtime binds ports for a platform without changing the agent.
+A port is an effectful capability required by a machine, such as event storage, exclusive writing, routing, session inspection, or a due-time wake. A runtime binds ports for a platform without changing the agent.

--- a/docs/events.md
+++ b/docs/events.md
@@ -14,6 +14,7 @@ Common fields include:
 - `origin` for the session, turn, and call that sent a cross-session message
 - `usage` on a cross-session reply for the sender's inclusive spend
 - `continuation` on a model result for opaque provider state
+- `attempt`, `notBefore`, and `reason` on a model deferral for the journaled wait
 
 Unknown fields and event types survive reads and folds.
 
@@ -37,6 +38,7 @@ Examples:
 - a model result dedups by turn and call id
 - a tool result dedups by turn and call id
 - a budget grant or denial dedups by turn and request call id
+- a model deferral has no key, so every wait stays in the log as evidence
 
 This lets providers reuse `call_1` in later turns without the store confusing separate calls. A grant and denial for one budget request share a key, so the first committed decision wins.
 
@@ -44,7 +46,7 @@ This lets providers reuse `call_1` in later turns without the store confusing se
 
 | Module | Event types |
 | --- | --- |
-| inference | `MessageReceived`, `ModelCalled`, `ModelReturned`, `TextReturned`, `TurnCompleted`, `TurnFailed`, `ReplyDelivered` |
+| inference | `MessageReceived`, `ModelCalled`, `ModelDeferred`, `AlarmFired`, `ModelReturned`, `TextReturned`, `TurnCompleted`, `TurnFailed`, `ReplyDelivered` |
 | native-tools | `ToolCalled`, `ToolReturned` |
 | budget | `BudgetExhausted`, `BudgetRequested`, `BudgetGranted`, `BudgetDenied` |
 | contract | `AnswerRejected` |

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -23,7 +23,7 @@ const agent = createAgent({
 - the model loop and reply machine
 - the static system instruction
 - provider selection
-- give-up and contract-repair bounds
+- give-up, deferral, and contract-repair bounds
 - message and tool-result truncation limits
 - the `InferenceStateProjection` construction service
 
@@ -58,7 +58,9 @@ const asked = yield* vercelGatewayInference({ model: "anthropic/claude-opus-4.5"
 
 A module says which model answers, and saying that means saying what it accepts, so `inference()` takes either a provider or a `contextWindow` to build the default gateway with. The type rejects a module that names neither. Generated code meets no type, so the construction rejects it too.
 
-A gateway that is busy, unwell, or unreachable earns further attempts on a jittered exponential backoff, bounded by `retries`, and one attempt is bounded by `timeout`. Every attempt carries one idempotency key, so a retry after a reply this side never saw is the same call rather than a second one. A refusal earns no retry: a request refused for a bad key is refused the same way every time. A failure that outlives its retries becomes a failed action, which the model loop records as the turn's evidence.
+A gateway that is busy, unwell, or unreachable earns further attempts on a jittered exponential backoff, bounded by `retries`, and one attempt is bounded by `timeout`. Every attempt carries one idempotency key, so a retry after a reply this side never saw is the same call rather than a second one. A refusal earns no retry: a request refused for a bad key is refused the same way every time.
+
+A failure that outlives those in-flight retries is still transient. The model loop appends `ModelDeferred` with the attempt, the due time, and the reason, then rests. The runtime wakes the session at `notBefore` by delivering `AlarmFired`, and the loop retries with the same idempotency key. A `Retry-After` of more than two seconds skips the in-flight retries and defers immediately, so a twenty-minute queue is a due time in the log rather than a sleep inside an Effect. `deferAtMost` bounds how many times one call may wait, defaulting to eight. A crash that leaves a `ModelCalled` with no consequence is journaled the same way, so a restart sleeps instead of immediately issuing another request. A restart whose due time has already passed appends `AlarmFired` from the log and continues.
 
 An attempt this side stops waiting for is cancelled. Dropping the wait alone leaves the request running: the model finishes it, the gateway bills for it, and the retry asks for the same completion again, so one turn is paid for twice. `timeout` therefore bounds what the gateway is asked to do rather than only what this side waits for.
 

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -8,11 +8,12 @@ A runtime binds platform services. Agent modules and machines stay unchanged acr
 | --- | --- |
 | `EventLog` | Append, read, read from a watermark, and report the head offset |
 | `Writer` | Serialize work for one session |
+| `Alarm` | Deliver a wake event to a session at a due time |
 | `Router` | Deliver asynchronous events or perform synchronous calls between sessions |
 | `Sessions` | List the addresses being served and read one session's log |
 | `Self` | Expose the current session address |
 
-The harness turn path requires `EventLog`, `Writer`, `Router`, and `Self`. Session inspection uses `Sessions`.
+The harness turn path requires `EventLog`, `Writer`, `Router`, `Self`, and `Alarm`. Session inspection uses `Sessions`.
 
 ## In-Memory Runtime
 
@@ -31,7 +32,7 @@ const runtime = InMemoryRuntime({
 })
 ```
 
-It uses arrays, maps, and a semaphore. Agents, routing, replay, and concurrent sessions run without external services. State lives for the lifetime of the layer and disappears with the process.
+It uses arrays, maps, and a semaphore. Agents, routing, replay, and concurrent sessions run without external services. State lives for the lifetime of the layer and disappears with the process. An alarm is a timer: `Alarm.set` sleeps until the due time and then delivers the wake event through whatever serves that address.
 
 ## The Session Registry
 
@@ -49,6 +50,6 @@ A call cycle would deadlock on writer leases, so [`serve`](orchestration.md#serv
 
 ## Implementing a Runtime
 
-Use the core conformance utilities for event log and machine guarantees. Preserve append order, dedup behavior, writer exclusion, and deterministic reads. Keep platform vocabulary inside the binding.
+Use the core conformance utilities for event log and machine guarantees. Preserve append order, dedup behavior, writer exclusion, and deterministic reads. Keep platform vocabulary inside the binding. Bind `Alarm` to the platform's due-time primitive: Durable Object storage alarms, a Postgres index on `notBefore`, or an in-memory timer.
 
 [Architecture](architecture.md) shows where runtime ports enter turn execution.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,7 +20,7 @@ export {
 export { actor, send, Self, type Actor } from "./actor"
 export { Router } from "./router"
 export { Sessions } from "./sessions"
-export { Writer } from "./ports"
+export { Alarm, Writer } from "./ports"
 export {
   conformance,
   type Check,

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1,4 +1,5 @@
 import { Context, Effect } from "effect"
+import type { Event } from "./event"
 // The platform seams that are not the log. Each one is a guarantee every runtime owes and no
 // runtime owes twice: the core names what it needs, and one layer binds the set. A port here holds
 // no domain knowledge, so the same agent code runs on a laptop, on a server, and on an edge worker.
@@ -15,3 +16,16 @@ export class Writer extends Context.Service<
     readonly hold: <A, E, R>(session: string, work: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
   }
 >()("flamecast/Writer") {}
+
+// A wake at a due time. The caller records why it is waiting in the log, then asks the runtime to
+// deliver `event` to `session` at `at`. The machine rests. A restart reads the log and arms again.
+//
+// The port is the schedule, not the wait: `set` returns once the wake is armed. Durable Objects
+// bind it to `state.storage.setAlarm`. A Postgres runtime writes a due-time index. In memory it is
+// a timer. One arm per session; a later `set` replaces the earlier one.
+export class Alarm extends Context.Service<
+  Alarm,
+  {
+    readonly set: (session: string, at: number, event: Event) => Effect.Effect<void>
+  }
+>()("flamecast/Alarm") {}

--- a/packages/harness/src/alphabet.ts
+++ b/packages/harness/src/alphabet.ts
@@ -55,6 +55,34 @@ export const modelCalled = (fields: Stamped & { readonly callId: string }): Even
   at: fields.at
 })
 
+export const modelDeferred = (
+  fields: Stamped & {
+    readonly callId: string
+    readonly attempt: number
+    readonly notBefore: number
+    readonly reason: string
+  }
+): Event => ({
+  type: "ModelDeferred",
+  turn: fields.turn,
+  callId: fields.callId,
+  attempt: fields.attempt,
+  notBefore: fields.notBefore,
+  reason: fields.reason,
+  at: fields.at
+})
+
+export const alarmFired = (
+  fields: Stamped & {
+    readonly callId: string
+  }
+): Event => ({
+  type: "AlarmFired",
+  turn: fields.turn,
+  callId: fields.callId,
+  at: fields.at
+})
+
 export const modelReturned = (
   fields: Stamped & {
     readonly callId: string

--- a/packages/harness/src/boundary.ts
+++ b/packages/harness/src/boundary.ts
@@ -1,7 +1,8 @@
 import type { Event } from "@flamecast/core"
 
-// A turn's boundary: where a settle left it. A turn ends in a terminal, or it parks on a budget
-// ask. Pure over the log, so a re-driven settle reads the same boundary.
+// A turn's boundary: where a settle left it. A turn ends in a terminal, it parks on a budget
+// ask, or it defers a model call until a due time. Pure over the log, so a re-driven settle reads
+// the same boundary.
 //
 // A parent reads this result from the event returned by `Router.call`. Core carries events and knows
 // no domain, so the harness interprets the event with the alphabet that wrote it.
@@ -14,6 +15,13 @@ export type CallResult =
       readonly callId: string
       readonly reason: string
       readonly amount: number
+    }
+  | {
+      readonly kind: "deferred"
+      readonly callId: string
+      readonly attempt: number
+      readonly notBefore: number
+      readonly reason: string
     }
 
 const stampOf = (event: Event): string | undefined =>
@@ -46,11 +54,35 @@ export const boundaryOf = (log: ReadonlyArray<Event>, turn: string): CallResult 
       pending = undefined
     }
   }
-  if (pending === undefined) return undefined
-  return {
-    kind: "parked",
-    callId: String(pending.callId ?? ""),
-    reason: String(pending.reason ?? ""),
-    amount: Number(pending.amount ?? 0)
+  if (pending !== undefined) {
+    return {
+      kind: "parked",
+      callId: String(pending.callId ?? ""),
+      reason: String(pending.reason ?? ""),
+      amount: Number(pending.amount ?? 0)
+    }
   }
+  // A deferral is the last model wait that no wake and no later attempt has answered.
+  for (let index = log.length - 1; index >= 0; index--) {
+    const event = log[index]
+    if (event === undefined || stampOf(event) !== turn) continue
+    if (event.type === "ModelDeferred") {
+      return {
+        kind: "deferred",
+        callId: String(event.callId ?? ""),
+        attempt: Number(event.attempt ?? 0),
+        notBefore: Number(event.notBefore ?? 0),
+        reason: String(event.reason ?? "")
+      }
+    }
+    if (
+      event.type === "AlarmFired" ||
+      event.type === "ModelReturned" ||
+      event.type === "ModelCalled" ||
+      event.type === "ToolCalled"
+    ) {
+      break
+    }
+  }
+  return undefined
 }

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -65,13 +65,16 @@ export {
   turnHead,
   turnOf,
   turnView,
-  usageIn
+  usageIn,
+  pendingDeferral,
+  type PendingDeferral
 } from "./turns"
 export { checkpointOf, estimateTokens, keepUpTo, suffixOf, type Checkpoint } from "./context"
 export { boundaryOf, type CallResult } from "./boundary"
 export { keyOf } from "./keys"
 export {
   answerRejected,
+  alarmFired,
   budgetDenied,
   budgetExhausted,
   budgetGranted,
@@ -79,6 +82,7 @@ export {
   compactionCompleted,
   messageReceived,
   modelCalled,
+  modelDeferred,
   modelReturned,
   replyDelivered,
   textReturned,

--- a/packages/harness/src/infer.ts
+++ b/packages/harness/src/infer.ts
@@ -71,6 +71,12 @@ export type Action =
       readonly continuation?: ProviderContinuation | undefined
     }
   | { readonly kind: "fail"; readonly error: string; readonly usage?: Usage | undefined }
+  | {
+      readonly kind: "defer"
+      readonly error: string
+      readonly retryAfterMs?: number | undefined
+      readonly usage?: Usage | undefined
+    }
 
 export interface InferenceState {
   readonly provider: string

--- a/packages/harness/src/keys.ts
+++ b/packages/harness/src/keys.ts
@@ -9,7 +9,8 @@ import { dedupKey, type DedupKey, type Event } from "@flamecast/core"
 // the log the way the store does.
 //
 // An event type absent from the table has no key and always lands. That is deliberate for a mark:
-// the repetition of `ModelCalled` is the evidence that an attempt died, so the log keeps every copy.
+// the repetition of `ModelCalled` and `ModelDeferred` is the evidence that an attempt died or
+// waited, so the log keeps every copy.
 //
 // THE SCOPE RULE. A key has to name the scope its id is unique in, and no wider. The store already
 // scopes every key to one session, so what is left is the turn. An id the world hands us is unique

--- a/packages/harness/src/module.ts
+++ b/packages/harness/src/module.ts
@@ -1,5 +1,6 @@
-import { Clock, Context, Effect } from "effect"
+import { Clock, Context, Effect, Option } from "effect"
 import {
+  Alarm,
   EventLog,
   Router,
   Self,
@@ -11,6 +12,7 @@ import {
   type EventLogStore,
   type Machine
 } from "@flamecast/core"
+import { alarmFired } from "./alphabet"
 import { boundaryOf, type CallResult } from "./boundary"
 import { type ModelRequest, type NativeToolSpec, type Usage } from "./infer"
 import { keyOf } from "./keys"
@@ -24,9 +26,9 @@ import {
   type Nudge,
   type RenderPlan
 } from "./definition"
-import { turnHead, usageIn } from "./turns"
+import { pendingDeferral, turnHead, usageIn } from "./turns"
 
-export type AgentServices = EventLog | Writer | Router | Self
+export type AgentServices = EventLog | Writer | Router | Self | Alarm
 
 export interface ModulePart<R = never> {
   readonly events?: ReadonlyArray<string>
@@ -275,6 +277,31 @@ const build = <R, Services>(
       const writer = yield* Writer
       return yield* writer.hold(yield* Self, work)
     })
+  const settleDue = (turn: string) =>
+    Effect.gen(function* () {
+      const store = yield* EventLog
+      while (true) {
+        yield* settleAll(machines.machines)
+        const log = yield* store.read
+        const pending = pendingDeferral(log)
+        if (pending === undefined || pending.turn !== turn) return resultOf(log, turn)
+        const now = yield* Clock.currentTimeMillis
+        if (now < pending.notBefore) {
+          const alarm = yield* Effect.serviceOption(Alarm)
+          if (Option.isSome(alarm)) {
+            yield* alarm.value.set(
+              yield* Self,
+              pending.notBefore,
+              alarmFired({ turn: pending.turn, callId: pending.callId, at: now })
+            )
+          }
+          return resultOf(log, turn)
+        }
+        yield* store.append([
+          alarmFired({ turn: pending.turn, callId: pending.callId, at: now })
+        ])
+      }
+    })
   const branch = (recorded: ReadonlyArray<Event>, options: BranchOptions = {}) => {
     const upTo = Math.max(0, Math.min(options.at ?? recorded.length, recorded.length))
     const seed = recorded.slice(0, upTo)
@@ -290,10 +317,9 @@ const build = <R, Services>(
       scoped(
         held(
           Effect.gen(function* () {
-            const store = yield* EventLog
             const at = yield* Clock.currentTimeMillis
             yield* send(machines, headOf(message, definition, at))
-            return resultOf(yield* store.read, message.id)
+            return yield* settleDue(message.id)
           })
         )
       ),
@@ -307,9 +333,8 @@ const build = <R, Services>(
           Effect.gen(function* () {
             const store = yield* EventLog
             yield* store.append(recorded)
-            yield* settleAll(machines.machines)
             const log = yield* store.read
-            return resultOf(log, lastTurnOf(log))
+            return yield* settleDue(lastTurnOf(log))
           })
         )
       ),

--- a/packages/harness/src/modules/inference.test.ts
+++ b/packages/harness/src/modules/inference.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "bun:test"
+import { Clock, Effect, Layer } from "effect"
+import { TestClock } from "effect/testing"
+import type { Event } from "@flamecast/core"
+import { InMemoryRuntime } from "@flamecast/runtime-in-memory"
+import { alarmFired } from "../alphabet"
+import { inferWith, type Action, type ModelRequest } from "../infer"
+import { keyOf } from "../keys"
+import { createAgent } from "../module"
+import { serve } from "../serve"
+import { inference } from "./inference"
+
+const usage = { promptTokens: 10, completionTokens: 2, costUsd: 0.0001 }
+
+const scripted = (actions: ReadonlyArray<Action>) => {
+  const seen: Array<ModelRequest> = []
+  const keys: Array<string> = []
+  return {
+    seen,
+    keys,
+    layer: inferWith(async (request, key) => {
+      seen.push(request)
+      keys.push(key)
+      const next = actions[seen.length - 1]
+      if (next === undefined) throw new Error(`the stub model ran out of actions after ${seen.length}`)
+      return next
+    }, { contextWindow: 200_000 })
+  }
+}
+
+describe("a deferred model call", () => {
+  const agent = createAgent({
+    modules: [inference({ contextWindow: 200_000, deferAtMost: 2 })]
+  })
+
+  test("journals the wait and rests, then retries with the same key", async () => {
+    const model = scripted([
+      { kind: "defer", error: "the gateway is queued", retryAfterMs: 60_000, usage },
+      { kind: "complete", output: "done", usage }
+    ])
+    const layer = Layer.merge(InMemoryRuntime({ keyOf, session: "user-42" }), model.layer)
+
+    const parked = await Effect.runPromise(
+      Effect.provide(
+        Effect.gen(function* () {
+          const result = yield* agent.turn({ id: "m-1", text: "hello" })
+          return { result, log: yield* agent.log }
+        }),
+        layer
+      )
+    )
+
+    expect(parked.result).toMatchObject({
+      kind: "deferred",
+      callId: "m-1/infer/0",
+      attempt: 1,
+      reason: "the gateway is queued"
+    })
+    expect(parked.log.map((event) => event.type)).toEqual([
+      "MessageReceived",
+      "ModelCalled",
+      "ModelDeferred"
+    ])
+    expect(model.keys).toEqual(["m-1/infer/0"])
+    const deferred = parked.log.find((event) => event.type === "ModelDeferred")
+    expect(Number(deferred?.notBefore)).toBe(Number(deferred?.at) + 60_000)
+
+    const resumed = await Effect.runPromise(
+      Effect.provide(
+        Effect.gen(function* () {
+          const result = yield* agent.replay([
+            alarmFired({
+              turn: "m-1",
+              callId: "m-1/infer/0",
+              at: yield* Clock.currentTimeMillis
+            })
+          ])
+          return { result, log: yield* agent.log }
+        }),
+        layer
+      )
+    )
+
+    expect(resumed.result).toMatchObject({ kind: "completed", output: "done" })
+    expect(model.keys).toEqual(["m-1/infer/0", "m-1/infer/0"])
+    expect(resumed.log.map((event) => event.type)).toEqual([
+      "MessageReceived",
+      "ModelCalled",
+      "ModelDeferred",
+      "AlarmFired",
+      "ModelCalled",
+      "ModelReturned",
+      "TurnCompleted",
+      "ReplyDelivered"
+    ])
+  })
+
+  test("gives up once the deferrals are spent", async () => {
+    const model = scripted([
+      { kind: "defer", error: "queued", retryAfterMs: 60_000, usage },
+      { kind: "defer", error: "still queued", retryAfterMs: 60_000, usage }
+    ])
+    const layer = Layer.merge(InMemoryRuntime({ keyOf, session: "user-42" }), model.layer)
+    const wake = (at: number) => alarmFired({ turn: "m-1", callId: "m-1/infer/0", at })
+
+    const first = await Effect.runPromise(Effect.provide(agent.turn({ id: "m-1", text: "hello" }), layer))
+    expect(first.kind).toBe("deferred")
+
+    const second = await Effect.runPromise(Effect.provide(agent.replay([wake(2)]), layer))
+    expect(second).toMatchObject({ kind: "deferred", attempt: 2 })
+
+    const third = await Effect.runPromise(Effect.provide(agent.replay([wake(3)]), layer))
+    expect(third).toMatchObject({ kind: "failed", error: "the model was deferred 2 times" })
+    expect(model.keys).toHaveLength(2)
+  })
+
+  test("a died attempt becomes a deferral instead of retrying immediately", async () => {
+    const model = scripted([{ kind: "complete", output: "recovered", usage }])
+    const layer = Layer.merge(InMemoryRuntime({ keyOf, session: "user-42" }), model.layer)
+    const seeded: ReadonlyArray<Event> = [
+      { type: "MessageReceived", id: "m-1", text: "hello", at: 1 },
+      { type: "ModelCalled", turn: "m-1", callId: "m-1/infer/0", at: 2 }
+    ]
+
+    const parked = await Effect.runPromise(Effect.provide(agent.replay(seeded), layer))
+    expect(parked).toMatchObject({
+      kind: "deferred",
+      callId: "m-1/infer/0",
+      reason: "the model attempt died"
+    })
+    expect(model.keys).toEqual([])
+
+    const resumed = await Effect.runPromise(
+      Effect.provide(
+        agent.replay([alarmFired({ turn: "m-1", callId: "m-1/infer/0", at: 3 })]),
+        layer
+      )
+    )
+    expect(resumed).toMatchObject({ kind: "completed", output: "recovered" })
+    expect(model.keys).toEqual(["m-1/infer/0"])
+  })
+
+  test("a restart whose due time has passed wakes from the log", async () => {
+    const model = scripted([{ kind: "complete", output: "late", usage }])
+    const seeded: ReadonlyArray<Event> = [
+      { type: "MessageReceived", id: "m-1", text: "hello", at: 1 },
+      { type: "ModelCalled", turn: "m-1", callId: "m-1/infer/0", at: 2 },
+      {
+        type: "ModelDeferred",
+        turn: "m-1",
+        callId: "m-1/infer/0",
+        attempt: 1,
+        notBefore: 0,
+        reason: "queued",
+        at: 3
+      }
+    ]
+    const result = await Effect.runPromise(
+      Effect.provide(
+        agent.replay(seeded),
+        Layer.merge(InMemoryRuntime({ keyOf, session: "user-42" }), model.layer)
+      )
+    )
+    expect(result).toMatchObject({ kind: "completed", output: "late" })
+    expect(model.keys).toEqual(["m-1/infer/0"])
+  })
+})
+
+describe("an in-memory alarm", () => {
+  test("wakes a served session at the due time", async () => {
+    const agent = createAgent({
+      modules: [inference({ contextWindow: 200_000 })]
+    })
+    const model = scripted([
+      { kind: "defer", error: "queued", retryAfterMs: 60_000, usage },
+      { kind: "complete", output: "awake", usage }
+    ])
+    const runtime = InMemoryRuntime({
+      keyOf,
+      session: "user-42",
+      sessions: { "user-42": serve(agent) }
+    })
+
+    const log = await Effect.runPromise(
+      Effect.gen(function* () {
+        const parked = yield* agent.turn({ id: "m-1", text: "hello" })
+        expect(parked.kind).toBe("deferred")
+        yield* TestClock.adjust("1 minute")
+        yield* Effect.yieldNow
+        return yield* agent.log
+      }).pipe(Effect.provide(Layer.mergeAll(runtime, model.layer, TestClock.layer())))
+    )
+
+    expect(log.map((event) => event.type)).toContain("TurnCompleted")
+    expect(model.keys).toEqual(["m-1/infer/0", "m-1/infer/0"])
+  })
+})

--- a/packages/harness/src/modules/inference.ts
+++ b/packages/harness/src/modules/inference.ts
@@ -11,6 +11,7 @@ import {
 import {
   messageReceived,
   modelCalled,
+  modelDeferred,
   modelReturned,
   replyDelivered,
   textReturned,
@@ -38,6 +39,7 @@ export class InferenceStateProjection extends Context.Service<
 export interface InferenceSettings {
   readonly system?: string
   readonly giveUpAfter?: number
+  readonly deferAtMost?: number
   readonly repairAtMost?: number
   readonly messageTruncateAt?: number
   readonly resultTruncateAt?: number
@@ -69,6 +71,34 @@ const diedAttempts = (view: ReadonlyArray<Event>): number => {
   return died
 }
 
+const openCallId = (view: ReadonlyArray<Event>): string | undefined => {
+  for (let index = view.length - 1; index >= 0; index--) {
+    const event = view[index]
+    if (event?.type === "ModelReturned") return undefined
+    if (event?.type === "ModelCalled") return String(event.callId ?? "")
+  }
+  return undefined
+}
+
+const completedCalls = (view: ReadonlyArray<Event>) =>
+  view.filter((event) => event.type === "ModelReturned").length
+
+const deferralsOf = (view: ReadonlyArray<Event>, callId: string) =>
+  view.filter((event) => event.type === "ModelDeferred" && String(event.callId ?? "") === callId)
+    .length
+
+// A single wait is capped at twenty minutes, which is long enough for a queued tier to drain and
+// short enough that a missing Retry-After still bounds the park. Exponential backoff without a
+// header starts at five seconds, then twenty, then eighty, and hits the cap on the fifth wait.
+const DEFER_CAP_MS = 20 * 60 * 1000
+
+const deferDelayMs = (attempt: number, retryAfterMs?: number) => {
+  if (retryAfterMs !== undefined && Number.isFinite(retryAfterMs) && retryAfterMs > 0) {
+    return Math.min(DEFER_CAP_MS, retryAfterMs)
+  }
+  return Math.min(DEFER_CAP_MS, 5_000 * 4 ** Math.max(0, attempt - 1))
+}
+
 const consequenceOf = (action: Action, turn: string, at: number): Event =>
   action.kind === "call"
     ? toolCalled({
@@ -86,6 +116,7 @@ const inferMachine = (
   render: RenderPlan,
   selection: InferenceSelection,
   giveUpAfter: number,
+  deferAtMost: number,
   repairAtMost: number
 ) =>
   machine({
@@ -128,14 +159,50 @@ const inferMachine = (
                 })
               ]
             }
-            const marks = view.filter((event) => event.type === "ModelCalled").length
-            const key = `${turn}/infer/${marks - died}`
+            const key = openCallId(view) ?? `${turn}/infer/${completedCalls(view)}`
+            const deferrals = deferralsOf(view, key)
+            if (deferrals >= deferAtMost) {
+              return [
+                turnFailed({
+                  turn,
+                  error: `the model was deferred ${deferAtMost} times`,
+                  at
+                })
+              ]
+            }
+            // An orphaned mark is a crash mid-call. Journal the wait so a restart sleeps instead of
+            // immediately issuing another request against a queue that has not moved.
+            if (died > 0) {
+              return [
+                modelDeferred({
+                  turn,
+                  callId: key,
+                  attempt: died,
+                  notBefore: at + deferDelayMs(died),
+                  reason: "the model attempt died",
+                  at
+                })
+              ]
+            }
             const store = yield* EventLog
             yield* store.append([modelCalled({ turn, callId: key, at })])
             const override = yield* Effect.serviceOption(Infer)
             const provider = Option.getOrElse(override, () => selectedInference(selection, log))
             const action = yield* provider.react(modelRequest({ render }, log), key)
             const after = yield* Clock.currentTimeMillis
+            if (action.kind === "defer") {
+              const attempt = deferrals + 1
+              return [
+                modelDeferred({
+                  turn,
+                  callId: key,
+                  attempt,
+                  notBefore: after + deferDelayMs(attempt, action.retryAfterMs),
+                  reason: action.error,
+                  at: after
+                })
+              ]
+            }
             const continuation = action.kind === "fail" ? undefined : action.continuation
             return [
               modelReturned({
@@ -151,8 +218,14 @@ const inferMachine = (
               consequenceOf(action, turn, after)
             ]
           }),
-        on: { ToolCalled: "waiting", TurnCompleted: "idle", TurnFailed: "idle" }
+        on: {
+          ModelDeferred: "deferred",
+          ToolCalled: "waiting",
+          TurnCompleted: "idle",
+          TurnFailed: "idle"
+        }
       },
+      deferred: { on: { AlarmFired: "thinking" } },
       waiting: { on: { ToolReturned: "thinking" } }
     }
   })
@@ -221,6 +294,7 @@ export const inference = (options: InferenceOptions) => {
   const selection = selectionOf(options)
   const system = options.system ?? BASE_SYSTEM
   const giveUpAfter = options.giveUpAfter ?? 3
+  const deferAtMost = options.deferAtMost ?? 8
   const repairAtMost = options.repairAtMost ?? 2
   // Truncation is what the caller asked for and nothing more. A default bound here would cut a long
   // message down on the way to the model while the log kept the whole thing, so the record and the
@@ -240,12 +314,13 @@ export const inference = (options: InferenceOptions) => {
   }
   return defineModule({
     id: "inference",
-    version: "3",
+    version: "4",
     identity: {
       provider: initial.id,
       state: initial.state([]),
       system,
       giveUpAfter,
+      deferAtMost,
       repairAtMost,
       ...truncation
     },
@@ -256,6 +331,8 @@ export const inference = (options: InferenceOptions) => {
       events: [
         "MessageReceived",
         "ModelCalled",
+        "ModelDeferred",
+        "AlarmFired",
         "ModelReturned",
         "TextReturned",
         "ToolCalled",
@@ -270,7 +347,7 @@ export const inference = (options: InferenceOptions) => {
       // reply machine reaches the router and this session's name, so the module says so and the
       // agent's own requirement carries it to the runtime.
       machines: (render): ReadonlyArray<Machine<EventLog | Router | Self, never>> => [
-        erase(inferMachine(render, selection, giveUpAfter, repairAtMost)),
+        erase(inferMachine(render, selection, giveUpAfter, deferAtMost, repairAtMost)),
         erase(replyMachine)
       ]
     })

--- a/packages/harness/src/providers/gateway.test.ts
+++ b/packages/harness/src/providers/gateway.test.ts
@@ -419,8 +419,8 @@ describe("Vercel AI Gateway", () => {
 
     const action = await Effect.runPromise(provider.react(request, "k"))
 
-    expect(action.kind).toBe("fail")
-    expect(String(action.kind === "fail" ? action.error : "")).toContain("timeout")
+    expect(action.kind).toBe("defer")
+    expect(String(action.kind === "defer" ? action.error : "")).toContain("timeout")
     // One attempt, because the caller asked for no retries.
     expect(seen).toHaveLength(1)
     expect(seen[0]?.get("x-trace")).toBe("abc")

--- a/packages/harness/src/providers/http.ts
+++ b/packages/harness/src/providers/http.ts
@@ -12,6 +12,7 @@ import type { Action } from "../infer"
 // same way every time, so retrying it spends money and time to learn nothing.
 interface Transient {
   readonly reason: string
+  readonly retryAfterMs?: number
 }
 
 const RETRYABLE = new Set([408, 409, 425, 429])
@@ -19,6 +20,18 @@ const RETRYABLE = new Set([408, 409, 425, 429])
 const isTransient = (status: number) => status >= 500 || RETRYABLE.has(status)
 
 const DEFAULT_RETRIES = 2
+
+// A Retry-After of more than two seconds is a queue, not a blip. Honouring it inside this Effect
+// would hold the turn open for the wait, and a crash would lose it. Returning it on the action lets
+// the log record the due time and the runtime wake the session.
+const QUEUE_RETRY_AFTER_MS = 2_000
+
+const retryAfterMsOf = (header: string | null) => {
+  if (header === null || header === "") return undefined
+  const seconds = Number(header)
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000
+  return undefined
+}
 
 // How long one attempt may take before this side stops waiting. It is a guard against a socket that
 // has gone quiet, so it sits well outside the range where real answers land: a reasoning model
@@ -71,7 +84,10 @@ export interface Attempt {
 
 // The request, its retries, and the one outcome they settle on.
 export const sent = (attempt: Attempt) => {
-  const failed = (reason: string): Transient => ({ reason })
+  const failed = (reason: string, retryAfterMs?: number): Transient => ({
+    reason,
+    ...(retryAfterMs === undefined ? {} : { retryAfterMs })
+  })
   const one = Effect.gen(function* () {
     const response = yield* Effect.tryPromise({
       // The signal is what makes an interruption reach the gateway. Without it, a timed-out attempt
@@ -93,7 +109,17 @@ export const sent = (attempt: Attempt) => {
     })
     if (!response.ok) {
       const reason = `${attempt.provider} returned HTTP ${response.status}: ${text}`
-      if (isTransient(response.status)) return yield* Effect.fail(failed(reason))
+      const retryAfterMs = retryAfterMsOf(response.headers.get("retry-after"))
+      if (isTransient(response.status)) {
+        if (retryAfterMs !== undefined && retryAfterMs > QUEUE_RETRY_AFTER_MS) {
+          return {
+            kind: "defer",
+            error: reason,
+            retryAfterMs
+          } satisfies Action
+        }
+        return yield* Effect.fail(failed(reason, retryAfterMs))
+      }
       return { kind: "fail", error: reason } satisfies Action
     }
     try {
@@ -113,12 +139,13 @@ export const sent = (attempt: Attempt) => {
       orElse: () => Effect.fail(failed("no response within the request timeout"))
     }),
     Effect.retry({ schedule: backoff, times: attempt.retries ?? DEFAULT_RETRIES }),
-    // A failure that outlived its retries becomes the turn's evidence. The inference module reads
-    // it, and the log carries what happened.
+    // A failure that outlived its retries is still transient: the log records a deferral and the
+    // runtime wakes the session at the due time, so a restart can wait out the queue.
     Effect.catch((failure) =>
       Effect.succeed({
-        kind: "fail",
-        error: `${attempt.provider} request failed: ${failure.reason}`
+        kind: "defer",
+        error: `${attempt.provider} request failed: ${failure.reason}`,
+        ...(failure.retryAfterMs === undefined ? {} : { retryAfterMs: failure.retryAfterMs })
       } satisfies Action)
     ),
     Effect.catchDefect((defect) =>

--- a/packages/harness/src/providers/retry.test.ts
+++ b/packages/harness/src/providers/retry.test.ts
@@ -73,7 +73,7 @@ describe("a transient failure", () => {
     const gateway = responder([500, 500, 500, 500])
     const result = await settled(provider(gateway.stub).react(request, "turn/infer/0"))
 
-    expect(result).toMatchObject({ kind: "fail" })
+    expect(result).toMatchObject({ kind: "defer" })
     expect(String((result as { error: string }).error)).toContain("HTTP 500")
     // The default is two further attempts, so a failing call is made three times and no more.
     expect(gateway.seen).toHaveLength(3)
@@ -84,6 +84,18 @@ describe("a transient failure", () => {
     await settled(provider(gateway.stub).react(request, "turn/infer/2"))
 
     expect(new Set(gateway.seen)).toEqual(new Set(["turn/infer/2"]))
+  })
+
+  test("a Retry-After of minutes defers immediately, so the wait lives in the log", async () => {
+    const seen: Array<string> = []
+    const stub = (async () => {
+      seen.push("hit")
+      return new Response("queued", { status: 429, headers: { "retry-after": "1200" } })
+    }) as unknown as typeof fetch
+    const result = await settled(provider(stub, { retries: 2 }).react(request, "turn/infer/0"))
+
+    expect(result).toMatchObject({ kind: "defer", retryAfterMs: 1_200_000 })
+    expect(seen).toHaveLength(1)
   })
 
   test("a network failure is retried like a busy gateway", async () => {
@@ -137,7 +149,7 @@ describe("a silent gateway", () => {
       provider(gateway.stub, { retries: 0, timeout: "2 minutes" }).react(request, "turn/infer/0")
     )
 
-    expect(result).toMatchObject({ kind: "fail" })
+    expect(result).toMatchObject({ kind: "defer" })
     expect(String((result as { error: string }).error)).toContain("timeout")
     expect(gateway.attempts()).toBe(1)
   })
@@ -163,6 +175,6 @@ describe("a silent gateway", () => {
       provider(gateway.stub, { retries: 0, timeout: "30 seconds" }).react(request, "turn/infer/0")
     )
 
-    expect(result).toMatchObject({ kind: "fail" })
+    expect(result).toMatchObject({ kind: "defer" })
   })
 })

--- a/packages/harness/src/serve.ts
+++ b/packages/harness/src/serve.ts
@@ -68,6 +68,16 @@ const terminalOf = (result: TurnResult, log: ReadonlyArray<Event>): Event => {
         amount: result.amount,
         usage
       }
+    case "deferred":
+      return {
+        type: "ModelDeferred",
+        turn: result.turn,
+        callId: result.callId,
+        attempt: result.attempt,
+        notBefore: result.notBefore,
+        reason: result.reason,
+        usage
+      }
     case "open":
       return {
         type: "TurnFailed",
@@ -121,7 +131,8 @@ export const serve = <R = never, Services = unknown>(
         }
       }
       // A message opens a turn. Any other event is a delivery the session absorbs, which is how a
-      // budget grant wakes a parked turn: append, settle, and report where the turn now stands.
+      // budget grant or a due alarm wakes a parked turn: append, settle, and report where the turn
+      // now stands.
       const result =
         event.type === "MessageReceived"
           ? yield* agent.turn(messageOf(event))

--- a/packages/harness/src/turns.ts
+++ b/packages/harness/src/turns.ts
@@ -43,6 +43,45 @@ export const turnView = (log: ReadonlyArray<Event>): ReadonlyArray<Event> => {
   return head === undefined ? [] : [head, ...stamped(log, idOf(head))]
 }
 
+export interface PendingDeferral {
+  readonly turn: string
+  readonly callId: string
+  readonly attempt: number
+  readonly notBefore: number
+  readonly reason: string
+}
+
+// The open model wait on the current turn: a `ModelDeferred` that no wake and no later attempt has
+// answered. The agent loop arms an alarm for it, or appends the wake when the due time has already
+// passed, so a restart continues from the log rather than from a timer that died with the process.
+export const pendingDeferral = (log: ReadonlyArray<Event>): PendingDeferral | undefined => {
+  const view = turnView(log)
+  for (let index = view.length - 1; index >= 0; index--) {
+    const event = view[index]
+    if (event === undefined) continue
+    if (event.type === "ModelDeferred") {
+      return {
+        turn: String(event.turn ?? ""),
+        callId: String(event.callId ?? ""),
+        attempt: Number(event.attempt ?? 0),
+        notBefore: Number(event.notBefore ?? 0),
+        reason: String(event.reason ?? "")
+      }
+    }
+    if (
+      event.type === "AlarmFired" ||
+      event.type === "ModelReturned" ||
+      event.type === "ModelCalled" ||
+      event.type === "ToolCalled" ||
+      event.type === "TurnCompleted" ||
+      event.type === "TurnFailed"
+    ) {
+      return undefined
+    }
+  }
+  return undefined
+}
+
 // The turn owed a reply: terminal stamped, reply not. It lags one stage behind `turnView` on
 // purpose, so a queued next turn never steals a finished turn's reply.
 export const replyView = (log: ReadonlyArray<Event>): ReadonlyArray<Event> => {
@@ -147,6 +186,12 @@ const detailOf = (event: Event, callWidth: number): string => {
     case "MessageReceived":
       return `${quoted(event.text)}   agent=${String(event.agent ?? "")}`
     case "ModelCalled":
+      return call("")
+    case "ModelDeferred":
+      return call(
+        `attempt=${String(event.attempt ?? "")} notBefore=${String(event.notBefore ?? "")} ${quoted(event.reason)}`
+      )
+    case "AlarmFired":
       return call("")
     case "ModelReturned":
       return call(usageLine(event.usage))

--- a/packages/runtime-in-memory/src/runtime.test.ts
+++ b/packages/runtime-in-memory/src/runtime.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test"
-import { Effect, Fiber } from "effect"
+import { Clock, Effect, Fiber, Layer } from "effect"
+import { TestClock } from "effect/testing"
 import {
+  Alarm,
   EventLog,
   Router,
   Self,
@@ -16,8 +18,8 @@ import {
 } from "@flamecast/core"
 import { InMemoryRuntime, type InMemoryOptions, type SessionPorts } from "./runtime"
 
-// The runtime owes eight ports and six log guarantees. These tests read each guarantee back through
-// the port, because a runtime is trusted for what the core can observe through the seam.
+// The runtime owes the published ports and six log guarantees. These tests read each guarantee back
+// through the port, because a runtime is trusted for what the core can observe through the seam.
 
 const ev = (type: string): Event => ({ type })
 
@@ -360,5 +362,67 @@ describe("machines over the runtime", () => {
       'the store appended a redelivered event twice for the key "flamecast/conformance/dedup-probe"',
       "the store returned 2 copies of one redelivered event from its watermark"
     ])
+  })
+})
+
+describe("the alarm", () => {
+  test("delivers the wake event to a served session after the due time", async () => {
+    const seen: Array<string> = []
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* (yield* Alarm).set("ag/child", (yield* Clock.currentTimeMillis) + 60_000, ev("Woke"))
+        yield* TestClock.adjust("1 minute")
+        yield* Effect.yieldNow
+      }).pipe(
+        Effect.provide(
+          Layer.merge(
+            InMemoryRuntime({
+              keyOf: dedupKey,
+              sessions: {
+                "ag/*": () => (event: Event) => {
+                  seen.push(event.type)
+                  return Effect.succeed({ type: "TurnCompleted" })
+                }
+              }
+            }),
+            TestClock.layer()
+          )
+        )
+      )
+    )
+    expect(seen).toEqual(["Woke"])
+  })
+
+  test("a later set replaces the earlier arm", async () => {
+    const seen: Array<string> = []
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const alarm = yield* Alarm
+        const now = yield* Clock.currentTimeMillis
+        yield* alarm.set("ag/child", now + 60_000, ev("First"))
+        yield* alarm.set("ag/child", now + 120_000, ev("Second"))
+        yield* TestClock.adjust("1 minute")
+        yield* Effect.yieldNow
+        expect(seen).toEqual([])
+        yield* TestClock.adjust("1 minute")
+        yield* Effect.yieldNow
+      }).pipe(
+        Effect.provide(
+          Layer.merge(
+            InMemoryRuntime({
+              keyOf: dedupKey,
+              sessions: {
+                "ag/*": () => (event: Event) => {
+                  seen.push(event.type)
+                  return Effect.succeed({ type: "TurnCompleted" })
+                }
+              }
+            }),
+            TestClock.layer()
+          )
+        )
+      )
+    )
+    expect(seen).toEqual(["Second"])
   })
 })

--- a/packages/runtime-in-memory/src/runtime.ts
+++ b/packages/runtime-in-memory/src/runtime.ts
@@ -1,5 +1,6 @@
-import { Context, Effect, Layer, Semaphore } from "effect"
+import { Clock, Context, Duration, Effect, Fiber, Layer, Semaphore } from "effect"
 import {
+  Alarm,
   EventLog,
   Router,
   Self,
@@ -42,6 +43,7 @@ export type SessionPorts =
   | Router
   | Sessions
   | Self
+  | Alarm
 
 // What a family of addresses answers with: the address goes in, and what serves it comes out.
 export type SessionFactory<R = never> = (address: string) => Serve<R>
@@ -202,6 +204,7 @@ export const InMemoryRuntime = <R = never, const Keys = Readonly<Record<string, 
         Effect.provideService(Writer, writer),
         Effect.provideService(Router, router),
         Effect.provideService(Sessions, sessions),
+        Effect.provideService(Alarm, alarm),
         Effect.provideContext(services)
       ) as Effect.Effect<Event>
     })
@@ -211,12 +214,38 @@ export const InMemoryRuntime = <R = never, const Keys = Readonly<Record<string, 
     call: routed
   }
 
+  // One due wake per session. A later `set` interrupts the earlier timer, which is the in-process
+  // form of Durable Object storage holding a single alarm. The timer is a detached fiber so a turn
+  // that has already returned still wakes. Delivery goes through whatever serves the address, so a
+  // session reached only by `agent.turn` is woken by replaying the wake event.
+  const alarms = new Map<string, Fiber.Fiber<unknown, never>>()
+  const alarm = {
+    set: (address: string, at: number, event: Event) =>
+      Effect.gen(function* () {
+        const prior = alarms.get(address)
+        if (prior !== undefined) {
+          yield* Fiber.interrupt(prior)
+          alarms.delete(address)
+        }
+        if (serveOf(address) === undefined) return
+        const fiber = yield* Effect.forkDetach(
+          Effect.gen(function* () {
+            const now = yield* Clock.currentTimeMillis
+            if (at > now) yield* Effect.sleep(Duration.millis(at - now))
+            yield* routed(address, event)
+          })
+        )
+        alarms.set(address, fiber)
+      })
+  }
+
   return Layer.mergeAll(
     Layer.succeedContext(services),
     Layer.succeed(EventLog, storeOf(session)),
     Layer.succeed(Writer, writer),
     Layer.succeed(Router, router),
     Layer.succeed(Sessions, sessions),
-    Layer.succeed(Self, session)
+    Layer.succeed(Self, session),
+    Layer.succeed(Alarm, alarm)
   )
 }


### PR DESCRIPTION
## Summary
- Add an `Alarm` port and a `ModelDeferred` event so a transient model failure parks the turn with `attempt`, `notBefore`, and `reason` in the log instead of retrying inside an Effect.
- The runtime wakes the session at `notBefore` (`AlarmFired`) and the inference loop retries with the same idempotency key. In-memory is a timer; a Durable Object binds native alarms; Postgres would index due time.
- Exhausted HTTP transients and a `Retry-After` of more than two seconds become `kind: "defer"`. A crash that leaves an orphaned `ModelCalled` is journaled the same way. `deferAtMost` (default 8) bounds how many times one call may wait.

## Test plan
- [x] `bun run gate` passes locally
- [ ] Replay a log that ends in `ModelCalled` and confirm it becomes `ModelDeferred` rather than immediately calling the model
- [ ] Replay `AlarmFired` after a deferral and confirm the same idempotency key is reused
- [ ] Seed a `ModelDeferred` whose `notBefore` is in the past and confirm a restart continues
- [ ] Serve a session through `InMemoryRuntime` with TestClock and confirm the alarm wakes it after the due time


Made with [Cursor](https://cursor.com)