### PR TITLE
fix: honour routes on the OpenAI-compatible gateway path

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -110,7 +110,7 @@ The last run, on 2026-08-17, read more with the state preserved for every model:
 
 A response the gateway stopped at its completion-token limit is a failed action too. The fragment it returns has the shape of an answer, so reading it as one would finish a turn on half a sentence or dispatch a tool call whose arguments stop mid-JSON. The failure carries the usage, because those tokens were spent.
 
-The OpenAI-compatible provider requests serial tool calling with `parallel_tool_calls: false`. The harness action type carries one tool call, so a response that still contains several calls becomes a visible failed action with its usage. No call is silently dropped.
+The OpenAI-compatible provider requests serial tool calling with `parallel_tool_calls: false`. The harness action type carries one tool call, so a response that still contains several calls becomes a visible failed action with its usage. No call is silently dropped. The failure names `routes`, because that option reaches a provider that honours the serial request, and it is forwarded on this path the same way it is on the Messages path.
 
 A request estimated past a known context window is refused before it is sent. It cannot succeed, so sending it buys a slow refusal in the gateway's words, and this one names both sizes and the model they belong to. The estimate is characters over four, which runs low against JSON and code, so a refusal means the request is past the window rather than near it.
 

--- a/packages/harness/src/providers/gateway.test.ts
+++ b/packages/harness/src/providers/gateway.test.ts
@@ -160,8 +160,36 @@ describe("Vercel AI Gateway", () => {
     const action = await Effect.runPromise(provider.react(request, "k"))
 
     expect(action.kind).toBe("fail")
-    expect(String(action.kind === "fail" ? action.error : "")).toContain("multiple tool calls")
+    const reason = String(action.kind === "fail" ? action.error : "")
+    expect(reason).toContain("multiple tool calls")
+    expect(reason).toContain("routes")
     expect(action.usage).toEqual({ promptTokens: 10, completionTokens: 4, costUsd: 0.001 })
+  })
+
+  // The defect this pins: `routes` was accepted on the gateway options and applied only on the
+  // Anthropic path, so a DeepSeek (or any other OpenAI-compatible) model silently dropped it.
+  test("pins a route on the OpenAI-compatible path when the caller names one", async () => {
+    const bodies: Array<Record<string, unknown>> = []
+    const stub = (async (_url: string, init: RequestInit) => {
+      bodies.push(JSON.parse(String(init.body)) as Record<string, unknown>)
+      return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
+        status: 200
+      })
+    }) as unknown as typeof fetch
+    const of = (routes?: ReadonlyArray<string>) =>
+      vercelGatewayInference({
+        apiKey: "vercel-key",
+        model: "deepseek/deepseek-v4-pro",
+        contextWindow: 200_000,
+        fetch: stub,
+        ...(routes === undefined ? {} : { routes })
+      })
+
+    await Effect.runPromise(of().react(request, "k"))
+    await Effect.runPromise(of(["deepseek"]).react(request, "k"))
+
+    expect(bodies[0]).not.toHaveProperty("providerOptions")
+    expect(bodies[1]?.providerOptions).toEqual({ gateway: { only: ["deepseek"] } })
   })
 
   // The catalog is cached per gateway for the life of the process, so each of these tests names its

--- a/packages/harness/src/providers/openai-chat.ts
+++ b/packages/harness/src/providers/openai-chat.ts
@@ -33,6 +33,9 @@ export interface OpenAiChatOptions {
   // How many further attempts a transient failure earns, and how long one attempt may take.
   readonly retries?: number
   readonly timeout?: Duration.Input
+  // Fields an endpoint understands that chat completions does not define. A gateway in front of this
+  // API takes routing options here, so this file holds no vendor's routing vocabulary.
+  readonly body?: Readonly<Record<string, unknown>>
 }
 
 // What a gateway forwards rather than fixes. Every gateway built on this provider takes the same
@@ -214,7 +217,11 @@ const actionOf = (body: ChatResponse): Action => {
   if (calls.length > 1) {
     return {
       kind: "fail",
-      error: "the inference gateway returned multiple tool calls, but this agent executes one call at a time",
+      error:
+        "the inference gateway returned multiple tool calls, but this agent executes one call at " +
+        "a time. This request asked for one call at a time, so the route that served it does not " +
+        "honour that setting. Amazon Bedrock is one such route. Name the providers that may serve " +
+        "this model with the routes option to reach one that does.",
       usage
     }
   }
@@ -292,7 +299,8 @@ const reacted = (
       : { max_tokens: options.maxOutputTokens }),
     ...(request.tools.length === 0
       ? {}
-      : { tools: request.tools.map(tool), parallel_tool_calls: false })
+      : { tools: request.tools.map(tool), parallel_tool_calls: false }),
+    ...options.body
   })
   const refusal = overWindow(body, options.provider, options.model, options.contextWindow)
   if (refusal !== undefined) return Effect.succeed(refusal)

--- a/packages/harness/src/providers/vercel-gateway.ts
+++ b/packages/harness/src/providers/vercel-gateway.ts
@@ -117,6 +117,11 @@ const isAnthropic = (model: string) => model.startsWith("anthropic/")
 // fails and names `maxOutputTokens`, so a ceiling too low for the work says so.
 const SAFE_OUTPUT_TOKENS = 8192
 
+const routed = (options: VercelGatewayInferenceOptions) =>
+  options.routes === undefined
+    ? {}
+    : { body: { providerOptions: { gateway: { only: options.routes } } } }
+
 const build = (
   options: VercelGatewayInferenceOptions,
   model: string,
@@ -139,9 +144,7 @@ const build = (
       // number that would have been safe for every model at once.
       maxOutputTokens: options.maxOutputTokens ?? publishedOutputTokens ?? SAFE_OUTPUT_TOKENS,
       ...(options.effort === undefined ? {} : { effort: options.effort }),
-      ...(options.routes === undefined
-        ? {}
-        : { body: { providerOptions: { gateway: { only: options.routes } } } })
+      ...routed(options)
     })
   }
   return openAiChatInference({
@@ -151,7 +154,8 @@ const build = (
     contextWindow,
     endpoint: `${baseUrl}/chat/completions`,
     apiKey,
-    ...transport(options)
+    ...transport(options),
+    ...routed(options)
   })
 }
 


### PR DESCRIPTION
## Summary
- `routes` was accepted on `VercelGatewayInferenceOptions` and applied only on the Anthropic Messages path, so every OpenAI-compatible model (DeepSeek included) silently dropped it.
- The chat-completions adapter now takes the same extra `body` fields the Messages adapter does, and a multi-call failure names `routes` as the remedy.

## Test plan
- [x] `bun test packages/harness/src/providers/gateway.test.ts packages/harness/src/providers/anthropic-messages.test.ts`
- [x] `bun run gate`
- [ ] Confirm a DeepSeek `routes: ["deepseek"]` request includes `providerOptions.gateway.only`


Made with [Cursor](https://cursor.com)