### PR TITLE
feat: reserve model spend and project per-request options

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,7 @@ sequenceDiagram
   Machines->>Log: append ModelCalled
   Machines->>Provider: react(agent.request(log))
   Provider-->>Machines: Action
-  Machines->>Log: append ModelReturned and consequence
+  Machines->>Log: append ModelReturned or ModelSettled, then consequence
   Machines->>Tools: run when ToolCalled
   Tools-->>Log: append ToolReturned
   Machines->>Log: append TurnCompleted or TurnFailed
@@ -58,6 +58,8 @@ This shape keeps common request prefixes stable across turns. Dynamic budget, co
 Effect service keys form the module dependency graph. A producer contributes a typed `Context`. A consumer declares service keys and receives a context containing only those dependencies.
 
 The compaction module demonstrates the pattern. Inference provides a pure projection of the selected model and [context window](modules.md#the-context-window). Compaction reads that projection with `Context.get` and computes its thresholds from the current window. A model switch changes thresholds without a global registry or hidden module state, and a window the projection does not report yet leaves compaction resting rather than dividing a figure the framework chose.
+
+`RequestOptionsProjection` is the same kind of service on the other side of the request. A module contributes a fold from the log to per-request settings, and inference applies it when it builds `agent.request(log)`. A tier policy is then a machine over the log: flex by default, standard after two deferrals in the turn. Replay sends the same choice.
 
 Pure construction services use Effect `Context` directly. Effectful capabilities use Effect requirements and Layers. A service can be a projection when another module needs a typed derived value during construction.
 

--- a/docs/building-an-agent.md
+++ b/docs/building-an-agent.md
@@ -76,6 +76,16 @@ const inferenceModule = inference({
 
 Provider selection can be a function of the log. The inference module provides its selected-state projection as an Effect construction service, so dependent modules can consume it through typed dependency injection.
 
+Per-request provider settings are a projection too. `flexThenStandard()` asks for flex until the current turn has two deferrals, then standard:
+
+```ts
+import { createAgent, flexThenStandard, inference } from "flamecast-core/harness"
+
+const agent = createAgent({
+  modules: [inference({ contextWindow: 200_000 }), flexThenStandard()]
+})
+```
+
 ## Add Tools Through the Default Pack
 
 A tool declares its input once, as a `Schema`. The declaration is lowered to the JSON Schema the model reads, and arguments are decoded against it before the handler runs, so the handler receives the type its own schema describes.

--- a/docs/events.md
+++ b/docs/events.md
@@ -15,6 +15,8 @@ Common fields include:
 - `usage` on a cross-session reply for the sender's inclusive spend
 - `continuation` on a model result for opaque provider state
 - `attempt`, `notBefore`, and `reason` on a model deferral for the journaled wait
+- `reserved` on a model call for the estimated spend of an in-flight attempt
+- `reason` on a model settle for why an attempt closed without a provider result
 
 Unknown fields and event types survive reads and folds.
 
@@ -36,6 +38,7 @@ Examples:
 
 - an inbound message dedups by message id
 - a model result dedups by turn and call id
+- a model settle has no key, so every closed reservation stays in the log as evidence
 - a tool result dedups by turn and call id
 - a budget grant or denial dedups by turn and request call id
 - a model deferral has no key, so every wait stays in the log as evidence
@@ -46,7 +49,7 @@ This lets providers reuse `call_1` in later turns without the store confusing se
 
 | Module | Event types |
 | --- | --- |
-| inference | `MessageReceived`, `ModelCalled`, `ModelDeferred`, `AlarmFired`, `ModelReturned`, `TextReturned`, `TurnCompleted`, `TurnFailed`, `ReplyDelivered` |
+| inference | `MessageReceived`, `ModelCalled`, `ModelDeferred`, `AlarmFired`, `ModelSettled`, `ModelReturned`, `TextReturned`, `TurnCompleted`, `TurnFailed`, `ReplyDelivered` |
 | native-tools | `ToolCalled`, `ToolReturned` |
 | budget | `BudgetExhausted`, `BudgetRequested`, `BudgetGranted`, `BudgetDenied` |
 | contract | `AnswerRejected` |

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -60,7 +60,9 @@ A module says which model answers, and saying that means saying what it accepts,
 
 A gateway that is busy, unwell, or unreachable earns further attempts on a jittered exponential backoff, bounded by `retries`, and one attempt is bounded by `timeout`. Every attempt carries one idempotency key, so a retry after a reply this side never saw is the same call rather than a second one. A refusal earns no retry: a request refused for a bad key is refused the same way every time.
 
-A failure that outlives those in-flight retries is still transient. The model loop appends `ModelDeferred` with the attempt, the due time, and the reason, then rests. The runtime wakes the session at `notBefore` by delivering `AlarmFired`, and the loop retries with the same idempotency key. A `Retry-After` of more than two seconds skips the in-flight retries and defers immediately, so a twenty-minute queue is a due time in the log rather than a sleep inside an Effect. `deferAtMost` bounds how many times one call may wait, defaulting to eight. A crash that leaves a `ModelCalled` with no consequence is journaled the same way, so a restart sleeps instead of immediately issuing another request. A restart whose due time has already passed appends `AlarmFired` from the log and continues.
+A failure that outlives those in-flight retries is still transient. The model loop appends `ModelDeferred` with the attempt, the due time, and the reason, then rests. The runtime wakes the session at `notBefore` by delivering `AlarmFired`, and the loop retries with the same idempotency key. A `Retry-After` of more than two seconds skips the in-flight retries and defers immediately, so a twenty-minute queue is a due time in the log rather than a sleep inside an Effect. `deferAtMost` bounds how many times one call may wait, defaulting to eight. A crash that leaves a `ModelCalled` with no consequence is journaled the same way, so a restart sleeps instead of immediately issuing another request. The next settle also appends `ModelSettled` with the reservation `ModelCalled` carried, so spend that never got a `ModelReturned` stays on the record. A restart whose due time has already passed appends `AlarmFired` from the log and continues.
+
+`ModelCalled` carries `reserved`, an estimate of prompt tokens and, when the provider holds a price table, of cost. A gateway catalog that publishes `pricing.input` and `pricing.output` fills that table at construction, and a caller can pass `pricing` on a provider that has no catalog. `usageIn` reports `settled` from `ModelReturned` and `unsettled` from in-flight `ModelCalled` rows plus `ModelSettled`. A cost the provider reported, including zero, is kept. A cost the provider omitted is filled from the table when one exists, and is left absent when none does: absence is unknown.
 
 An attempt this side stops waiting for is cancelled. Dropping the wait alone leaves the request running: the model finishes it, the gateway bills for it, and the retry asks for the same completion again, so one turn is paid for twice. `timeout` therefore bounds what the gateway is asked to do rather than only what this side waits for.
 
@@ -113,6 +115,18 @@ A response the gateway stopped at its completion-token limit is a failed action 
 The OpenAI-compatible provider requests serial tool calling with `parallel_tool_calls: false`. The harness action type carries one tool call, so a response that still contains several calls becomes a visible failed action with its usage. No call is silently dropped. The failure names `routes`, because that option reaches a provider that honours the serial request, and it is forwarded on this path the same way it is on the Messages path.
 
 A request estimated past a known context window is refused before it is sent. It cannot succeed, so sending it buys a slow refusal in the gateway's words, and this one names both sizes and the model they belong to. The estimate is characters over four, which runs low against JSON and code, so a refusal means the request is past the window rather than near it.
+
+## requestOptions
+
+`requestOptions(of)` contributes `RequestOptionsProjection`. The projection is a fold from the log to per-request provider settings: service tier, temperature, output ceiling, effort, routes, and a body overlay. Inference reads it when it builds the model request, so the settings are a projection the way `InferenceStateProjection` feeds compaction, and invariant 4 still holds: model requests are pure projections of the log.
+
+`flexThenStandard()` is the shipped policy. It asks for flex until the current turn has two `ModelDeferred` events, then standard. A replay of the same log sends the same tier. `agent.request(log)` shows the choice without calling a provider.
+
+```ts
+const agent = createAgent({
+  modules: [inference({ contextWindow: 200_000 }), flexThenStandard(), nativeTools([lookup])]
+})
+```
 
 ## nativeTools
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -37,7 +37,7 @@ import { InferenceStateProjection } from "flamecast-core/harness"
 const selected = Context.get(agent.services, InferenceStateProjection)(log)
 ```
 
-Effect construction services expose typed module values, including projections. Machine state can be reconstructed with `foldOf(machine, log)`.
+Effect construction services expose typed module values, including projections. Machine state can be reconstructed with `foldOf(machine, log)`. `RequestOptionsProjection` is the same kind of service: a module contributes a fold, and `agent.request(log).options` is what that fold chose.
 
 ## Replay
 
@@ -77,7 +77,7 @@ const total = treeUsageIn(log, "m-1")
 const toolCalls = toolCallsOf(log)
 ```
 
-`usageIn(log, turn)` sums the prompt tokens, completion tokens, and provider cost for one turn. The values come from its `ModelReturned` events.
+`usageIn(log, turn)` sums the prompt tokens, completion tokens, and provider cost for one turn. `settled` comes from `ModelReturned`. `unsettled` comes from a `ModelCalled` still in flight and from a `ModelSettled` that closed an attempt without a result. `costUsd` is present when every part of that total is known. A provider that reported zero is free. A provider that omitted cost leaves `costUsd` absent unless a price table filled it.
 
 `treeUsageIn(log, turn)` adds the usage every sub-agent result reported, and a child reports its own tree usage, so the sum covers the whole delegation tree from one log.
 

--- a/packages/codemode/src/guide.test.ts
+++ b/packages/codemode/src/guide.test.ts
@@ -100,7 +100,7 @@ describe("building a swarm, as the guide tells it", () => {
     expect(ran.answer.output).toBe("checked")
     const head = ran.childLog.find((event) => event.type === "MessageReceived")
     expect(head?.origin).toMatchObject({ session: "agent:lead", turn: "m-1", call: "c-1" })
-    expect(treeUsageIn(ran.leadLog, "m-1")).toEqual(spent)
+    expect(treeUsageIn(ran.leadLog, "m-1")).toMatchObject(spent)
   })
 
   test("workers spawn by address and fan out from code on Promise.all", async () => {

--- a/packages/codemode/src/tool.ts
+++ b/packages/codemode/src/tool.ts
@@ -1,5 +1,5 @@
 import { Effect, Schema } from "effect"
-import { usageOf, type NativeTool, type NativeToolContext, type Usage } from "@flamecast/harness/infer"
+import { sumUsage, usageOf, ZERO_USAGE, type NativeTool, type NativeToolContext, type Usage } from "@flamecast/harness/infer"
 import { tool } from "@flamecast/harness/tool"
 import {
   surfaceOf,
@@ -80,7 +80,7 @@ export const codemode = <R = never>(
           return {
             output: [],
             calls: [],
-            usage: NO_SPEND,
+            usage: ZERO_USAGE,
             error: "no source to run"
           } satisfies CodemodeResult
         }
@@ -135,19 +135,13 @@ export const codemode = <R = never>(
           ...(outcome.error === undefined ? {} : { error: outcome.error }),
           calls,
           usage: spend.reduce(
-            (total, one) => ({
-              promptTokens: total.promptTokens + one.promptTokens,
-              completionTokens: total.completionTokens + one.completionTokens,
-              costUsd: total.costUsd + one.costUsd
-            }),
-            NO_SPEND
+            (total, one) => sumUsage([total, one]),
+            ZERO_USAGE
           )
         } satisfies CodemodeResult
       })
   })
 }
-
-const NO_SPEND: Usage = { promptTokens: 0, completionTokens: 0, costUsd: 0 }
 
 // The script's identity inside its turn. It names the provider call that asked, so two scripts in
 // one turn mint different ids and a redispatch of one script mints the id it minted before.

--- a/packages/harness/src/agent.test.ts
+++ b/packages/harness/src/agent.test.ts
@@ -86,7 +86,9 @@ describe("the smallest agent", () => {
       "ReplyDelivered"
     ])
     expect(result).toMatchObject({ kind: "completed", output: "We are open 9 to 5.", turn: "m-1" })
-    expect(result.usage).toEqual(usage)
+    expect(result.usage).toMatchObject(usage)
+    expect(result.usage.settled).toEqual(usage)
+    expect(result.usage.unsettled).toEqual({ promptTokens: 0, completionTokens: 0, costUsd: 0 })
     // The turn pins the program that ran it, so a replay can verify provenance.
     expect(log[0]?.agent).toBe(agent.definition.id)
     expect(model.seen[0]?.system).toBe("You are a support agent. Answer in plain text.")

--- a/packages/harness/src/alphabet.ts
+++ b/packages/harness/src/alphabet.ts
@@ -1,5 +1,5 @@
 import type { Event } from "@flamecast/core"
-import type { ProviderContinuation, Usage } from "./infer"
+import type { ProviderContinuation, RequestOptions, Usage } from "./infer"
 import type { MessageOrigin } from "./module"
 
 // The harness's own events, as constructors. `Event` is open because a reader must survive an
@@ -48,10 +48,18 @@ export const messageReceived = (fields: {
   ...(fields.usage === undefined ? {} : { usage: fields.usage })
 })
 
-export const modelCalled = (fields: Stamped & { readonly callId: string }): Event => ({
+export const modelCalled = (
+  fields: Stamped & {
+    readonly callId: string
+    readonly reserved: Usage
+    readonly options?: RequestOptions
+  }
+): Event => ({
   type: "ModelCalled",
   turn: fields.turn,
   callId: fields.callId,
+  reserved: fields.reserved,
+  ...(fields.options === undefined ? {} : { options: fields.options }),
   at: fields.at
 })
 
@@ -68,6 +76,21 @@ export const modelDeferred = (
   callId: fields.callId,
   attempt: fields.attempt,
   notBefore: fields.notBefore,
+  reason: fields.reason,
+  at: fields.at
+})
+
+export const modelSettled = (
+  fields: Stamped & {
+    readonly callId: string
+    readonly usage: Usage
+    readonly reason: string
+  }
+): Event => ({
+  type: "ModelSettled",
+  turn: fields.turn,
+  callId: fields.callId,
+  usage: fields.usage,
   reason: fields.reason,
   at: fields.at
 })

--- a/packages/harness/src/definition.ts
+++ b/packages/harness/src/definition.ts
@@ -1,6 +1,7 @@
 import type { Context } from "effect"
 import type { Event, Machine } from "@flamecast/core"
-import type { NativeToolSpec } from "./infer"
+import type { NativeToolSpec, RequestOptions } from "./infer"
+import type { Projection } from "./projection"
 import { sha256 } from "./sha256"
 
 export interface Instruction {
@@ -33,6 +34,7 @@ export interface RenderPlan {
   // compaction module checkpoints the log against the provider's window.
   readonly messageTruncateAt?: number
   readonly resultTruncateAt?: number
+  readonly requestOptions?: Projection<RequestOptions>
 }
 
 export interface ModuleManifest {

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -7,6 +7,16 @@ export {
   customInference,
   inferWith,
   selectedInference,
+  usageOf,
+  sumUsage,
+  spendOf,
+  priced,
+  costOf,
+  reservedUsage,
+  settledUsage,
+  applyRequestOptions,
+  ZERO_USAGE,
+  RequestOptionsProjection,
   type Action,
   type AgentMessage,
   type NativeToolCall,
@@ -14,11 +24,14 @@ export {
   type InferenceProvider,
   type InferenceSelection,
   type InferenceState,
+  type ModelPricing,
   type ModelRequest,
   type NativeTool,
   type NativeToolContext,
   type NativeToolSpec,
   type ProviderContinuation,
+  type RequestOptions,
+  type Spend,
   type Usage
 } from "./infer"
 export {
@@ -84,6 +97,7 @@ export {
   modelCalled,
   modelDeferred,
   modelReturned,
+  modelSettled,
   replyDelivered,
   textReturned,
   toolCalled,
@@ -125,6 +139,7 @@ export {
   type InferenceOptions,
   type InferenceSettings
 } from "./modules/inference"
+export { flexThenStandard, requestOptions, type RequestOptionsModule } from "./modules/request-options"
 export { nativeTools } from "./modules/native-tools"
 export {
   budgetOf,

--- a/packages/harness/src/infer.ts
+++ b/packages/harness/src/infer.ts
@@ -1,5 +1,7 @@
 import { Context, Effect, Layer } from "effect"
 import type { Event } from "@flamecast/core"
+import { estimateTextTokens } from "./context"
+import type { Projection } from "./projection"
 
 export interface NativeToolSpec {
   readonly name: string
@@ -42,16 +44,142 @@ export interface AgentMessage {
   readonly continuation?: ProviderContinuation
 }
 
+export interface RequestOptions {
+  readonly serviceTier?: string
+  readonly temperature?: number
+  readonly maxOutputTokens?: number
+  readonly effort?: "low" | "medium" | "high"
+  readonly routes?: ReadonlyArray<string>
+  readonly body?: Readonly<Record<string, unknown>>
+}
+
+export class RequestOptionsProjection extends Context.Service<
+  RequestOptionsProjection,
+  Projection<RequestOptions>
+>()("flamecast/RequestOptionsProjection") {}
+
 export interface ModelRequest {
   readonly system: string
   readonly messages: ReadonlyArray<AgentMessage>
   readonly tools: ReadonlyArray<NativeToolSpec>
+  readonly options?: RequestOptions
 }
 
 export interface Usage {
   readonly promptTokens: number
   readonly completionTokens: number
-  readonly costUsd: number
+  // Present when the figure is known: the provider reported it, including zero, or a price table
+  // filled it from token counts. Absent when nobody could say. That absence is unknown cost.
+  readonly costUsd?: number
+}
+
+export interface Spend extends Usage {
+  readonly settled: Usage
+  readonly unsettled: Usage
+}
+
+export const ZERO_USAGE: Usage = { promptTokens: 0, completionTokens: 0, costUsd: 0 }
+
+export interface ModelPricing {
+  readonly promptUsdPerToken: number
+  readonly completionUsdPerToken: number
+}
+
+export const costOf = (
+  pricing: ModelPricing | undefined,
+  promptTokens: number,
+  completionTokens: number
+): number | undefined =>
+  pricing === undefined
+    ? undefined
+    : promptTokens * pricing.promptUsdPerToken + completionTokens * pricing.completionUsdPerToken
+
+export const priced = (usage: Usage, pricing?: ModelPricing): Usage => {
+  if (usage.costUsd !== undefined) return usage
+  const costUsd = costOf(pricing, usage.promptTokens, usage.completionTokens)
+  return costUsd === undefined ? usage : { ...usage, costUsd }
+}
+
+export const reservedUsage = (request: ModelRequest, pricing?: ModelPricing): Usage =>
+  priced(
+    {
+      promptTokens: estimateTextTokens(
+        JSON.stringify({
+          system: request.system,
+          messages: request.messages,
+          tools: request.tools
+        })
+      ),
+      completionTokens: 0
+    },
+    pricing
+  )
+
+export const settledUsage = (
+  reported: unknown,
+  reserved: Usage,
+  pricing?: ModelPricing
+): Usage => {
+  if (reported === undefined) return ZERO_USAGE
+  const usage = priced(usageOf(reported), pricing)
+  if (usage.costUsd !== undefined || reserved.costUsd === undefined) return usage
+  return { ...usage, costUsd: reserved.costUsd }
+}
+
+export const sumUsage = (parts: ReadonlyArray<Usage>): Usage => {
+  if (parts.length === 0) return ZERO_USAGE
+  let promptTokens = 0
+  let completionTokens = 0
+  let costUsd = 0
+  let known = true
+  for (const part of parts) {
+    promptTokens += part.promptTokens
+    completionTokens += part.completionTokens
+    if (part.costUsd === undefined) known = false
+    else costUsd += part.costUsd
+  }
+  return {
+    promptTokens,
+    completionTokens,
+    ...(known ? { costUsd } : {})
+  }
+}
+
+export const spendOf = (settled: Usage, unsettled: Usage): Spend => ({
+  ...sumUsage([settled, unsettled]),
+  settled,
+  unsettled
+})
+
+const recordOf = (value: unknown): Readonly<Record<string, unknown>> | undefined =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Readonly<Record<string, unknown>>)
+    : undefined
+
+// Per-request options overlay construction-time fields. The request is a projection of the log, so
+// a tier policy is a fold rather than a mutable argument to `react`.
+export const applyRequestOptions = (
+  body: Readonly<Record<string, unknown>>,
+  options: RequestOptions | undefined
+): Readonly<Record<string, unknown>> => {
+  if (options === undefined) return body
+  const existing = recordOf(body.providerOptions) ?? {}
+  return {
+    ...body,
+    ...(options.maxOutputTokens === undefined ? {} : { max_tokens: options.maxOutputTokens }),
+    ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
+    ...(options.serviceTier === undefined ? {} : { service_tier: options.serviceTier }),
+    ...(options.effort === undefined ? {} : { output_config: { effort: options.effort } }),
+    ...(options.routes === undefined
+      ? {}
+      : {
+          providerOptions: {
+            ...existing,
+            gateway: { ...recordOf(existing.gateway), only: options.routes }
+          }
+        }),
+    ...options.body
+  }
 }
 
 export type Action =
@@ -90,6 +218,10 @@ export interface InferenceState {
   // and one that had not, and a machine guard reads this, so the same log would fold two ways and a
   // replay would diverge from the run it replays.
   readonly contextWindow: number
+  // What the model costs, when a catalog or a caller has said. A figure written here would be wrong
+  // for every model it was never measured against, so absence means the projection cannot price a
+  // turn, and a missing provider cost stays unknown rather than becoming zero.
+  readonly pricing?: ModelPricing
 }
 
 export interface InferenceProvider {
@@ -113,6 +245,7 @@ export interface CustomInferenceOptions {
   // What the model behind this function accepts. Required for the same reason the projection is:
   // whoever wrote the function is the only one who can say, and nobody downstream can guess.
   readonly contextWindow: number
+  readonly pricing?: ModelPricing
 }
 
 export const customInference = (
@@ -125,7 +258,8 @@ export const customInference = (
     state: () => ({
       provider: options.id ?? "custom",
       model,
-      contextWindow: options.contextWindow
+      contextWindow: options.contextWindow,
+      ...(options.pricing === undefined ? {} : { pricing: options.pricing })
     }),
     react: (request, key) => Effect.promise(() => react(request, key))
   }
@@ -143,6 +277,6 @@ export const usageOf = (value: unknown): Usage => {
   return {
     promptTokens: typeof carried?.promptTokens === "number" ? carried.promptTokens : 0,
     completionTokens: typeof carried?.completionTokens === "number" ? carried.completionTokens : 0,
-    costUsd: typeof carried?.costUsd === "number" ? carried.costUsd : 0
+    ...(typeof carried?.costUsd === "number" ? { costUsd: carried.costUsd } : {})
   }
 }

--- a/packages/harness/src/keys.ts
+++ b/packages/harness/src/keys.ts
@@ -9,7 +9,7 @@ import { dedupKey, type DedupKey, type Event } from "@flamecast/core"
 // the log the way the store does.
 //
 // An event type absent from the table has no key and always lands. That is deliberate for a mark:
-// the repetition of `ModelCalled` and `ModelDeferred` is the evidence that an attempt died or
+// the repetition of `ModelCalled`, `ModelSettled`, and `ModelDeferred` is the evidence that an attempt died or
 // waited, so the log keeps every copy.
 //
 // THE SCOPE RULE. A key has to name the scope its id is unique in, and no wider. The store already

--- a/packages/harness/src/module.ts
+++ b/packages/harness/src/module.ts
@@ -14,7 +14,7 @@ import {
 } from "@flamecast/core"
 import { alarmFired } from "./alphabet"
 import { boundaryOf, type CallResult } from "./boundary"
-import { type ModelRequest, type NativeToolSpec, type Usage } from "./infer"
+import { type ModelRequest, type NativeToolSpec, type Spend, type Usage, RequestOptionsProjection } from "./infer"
 import { keyOf } from "./keys"
 import { modelRequest } from "./render"
 import {
@@ -171,7 +171,7 @@ export type TurnOutcome = CallResult | { readonly kind: "open" }
 
 export type TurnResult = TurnOutcome & {
   readonly turn: string
-  readonly usage: Usage
+  readonly usage: Spend
 }
 
 export interface BranchOptions {
@@ -453,6 +453,11 @@ const compile = <R, Services>(
       nudges: []
     } satisfies RenderPlan
   )
+  const requestOptions = serviceKeys.has(RequestOptionsProjection.key)
+    ? Context.get(services as Context.Context<RequestOptionsProjection>, RequestOptionsProjection)
+    : undefined
+  const planned: RenderPlan =
+    requestOptions === undefined ? render : { ...render, requestOptions }
   // Identity is hashed into the agent id, and the hash serializes a function as the constant
   // "[function]". Two modules whose behavior differs only inside a function would then share an
   // id. The value has to be data for the hash to identify a program reliably.
@@ -471,7 +476,7 @@ const compile = <R, Services>(
     ...(module.identity === undefined ? {} : { identity: module.identity })
   }))
   const machines = parts.flatMap((part) =>
-    typeof part.machines === "function" ? part.machines(render) : (part.machines ?? [])
+    typeof part.machines === "function" ? part.machines(planned) : (part.machines ?? [])
   )
   const machineIds = new Set<string>()
   for (const machine of machines) {
@@ -504,8 +509,8 @@ const compile = <R, Services>(
   // A withdrawal that names no tool is a typo that reads as working: the nudge fires, the surface
   // is unchanged, and the tool it meant to take away stays in front of the model. Nudges that
   // compute their tools from the log are exempt, since their names are only known at render time.
-  const offered = new Set(render.nativeTools.map((tool) => tool.name))
-  for (const nudge of render.nudges) {
+  const offered = new Set(planned.nativeTools.map((tool) => tool.name))
+  for (const nudge of planned.nudges) {
     for (const name of nudge.withdrawsNativeTools ?? []) {
       if (name !== WITHDRAW_ALL && !offered.has(name)) {
         throw new Error(`nudge "${nudge.id}" withdraws "${name}", which no module offers`)
@@ -517,7 +522,7 @@ const compile = <R, Services>(
     modules: manifests,
     events: [...new Set(parts.flatMap((part) => part.events ?? []))].sort(),
     machines: machines as ReadonlyArray<Machine<R, never>>,
-    render,
+    render: planned,
     services: services as unknown as Context.Context<Services>
   }
 }

--- a/packages/harness/src/modules/inference.test.ts
+++ b/packages/harness/src/modules/inference.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, test } from "bun:test"
-import { Clock, Effect, Layer } from "effect"
+import { Clock, Context, Effect, Layer } from "effect"
 import { TestClock } from "effect/testing"
 import type { Event } from "@flamecast/core"
 import { InMemoryRuntime } from "@flamecast/runtime-in-memory"
 import { alarmFired } from "../alphabet"
-import { inferWith, type Action, type ModelRequest } from "../infer"
+import { inferWith, RequestOptionsProjection, type Action, type ModelRequest } from "../infer"
 import { keyOf } from "../keys"
 import { createAgent } from "../module"
 import { serve } from "../serve"
 import { inference } from "./inference"
+import { flexThenStandard } from "./request-options"
 
 const usage = { promptTokens: 10, completionTokens: 2, costUsd: 0.0001 }
 
@@ -59,6 +60,7 @@ describe("a deferred model call", () => {
     expect(parked.log.map((event) => event.type)).toEqual([
       "MessageReceived",
       "ModelCalled",
+      "ModelSettled",
       "ModelDeferred"
     ])
     expect(model.keys).toEqual(["m-1/infer/0"])
@@ -86,6 +88,7 @@ describe("a deferred model call", () => {
     expect(resumed.log.map((event) => event.type)).toEqual([
       "MessageReceived",
       "ModelCalled",
+      "ModelSettled",
       "ModelDeferred",
       "AlarmFired",
       "ModelCalled",
@@ -129,6 +132,13 @@ describe("a deferred model call", () => {
       reason: "the model attempt died"
     })
     expect(model.keys).toEqual([])
+    const log = await Effect.runPromise(Effect.provide(agent.log, layer))
+    expect(log.map((event) => event.type)).toEqual([
+      "MessageReceived",
+      "ModelCalled",
+      "ModelSettled",
+      "ModelDeferred"
+    ])
 
     const resumed = await Effect.runPromise(
       Effect.provide(
@@ -193,5 +203,121 @@ describe("an in-memory alarm", () => {
 
     expect(log.map((event) => event.type)).toContain("TurnCompleted")
     expect(model.keys).toEqual(["m-1/infer/0", "m-1/infer/0"])
+  })
+})
+
+describe("reserve then settle", () => {
+  test("ModelCalled carries a reservation, and a live result settles it", async () => {
+    const agent = createAgent({ modules: [inference({ contextWindow: 200_000 })] })
+    const model = scripted([{ kind: "complete", output: "done", usage }])
+    const { log, result } = await Effect.runPromise(
+      Effect.provide(
+        Effect.gen(function* () {
+          const result = yield* agent.turn({ id: "m-1", text: "hello" })
+          return { result, log: yield* agent.log }
+        }),
+        Layer.merge(InMemoryRuntime({ keyOf, session: "user-42" }), model.layer)
+      )
+    )
+    const called = log.find((event) => event.type === "ModelCalled")
+    expect(Number((called?.reserved as { promptTokens?: number } | undefined)?.promptTokens)).toBeGreaterThan(
+      0
+    )
+    expect(result.usage.settled).toEqual(usage)
+    expect(result.usage.unsettled).toEqual({ promptTokens: 0, completionTokens: 0, costUsd: 0 })
+  })
+
+  test("a price table fills a cost the provider omitted, and a reported zero stays zero", async () => {
+    const pricing = { promptUsdPerToken: 0.001, completionUsdPerToken: 0.002 }
+    const agent = createAgent({ modules: [inference({ contextWindow: 200_000 })] })
+    const omitted = inferWith(
+      async () => ({
+        kind: "complete",
+        output: "ok",
+        usage: { promptTokens: 10, completionTokens: 4 }
+      }),
+      { contextWindow: 200_000, pricing }
+    )
+    const filled = await Effect.runPromise(
+      Effect.provide(
+        agent.turn({ id: "m-1", text: "hello" }),
+        Layer.merge(InMemoryRuntime({ keyOf, session: "user-1" }), omitted)
+      )
+    )
+    expect(filled.usage.settled.costUsd).toBeCloseTo(10 * 0.001 + 4 * 0.002, 10)
+
+    const reported = inferWith(
+      async () => ({
+        kind: "complete",
+        output: "ok",
+        usage: { promptTokens: 10, completionTokens: 4, costUsd: 0 }
+      }),
+      { contextWindow: 200_000, pricing }
+    )
+    const zero = await Effect.runPromise(
+      Effect.provide(
+        agent.turn({ id: "m-2", text: "hello" }),
+        Layer.merge(InMemoryRuntime({ keyOf, session: "user-2" }), reported)
+      )
+    )
+    expect(zero.usage.settled.costUsd).toBe(0)
+  })
+})
+
+describe("per-request options as a projection", () => {
+  test("flex by default, then standard after two deferrals in the turn", async () => {
+    const agent = createAgent({
+      modules: [inference({ contextWindow: 200_000, deferAtMost: 4 }), flexThenStandard()]
+    })
+    const model = scripted([
+      { kind: "defer", error: "queued", retryAfterMs: 1_000, usage },
+      { kind: "defer", error: "queued", retryAfterMs: 1_000, usage },
+      { kind: "complete", output: "done", usage }
+    ])
+    const layer = Layer.merge(InMemoryRuntime({ keyOf, session: "user-42" }), model.layer)
+    const wake = (at: number) => alarmFired({ turn: "m-1", callId: "m-1/infer/0", at })
+
+    await Effect.runPromise(Effect.provide(agent.turn({ id: "m-1", text: "hello" }), layer))
+    await Effect.runPromise(Effect.provide(agent.replay([wake(2)]), layer))
+    await Effect.runPromise(Effect.provide(agent.replay([wake(3)]), layer))
+
+    expect(model.seen.map((request) => request.options?.serviceTier)).toEqual([
+      "flex",
+      "flex",
+      "standard"
+    ])
+  })
+
+  test("agent.request exposes the projected options", () => {
+    const agent = createAgent({
+      modules: [inference({ contextWindow: 200_000 }), flexThenStandard()]
+    })
+    expect(agent.request([]).options).toEqual({ serviceTier: "flex" })
+    expect(Context.get(agent.services, RequestOptionsProjection)([])).toEqual({
+      serviceTier: "flex"
+    })
+    expect(
+      agent.request([
+        { type: "MessageReceived", id: "m-1", text: "hello", at: 1 },
+        {
+          type: "ModelDeferred",
+          turn: "m-1",
+          callId: "k",
+          attempt: 1,
+          notBefore: 2,
+          reason: "q",
+          at: 2
+        },
+        {
+          type: "ModelDeferred",
+          turn: "m-1",
+          callId: "k",
+          attempt: 2,
+          notBefore: 3,
+          reason: "q",
+          at: 3
+        }
+      ]).options
+    ).toEqual({ serviceTier: "standard" })
   })
 })

--- a/packages/harness/src/modules/inference.ts
+++ b/packages/harness/src/modules/inference.ts
@@ -3,6 +3,8 @@ import { EventLog, Router, Self, erase, machine, type Event, type Machine } from
 import {
   Infer,
   selectedInference,
+  settledUsage,
+  reservedUsage,
   usageOf,
   type Action,
   type InferenceSelection,
@@ -13,6 +15,7 @@ import {
   modelCalled,
   modelDeferred,
   modelReturned,
+  modelSettled,
   replyDelivered,
   textReturned,
   toolCalled,
@@ -80,6 +83,28 @@ const openCallId = (view: ReadonlyArray<Event>): string | undefined => {
   return undefined
 }
 
+const lastCalled = (view: ReadonlyArray<Event>): Event | undefined => {
+  for (let index = view.length - 1; index >= 0; index--) {
+    const event = view[index]
+    if (event?.type === "ModelCalled") return event
+  }
+  return undefined
+}
+
+const closeOrphan = (view: ReadonlyArray<Event>, turn: string, at: number): ReadonlyArray<Event> => {
+  const called = lastCalled(view)
+  if (called === undefined) return []
+  return [
+    modelSettled({
+      turn,
+      callId: String(called.callId ?? ""),
+      usage: usageOf(called.reserved),
+      reason: "the model attempt died",
+      at
+    })
+  ]
+}
+
 const completedCalls = (view: ReadonlyArray<Event>) =>
   view.filter((event) => event.type === "ModelReturned").length
 
@@ -140,8 +165,10 @@ const inferMachine = (
             const view = turnView(log)
             const at = yield* Clock.currentTimeMillis
             const died = diedAttempts(view)
+            const key = openCallId(view) ?? `${turn}/infer/${completedCalls(view)}`
             if (died >= giveUpAfter) {
               return [
+                ...closeOrphan(view, turn, at),
                 turnFailed({
                   turn,
                   error: `the model attempt died ${giveUpAfter} times in a row`,
@@ -159,10 +186,10 @@ const inferMachine = (
                 })
               ]
             }
-            const key = openCallId(view) ?? `${turn}/infer/${completedCalls(view)}`
             const deferrals = deferralsOf(view, key)
             if (deferrals >= deferAtMost) {
               return [
+                ...closeOrphan(view, turn, at),
                 turnFailed({
                   turn,
                   error: `the model was deferred ${deferAtMost} times`,
@@ -170,10 +197,12 @@ const inferMachine = (
                 })
               ]
             }
-            // An orphaned mark is a crash mid-call. Journal the wait so a restart sleeps instead of
-            // immediately issuing another request against a queue that has not moved.
+            // An orphaned mark is a crash mid-call. Close the reservation so cost does not vanish,
+            // then journal the wait so a restart sleeps instead of immediately issuing another
+            // request against a queue that has not moved.
             if (died > 0) {
               return [
+                ...closeOrphan(view, turn, at),
                 modelDeferred({
                   turn,
                   callId: key,
@@ -185,14 +214,32 @@ const inferMachine = (
               ]
             }
             const store = yield* EventLog
-            yield* store.append([modelCalled({ turn, callId: key, at })])
             const override = yield* Effect.serviceOption(Infer)
             const provider = Option.getOrElse(override, () => selectedInference(selection, log))
-            const action = yield* provider.react(modelRequest({ render }, log), key)
+            const request = modelRequest({ render }, log)
+            const reserved = reservedUsage(request, provider.state(log).pricing)
+            yield* store.append([
+              modelCalled({
+                turn,
+                callId: key,
+                reserved,
+                ...(request.options === undefined ? {} : { options: request.options }),
+                at
+              })
+            ])
+            const action = yield* provider.react(request, key)
             const after = yield* Clock.currentTimeMillis
+            const usage = settledUsage(action.usage, reserved, provider.state(log).pricing)
             if (action.kind === "defer") {
               const attempt = deferrals + 1
               return [
+                modelSettled({
+                  turn,
+                  callId: key,
+                  usage,
+                  reason: action.error,
+                  at: after
+                }),
                 modelDeferred({
                   turn,
                   callId: key,
@@ -208,7 +255,7 @@ const inferMachine = (
               modelReturned({
                 turn,
                 callId: key,
-                usage: usageOf(action.usage),
+                usage,
                 ...(continuation === undefined ? {} : { continuation }),
                 at: after
               }),
@@ -314,7 +361,7 @@ export const inference = (options: InferenceOptions) => {
   }
   return defineModule({
     id: "inference",
-    version: "4",
+    version: "5",
     identity: {
       provider: initial.id,
       state: initial.state([]),
@@ -333,6 +380,7 @@ export const inference = (options: InferenceOptions) => {
         "ModelCalled",
         "ModelDeferred",
         "AlarmFired",
+        "ModelSettled",
         "ModelReturned",
         "TextReturned",
         "ToolCalled",

--- a/packages/harness/src/modules/request-options.ts
+++ b/packages/harness/src/modules/request-options.ts
@@ -1,0 +1,34 @@
+import { Context } from "effect"
+import { RequestOptionsProjection, type RequestOptions } from "../infer"
+import { defineModule } from "../module"
+import type { Projection } from "../projection"
+import { turnView } from "../turns"
+
+export interface RequestOptionsModule {
+  readonly id?: string
+  readonly of: Projection<RequestOptions>
+}
+
+export const requestOptions = (of: Projection<RequestOptions> | RequestOptionsModule) => {
+  const policy = typeof of === "function" ? { of } : of
+  return defineModule({
+    id: "request-options",
+    version: "1",
+    identity: { id: policy.id ?? "custom" },
+    services: Context.make(RequestOptionsProjection, policy.of),
+    setup: () => ({})
+  })
+}
+
+// Flex by default. After `after` deferrals in the current turn, standard. The request is a
+// projection of the log, so the same fold chooses the same tier on replay.
+export const flexThenStandard = (after = 2) =>
+  requestOptions({
+    id: `flex-then-standard:${after}`,
+    of: (log) => ({
+      serviceTier:
+        turnView(log).filter((event) => event.type === "ModelDeferred").length >= after
+          ? "standard"
+          : "flex"
+    })
+  })

--- a/packages/harness/src/providers/anthropic-messages.test.ts
+++ b/packages/harness/src/providers/anthropic-messages.test.ts
@@ -73,7 +73,7 @@ describe("an Anthropic model on the Vercel gateway", () => {
     expect(await Effect.runPromise(provider(stub).react(request, "turn/infer/0"))).toEqual({
       kind: "complete",
       output: "Invoice INV-4182.",
-      usage: { promptTokens: 8, completionTokens: 3, costUsd: 0 }
+      usage: { promptTokens: 8, completionTokens: 3 }
     })
     expect(calls[0]?.url).toBe("https://ai-gateway.vercel.sh/v1/messages")
     expect(calls[0]?.headers.get("anthropic-version")).toBe("2023-06-01")
@@ -279,7 +279,7 @@ describe("an Anthropic model on the Vercel gateway", () => {
     expect(action.kind).toBe("fail")
     expect(String(action.kind === "fail" ? action.error : "")).toContain("output-token limit")
     expect(String(action.kind === "fail" ? action.error : "")).toContain("maxOutputTokens")
-    expect(action.usage).toEqual({ promptTokens: 900, completionTokens: 8192, costUsd: 0 })
+    expect(action.usage).toEqual({ promptTokens: 900, completionTokens: 8192 })
   })
 
   test("refuses multiple tool calls instead of dropping all but the first", async () => {
@@ -318,7 +318,7 @@ describe("an Anthropic model on the Vercel gateway", () => {
       ).react(request, "k")
     )
 
-    expect(action.usage).toEqual({ promptTokens: 512, completionTokens: 5, costUsd: 0 })
+    expect(action.usage).toEqual({ promptTokens: 512, completionTokens: 5 })
   })
 })
 

--- a/packages/harness/src/providers/anthropic-messages.ts
+++ b/packages/harness/src/providers/anthropic-messages.ts
@@ -4,11 +4,13 @@ import type {
   Action,
   AgentMessage,
   InferenceProvider,
+  ModelPricing,
   ModelRequest,
   NativeToolSpec,
   ProviderContinuation,
   Usage
 } from "../infer"
+import { applyRequestOptions, priced } from "../infer"
 
 const ANTHROPIC_MESSAGES_PROTOCOL = "anthropic-messages/v1"
 
@@ -44,6 +46,7 @@ export interface AnthropicMessagesOptions {
   // Fields an endpoint understands that the Messages API does not define. A gateway in front of this
   // API takes routing options here, so this file holds no vendor's routing vocabulary.
   readonly body?: Readonly<Record<string, unknown>>
+  readonly pricing?: ModelPricing
 }
 
 interface ContentBlock {
@@ -189,10 +192,7 @@ const usageOf = (usage: MessagesResponse["usage"]): Usage => {
       count(usage?.input_tokens) +
       count(usage?.cache_read_input_tokens) +
       count(usage?.cache_creation_input_tokens),
-    completionTokens: count(usage?.output_tokens),
-    // This API prices a turn nowhere in its reply, so the turn's cost is counted from its tokens
-    // elsewhere rather than invented here.
-    costUsd: 0
+    completionTokens: count(usage?.output_tokens)
   }
 }
 
@@ -262,7 +262,8 @@ export const anthropicMessagesInference = (
   state: () => ({
     provider: options.provider,
     model: options.model,
-    contextWindow: options.contextWindow
+    contextWindow: options.contextWindow,
+    ...(options.pricing === undefined ? {} : { pricing: options.pricing })
   }),
   react: (request: ModelRequest, key: string) =>
     Effect.gen(function* () {
@@ -298,25 +299,30 @@ const reacted = (
         "place would call the tool with none of it."
     } satisfies Action)
   }
-  const body = JSON.stringify({
-    model: options.model,
-    max_tokens: options.maxOutputTokens,
-    ...(request.system === "" ? {} : { system: request.system }),
-    messages: converted.messages,
-    ...(request.tools.length === 0
-      ? {}
-      : {
-          tools: request.tools.map(tool),
-          // One call at a time, because the harness answers one at a time and this API requires a
-          // result for every call before the conversation continues.
-          tool_choice: { type: "auto", disable_parallel_tool_use: true }
-        }),
-    ...(options.effort === undefined ? {} : { output_config: { effort: options.effort } }),
-    ...(options.thinkingBudget === undefined
-      ? {}
-      : { thinking: { type: "enabled", budget_tokens: options.thinkingBudget } }),
-    ...options.body
-  })
+  const body = JSON.stringify(
+    applyRequestOptions(
+      {
+        model: options.model,
+        max_tokens: options.maxOutputTokens,
+        ...(request.system === "" ? {} : { system: request.system }),
+        messages: converted.messages,
+        ...(request.tools.length === 0
+          ? {}
+          : {
+              tools: request.tools.map(tool),
+              // One call at a time, because the harness answers one at a time and this API requires a
+              // result for every call before the conversation continues.
+              tool_choice: { type: "auto", disable_parallel_tool_use: true }
+            }),
+        ...(options.effort === undefined ? {} : { output_config: { effort: options.effort } }),
+        ...(options.thinkingBudget === undefined
+          ? {}
+          : { thinking: { type: "enabled", budget_tokens: options.thinkingBudget } }),
+        ...options.body
+      },
+      request.options
+    )
+  )
   const refusal = overWindow(body, options.provider, options.model, options.contextWindow)
   if (refusal !== undefined) return Effect.succeed(refusal)
   return sent({
@@ -336,6 +342,10 @@ const reacted = (
     provider: options.provider,
     ...(options.retries === undefined ? {} : { retries: options.retries }),
     ...(options.timeout === undefined ? {} : { timeout: options.timeout }),
-    read: (parsed) => actionOf(parsed as MessagesResponse)
+    read: (parsed) => {
+      const action = actionOf(parsed as MessagesResponse)
+      if (action.usage === undefined) return action
+      return { ...action, usage: priced(action.usage, options.pricing) }
+    }
   })
 }

--- a/packages/harness/src/providers/cloudflare-gateway.ts
+++ b/packages/harness/src/providers/cloudflare-gateway.ts
@@ -1,5 +1,5 @@
 import { Config, Duration, Redacted } from "effect"
-import type { InferenceProvider } from "../infer"
+import type { InferenceProvider, ModelPricing } from "../infer"
 import { environment, environmentNumber } from "./environment"
 import { openAiChatInference, transport } from "./openai-chat"
 
@@ -19,6 +19,7 @@ export interface CloudflareGatewayInferenceOptions {
   readonly retries?: number
   readonly timeout?: Duration.Input
   readonly maxOutputTokens?: number
+  readonly pricing?: ModelPricing
 }
 
 export const cloudflareGatewayInference = (

--- a/packages/harness/src/providers/gateway.test.ts
+++ b/packages/harness/src/providers/gateway.test.ts
@@ -192,6 +192,57 @@ describe("Vercel AI Gateway", () => {
     expect(bodies[1]?.providerOptions).toEqual({ gateway: { only: ["deepseek"] } })
   })
 
+  test("sends a per-request service tier on the OpenAI-compatible path", async () => {
+    const bodies: Array<Record<string, unknown>> = []
+    const stub = (async (_url: string, init: RequestInit) => {
+      bodies.push(JSON.parse(String(init.body)) as Record<string, unknown>)
+      return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), {
+        status: 200
+      })
+    }) as unknown as typeof fetch
+    const provider = vercelGatewayInference({
+      apiKey: "vercel-key",
+      model: "google/gemini-3.1-pro",
+      contextWindow: 200_000,
+      fetch: stub
+    })
+
+    await Effect.runPromise(provider.react({ ...request, options: { serviceTier: "flex" } }, "k"))
+
+    expect(bodies[0]?.service_tier).toBe("flex")
+  })
+
+  test("a reported zero stays zero, and an omitted cost stays absent", async () => {
+    const of = (usage: unknown) =>
+      vercelGatewayInference({
+        apiKey: "vercel-key",
+        model: "openai/test-model",
+        contextWindow: 200_000,
+        fetch: (async () =>
+          new Response(
+            JSON.stringify({ choices: [{ message: { content: "ok" } }], usage }),
+            { status: 200 }
+          )) as unknown as typeof fetch
+      })
+
+    const zero = await Effect.runPromise(
+      of({ prompt_tokens: 8, completion_tokens: 3, cost: 0 }).react(request, "k")
+    )
+    const omitted = await Effect.runPromise(
+      of({ prompt_tokens: 8, completion_tokens: 3 }).react(request, "k")
+    )
+
+    expect(zero.kind === "complete" ? zero.usage : undefined).toEqual({
+      promptTokens: 8,
+      completionTokens: 3,
+      costUsd: 0
+    })
+    expect(omitted.kind === "complete" ? omitted.usage : undefined).toEqual({
+      promptTokens: 8,
+      completionTokens: 3
+    })
+  })
+
   // The catalog is cached per gateway for the life of the process, so each of these tests names its
   // own gateway and reads its own catalog.
   const gateway = (
@@ -282,6 +333,44 @@ describe("Vercel AI Gateway", () => {
 
     expect(fresh.state([])).toEqual(used.state([]))
     expect(fresh.state([]).contextWindow).toBe(750_000)
+  })
+
+  test("reads published pricing from the catalog and prices an omitted cost", async () => {
+    const provider = await Effect.runPromise(
+      vercelGatewayInference({
+        apiKey: "vercel-key",
+        model: "openai/test-model",
+        baseUrl: "https://catalog-price.invalid/v1",
+        fetch: gateway(
+          [],
+          {
+            object: "list",
+            data: [
+              {
+                id: "openai/test-model",
+                context_window: 100_000,
+                pricing: { input: "0.001", output: "0.002" }
+              }
+            ]
+          },
+          {
+            choices: [{ message: { content: "ok" } }],
+            usage: { prompt_tokens: 10, completion_tokens: 4 }
+          }
+        )
+      })
+    )
+
+    expect(provider.state([]).pricing).toEqual({
+      promptUsdPerToken: 0.001,
+      completionUsdPerToken: 0.002
+    })
+    const action = await Effect.runPromise(provider.react(request, "k"))
+    expect(action.kind === "complete" ? action.usage : undefined).toEqual({
+      promptTokens: 10,
+      completionTokens: 4,
+      costUsd: 10 * 0.001 + 4 * 0.002
+    })
   })
 
   test("takes the caller's context window and asks the gateway nothing", async () => {
@@ -530,7 +619,7 @@ describe("Cloudflare AI Gateway", () => {
     expect(await Effect.runPromise(provider.react(request, "k"))).toEqual({
       kind: "complete",
       output: "Invoice INV-4182.",
-      usage: { promptTokens: 8, completionTokens: 3, costUsd: 0 }
+      usage: { promptTokens: 8, completionTokens: 3 }
     })
     expect(calls[0]?.url).toBe(
       "https://api.cloudflare.com/client/v4/accounts/account-1/ai/v1/chat/completions"

--- a/packages/harness/src/providers/openai-chat.ts
+++ b/packages/harness/src/providers/openai-chat.ts
@@ -4,11 +4,13 @@ import type {
   Action,
   AgentMessage,
   InferenceProvider,
+  ModelPricing,
   ModelRequest,
   NativeToolSpec,
   ProviderContinuation,
   Usage
 } from "../infer"
+import { applyRequestOptions, priced } from "../infer"
 
 const OPENAI_CHAT_PROTOCOL = "openai-chat-completions/v1"
 
@@ -36,6 +38,7 @@ export interface OpenAiChatOptions {
   // Fields an endpoint understands that chat completions does not define. A gateway in front of this
   // API takes routing options here, so this file holds no vendor's routing vocabulary.
   readonly body?: Readonly<Record<string, unknown>>
+  readonly pricing?: ModelPricing
 }
 
 // What a gateway forwards rather than fixes. Every gateway built on this provider takes the same
@@ -50,6 +53,7 @@ export interface TransportOptions {
   // for the model, which is the right answer until a turn asks for a long generated artifact. A
   // default sized for chat can cut that artifact off partway through.
   readonly maxOutputTokens?: number
+  readonly pricing?: ModelPricing
 }
 
 export const transport = (options: TransportOptions) => ({
@@ -57,7 +61,8 @@ export const transport = (options: TransportOptions) => ({
   ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
   ...(options.retries === undefined ? {} : { retries: options.retries }),
   ...(options.timeout === undefined ? {} : { timeout: options.timeout }),
-  ...(options.maxOutputTokens === undefined ? {} : { maxOutputTokens: options.maxOutputTokens })
+  ...(options.maxOutputTokens === undefined ? {} : { maxOutputTokens: options.maxOutputTokens }),
+  ...(options.pricing === undefined ? {} : { pricing: options.pricing })
 })
 
 interface ChatToolCall {
@@ -149,16 +154,19 @@ const message = (one: AgentMessage) => {
     : { role: one.role, content: one.content }
 }
 
-const usageOf = (usage: ChatResponse["usage"]): Usage => ({
-  promptTokens: typeof usage?.prompt_tokens === "number" ? usage.prompt_tokens : 0,
-  completionTokens: typeof usage?.completion_tokens === "number" ? usage.completion_tokens : 0,
-  costUsd:
+const usageOf = (usage: ChatResponse["usage"]): Usage => {
+  const cost =
     typeof usage?.cost_usd === "number"
       ? usage.cost_usd
       : typeof usage?.cost === "number"
         ? usage.cost
-        : 0
-})
+        : undefined
+  return {
+    promptTokens: typeof usage?.prompt_tokens === "number" ? usage.prompt_tokens : 0,
+    completionTokens: typeof usage?.completion_tokens === "number" ? usage.completion_tokens : 0,
+    ...(cost === undefined ? {} : { costUsd: cost })
+  }
+}
 
 const argumentsOf = (value: unknown): unknown => {
   if (typeof value !== "string") return value ?? {}
@@ -259,7 +267,8 @@ export const openAiChatInference = (options: OpenAiChatOptions): InferenceProvid
   state: () => ({
     provider: options.provider,
     model: options.model,
-    contextWindow: options.contextWindow
+    contextWindow: options.contextWindow,
+    ...(options.pricing === undefined ? {} : { pricing: options.pricing })
   }),
   react: (request: ModelRequest, key: string) =>
     Effect.gen(function* () {
@@ -288,20 +297,23 @@ const reacted = (
   key: string,
   authorization: string
 ) => {
-  const body = JSON.stringify({
-    model: options.model,
-    messages: [
-      ...(request.system === "" ? [] : [{ role: "system", content: request.system }]),
-      ...request.messages.map(message)
-    ],
-    ...(options.maxOutputTokens === undefined
-      ? {}
-      : { max_tokens: options.maxOutputTokens }),
-    ...(request.tools.length === 0
-      ? {}
-      : { tools: request.tools.map(tool), parallel_tool_calls: false }),
-    ...options.body
-  })
+  const body = JSON.stringify(
+    applyRequestOptions(
+      {
+        model: options.model,
+        messages: [
+          ...(request.system === "" ? [] : [{ role: "system", content: request.system }]),
+          ...request.messages.map(message)
+        ],
+        ...(options.maxOutputTokens === undefined ? {} : { max_tokens: options.maxOutputTokens }),
+        ...(request.tools.length === 0
+          ? {}
+          : { tools: request.tools.map(tool), parallel_tool_calls: false }),
+        ...options.body
+      },
+      request.options
+    )
+  )
   const refusal = overWindow(body, options.provider, options.model, options.contextWindow)
   if (refusal !== undefined) return Effect.succeed(refusal)
   return sent({
@@ -319,6 +331,10 @@ const reacted = (
     provider: options.provider,
     ...(options.retries === undefined ? {} : { retries: options.retries }),
     ...(options.timeout === undefined ? {} : { timeout: options.timeout }),
-    read: (parsed) => actionOf(parsed as ChatResponse)
+    read: (parsed) => {
+      const action = actionOf(parsed as ChatResponse)
+      if (action.usage === undefined) return action
+      return { ...action, usage: priced(action.usage, options.pricing) }
+    }
   })
 }

--- a/packages/harness/src/providers/vercel-gateway.ts
+++ b/packages/harness/src/providers/vercel-gateway.ts
@@ -1,5 +1,5 @@
 import { Config, Duration, Effect, Redacted } from "effect"
-import type { InferenceProvider } from "../infer"
+import type { InferenceProvider, ModelPricing } from "../infer"
 import { anthropicMessagesInference, type ThinkingEffort } from "./anthropic-messages"
 import { environment, environmentNumber } from "./environment"
 import { openAiChatInference, transport } from "./openai-chat"
@@ -19,6 +19,7 @@ export interface VercelGatewayInferenceOptions {
   readonly retries?: number
   readonly timeout?: Duration.Input
   readonly maxOutputTokens?: number
+  readonly pricing?: ModelPricing
   // How much an Anthropic model thinks before it answers. Ignored by a model on the
   // OpenAI-compatible surface, which takes its reasoning settings from the gateway's own default.
   readonly effort?: ThinkingEffort
@@ -41,6 +42,7 @@ export interface VercelGatewayInferenceOptions {
 interface Limits {
   readonly contextWindow: number
   readonly maxOutputTokens?: number
+  readonly pricing?: ModelPricing
 }
 
 const catalogs = new Map<string, Promise<ReadonlyMap<string, Limits>>>()
@@ -49,6 +51,17 @@ interface CatalogEntry {
   readonly id?: unknown
   readonly context_window?: unknown
   readonly max_tokens?: unknown
+  readonly pricing?: {
+    readonly input?: unknown
+    readonly output?: unknown
+  }
+}
+
+const pricingOf = (entry: CatalogEntry): ModelPricing | undefined => {
+  const promptUsdPerToken = Number(entry.pricing?.input)
+  const completionUsdPerToken = Number(entry.pricing?.output)
+  if (!Number.isFinite(promptUsdPerToken) || !Number.isFinite(completionUsdPerToken)) return undefined
+  return { promptUsdPerToken, completionUsdPerToken }
 }
 
 const readCatalog = async (
@@ -70,7 +83,8 @@ const readCatalog = async (
                 contextWindow: entry.context_window,
                 ...(typeof entry.max_tokens === "number"
                   ? { maxOutputTokens: entry.max_tokens }
-                  : {})
+                  : {}),
+                ...(pricingOf(entry) === undefined ? {} : { pricing: pricingOf(entry) })
               }
             ]
           ] as ReadonlyArray<readonly [string, Limits]>)
@@ -128,8 +142,10 @@ const build = (
   baseUrl: string,
   apiKey: Config.Config<Redacted.Redacted<string>>,
   contextWindow: number,
-  publishedOutputTokens?: number
+  publishedOutputTokens?: number,
+  publishedPricing?: ModelPricing
 ): InferenceProvider => {
+  const pricing = options.pricing ?? publishedPricing
   if (isAnthropic(model)) {
     return anthropicMessagesInference({
       id: `vercel-ai-gateway:${model}`,
@@ -144,6 +160,7 @@ const build = (
       // number that would have been safe for every model at once.
       maxOutputTokens: options.maxOutputTokens ?? publishedOutputTokens ?? SAFE_OUTPUT_TOKENS,
       ...(options.effort === undefined ? {} : { effort: options.effort }),
+      ...(pricing === undefined ? {} : { pricing }),
       ...routed(options)
     })
   }
@@ -155,6 +172,7 @@ const build = (
     endpoint: `${baseUrl}/chat/completions`,
     apiKey,
     ...transport(options),
+    ...(pricing === undefined ? {} : { pricing }),
     ...routed(options)
   })
 }
@@ -210,7 +228,8 @@ export function vercelGatewayInference(
           baseUrl,
           apiKey,
           published.contextWindow,
-          published.maxOutputTokens
+          published.maxOutputTokens,
+          published.pricing
         ),
       catch: (error) => (error instanceof Error ? error : new Error(String(error)))
     })

--- a/packages/harness/src/render.ts
+++ b/packages/harness/src/render.ts
@@ -160,6 +160,7 @@ export const modelRequest = (
     checkpoint.summary === ""
       ? []
       : [{ role: "user", content: `Summary of earlier work:\n${checkpoint.summary}` }]
+  const options = definition.render.requestOptions?.(log) ?? {}
   return {
     system: systemPrompt(definition.render, log),
     messages: [
@@ -167,6 +168,7 @@ export const modelRequest = (
       ...renderMessages(definition.render, suffix),
       ...tailNudgeMessages(definition.render, log)
     ],
-    tools: nativeToolSurface(definition.render, log)
+    tools: nativeToolSurface(definition.render, log),
+    ...(Object.keys(options).length === 0 ? {} : { options })
   }
 }

--- a/packages/harness/src/serve.test.ts
+++ b/packages/harness/src/serve.test.ts
@@ -79,12 +79,12 @@ describe("serve", () => {
     expect(result.terminal).toMatchObject({
       type: "TurnCompleted",
       output: "verified",
-      usage: { promptTokens: 5, completionTokens: 7, costUsd: 0.01 }
+      usage: { completionTokens: 7, settled: { completionTokens: 7, costUsd: 0.01, promptTokens: 5 } }
     })
     const head = result.childLog.find((event) => event.type === "MessageReceived")
     expect(head?.origin).toEqual({ session: "agent:supervisor", turn: "m-1", call: "c-1" })
     expect(String(head?.id)).toBe("ask_verify:m-1:c-1")
-    expect(treeUsageIn(result.parentLog, "m-1")).toEqual({
+    expect(treeUsageIn(result.parentLog, "m-1")).toMatchObject({
       promptTokens: 5,
       completionTokens: 7,
       costUsd: 0.01

--- a/packages/harness/src/turns.test.ts
+++ b/packages/harness/src/turns.test.ts
@@ -10,6 +10,7 @@ import {
   turnView,
   usageIn
 } from "./turns"
+import { spendOf, ZERO_USAGE, type Usage } from "./infer"
 
 const message = (id: string, at: number): Event => ({ type: "MessageReceived", id, text: id, at })
 const stamped = (type: string, turn: string, at: number): Event => ({ type, turn, at })
@@ -146,24 +147,81 @@ describe("usageIn", () => {
         at: 4
       }
     ]
-    expect(usageIn(log, "m-1")).toEqual({
-      promptTokens: 300,
-      completionTokens: 30,
-      costUsd: 0.003
-    })
+    expect(usageIn(log, "m-1")).toEqual(spendOf(
+      { promptTokens: 300, completionTokens: 30, costUsd: 0.003 },
+      ZERO_USAGE
+    ))
   })
 
   test("reads zero from a turn that never called the model", () => {
-    expect(usageIn([message("m-1", 1)], "m-1")).toEqual({
-      promptTokens: 0,
-      completionTokens: 0,
-      costUsd: 0
-    })
+    expect(usageIn([message("m-1", 1)], "m-1")).toEqual(spendOf(ZERO_USAGE, ZERO_USAGE))
+  })
+
+  test("an in-flight call is unsettled, using the reservation ModelCalled carried", () => {
+    const log: ReadonlyArray<Event> = [
+      message("m-1", 1),
+      {
+        type: "ModelCalled",
+        turn: "m-1",
+        callId: "k-0",
+        reserved: { promptTokens: 80, completionTokens: 0, costUsd: 0.002 },
+        at: 2
+      }
+    ]
+    expect(usageIn(log, "m-1")).toEqual(
+      spendOf(ZERO_USAGE, { promptTokens: 80, completionTokens: 0, costUsd: 0.002 })
+    )
+  })
+
+  test("an orphaned call that settled without a result stays unsettled", () => {
+    const log: ReadonlyArray<Event> = [
+      message("m-1", 1),
+      {
+        type: "ModelCalled",
+        turn: "m-1",
+        callId: "k-0",
+        reserved: { promptTokens: 80, completionTokens: 0, costUsd: 0.002 },
+        at: 2
+      },
+      {
+        type: "ModelSettled",
+        turn: "m-1",
+        callId: "k-0",
+        usage: { promptTokens: 80, completionTokens: 0, costUsd: 0.002 },
+        reason: "the model attempt died",
+        at: 3
+      }
+    ]
+    expect(usageIn(log, "m-1")).toEqual(
+      spendOf(ZERO_USAGE, { promptTokens: 80, completionTokens: 0, costUsd: 0.002 })
+    )
+  })
+
+  test("a provider that omitted cost is unknown, and a reported zero is free", () => {
+    const log: ReadonlyArray<Event> = [
+      message("m-1", 1),
+      {
+        type: "ModelReturned",
+        turn: "m-1",
+        callId: "k-0",
+        usage: { promptTokens: 10, completionTokens: 4 },
+        at: 2
+      },
+      {
+        type: "ModelReturned",
+        turn: "m-2",
+        callId: "k-0",
+        usage: { promptTokens: 10, completionTokens: 4, costUsd: 0 },
+        at: 3
+      }
+    ]
+    expect(usageIn(log, "m-1").costUsd).toBeUndefined()
+    expect(usageIn(log, "m-2").costUsd).toBe(0)
   })
 })
 
 describe("treeUsageIn", () => {
-  const spent = (promptTokens: number, completionTokens: number, costUsd: number) => ({
+  const spent = (promptTokens: number, completionTokens: number, costUsd: number): Usage => ({
     promptTokens,
     completionTokens,
     costUsd
@@ -194,15 +252,15 @@ describe("treeUsageIn", () => {
   ]
 
   test("folds in every tool result that reports spend", () => {
-    expect(treeUsageIn(log, "m-1")).toEqual(spent(15, 8, 0.016))
+    expect(treeUsageIn(log, "m-1")).toEqual(spendOf(spent(15, 8, 0.016), ZERO_USAGE))
   })
 
   test("leaves a tool that spent nothing out of the total", () => {
-    expect(usageIn(log, "m-1")).toEqual(spent(10, 5, 0.01))
+    expect(usageIn(log, "m-1")).toEqual(spendOf(spent(10, 5, 0.01), ZERO_USAGE))
   })
 
   test("reads zero from a turn with nothing recorded", () => {
-    expect(treeUsageIn(log, "m-9")).toEqual(spent(0, 0, 0))
+    expect(treeUsageIn(log, "m-9")).toEqual(spendOf(ZERO_USAGE, ZERO_USAGE))
   })
 })
 

--- a/packages/harness/src/turns.ts
+++ b/packages/harness/src/turns.ts
@@ -1,5 +1,5 @@
 import type { Event } from "@flamecast/core"
-import { usageOf, type Usage } from "./infer"
+import { spendOf, sumUsage, usageOf, type Spend, type Usage } from "./infer"
 
 // Turn attribution. A turn is headed by one `MessageReceived`, and every event emitted while
 // serving it carries `turn: <head id>`. Attribution is a fact in the log, never a derivation from
@@ -115,23 +115,33 @@ export const servedLog = (log: ReadonlyArray<Event>): ReadonlyArray<Event> => {
   return out
 }
 
-const summed = (parts: ReadonlyArray<Usage>): Usage =>
-  parts.reduce(
-    (total, one) => ({
-      promptTokens: total.promptTokens + one.promptTokens,
-      completionTokens: total.completionTokens + one.completionTokens,
-      costUsd: total.costUsd + one.costUsd
-    }),
-    { promptTokens: 0, completionTokens: 0, costUsd: 0 }
-  )
-
-// What one turn spent on the model.
-export const usageIn = (log: ReadonlyArray<Event>, turn: string): Usage =>
-  summed(
-    log
-      .filter((event) => event.type === "ModelReturned" && stampOf(event) === turn)
-      .map((event) => usageOf(event.usage))
-  )
+// What one turn spent on the model. Settled figures come from `ModelReturned`. Unsettled figures
+// come from a `ModelCalled` still in flight and from a `ModelSettled` that closed an attempt that
+// never returned a result, using the reservation `ModelCalled` carried.
+export const usageIn = (log: ReadonlyArray<Event>, turn: string): Spend => {
+  const settled: Array<Usage> = []
+  const unsettled: Array<Usage> = []
+  let open: Usage | undefined
+  for (const event of log) {
+    if (stampOf(event) !== turn) continue
+    if (event.type === "ModelCalled") {
+      if (open !== undefined) unsettled.push(open)
+      open = usageOf(event.reserved)
+      continue
+    }
+    if (event.type === "ModelReturned") {
+      settled.push(usageOf(event.usage))
+      open = undefined
+      continue
+    }
+    if (event.type === "ModelSettled") {
+      unsettled.push(usageOf(event.usage))
+      open = undefined
+    }
+  }
+  if (open !== undefined) unsettled.push(open)
+  return spendOf(sumUsage(settled), sumUsage(unsettled))
+}
 
 // A tool result that reports what it spent. A sub-agent reports its own tree usage, and so does a
 // tool that reached a model by another route, such as a script that delegated inside a sandbox.
@@ -146,20 +156,21 @@ const reportedUsage = (event: Event): Usage | undefined => {
 
 // What one turn spent including everything it reached. The sum is inclusive over the whole
 // delegation tree without reading another session's log.
-export const treeUsageIn = (log: ReadonlyArray<Event>, turn: string): Usage =>
-  summed([
-    usageIn(log, turn),
-    ...log
-      .filter((event) => stampOf(event) === turn)
-      .map(reportedUsage)
-      .filter((usage): usage is Usage => usage !== undefined)
-  ])
+export const treeUsageIn = (log: ReadonlyArray<Event>, turn: string): Spend => {
+  const local = usageIn(log, turn)
+  const nested = log
+    .filter((event) => stampOf(event) === turn)
+    .map(reportedUsage)
+    .filter((usage): usage is Usage => usage !== undefined)
+  return spendOf(sumUsage([local.settled, ...nested]), local.unsettled)
+}
 
 const quoted = (value: unknown): string => `"${String(value ?? "")}"`
 
 const usageLine = (value: unknown): string => {
   const usage = usageOf(value)
-  return `${usage.promptTokens} in / ${usage.completionTokens} out / $${usage.costUsd.toFixed(4)}`
+  const cost = usage.costUsd === undefined ? "unknown" : `$${usage.costUsd.toFixed(4)}`
+  return `${usage.promptTokens} in / ${usage.completionTokens} out / ${cost}`
 }
 
 // The columns the readable rendering lines up on: the ordinal, the event type, the turn (or the
@@ -186,13 +197,15 @@ const detailOf = (event: Event, callWidth: number): string => {
     case "MessageReceived":
       return `${quoted(event.text)}   agent=${String(event.agent ?? "")}`
     case "ModelCalled":
-      return call("")
+      return call(event.reserved === undefined ? "" : `reserved ${usageLine(event.reserved)}`)
     case "ModelDeferred":
       return call(
         `attempt=${String(event.attempt ?? "")} notBefore=${String(event.notBefore ?? "")} ${quoted(event.reason)}`
       )
     case "AlarmFired":
       return call("")
+    case "ModelSettled":
+      return call(`${usageLine(event.usage)} ${quoted(event.reason)}`)
     case "ModelReturned":
       return call(usageLine(event.usage))
     case "TextReturned":


### PR DESCRIPTION
## Summary
- Reserve estimated spend on `ModelCalled` and append `ModelSettled` when an attempt dies or defers, so `usageIn` reports settled vs unsettled instead of silent zero.
- Treat a provider-reported zero as free and an omitted cost as unknown, filling the latter from a catalog or caller price table.
- Add `RequestOptionsProjection` so per-request settings (including `flexThenStandard()`) are a fold over the log, keeping model requests a pure projection.

## Test plan
- [x] `bun run gate` passes
- [ ] A turn that crashes after `ModelCalled` records `ModelSettled` with the reservation and `usageIn.unsettled` is nonzero
- [ ] A gateway reply with tokens and no cost stays unknown without pricing, and fills from catalog pricing when present
- [ ] A reply with `cost: 0` stays zero even when a price table exists
- [ ] `flexThenStandard()` sends `service_tier: flex`, then `standard` after two deferrals in the turn
- [ ] `agent.request(log).options` matches the projection


Made with [Cursor](https://cursor.com)