### PR TITLE
docs: themed readme diagrams

### DIFF
--- a/docs/assets/agent-loop.svg
+++ b/docs/assets/agent-loop.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 332.99299999999994 389.3" width="332.99299999999994" height="389.3" style="background:var(--bg)">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 756.2909999999999 169.5" width="756.2909999999999" height="169.5" style="background:var(--bg)">
 <style>
   :root { --bg:#ffffff;--fg:#1f2328;--accent:#d97706;--muted:#656d76; }
   @media (prefers-color-scheme: dark) { :root { --bg:#0d1117;--fg:#e6edf3;--accent:#f59e0b;--muted:#8b949e; } }
@@ -29,42 +29,42 @@
     <polygon points="8 0, 0 2.5, 8 5" fill="var(--_arrow)" stroke="var(--_arrow)" stroke-width="0.75" stroke-linejoin="round" />
   </marker>
 </defs>
-<polyline class="edge" data-from="log" data-to="infer" data-style="solid" data-arrow-start="false" data-arrow-end="true" points="114.40069999999996,169.2 114.40069999999996,157.2 16.039999999999964,157.2 16.039999999999964,88.9 44.51333333333329,88.9 44.51333333333329,52.900000000000006" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
-<polyline class="edge" data-from="log" data-to="tools" data-style="solid" data-arrow-start="false" data-arrow-end="true" points="152.22509999999997,169.2 152.22509999999997,145.2 184.49799999999996,145.2 184.49799999999996,88.9 196.30059999999995,88.9 196.30059999999995,52.900000000000006" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
-<polyline class="edge" data-from="log" data-to="compaction" data-style="solid" data-arrow-start="false" data-arrow-end="true" points="127.0088333333333,220.10000000000002 127.0088333333333,256.1 108.76899999999996,256.1 108.76899999999996,324.40000000000003 124.6623333333333,324.40000000000003 124.6623333333333,336.40000000000003" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
-<polyline class="edge" data-from="infer" data-to="log" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="ToolCalled or TurnCompleted" points="67.38866666666664,52.900000000000006 67.38866666666664,88.9 101.03999999999996,88.9 101.03999999999996,145.2 133.31289999999996,145.2 133.31289999999996,169.2" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
-<polyline class="edge" data-from="tools" data-to="log" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="ToolReturned" points="219.6699333333333,52.900000000000006 219.6699333333333,88.9 232.99799999999996,88.9 232.99799999999996,157.2 171.13729999999998,157.2 171.13729999999998,169.2" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
-<polyline class="edge" data-from="compaction" data-to="log" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="CompactionCompleted" points="160.87566666666663,336.40000000000003 160.87566666666663,324.40000000000003 176.76899999999995,324.40000000000003 176.76899999999995,256.1 158.52916666666664,256.1 158.52916666666664,220.10000000000002" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="log" data-to="infer" data-style="solid" data-arrow-start="false" data-arrow-end="true" points="328.084,51.63 316.084,51.63 316.084,23.450000000000003 316.084,23.450000000000003 316.084,28.300000000000004 84.62599999999999,28.300000000000004" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="log" data-to="tools" data-style="solid" data-arrow-start="false" data-arrow-end="true" points="328.084,71.99000000000001 304.084,71.99000000000001 304.084,88.35000000000001 304.084,88.35000000000001 304.084,93.2 157.094,93.2" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="log" data-to="compaction" data-style="solid" data-arrow-start="false" data-arrow-end="true" points="422.64500000000004,58.41666666666667 619.651,58.41666666666667 619.651,55.900000000000006 619.651,55.900000000000006 619.651,60.75000000000001 631.651,60.75000000000001" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="infer" data-to="log" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="ToolCalled or TurnCompleted" points="84.62599999999999,40.60000000000001 120.62599999999999,40.60000000000001 120.62599999999999,45.45 304.084,45.45 304.084,61.81 328.084,61.81" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="tools" data-to="log" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="ToolReturned" points="157.094,105.50000000000001 193.094,105.50000000000001 193.094,110.35000000000001 316.084,110.35000000000001 316.084,82.17000000000002 328.084,82.17000000000002" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="compaction" data-to="log" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="CompactionCompleted" points="631.651,73.05000000000001 619.651,73.05000000000001 619.651,77.9 458.64500000000004,77.9 458.64500000000004,75.38333333333334 422.64500000000004,75.38333333333334" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
 <g class="edge-label" data-from="infer" data-to="log" data-label="ToolCalled or TurnCompleted">
-  <rect x="23.039999999999964" y="95.9" width="155.458" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="100.76899999999996" y="111.05000000000001" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">ToolCalled or TurnCompleted</text>
+  <rect x="128.62599999999998" y="29.450000000000003" width="155.458" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="206.35499999999996" y="44.6" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">ToolCalled or TurnCompleted</text>
 </g>
 <g class="edge-label" data-from="tools" data-to="log" data-label="ToolReturned">
-  <rect x="191.49799999999996" y="95.9" width="82.99000000000001" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="232.99299999999997" y="111.05000000000001" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">ToolReturned</text>
+  <rect x="201.094" y="94.35000000000001" width="82.99000000000001" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="242.589" y="109.50000000000001" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">ToolReturned</text>
 </g>
 <g class="edge-label" data-from="compaction" data-to="log" data-label="CompactionCompleted">
-  <rect x="115.76899999999996" y="263.1" width="121.006" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="176.27199999999996" y="278.25" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">CompactionCompleted</text>
+  <rect x="466.64500000000004" y="61.90000000000001" width="121.006" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="527.148" y="77.05000000000001" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">CompactionCompleted</text>
 </g>
 <g class="node" data-id="log" data-label="event log" data-shape="cylinder">
-  <rect x="95.48849999999996" y="176.2" width="94.561" height="36.900000000000006" fill="var(--_node-fill)" stroke="none" />
-  <line x1="95.48849999999996" y1="176.2" x2="95.48849999999996" y2="213.1" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <line x1="190.04949999999997" y1="176.2" x2="190.04949999999997" y2="213.1" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <ellipse cx="142.76899999999995" cy="213.1" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <ellipse cx="142.76899999999995" cy="176.2" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="142.76899999999995" y="194.64999999999998" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">event log</text>
+  <rect x="328.084" y="48.45" width="94.561" height="36.900000000000006" fill="var(--_node-fill)" stroke="none" />
+  <line x1="328.084" y1="48.45" x2="328.084" y2="85.35000000000001" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <line x1="422.645" y1="48.45" x2="422.645" y2="85.35000000000001" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <ellipse cx="375.3645" cy="85.35000000000001" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <ellipse cx="375.3645" cy="48.45" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="375.3645" y="66.9" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">event log</text>
 </g>
 <g class="node" data-id="infer" data-label="infer" data-shape="rectangle">
-  <rect x="21.637999999999977" y="16" width="68.62599999999999" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="55.95099999999997" y="34.45" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">infer</text>
+  <rect x="16" y="16" width="68.62599999999999" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="50.312999999999995" y="34.45" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">infer</text>
 </g>
 <g class="node" data-id="tools" data-label="tools" data-shape="rectangle">
-  <rect x="172.9312666666666" y="16" width="70.108" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="207.9852666666666" y="34.45" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">tools</text>
+  <rect x="86.98599999999998" y="80.9" width="70.108" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="122.03999999999998" y="99.35000000000001" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">tools</text>
 </g>
 <g class="node" data-id="compaction" data-label="compaction" data-shape="rectangle">
-  <rect x="88.44899999999996" y="336.40000000000003" width="108.64" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="142.76899999999995" y="354.85" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">compaction</text>
+  <rect x="631.651" y="48.45" width="108.64" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="685.971" y="66.9" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">compaction</text>
 </g>
 </svg>

--- a/docs/assets/reconciler-loop.svg
+++ b/docs/assets/reconciler-loop.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 284.485 542.5" width="284.485" height="542.5" style="background:var(--bg)">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1013.349 122.6" width="1013.349" height="122.6" style="background:var(--bg)">
 <style>
   :root { --bg:#ffffff;--fg:#1f2328;--accent:#d97706;--muted:#656d76; }
   @media (prefers-color-scheme: dark) { :root { --bg:#0d1117;--fg:#e6edf3;--accent:#f59e0b;--muted:#8b949e; } }
@@ -29,44 +29,44 @@
     <polygon points="8 0, 0 2.5, 8 5" fill="var(--_arrow)" stroke="var(--_arrow)" stroke-width="0.75" stroke-linejoin="round" />
   </marker>
 </defs>
-<polyline class="edge" data-from="log" data-to="reactor" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="events" points="184.622,373.3 184.622,477.6000000000001 137.71266666666668,477.6000000000001 137.71266666666668,489.6000000000001" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
-<polyline class="edge" data-from="reactor" data-to="transitions" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="transitions = f(log)" points="108.90933333333334,489.6000000000001 108.90933333333334,477.6000000000001 62,477.6000000000001 62,409.3 105.94533333333334,409.3 105.94533333333334,52.900000000000006" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
-<polyline class="edge" data-from="transitions" data-to="act" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="keys the log does not record" points="140.67666666666668,52.900000000000006 140.67666666666668,88.9 184.622,88.9 184.622,169.2" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
-<polyline class="edge" data-from="act" data-to="log" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="events, keyed record last" points="184.622,206.10000000000002 184.622,322.40000000000003" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="log" data-to="reactor" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="events" points="773.2130000000001,63.45 898.9390000000001,63.45 898.9390000000001,51.375 910.9390000000001,51.375" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="reactor" data-to="transitions" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="transitions = f(log)" points="910.9390000000001,39.074999999999996 898.9390000000001,39.074999999999996 898.9390000000001,26.999999999999996 527.03,26.999999999999996 527.03,39.074999999999996 120.19400000000002,39.074999999999996" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="transitions" data-to="act" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="keys the log does not record" points="120.19400000000002,51.375 156.19400000000002,51.375 156.19400000000002,63.45 358.30600000000004,63.45" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="act" data-to="log" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="events, keyed record last" points="453.60800000000006,63.45 678.652,63.45" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
 <g class="edge-label" data-from="log" data-to="reactor" data-label="events">
-  <rect x="159.622" y="416.30000000000007" width="49.726000000000006" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="184.485" y="431.45000000000005" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">events</text>
+  <rect x="817.2130000000001" y="47.45" width="49.726000000000006" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="842.0760000000001" y="62.6" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">events</text>
 </g>
 <g class="edge-label" data-from="reactor" data-to="transitions" data-label="transitions = f(log)">
-  <rect x="12" y="416.30000000000007" width="99.62200000000003" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="61.811000000000014" y="431.45000000000005" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">transitions = f(log)</text>
+  <rect x="535.03" y="10.999999999999998" width="99.62200000000003" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="584.841" y="26.15" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">transitions = f(log)</text>
 </g>
 <g class="edge-label" data-from="transitions" data-to="act" data-label="keys the log does not record">
-  <rect x="109.12200000000001" y="95.9" width="150.11200000000002" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="184.17800000000003" y="111.05000000000001" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">keys the log does not record</text>
+  <rect x="164.19400000000002" y="47.45" width="150.11200000000002" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="239.25000000000003" y="62.6" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">keys the log does not record</text>
 </g>
 <g class="edge-label" data-from="act" data-to="log" data-label="events, keyed record last">
-  <rect x="115.62200000000001" y="249.1" width="137.04400000000004" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="184.14400000000003" y="264.25" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">events, keyed record last</text>
+  <rect x="497.60799999999995" y="47.45" width="137.04400000000004" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="566.13" y="62.6" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">events, keyed record last</text>
 </g>
 <g class="node" data-id="log" data-label="event log" data-shape="cylinder">
-  <rect x="137.34150000000002" y="329.40000000000003" width="94.561" height="36.900000000000006" fill="var(--_node-fill)" stroke="none" />
-  <line x1="137.34150000000002" y1="329.40000000000003" x2="137.34150000000002" y2="366.30000000000007" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <line x1="231.90250000000003" y1="329.40000000000003" x2="231.90250000000003" y2="366.30000000000007" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <ellipse cx="184.622" cy="366.30000000000007" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <ellipse cx="184.622" cy="329.40000000000003" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="184.622" y="347.85" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">event log</text>
+  <rect x="678.652" y="45" width="94.561" height="36.900000000000006" fill="var(--_node-fill)" stroke="none" />
+  <line x1="678.652" y1="45" x2="678.652" y2="81.9" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <line x1="773.2130000000001" y1="45" x2="773.2130000000001" y2="81.9" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <ellipse cx="725.9325" cy="81.9" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <ellipse cx="725.9325" cy="45" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="725.9325" y="63.45" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">event log</text>
 </g>
 <g class="node" data-id="reactor" data-label="reactor" data-shape="rectangle">
-  <rect x="80.10600000000002" y="489.6000000000001" width="86.41" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="123.31100000000002" y="508.05000000000007" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">reactor</text>
+  <rect x="910.9390000000001" y="26.77499999999999" width="86.41" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="954.1440000000001" y="45.224999999999994" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">reactor</text>
 </g>
 <g class="node" data-id="transitions" data-label="transitions" data-shape="rectangle">
-  <rect x="71.214" y="16" width="104.19400000000002" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="123.311" y="34.45" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">transitions</text>
+  <rect x="16" y="26.77499999999999" width="104.19400000000002" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="68.09700000000001" y="45.224999999999994" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">transitions</text>
 </g>
 <g class="node" data-id="act" data-label="act(input)" data-shape="rectangle">
-  <rect x="136.97100000000003" y="169.2" width="95.30199999999999" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="184.622" y="187.64999999999998" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">act(input)</text>
+  <rect x="358.30600000000004" y="45" width="95.30199999999999" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="405.95700000000005" y="63.45" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">act(input)</text>
 </g>
 </svg>

--- a/docs/assets/reconciler-loop.svg
+++ b/docs/assets/reconciler-loop.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1013.349 122.6" width="1013.349" height="122.6" style="background:var(--bg)">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980.6790000000001 122.6" width="980.6790000000001" height="122.6" style="background:var(--bg)">
 <style>
   :root { --bg:#ffffff;--fg:#1f2328;--accent:#d97706;--muted:#656d76; }
   @media (prefers-color-scheme: dark) { :root { --bg:#0d1117;--fg:#e6edf3;--accent:#f59e0b;--muted:#8b949e; } }
@@ -29,44 +29,44 @@
     <polygon points="8 0, 0 2.5, 8 5" fill="var(--_arrow)" stroke="var(--_arrow)" stroke-width="0.75" stroke-linejoin="round" />
   </marker>
 </defs>
-<polyline class="edge" data-from="log" data-to="reactor" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="events" points="773.2130000000001,63.45 898.9390000000001,63.45 898.9390000000001,51.375 910.9390000000001,51.375" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
-<polyline class="edge" data-from="reactor" data-to="transitions" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="transitions = f(log)" points="910.9390000000001,39.074999999999996 898.9390000000001,39.074999999999996 898.9390000000001,26.999999999999996 527.03,26.999999999999996 527.03,39.074999999999996 120.19400000000002,39.074999999999996" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
-<polyline class="edge" data-from="transitions" data-to="act" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="keys the log does not record" points="120.19400000000002,51.375 156.19400000000002,51.375 156.19400000000002,63.45 358.30600000000004,63.45" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
-<polyline class="edge" data-from="act" data-to="log" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="events, keyed record last" points="453.60800000000006,63.45 678.652,63.45" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="log" data-to="reactor" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="events" points="740.5430000000001,63.45 866.2690000000001,63.45 866.2690000000001,51.375 878.2690000000001,51.375" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="reactor" data-to="transitions" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="transitions = f(log)" points="878.2690000000001,39.074999999999996 866.2690000000001,39.074999999999996 866.2690000000001,26.999999999999996 494.36,26.999999999999996 494.36,39.074999999999996 120.19400000000002,39.074999999999996" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="transitions" data-to="act" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="unrecorded keys fire" points="120.19400000000002,51.375 156.19400000000002,51.375 156.19400000000002,63.45 325.6360000000001,63.45" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="act" data-to="log" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="events, keyed record last" points="420.9380000000001,63.45 645.9820000000001,63.45" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
 <g class="edge-label" data-from="log" data-to="reactor" data-label="events">
-  <rect x="817.2130000000001" y="47.45" width="49.726000000000006" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="842.0760000000001" y="62.6" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">events</text>
+  <rect x="784.5430000000001" y="47.45" width="49.726000000000006" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="809.4060000000002" y="62.6" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">events</text>
 </g>
 <g class="edge-label" data-from="reactor" data-to="transitions" data-label="transitions = f(log)">
-  <rect x="535.03" y="10.999999999999998" width="99.62200000000003" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="584.841" y="26.15" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">transitions = f(log)</text>
+  <rect x="502.36" y="10.999999999999998" width="99.62200000000003" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="552.171" y="26.15" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">transitions = f(log)</text>
 </g>
-<g class="edge-label" data-from="transitions" data-to="act" data-label="keys the log does not record">
-  <rect x="164.19400000000002" y="47.45" width="150.11200000000002" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="239.25000000000003" y="62.6" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">keys the log does not record</text>
+<g class="edge-label" data-from="transitions" data-to="act" data-label="unrecorded keys fire">
+  <rect x="164.19400000000002" y="47.45" width="117.44200000000004" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="222.91500000000002" y="62.6" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">unrecorded keys fire</text>
 </g>
 <g class="edge-label" data-from="act" data-to="log" data-label="events, keyed record last">
-  <rect x="497.60799999999995" y="47.45" width="137.04400000000004" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="566.13" y="62.6" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">events, keyed record last</text>
+  <rect x="464.938" y="47.45" width="137.04400000000004" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="533.46" y="62.6" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">events, keyed record last</text>
 </g>
 <g class="node" data-id="log" data-label="event log" data-shape="cylinder">
-  <rect x="678.652" y="45" width="94.561" height="36.900000000000006" fill="var(--_node-fill)" stroke="none" />
-  <line x1="678.652" y1="45" x2="678.652" y2="81.9" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <line x1="773.2130000000001" y1="45" x2="773.2130000000001" y2="81.9" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <ellipse cx="725.9325" cy="81.9" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <ellipse cx="725.9325" cy="45" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="725.9325" y="63.45" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">event log</text>
+  <rect x="645.9820000000001" y="45" width="94.561" height="36.900000000000006" fill="var(--_node-fill)" stroke="none" />
+  <line x1="645.9820000000001" y1="45" x2="645.9820000000001" y2="81.9" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <line x1="740.5430000000001" y1="45" x2="740.5430000000001" y2="81.9" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <ellipse cx="693.2625" cy="81.9" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <ellipse cx="693.2625" cy="45" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="693.2625" y="63.45" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">event log</text>
 </g>
 <g class="node" data-id="reactor" data-label="reactor" data-shape="rectangle">
-  <rect x="910.9390000000001" y="26.77499999999999" width="86.41" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="954.1440000000001" y="45.224999999999994" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">reactor</text>
+  <rect x="878.2690000000001" y="26.77499999999999" width="86.41" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="921.4740000000002" y="45.224999999999994" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">reactor</text>
 </g>
 <g class="node" data-id="transitions" data-label="transitions" data-shape="rectangle">
   <rect x="16" y="26.77499999999999" width="104.19400000000002" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
   <text x="68.09700000000001" y="45.224999999999994" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">transitions</text>
 </g>
 <g class="node" data-id="act" data-label="act(input)" data-shape="rectangle">
-  <rect x="358.30600000000004" y="45" width="95.30199999999999" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="405.95700000000005" y="63.45" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">act(input)</text>
+  <rect x="325.6360000000001" y="45" width="95.30199999999999" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="373.2870000000001" y="63.45" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">act(input)</text>
 </g>
 </svg>

--- a/tools/render-diagrams.ts
+++ b/tools/render-diagrams.ts
@@ -12,7 +12,7 @@ const DIAGRAMS: Record<string, string> = {
   "reconciler-loop": `flowchart LR
   log[("event log")] -->|"events"| reactor["reactor"]
   reactor -->|"transitions = f(log)"| transitions["transitions"]
-  transitions -->|"keys the log does not record"| act["act(input)"]
+  transitions -->|"unrecorded keys fire"| act["act(input)"]
   act -->|"events, keyed record last"| log`,
   "agent-loop": `flowchart LR
   log[("event log")]

--- a/tools/render-diagrams.ts
+++ b/tools/render-diagrams.ts
@@ -9,12 +9,12 @@ import { fileURLToPath } from "node:url"
 const root = fileURLToPath(new URL("../", import.meta.url))
 
 const DIAGRAMS: Record<string, string> = {
-  "reconciler-loop": `flowchart TB
+  "reconciler-loop": `flowchart LR
   log[("event log")] -->|"events"| reactor["reactor"]
   reactor -->|"transitions = f(log)"| transitions["transitions"]
   transitions -->|"keys the log does not record"| act["act(input)"]
   act -->|"events, keyed record last"| log`,
-  "agent-loop": `flowchart TB
+  "agent-loop": `flowchart LR
   log[("event log")]
   log --> infer & tools & compaction
   infer -->|"ToolCalled or TurnCompleted"| log


### PR DESCRIPTION
Rework the README diagrams: the reconciler loop stays vertical (the horizontal try read worse), the transitions-to-act edge label becomes "unrecorded keys fire", and theming uses GitHub's documented picture mechanism with a light and a dark SVG per diagram. An SVG behind GitHub's image proxy cannot see the site's theme toggle, so a single internally-adaptive file tracks the OS instead and can disagree with the page; two variants under a prefers-color-scheme source is the reliable seam. Gate green.