### PR TITLE
feat(agent): name it createRlmAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ $$\{\mathrm{transitions}\} = f(\mathrm{log})$$
 ## Quickstart
 
 ```ts
-import { createAgent } from "@flamecast/agent/main"
+// An RLM agent: the model writes code over your packages and can spawn itself.
+import { createRlmAgent } from "@flamecast/agent/main"
 
-const agent = createAgent({
+const agent = createRlmAgent({
   packages: [invoices], // e.g. invoices.lookup({orderId})
   infer: async (trajectory) => nextAction(trajectory) // one inference, one action; platform/model binds a real provider
 })
@@ -71,7 +72,7 @@ An actor is a set of reactors over one log, plus the key derivation that decides
 packages/
   core/      contracts: Event, EventLog, KeyFragment, Transition, Reactor, Router
   code/      durable code execution
-  agent/     the agent as reactors, and createAgent
+  agent/     the agent as reactors, and createRlmAgent
   host/      the reference in-memory binding
 platform/
   model/     the Infer binding over TanStack AI

--- a/packages/agent/src/main.test.ts
+++ b/packages/agent/src/main.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import type { Event } from "@flamecast/core/event"
 import type { Action } from "./events"
-import { createAgent } from "./main"
+import { createRlmAgent } from "./main"
 
 const ROOT_LANE = "ag.root"
 
@@ -47,9 +47,9 @@ const scripted = async (trajectory: ReadonlyArray<Event>): Promise<Action> => {
   }
 }
 
-describe("createAgent", () => {
+describe("createRlmAgent", () => {
   test("one run fans out to two children and settles with their answers", async () => {
-    const mind = createAgent({ infer: scripted })
+    const mind = createRlmAgent({ infer: scripted })
     const reply = await mind.run("fan out and add")
     expect(reply.error).toBeUndefined()
     expect(reply.output).toBe('"4,6"')
@@ -66,11 +66,11 @@ describe("createAgent", () => {
   test("an agent initialises from a log: history carries, new runs continue past it", async () => {
     // Run one agent to a settled state, carry its log into a fresh one: the resumed agent
     // reads the same history, and a new run serves without colliding with a recorded id.
-    const first = createAgent({ infer: scripted })
+    const first = createRlmAgent({ infer: scripted })
     await first.run("sum 1+2")
     const carried = first.host.read(ROOT_LANE)
 
-    const resumed = createAgent({ infer: scripted, log: carried })
+    const resumed = createRlmAgent({ infer: scripted, log: carried })
     expect(resumed.host.read(ROOT_LANE)).toEqual(carried)
     const again = await resumed.run("sum 3+4")
     expect(again.output).toBe("7")
@@ -80,7 +80,7 @@ describe("createAgent", () => {
   })
 
   test("a second run reuses the root lane as a genuinely fresh turn", async () => {
-    const mind = createAgent({ infer: scripted })
+    const mind = createRlmAgent({ infer: scripted })
     await mind.run("fan out and add")
     const again = await mind.run("fan out and add")
     expect(again.output).toBe('"4,6"')

--- a/packages/agent/src/main.ts
+++ b/packages/agent/src/main.ts
@@ -10,8 +10,9 @@ import type { Action } from "./events"
 import { boundaryOf } from "./boundary"
 import { agentsPackage } from "./spawn"
 
-// createAgent is the front door: one hosted, spawn-capable agent over an
-// ambient in-process host. No actor exists outside a host (the Erlang-node
+// createRlmAgent is the front door: a Recursive Language Model agent, one hosted,
+// spawn-capable agent over an
+// ambient in-process host (tutorials/rlm-agent.md). No actor exists outside a host (the Erlang-node
 // shape); the user brings packages and a mind, the graph is whatever
 // their agent's code decides to spawn, and run answers when the ROOT
 // settles, however many lanes exist by then.
@@ -26,14 +27,14 @@ export interface CreateAgentOptions {
   readonly log?: ReadonlyArray<Event>
 }
 
-export interface HostedAgent {
+export interface RlmAgent {
   readonly run: (brief: string) => Promise<{ readonly output?: string; readonly error?: string }>
   readonly host: Host
 }
 
 const ROOT = "ag.root"
 
-export const createAgent = (options: CreateAgentOptions): HostedAgent => {
+export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
   const user = options.packages ?? []
   const infer = Layer.succeed(Infer, {
     react: (trajectory: ReadonlyArray<Event>, key?: string) => Effect.promise(() => options.infer(trajectory, key))


### PR DESCRIPTION
Rename the front door to what it builds: createAgent becomes createRlmAgent and RlmAgent, because the default agent is the Recursive Language Model shape (the model writes code over the packages, spawns itself recursively, and compaction bounds context while the log stays reachable, tutorials/rlm-agent.md). The plain createAgent name stays free for a plainer agent if one ever exists. README quickstart follows with a one-line gloss so the term teaches itself. Gate green.