### PR TITLE
docs: quickstart imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ $$\{\mathrm{transitions}\} = f(\mathrm{log})$$
 
 ```ts
 // An RLM agent: the model writes code over your packages and can spawn itself.
+import { Effect } from "effect"
 import { createRlmAgent } from "@flamecast/agent/main"
+import type { Package } from "@flamecast/code/packages"
 
 // A package is a named object of methods the agent's code can call.
 const invoices: Package = {


### PR DESCRIPTION
Import what the quickstart uses: the Package type and Effect were referenced without their import lines. The snippet now compiles as written.