### PR TITLE
fix(model): truncation fails loudly

### DIFF
--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -309,3 +309,49 @@ describe("retry-after", () => {
     expect(throttleDelayMs({ headers: { "retry-after": "1" } }, 3, NOW)).toBeUndefined()
   })
 })
+
+
+describe("truncation", () => {
+  const sse = (events: ReadonlyArray<Record<string, unknown>>): Response =>
+    new Response(events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("") + "data: [DONE]\n\n", {
+      status: 200,
+      headers: { "content-type": "text/event-stream" }
+    })
+
+  const cut = (text: string) =>
+    sse([
+      { choices: [{ delta: { content: text }, index: 0 }] },
+      { choices: [{ delta: {}, finish_reason: "length", index: 0 }] }
+    ])
+  const whole = (text: string) =>
+    sse([
+      { choices: [{ delta: { content: text }, index: 0 }] },
+      { choices: [{ delta: {}, finish_reason: "stop", index: 0 }] }
+    ])
+
+  test("a cut answer retries up the ladder and the whole one completes", async () => {
+    let calls = 0
+    const fetchImpl = (async () => (calls++ === 0 ? cut("half an ans") : whole("the whole answer"))) as unknown as typeof fetch
+    const layer = realInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", fetch: fetchImpl })
+    const action = await Effect.runPromise(
+      Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
+        Effect.provide(layer)
+      ) as Effect.Effect<{ kind: string; output?: string }>
+    )
+    expect(calls).toBe(2)
+    expect(action.kind).toBe("complete")
+    expect(action.output).toBe("the whole answer")
+  })
+
+  test("the top rung still truncating fails the turn loudly, never half an answer", async () => {
+    const fetchImpl = (async () => cut("half")) as unknown as typeof fetch
+    const layer = realInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", fetch: fetchImpl })
+    const action = await Effect.runPromise(
+      Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
+        Effect.provide(layer)
+      ) as Effect.Effect<{ kind: string; error?: string }>
+    )
+    expect(action.kind).toBe("fail")
+    expect(action.error).toContain("output ceiling")
+  })
+})

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -332,7 +332,7 @@ describe("truncation", () => {
   test("a cut answer retries up the ladder and the whole one completes", async () => {
     let calls = 0
     const fetchImpl = (async () => (calls++ === 0 ? cut("half an ans") : whole("the whole answer"))) as unknown as typeof fetch
-    const layer = realInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", fetch: fetchImpl })
+    const layer = realInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", packagesInScope: "", fetch: fetchImpl as never })
     const action = await Effect.runPromise(
       Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
         Effect.provide(layer)
@@ -345,7 +345,7 @@ describe("truncation", () => {
 
   test("the top rung still truncating fails the turn loudly, never half an answer", async () => {
     const fetchImpl = (async () => cut("half")) as unknown as typeof fetch
-    const layer = realInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", fetch: fetchImpl })
+    const layer = realInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", packagesInScope: "", fetch: fetchImpl as never })
     const action = await Effect.runPromise(
       Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
         Effect.provide(layer)

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -245,11 +245,30 @@ export const throttleDelayMs = (e: unknown, attempt: number, now: number): numbe
 
 const realSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
+// A response cut at the output ceiling is a failed attempt, never an answer: cut prose would
+// terminate the turn half-written, and a cut tool call's arguments stopped mid-JSON, so
+// decoding the fragment executes half a program. The industry answer is retry with a higher
+// ceiling (Anthropic documents exactly this for incomplete tool_use; the AI SDK removed its
+// continuation feature in v5), so the attempt re-runs up the ladder, in-act like the throttle
+// retries, and the top rung failing truncates LOUDLY as the turn's terminal
+// (model.test.ts, "truncation").
+export const MAX_TOKENS_LADDER = [32_768, 65_536]
+
+class TruncatedError extends Error {
+  readonly truncated = true
+  constructor(ceiling: number) {
+    super(`the model's answer was cut at the ${ceiling}-token output ceiling`)
+  }
+}
+
+const isTruncated = (e: unknown): e is TruncatedError =>
+  typeof e === "object" && e !== null && (e as { truncated?: unknown }).truncated === true
+
 // The Converse leg, v5's shape cut to its core: the SDK authenticates to the GATEWAY (its own
 // authorization header is stripped; `cf-aig-authorization` carries our token, the gateway holds
 // the AWS credential), and the dynamic SDK import is resolved statically because wrangler's
 // esbuild cannot follow the adapter's indirection on workerd.
-const bedrockAdapter = (config: ModelConfig) => {
+const bedrockAdapter = (config: ModelConfig, maxTokens: number) => {
   const handler = new (class extends FetchHttpHandler {
     override async handle(request: Parameters<FetchHttpHandler["handle"]>[0], handlerOptions?: Parameters<FetchHttpHandler["handle"]>[1]) {
       request.headers = Object.fromEntries(Object.entries(request.headers).filter(([k]) => k.toLowerCase() !== "authorization"))
@@ -276,7 +295,7 @@ const bedrockAdapter = (config: ModelConfig) => {
       const input = super.buildInput(options) as BedrockRuntime.ConverseStreamCommandInput
       // Converse truncates at its own small default otherwise, and a truncated stream ends an
       // `answer` tool call with EMPTY arguments: a whole generated code body silently gone.
-      input.inferenceConfig = { ...input.inferenceConfig, maxTokens: 32_768 }
+      input.inferenceConfig = { ...input.inferenceConfig, maxTokens }
       return input
     }
   })({ apiKey: "byok", region, baseURL: config.baseUrl }, config.model as (typeof BEDROCK_CONVERSE_MODELS)[number])
@@ -303,11 +322,11 @@ const withKey = (base: FetchImpl | undefined, key: string | undefined): FetchImp
 
 export const realInfer = (config: ModelConfig) => {
   const sleep = config.sleep ?? realSleep
-  const attemptOnce = async (trajectory: ReadonlyArray<Event>, key: string | undefined): Promise<Action> => {
+  const attemptOnce = async (trajectory: ReadonlyArray<Event>, key: string | undefined, maxTokens: number): Promise<Action> => {
     const fetcher = withKey(config.fetch, key)
     const adapter =
       config.provider === "bedrock"
-        ? bedrockAdapter(config)
+        ? bedrockAdapter(config, maxTokens)
         : openaiCompatibleText(config.model, {
             name: "flamecast",
             baseURL: config.baseUrl,
@@ -329,15 +348,26 @@ export const realInfer = (config: ModelConfig) => {
       logger: noopLogger
     } as never)
     const result = await new StreamProcessor().process(bounded(stream))
+    if (result.finishReason === "length") throw new TruncatedError(maxTokens)
     return actionOf(result, schema)
   }
   return Layer.succeed(Infer, {
     react: (trajectory: ReadonlyArray<Event>, key?: string) =>
       Effect.promise(async () => {
+        let rung = 0
         for (let attempt = 0; ; attempt++) {
           try {
-            return await attemptOnce(trajectory, key)
+            return await attemptOnce(trajectory, key, MAX_TOKENS_LADDER[rung]!)
           } catch (e) {
+            if (isTruncated(e)) {
+              if (rung + 1 < MAX_TOKENS_LADDER.length) {
+                rung += 1
+                continue
+              }
+              // The top rung still truncates: the turn fails loudly instead of shipping half an
+              // answer, and the error names the remedy.
+              return { kind: "fail", error: `${e.message}; the answer does not fit the largest ceiling, so the task must produce less at once` }
+            }
             if (!isThrottleShaped(e)) throw e
             const delay = throttleDelayMs(e, attempt, Date.now())
             if (delay === undefined) throw e


### PR DESCRIPTION
A response cut at the output ceiling was decoded as if finished: cut prose terminated the turn half-written, and a cut tool call's mid-JSON arguments executed as half a program (the recorded scar: a generated code body silently gone, mitigated until now only by a hardcoded 32k ceiling). The binding now reads finishReason.

The shape follows the industry consensus over the removed driver's nudge design: Anthropic documents retry-with-a-higher-ceiling for incomplete tool_use; the AI SDK removed its continuation feature in v5; no surveyed framework continues a cut tool call.

- finishReason length throws in-act and the attempt retries up a token ladder (32k then 64k), beside the throttle retries, so marks count only real failures
- the Bedrock leg's ceiling is the ladder rung instead of the hardcode; the OpenAI-compatible leg detects and fails (its per-request ceiling option is untraced, noted for the limits work)
- the top rung still truncating fails the turn LOUDLY with the remedy named, never half an answer
- two end-to-end tests through a fake SSE endpoint (cut then whole completes on the second rung; always-cut fails with the ceiling named); gate green