### PR TITLE
feat(model): declared output limits

### DIFF
--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { Infer } from "@flamecast/agent/infer"
-import { actionOf, modelAskOf, modelIdOf, realInfer, retryAfterMsOf, throttleDelayMs } from "./model"
+import { actionOf, ladderOf, modelAskOf, modelIdOf, realInfer, retryAfterMsOf, throttleDelayMs } from "./model"
 
 // The model binding: the trajectory renders into the provider conversation, the streamed reply
 // decodes into one Action, and the whole loop round-trips through a fake OpenAI-compatible SSE
@@ -353,5 +353,32 @@ describe("truncation", () => {
     )
     expect(action.kind).toBe("fail")
     expect(action.error).toContain("output ceiling")
+  })
+})
+
+
+describe("declared limits", () => {
+  test("the ladder never exceeds the declared ceiling, and the ceiling is the last rung", () => {
+    expect(ladderOf(undefined)).toEqual([32_768, 65_536])
+    expect(ladderOf(64_000)).toEqual([32_768, 64_000])
+    expect(ladderOf(200_000)).toEqual([32_768, 65_536, 200_000])
+    expect(ladderOf(16_384)).toEqual([16_384])
+  })
+
+  test("the compatible leg states its ceiling on the wire", async () => {
+    let body: { max_tokens?: number } | undefined
+    const fetchImpl = (async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+      const request = input instanceof Request ? input : new Request(String(input), init)
+      body = JSON.parse(await request.text()) as { max_tokens?: number }
+      return new Response('data: {"choices":[{"delta":{"content":"ok"},"index":0}]}\n\ndata: {"choices":[{"delta":{},"finish_reason":"stop","index":0}]}\n\ndata: [DONE]\n\n', {
+        status: 200,
+        headers: { "content-type": "text/event-stream" }
+      })
+    }) as unknown as typeof fetch
+    const layer = realInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", packagesInScope: "", maxOutputTokens: 16_384, fetch: fetchImpl as never })
+    await Effect.runPromise(
+      Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(Effect.provide(layer)) as Effect.Effect<unknown>
+    )
+    expect(body?.max_tokens).toBe(16_384)
   })
 })

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -168,6 +168,11 @@ export interface ModelConfig {
   readonly model: string
   readonly packagesInScope: string
   readonly provider?: string
+  // The model's output ceiling, DECLARED by the operator rather than guessed: no wire this
+  // binding speaks publishes limits, so the number that bounds the truncation ladder is stated
+  // configuration. Absent, the ladder falls back to its built-in guesses and the compatible leg
+  // sends its rung explicitly rather than trusting a provider default.
+  readonly maxOutputTokens?: number
   readonly fetch?: FetchImpl // test seam
   readonly sleep?: (ms: number) => Promise<void> // test seam: swap the backoff wait for an instant one
 }
@@ -253,6 +258,15 @@ const realSleep = (ms: number): Promise<void> => new Promise((resolve) => setTim
 // retries, and the top rung failing truncates LOUDLY as the turn's terminal
 // (model.test.ts, "truncation").
 export const MAX_TOKENS_LADDER = [32_768, 65_536]
+
+// ladderOf bounds the retry ladder by the declared ceiling: never a rung above what the model
+// can produce, and the declared cap is always the last rung, so the loud failure names the
+// model's true limit (model.test.ts, "declared limits").
+export const ladderOf = (declared?: number): ReadonlyArray<number> => {
+  if (declared === undefined) return MAX_TOKENS_LADDER
+  const rungs = MAX_TOKENS_LADDER.filter((r) => r < declared)
+  return [...rungs, declared]
+}
 
 class TruncatedError extends Error {
   readonly truncated = true
@@ -345,6 +359,10 @@ export const realInfer = (config: ModelConfig) => {
       messages: req.messages.map(toMessage) as never,
       tools: req.tools.map(toTool) as never,
       systemPrompts: [req.system],
+      // The ceiling rides the wire explicitly on the compatible leg (provider-native sampling
+      // key), the same number the Bedrock leg pins through inferenceConfig: an unstated ceiling
+      // is a provider default nobody chose.
+      modelOptions: { max_tokens: maxTokens } as never,
       logger: noopLogger
     } as never)
     const result = await new StreamProcessor().process(bounded(stream))
@@ -354,13 +372,14 @@ export const realInfer = (config: ModelConfig) => {
   return Layer.succeed(Infer, {
     react: (trajectory: ReadonlyArray<Event>, key?: string) =>
       Effect.promise(async () => {
+        const ladder = ladderOf(config.maxOutputTokens)
         let rung = 0
         for (let attempt = 0; ; attempt++) {
           try {
-            return await attemptOnce(trajectory, key, MAX_TOKENS_LADDER[rung]!)
+            return await attemptOnce(trajectory, key, ladder[rung]!)
           } catch (e) {
             if (isTruncated(e)) {
-              if (rung + 1 < MAX_TOKENS_LADDER.length) {
+              if (rung + 1 < ladder.length) {
                 rung += 1
                 continue
               }


### PR DESCRIPTION
The limits half of the removed driver's read-limits-from-the-model, reshaped by what our wires offer: neither the Bedrock catalog nor the gateway publishes token limits (the bumped @tanstack/ai-bedrock catalog carries modalities only), so the ceiling becomes DECLARED configuration instead of a machine read, and never a silent guess.

- ModelConfig gains maxOutputTokens: the operator states the model's output ceiling
- the truncation ladder is bounded by the declaration (never a rung above the model's cap, the cap always the last rung), so the loud failure names the true limit
- the OpenAI-compatible leg states its rung on the wire as max_tokens through the adapter's provider-native modelOptions; an unstated ceiling was a provider default nobody chose
- absent a declaration, the built-in ladder stands unchanged
- ladder unit tests plus an end-to-end assertion that the compatible request body carries the declared ceiling; gate green