### PR TITLE
fix(model): key per ceiling rung

### DIFF
--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -329,18 +329,28 @@ describe("truncation", () => {
       { choices: [{ delta: {}, finish_reason: "stop", index: 0 }] }
     ])
 
-  test("a cut answer retries up the ladder and the whole one completes", async () => {
+  test("a cut answer retries up the ladder under a fresh idempotency key, and completes", async () => {
     let calls = 0
-    const fetchImpl = (async () => (calls++ === 0 ? cut("half an ans") : whole("the whole answer"))) as unknown as typeof fetch
+    const keys: Array<string | null> = []
+    const fetchImpl = (async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+      const request = input instanceof Request ? input : new Request(String(input), init)
+      keys.push(request.headers.get("Idempotency-Key"))
+      return calls++ === 0 ? cut("half an ans") : whole("the whole answer")
+    }) as unknown as typeof fetch
     const layer = realInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", packagesInScope: "", fetch: fetchImpl as never })
     const action = await Effect.runPromise(
-      Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
+      Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }], "t1/infer/0")).pipe(
         Effect.provide(layer)
       ) as Effect.Effect<{ kind: string; output?: string }>
     )
     expect(calls).toBe(2)
     expect(action.kind).toBe("complete")
     expect(action.output).toBe("the whole answer")
+    // The escalated retry is a different request, so it wears a different key: a deduping
+    // provider must not answer it with the cached truncated response.
+    expect(keys[0]).not.toBeNull()
+    expect(keys[1]).not.toBeNull()
+    expect(keys[1]).not.toBe(keys[0])
   })
 
   test("the top rung still truncating fails the turn loudly, never half an answer", async () => {

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -336,8 +336,14 @@ const withKey = (base: FetchImpl | undefined, key: string | undefined): FetchImp
 
 export const realInfer = (config: ModelConfig) => {
   const sleep = config.sleep ?? realSleep
-  const attemptOnce = async (trajectory: ReadonlyArray<Event>, key: string | undefined, maxTokens: number): Promise<Action> => {
-    const fetcher = withKey(config.fetch, key)
+  const attemptOnce = async (trajectory: ReadonlyArray<Event>, key: string | undefined, maxTokens: number, rung: number): Promise<Action> => {
+    // A changed ceiling is a different request, so it mints a different idempotency key: a
+    // provider that dedups would otherwise answer the escalated retry with the cached truncated
+    // response, and the ladder would climb nowhere (the removed driver learned this,
+    // flamework #22). Rung zero keeps the bare key, so crash-retries of the same request still
+    // collapse.
+    const keyForRung = key === undefined ? undefined : rung === 0 ? key : `${key}/mt${maxTokens}`
+    const fetcher = withKey(config.fetch, keyForRung)
     const adapter =
       config.provider === "bedrock"
         ? bedrockAdapter(config, maxTokens)
@@ -376,7 +382,7 @@ export const realInfer = (config: ModelConfig) => {
         let rung = 0
         for (let attempt = 0; ; attempt++) {
           try {
-            return await attemptOnce(trajectory, key, ladder[rung]!)
+            return await attemptOnce(trajectory, key, ladder[rung]!, rung)
           } catch (e) {
             if (isTruncated(e)) {
               if (rung + 1 < ladder.length) {


### PR DESCRIPTION
The settle-once audit against the removed driver's #22 found one live defect in the new truncation ladder: an escalated retry reused the attempt's idempotency key while carrying a different max_tokens, so a provider that dedups would answer it with the cached truncated response and the ladder would climb nowhere. A changed setting is a different request and now mints a different key (bare key on rung zero, so crash-retries of the same request still collapse; /mt<ceiling> suffix above it). The rest of #22's settle-once class does not exist here: keys are the settle-once mechanism in the reconciler (packages/core/tla/Reconcile.tla, CommitOne), and the spend accounting it guarded is the parked reservation work. Ladder test now asserts distinct keys across rungs; gate green.