### PR TITLE
fix(agent): compact inside a turn

### DIFF
--- a/docs/explanations/reactors.md
+++ b/docs/explanations/reactors.md
@@ -35,17 +35,18 @@ const compact = async (span: Span): Promise<CompactionCompleted[]> => {
 }
 
 // compaction enables one compact transition when the events since the
-// last checkpoint outgrow the budget. The key is the checkpoint index,
-// so a completion moves the checkpoint and retires the key: one fire
-// per crossing.
+// last checkpoint outgrow the budget. The key is the event the next
+// checkpoint keeps from, so a completion moves the checkpoint and
+// retires the key: one fire per crossing.
 const compaction: Reactor = (events) => {
   const checkpoint = lastCheckpoint(events)
-  const since = events.slice(checkpoint.upTo)
+  const since = events.slice(indexOf(events, checkpoint.keepFrom))
   if (estimateTokens(since) <= BUDGET) return []
 
+  const cut = cutOf(since)
   return [{
-    key: `compact/${checkpoint.upTo}`,
-    input: { summary: checkpoint.summary, events: since },
+    key: `compact/${cut.id}`,
+    input: { summary: checkpoint.summary, events: since.slice(0, cut.at) },
     act: compact,
   }]
 }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -112,39 +112,44 @@ Notice the key: the count of answered calls. A crashed inference never records `
 **Compaction.** The loop appends forever, and the trajectory grows with it. Keeping it small is a capability, so it is a reactor. Assume a token estimate `sizeOf(events)` and a `BUDGET` it compares against.
 
 ```ts
-// CompactionCompleted is the checkpoint: the summary so far, and the index it covers.
-// A render reads the summary plus the events after upTo; nothing is deleted.
-type CompactionCompleted = { type: "CompactionCompleted"; summary: string; upTo: number }
+// CompactionCompleted is the checkpoint: the summary so far, and the event it keeps from.
+// A render reads the summary plus the events from keepFrom on; nothing is deleted.
+// The checkpoint names an event, never an index: a reactor folds the log while a render
+// folds a projection of it, and the same index is a different event in each.
+type CompactionCompleted = { type: "CompactionCompleted"; summary: string; keepFrom: string }
 
 // lastCheckpoint: the latest checkpoint, or the empty one.
-const lastCheckpoint: Projection<{ summary: string; upTo: number }> = (events) =>
-  events.findLast((e) => e.type === "CompactionCompleted") ?? { summary: "", upTo: 0 }
+const lastCheckpoint: Projection<{ summary: string; keepFrom: string }> = (events) =>
+  events.findLast((e) => e.type === "CompactionCompleted") ?? { summary: "", keepFrom: "" }
 ```
 
 ```ts
-// A Span is the stretch owed a summary: from the checkpoint it starts at,
-// up to the index the next checkpoint will cover.
-type Span = { summary: string; events: Event[]; from: number; upTo: number }
+// A Span is the stretch owed a summary: the events before the cut, and the
+// event the next checkpoint keeps from.
+type Span = { summary: string; events: Event[]; keepFrom: string }
 
 // spanOf: the span owed a summary, or null while the log is under budget.
+// cutOf picks a boundary a render can open on, so a kept tail never starts
+// with a tool result whose call was summarized away.
 const spanOf: Projection<Span | null> = (events) => {
   const checkpoint = lastCheckpoint(events)
-  const since = events.slice(checkpoint.upTo)
+  const since = events.slice(indexOf(events, checkpoint.keepFrom))
   if (sizeOf(since) <= BUDGET) return null
-  return { summary: checkpoint.summary, events: since, from: checkpoint.upTo, upTo: events.length }
+  const cut = cutOf(since)
+  return { summary: checkpoint.summary, events: since.slice(0, cut.at), keepFrom: cut.id }
 }
 
 // compact folds a span into the next checkpoint.
 const compact = async (span: Span): Promise<CompactionCompleted[]> => {
   const summary = await summarize(span.summary, span.events)
-  return [{ type: "CompactionCompleted", summary, upTo: span.upTo }]
+  return [{ type: "CompactionCompleted", summary, keepFrom: span.keepFrom }]
 }
 
 // compaction: enabled when the events since the checkpoint outgrow the budget.
 const compaction: Reactor = (events) => {
   const span = spanOf(events)
   if (!span) return []
-  return [{ key: `compact/${span.from}`, input: span, act: compact }]
+  return [{ key: `compact/${span.keepFrom}`, input: span, act: compact }]
 }
 ```
 

--- a/packages/agent/src/compaction.test.ts
+++ b/packages/agent/src/compaction.test.ts
@@ -8,40 +8,56 @@ import { agentActorKeys } from "./turn"
 import {
   COMPACTION_FIRE_TOKENS,
   COMPACTION_KEEP_TOKENS,
+  RESULT_RENDER_CAP,
   checkpointOf,
   compactionReactor,
   estimateTokens,
+  keepFromIndex,
   suffixOf
 } from "./compaction"
 
-// Compaction is a pure machine: a guard fires at a turn's end when the suffix passes FIRE tokens,
-// the pass summarizes down to a KEEP-token tail, and the checkpoint binds. The summarizer is the
-// ordinary Infer seam, stubbed here. The size measure is chars over four.
+// Compaction is a pure machine: a guard fires at a resolved tool round when the rendered suffix
+// passes FIRE tokens, the pass summarizes down to a KEEP-token tail, and the checkpoint binds by
+// event identity. The summarizer is the ordinary Infer seam, stubbed here. The size measure is
+// rendered chars over four.
 
-// A turn with a big tool result, sized so a few turns cross the token budget.
-const bigTurn = (i: number): Event[] => [
-  { type: "MessageReceived", id: `m${i}`, text: `question ${i}`, at: i * 3 },
-  { type: "ToolReturned", callId: `c${i}`, result: { data: "x".repeat(20_000) }, turn: `m${i}`, at: i * 3 + 1 },
-  { type: "ReplyDelivered", turn: `m${i}`, at: i * 3 + 2 }
+const head: Event = { type: "MessageReceived", id: "m0", text: "extract the covenants", at: 0 }
+
+// One resolved tool round inside the open turn, sized so a dozen rounds cross the token budget.
+const round = (i: number, turn = "m0"): Event[] => [
+  { type: "ToolCalled", callId: `c${i}`, name: "execute", arguments: { code: `run ${i}` }, turn, at: i * 2 + 1 },
+  { type: "ToolReturned", callId: `c${i}`, result: { data: "x".repeat(5_000) }, turn, at: i * 2 + 2 }
 ]
 
+const openTurn = (rounds: number): Event[] => {
+  const log: Event[] = [head]
+  for (let i = 1; i <= rounds; i++) log.push(...round(i))
+  return log
+}
+
 describe("the compaction measure and guard", () => {
-  test("estimateTokens is chars over four", () => {
-    expect(estimateTokens([{ type: "X", pad: "y".repeat(396) } as Event])).toBeGreaterThan(100)
+  test("the measure counts what a render sends: capped results, skipped lanes", () => {
+    const big: Event = { type: "ToolReturned", callId: "c", result: { data: "x".repeat(40_000) }, at: 1 }
+    expect(estimateTokens([big])).toBe(Math.ceil(RESULT_RENDER_CAP / 4))
+    const lane: Event = { type: "CodeSettled", execId: "c", result: 1, at: 2 } as Event
+    expect(estimateTokens([lane])).toBe(0)
   })
 
-  test("the guard fires on a turn end only when the suffix is over budget", () => {
-    const small = bigTurn(0).slice(0, 1).concat([{ type: "ReplyDelivered", at: 9 }])
-    expect(compactionReactor(small)).toHaveLength(0) // tiny suffix, no fire
-    const big: Event[] = []
-    for (let i = 0; i < 4; i++) big.push(...bigTurn(i)) // ~20k tokens, past the 16k FIRE
-    expect(estimateTokens(suffixOf(big))).toBeGreaterThan(COMPACTION_FIRE_TOKENS)
-    expect(compactionReactor(big)).toHaveLength(1) // a turn ended with the suffix over FIRE
+  test("the guard fires inside an open turn once a resolved round passes FIRE", () => {
+    expect(estimateTokens(suffixOf(openTurn(16)))).toBeGreaterThan(COMPACTION_FIRE_TOKENS)
+    expect(compactionReactor(openTurn(16))).toHaveLength(1) // no reply anywhere, the turn is live
+    expect(compactionReactor(openTurn(2))).toHaveLength(0) // under FIRE
+  })
+
+  test("the guard holds while a call is unanswered", () => {
+    const awaiting: Event[] = [
+      ...openTurn(16),
+      { type: "ToolCalled", callId: "c99", name: "execute", arguments: {}, turn: "m0", at: 99 }
+    ]
+    expect(compactionReactor(awaiting)).toHaveLength(0)
   })
 
   test("the guard is pure: the fold runs with the clock and randomness rigged to throw", () => {
-    const big: Event[] = []
-    for (let i = 0; i < 4; i++) big.push(...bigTurn(i))
     const realNow = Date.now
     const realRandom = Math.random
     Date.now = () => {
@@ -51,7 +67,7 @@ describe("the compaction measure and guard", () => {
       throw new Error("random in the compaction guard")
     }
     try {
-      expect(compactionReactor(big)).toHaveLength(1)
+      expect(compactionReactor(openTurn(16))).toHaveLength(1)
     } finally {
       Date.now = realNow
       Math.random = realRandom
@@ -62,32 +78,61 @@ describe("the compaction measure and guard", () => {
 const mailbox = actor<Infer | EventLog>([compactionReactor], agentActorKeys)
 
 describe("the compaction pass", () => {
-  test("a fire summarizes and checkpoints down to a KEEP-token tail", async () => {
-    const initial: Event[] = []
-    for (let i = 0; i < 6; i++) initial.push(...bigTurn(i)) // ~30k tokens of suffix
+  const run = async (initial: ReadonlyArray<Event>) => {
     const ref = Effect.runSync(Ref.make<ReadonlyArray<Event>>(initial))
     let briefed = ""
     const layers = Layer.mergeAll(
-      Layer.succeed(EventLog, withWatermark({
-        append: (events: ReadonlyArray<Event>) => Ref.update(ref, (log) => [...log, ...events]),
-        read: Ref.get(ref)
-      })),
+      Layer.succeed(
+        EventLog,
+        withWatermark({
+          append: (events: ReadonlyArray<Event>) => Ref.update(ref, (log) => [...log, ...events]),
+          read: Ref.get(ref)
+        })
+      ),
       Layer.succeed(Infer, {
         react: (trajectory: ReadonlyArray<Event>) => {
           briefed = String((trajectory[0] as { text?: unknown }).text ?? "")
-          return Effect.succeed({ kind: "complete" as const, output: "the user asked 0..N and got answers" })
+          return Effect.succeed({ kind: "complete" as const, output: "covenants 1 through 13 extracted" })
         }
       })
     )
     await Effect.runPromise(
       send(mailbox, { type: "CompactionFired", at: 999 }).pipe(Effect.provide(layers)) as Effect.Effect<void>
     )
-    const log = await Effect.runPromise(Ref.get(ref))
+    return { log: await Effect.runPromise(Ref.get(ref)), briefed: () => briefed }
+  }
+
+  test("a fire summarizes and checkpoints down to a KEEP-token tail, mid-turn", async () => {
+    const { log, briefed } = await run(openTurn(16))
     const checkpoint = checkpointOf(log)
-    expect(checkpoint.summary).toBe("the user asked 0..N and got answers")
-    // The retained tail fits the KEEP budget (allow one event of slack for the boundary event).
-    const tailBudget = COMPACTION_KEEP_TOKENS + estimateTokens([log[log.length - 1]!])
-    expect(estimateTokens(suffixOf(log))).toBeLessThanOrEqual(tailBudget)
-    expect(briefed).toContain("question 0")
+    expect(checkpoint.summary).toBe("covenants 1 through 13 extracted")
+    expect(keepFromIndex(log, checkpoint.keepFrom)).toBeGreaterThan(0)
+    // The retained tail fits KEEP plus at most one round of boundary slack.
+    const roundTokens = estimateTokens(round(1))
+    expect(estimateTokens(suffixOf(log))).toBeLessThanOrEqual(COMPACTION_KEEP_TOKENS + 2 * roundTokens)
+    expect(briefed()).toContain("extract the covenants")
+    expect(briefed()).toContain("run 1")
+  })
+
+  test("the cut lands on a boundary: a kept tail opens with a call, its return beside it", async () => {
+    const { log } = await run(openTurn(16))
+    const suffix = suffixOf(log)
+    expect(suffix[0]!.type).toBe("ToolCalled")
+    const callId = String((suffix[0] as { callId?: unknown }).callId)
+    expect(checkpointOf(log).keepFrom).toBe(`c:${callId}`)
+    expect(suffix.some((e) => e.type === "ToolReturned" && String((e as { callId?: unknown }).callId) === callId)).toBe(
+      true
+    )
+  })
+
+  test("a second crossing keys anew and reaches further", async () => {
+    const first = await run(openTurn(16))
+    const grown: Event[] = [...first.log]
+    for (let i = 17; i <= 32; i++) grown.push(...round(i))
+    const second = await run(grown)
+    const checkpoint = checkpointOf(second.log)
+    expect(keepFromIndex(second.log, checkpoint.keepFrom)).toBeGreaterThan(
+      keepFromIndex(first.log, checkpointOf(first.log).keepFrom)
+    )
   })
 })

--- a/packages/agent/src/compaction.ts
+++ b/packages/agent/src/compaction.ts
@@ -2,63 +2,153 @@ import { Clock, Effect } from "effect"
 import { transition, type Reactor } from "@flamecast/core/actor"
 import { compactionCompleted } from "./events"
 import type { Event } from "@flamecast/core/event"
+import { turnOf, turnView } from "@flamecast/code/turns"
 import { Infer } from "./infer"
 
-// The compaction reactor: a pure observer of the context size, with the hysteresis design. A guard
-// fires compaction at a turn's end when the suffix since the last checkpoint passes FIRE, and the
-// pass summarizes down to a KEEP-token tail, so it runs once per crossing instead of on every event
-// after it. FIRE greater than KEEP is the hysteresis: the checkpoint drops the suffix well under
-// FIRE, so the guard does not re-fire until the suffix regrows. The trigger is the guard, not the
-// platform, so the whole decision is a pure fold of the log, byte-stable under replay.
+// The compaction reactor: a pure observer of the context size, with the hysteresis design. A
+// guard fires compaction at a resolved tool round, any moment the open turn awaits no call, when
+// the rendered suffix since the last checkpoint passes FIRE. A long turn therefore sheds context
+// while it runs, and the request stays bounded near FIRE under any window; a guard keyed to a
+// turn's end starves the one shape that grows, a single long tool loop (compaction.test.ts,
+// "fires inside an open turn"). The pass summarizes down to a KEEP-token tail. FIRE greater than
+// KEEP is the hysteresis: the checkpoint drops the suffix well under FIRE, so the guard does not
+// re-fire until the suffix regrows.
+//
+// The checkpoint names the first kept event by identity. The reactor folds the raw log while a
+// render folds the projection (trajectoryOf), and an index into one array means a different
+// event in the other the moment a queued message lands mid-turn; identity means the same event
+// in both (request.test.ts, "a checkpoint survives the projection"). A cut lands only on a
+// boundary that renders whole, a served turn head or a ToolCalled, so a kept tail never opens
+// with a tool result whose call was summarized away, a conversation every provider rejects.
+//
 // `CompactionCompleted` is the checkpoint: renders start from the summary plus the live suffix.
 // Nothing is deleted; the full log stays for the rubric and replay. Consecutive fires with no
 // completion between them are a crash-looping summarizer, and the usual give-up evidence applies.
 
-// estimateTokens estimates the span's tokens as chars over four. A real tokenizer would be a
-// dependency and an impure path, and every budget decision must fold the same on replay, so the
-// estimate is a pure function of the recorded bytes. The guard and the tail share this one
-// measure.
-export const estimateTokens = (events: ReadonlyArray<Event>): number =>
-  Math.ceil(events.reduce((n, e) => n + JSON.stringify(e).length, 0) / 4)
+// The render's truncation caps, stated once beside the measure that must agree with them;
+// request.ts renders with these.
+export const MESSAGE_RENDER_CAP = 12_000
+export const RESULT_RENDER_CAP = 6_000
 
-// COMPACTION_FIRE_TOKENS is the suffix size that fires a pass; COMPACTION_KEEP_TOKENS bounds the
-// retained tail the pass summarizes down to.
+// renderedChars counts the characters a render sends for one event: capped where the render
+// caps, zero for an event the render skips. The guard must measure the request the model sees;
+// a measure over raw event JSON counts tool results the render truncates and lanes the render
+// never shows, and fires against a size no request ever reaches.
+const renderedChars = (e: Event): number => {
+  const v = e as Record<string, unknown>
+  switch (e.type) {
+    case "MessageReceived":
+      return Math.min(String(v.text ?? "").length, MESSAGE_RENDER_CAP)
+    case "TextReturned":
+      return String(v.text ?? "").length
+    case "ToolCalled":
+      return JSON.stringify(v.arguments ?? {}).length
+    case "ToolReturned":
+      return Math.min(JSON.stringify(v.result ?? null).length, RESULT_RENDER_CAP)
+    case "TurnCompleted":
+      return String(v.output ?? "").length
+    case "TurnFailed":
+      return String(v.error ?? "").length
+    default:
+      return 0
+  }
+}
+
+// estimateTokens estimates the span's rendered tokens as chars over four. A real tokenizer would
+// be a dependency and an impure path, and every budget decision must fold the same on replay, so
+// the estimate is a pure function of the recorded events (compaction.test.ts, "the measure").
+export const estimateTokens = (events: ReadonlyArray<Event>): number =>
+  Math.ceil(events.reduce((n, e) => n + renderedChars(e), 0) / 4)
+
+// COMPACTION_FIRE_TOKENS is the rendered suffix size that fires a pass; COMPACTION_KEEP_TOKENS
+// bounds the retained tail the pass summarizes down to.
 export const COMPACTION_FIRE_TOKENS = 16_000
 export const COMPACTION_KEEP_TOKENS = 4_000
 
-// checkpointOf returns the last checkpoint: the index the next span starts from, and the summary
-// to date.
-export const checkpointOf = (log: ReadonlyArray<Event>): { readonly upTo: number; readonly summary: string } => {
-  let upTo = 0
+// checkpointOf returns the last checkpoint: the identity the next span starts from, and the
+// summary to date.
+export const checkpointOf = (log: ReadonlyArray<Event>): { readonly keepFrom: string; readonly summary: string } => {
+  let keepFrom = ""
   let summary = ""
   for (const e of log) {
     if (e.type === "CompactionCompleted") {
-      upTo = Number((e as { upTo?: unknown }).upTo ?? 0)
+      keepFrom = String((e as { keepFrom?: unknown }).keepFrom ?? "")
       summary = String((e as { summary?: unknown }).summary ?? "")
     }
   }
-  return { upTo, summary }
+  return { keepFrom, summary }
+}
+
+// keepFromIndex resolves a checkpoint identity in one sequence: the first index holding the
+// named event, zero when the identity is empty or absent. Absence keeps everything, the safe
+// side; the guard then re-fires and cuts anew.
+export const keepFromIndex = (events: ReadonlyArray<Event>, keepFrom: string): number => {
+  if (keepFrom === "") return 0
+  for (let i = 0; i < events.length; i++) {
+    const e = events[i]!
+    const v = e as { callId?: unknown; id?: unknown }
+    if (keepFrom.startsWith("c:") && e.type === "ToolCalled" && String(v.callId) === keepFrom.slice(2)) return i
+    if (keepFrom.startsWith("m:") && e.type === "MessageReceived" && String(v.id) === keepFrom.slice(2)) return i
+  }
+  return 0
 }
 
 // suffixOf returns everything after the checkpoint: the span a render or a fire decision sees.
-export const suffixOf = (log: ReadonlyArray<Event>): ReadonlyArray<Event> => log.slice(checkpointOf(log).upTo)
+export const suffixOf = (log: ReadonlyArray<Event>): ReadonlyArray<Event> =>
+  log.slice(keepFromIndex(log, checkpointOf(log).keepFrom))
 
 // overContext reports whether the suffix has passed FIRE tokens. It is pure and total over the
 // log, so the fire decision re-folds identically on replay: it reads only the log, no clock and
 // no random source.
 const overContext = (log: ReadonlyArray<Event>): boolean => estimateTokens(suffixOf(log)) > COMPACTION_FIRE_TOKENS
 
-// keepUpTo returns the index the summary keeps from: the newest events whose tokens fit in KEEP.
-// It walks from the end, so the retained tail is bounded by tokens rather than a fixed event
-// count. The checkpoint never moves backward, so `prior.upTo` is the floor.
-const keepUpTo = (log: ReadonlyArray<Event>): number => {
+// atRoundBoundary gates the guard: a pass may land whenever the open turn awaits no tool call,
+// between turns included. A checkpoint landing mid-round would cut a call from the return the
+// world still owes it.
+const atRoundBoundary = (log: ReadonlyArray<Event>): boolean => {
+  const open = turnView(log)
+  if (open.length === 0) return true
+  const answered = new Set(
+    open.filter((e) => e.type === "ToolReturned").map((e) => String((e as { callId?: unknown }).callId))
+  )
+  return !open.some((e) => e.type === "ToolCalled" && !answered.has(String((e as { callId?: unknown }).callId)))
+}
+
+// boundaryIdOf returns the identity a cut at this event would record: a ToolCalled keeps its
+// return beside it, and a served head opens its turn whole. Any other position splits a pair or
+// names an event the projection cannot see, so it is no boundary.
+const boundaryIdOf = (e: Event, served: ReadonlySet<string>): string | undefined => {
+  const v = e as { callId?: unknown; id?: unknown }
+  if (e.type === "ToolCalled") return `c:${String(v.callId)}`
+  if (e.type === "MessageReceived" && served.has(String(v.id))) return `m:${String(v.id)}`
+  return undefined
+}
+
+// cutOf picks the next checkpoint: the newest boundary whose tail still fits KEEP, or failing
+// that the first boundary past the KEEP line, so the checkpoint always advances when a boundary
+// exists at all. The checkpoint never moves backward; no boundary past the prior one means no
+// cut, and the fire waits for the next round to offer one.
+const cutOf = (log: ReadonlyArray<Event>): { readonly keepFrom: string; readonly index: number } | undefined => {
+  const priorIndex = keepFromIndex(log, checkpointOf(log).keepFrom)
+  const served = new Set(log.map(turnOf).filter((t): t is string => t !== undefined))
   let tokens = 0
-  for (let i = log.length - 1; i >= 0; i--) {
+  let raw = priorIndex
+  for (let i = log.length - 1; i >= priorIndex; i--) {
     tokens += estimateTokens([log[i]!])
-    // Keep the newest event even when it alone exceeds KEEP, so a render always has recent context.
-    if (tokens > COMPACTION_KEEP_TOKENS) return Math.min(i + 1, log.length - 1)
+    if (tokens > COMPACTION_KEEP_TOKENS) {
+      raw = i + 1
+      break
+    }
   }
-  return 0
+  for (let i = Math.min(raw, log.length - 1); i > priorIndex; i--) {
+    const id = boundaryIdOf(log[i]!, served)
+    if (id !== undefined) return { keepFrom: id, index: i }
+  }
+  for (let i = Math.max(raw + 1, priorIndex + 1); i < log.length; i++) {
+    const id = boundaryIdOf(log[i]!, served)
+    if (id !== undefined) return { keepFrom: id, index: i }
+  }
+  return undefined
 }
 
 const lineOf = (e: Event): string | null => {
@@ -93,32 +183,29 @@ const firedUncovered = (log: ReadonlyArray<Event>): boolean => {
   return fires > passes
 }
 
-// turnEndedSinceCheckpoint gates the guard: a pass runs between turns, never mid-turn.
-const turnEndedSinceCheckpoint = (log: ReadonlyArray<Event>): boolean =>
-  suffixOf(log).some((e) => e.type === "ReplyDelivered")
-
-// compactionReactor derives a pass when the suffix has crossed FIRE at a turn boundary, or an
+// compactionReactor derives a pass when the suffix has crossed FIRE at a round boundary, or an
 // explicit `CompactionFired` stands uncovered. The act always advances the checkpoint (the
 // retained tail is bounded by KEEP < FIRE), so a served pass quiets the derivation instead of
-// re-firing. The checkpoint's key is where it reaches: cc:<upTo>. Its input is the span to fold,
-// a projection, so a retried fire summarizes the same span. A crash-looping summarizer
-// re-derives the same key and its retries absorb, while a later fire reaches further and keys
-// anew.
+// re-firing. The checkpoint's key is the identity it keeps from: cc:<keepFrom>. Its input is the
+// span to fold, a projection, so a retried fire summarizes the same span. A crash-looping
+// summarizer re-derives the same key and its retries absorb, while a later fire reaches further
+// and keys anew.
 export const compactionReactor: Reactor<Infer> = (log) => {
-  if (!(firedUncovered(log) || (overContext(log) && turnEndedSinceCheckpoint(log)))) return []
+  if (!(firedUncovered(log) || (overContext(log) && atRoundBoundary(log)))) return []
+  const cut = cutOf(log)
+  if (cut === undefined) return []
   const prior = checkpointOf(log)
-  const upTo = Math.max(prior.upTo, keepUpTo(log))
-  const span = log.slice(prior.upTo, upTo)
+  const span = log.slice(keepFromIndex(log, prior.keepFrom), cut.index)
   return [
     transition({
-      key: `cc:${upTo}`,
-      input: { upTo, summary: prior.summary, span },
+      key: `cc:${cut.keepFrom}`,
+      input: { keepFrom: cut.keepFrom, summary: prior.summary, span },
       act: (input) =>
         Effect.gen(function* () {
           const at = yield* Clock.currentTimeMillis
           const lines = input.span.map(lineOf).filter((l): l is string => l !== null)
           if (lines.length === 0) {
-            return [compactionCompleted({ upTo: input.upTo, summary: input.summary, at })]
+            return [compactionCompleted({ keepFrom: input.keepFrom, summary: input.summary, at })]
           }
           const brief = [
             "Summarize this agent history in a compact paragraph. Keep every fact a future turn could need: names, ids, decisions, unfinished work.",
@@ -126,11 +213,11 @@ export const compactionReactor: Reactor<Infer> = (log) => {
             lines.join("\n")
           ].join("\n\n")
           const action = yield* (yield* Infer).react(
-            [{ type: "MessageReceived", id: `compact-${input.upTo}`, text: brief, at }],
-            `compact-${input.upTo}`
+            [{ type: "MessageReceived", id: `compact-${input.keepFrom}`, text: brief, at }],
+            `compact-${input.keepFrom}`
           )
           const summary = action.kind === "complete" ? action.output : input.summary
-          return [compactionCompleted({ upTo: input.upTo, summary, at })]
+          return [compactionCompleted({ keepFrom: input.keepFrom, summary, at })]
         })
     })
   ]

--- a/packages/agent/src/events.ts
+++ b/packages/agent/src/events.ts
@@ -178,8 +178,8 @@ export const agentKeys: KeyFragment = {
       case "BudgetRequested":
         return `br:${String(v.callId)}`
       case "CompactionCompleted":
-        // The checkpoint's occurrence is where it reaches.
-        return `cc:${String(v.upTo)}`
+        // The checkpoint's occurrence is the identity it keeps from.
+        return `cc:${String(v.keepFrom)}`
       default:
         return undefined
     }
@@ -231,5 +231,5 @@ export const budgetDenied = (
 ): Event => ({ type: "BudgetDenied", ...fields }) as Event
 
 export const compactionCompleted = (
-  fields: { readonly upTo: number; readonly summary: string; readonly at: number }
+  fields: { readonly keepFrom: string; readonly summary: string; readonly at: number }
 ): Event => ({ type: "CompactionCompleted", ...fields }) as Event

--- a/packages/agent/src/request.test.ts
+++ b/packages/agent/src/request.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { Event } from "@flamecast/core/event"
+import { trajectoryOf } from "@flamecast/code/turns"
 import { modelRequest, renderMessages } from "./request"
 
 // The request is a pure projection of the trajectory: the message conversation, and the tool and
@@ -23,6 +24,43 @@ describe("renderMessages", () => {
       toolCalls: [{ id: "call_1", name: "execute", arguments: '{"code":"return 1"}' }]
     })
     expect(messages[2]).toMatchObject({ toolCallId: "call_1", content: '{"result":1}' })
+  })
+
+  test("a checkpoint survives the projection: identity anchors the same event in log and render", () => {
+    // A queued mid-turn message shifts every raw index by one once the projection excludes it. An
+    // index checkpoint would slice the render one event late and open it with a dangling tool
+    // result; the identity finds ToolCalled c2 wherever the projection put it.
+    const raw: ReadonlyArray<Event> = [
+      { type: "MessageReceived", id: "m1", text: "draft the addendum", at: 0 },
+      { type: "ModelCalled", callId: "m1/infer/0", ordinal: 1, turn: "m1", at: 1 },
+      { type: "ToolCalled", callId: "c1", name: "execute", arguments: { code: "read" }, turn: "m1", at: 2 },
+      { type: "ToolReturned", callId: "c1", result: { ok: 1 }, turn: "m1", at: 3 },
+      { type: "MessageReceived", id: "m2", text: "queued follow-up", at: 4 },
+      { type: "ToolCalled", callId: "c2", name: "execute", arguments: { code: "write" }, turn: "m1", at: 5 },
+      { type: "ToolReturned", callId: "c2", result: { ok: 2 }, turn: "m1", at: 6 },
+      { type: "CompactionCompleted", keepFrom: "c:c2", summary: "read the base contract", at: 7 }
+    ]
+    const messages = renderMessages(trajectoryOf(raw))
+    expect(messages[0]).toMatchObject({ role: "user", content: "draft the addendum" }) // the open head, verbatim
+    expect(String(messages[1]!.content)).toContain("read the base contract")
+    expect(messages[2]).toMatchObject({ role: "assistant", toolCalls: [{ id: "c2", name: "execute" }] })
+    expect(messages[3]).toMatchObject({ role: "tool", toolCallId: "c2" })
+    expect(messages).toHaveLength(4)
+  })
+
+  test("a head at the cut renders once, never verbatim and again from the suffix", () => {
+    const raw: ReadonlyArray<Event> = [
+      { type: "MessageReceived", id: "m1", text: "old task", at: 0 },
+      { type: "TurnCompleted", output: "done", turn: "m1", at: 1 },
+      { type: "ReplyDelivered", turn: "m1", at: 2 },
+      { type: "MessageReceived", id: "m2", text: "new task", at: 3 },
+      { type: "ModelCalled", callId: "m2/infer/0", ordinal: 1, turn: "m2", at: 4 },
+      { type: "CompactionCompleted", keepFrom: "m:m2", summary: "the old task finished", at: 5 }
+    ]
+    const messages = renderMessages(trajectoryOf(raw))
+    expect(messages.map((m) => m.role)).toEqual(["user", "user"])
+    expect(String(messages[0]!.content)).toContain("Summary of earlier work")
+    expect(messages[1]).toMatchObject({ content: "new task" })
   })
 })
 

--- a/packages/agent/src/request.ts
+++ b/packages/agent/src/request.ts
@@ -1,5 +1,5 @@
 import type { Event } from "@flamecast/core/event"
-import { checkpointOf } from "./compaction"
+import { MESSAGE_RENDER_CAP, RESULT_RENDER_CAP, checkpointOf, keepFromIndex } from "./compaction"
 import { outputSchemaOf } from "./contract"
 import { budgetSpent, canRequestBudget } from "./budget"
 
@@ -85,26 +85,45 @@ const BUDGET_NUDGE =
 const ESCALATE_NUDGE =
   "If the work genuinely needs more and the extra spend is worth it, you may call request_budget with a reason and an amount instead of answering. Ask only when it changes the result; otherwise answer now."
 
+const userMessageOf = (e: Event): AgentMessage => {
+  const v = e as Record<string, unknown>
+  const text = String(v.text ?? "")
+  return {
+    role: "user",
+    content:
+      text.length > MESSAGE_RENDER_CAP
+        ? `${text.slice(0, MESSAGE_RENDER_CAP)}…[truncated ${text.length} chars; read the full message with logs.events on this facet, id ${String(v.id)}]`
+        : text
+  }
+}
+
 // renderMessages rebuilds the trajectory as a conversation: reactions as assistant messages,
 // tool returns as tool messages, terminals as assistant text. Rendering starts from the last
-// checkpoint's summary plus the live suffix. Unknown event types fall through: tolerant reads.
+// checkpoint's summary plus the kept suffix, resolved by the checkpoint's identity so the same
+// event anchors the render and the reactor whatever the projection reordered
+// (request.test.ts, "a checkpoint survives the projection"). The open turn's head renders
+// verbatim ahead of the summary when the checkpoint passed it: the live task never shrinks to a
+// summary paragraph mid-turn. Unknown event types fall through: tolerant reads.
 export const renderMessages = (trajectory: ReadonlyArray<Event>): ReadonlyArray<AgentMessage> => {
   const messages: AgentMessage[] = []
   const checkpoint = checkpointOf(trajectory)
+  const from = keepFromIndex(trajectory, checkpoint.keepFrom)
+  const terminated = new Set(
+    trajectory
+      .filter((e) => e.type === "TurnCompleted" || e.type === "TurnFailed")
+      .map((e) => String((e as { turn?: unknown }).turn))
+  )
+  const openHead = trajectory.findIndex(
+    (e) => e.type === "MessageReceived" && !terminated.has(String((e as { id?: unknown }).id))
+  )
+  if (openHead !== -1 && openHead < from) messages.push(userMessageOf(trajectory[openHead]!))
   if (checkpoint.summary !== "") messages.push({ role: "user", content: `Summary of earlier work:\n${checkpoint.summary}` })
   let pendingText: string | null = null
-  for (const e of trajectory.slice(checkpoint.upTo)) {
+  for (const e of trajectory.slice(from)) {
     const v = e as Record<string, unknown>
     switch (e.type) {
       case "MessageReceived": {
-        const text = String(v.text ?? "")
-        messages.push({
-          role: "user",
-          content:
-            text.length > 12000
-              ? `${text.slice(0, 12000)}…[truncated ${text.length} chars; read the full message with logs.events on this facet, id ${String(v.id)}]`
-              : text
-        })
+        messages.push(userMessageOf(e))
         break
       }
       case "TextReturned": {
@@ -125,7 +144,7 @@ export const renderMessages = (trajectory: ReadonlyArray<Event>): ReadonlyArray<
         messages.push({
           role: "tool",
           toolCallId: String(v.callId),
-          content: body.length > 6000 ? `${body.slice(0, 6000)}…[truncated ${body.length} chars]` : body
+          content: body.length > RESULT_RENDER_CAP ? `${body.slice(0, RESULT_RENDER_CAP)}…[truncated ${body.length} chars]` : body
         })
         break
       }

--- a/packages/agent/src/tools.ts
+++ b/packages/agent/src/tools.ts
@@ -57,13 +57,22 @@ const settleFor = (
   callId: string
 ): { result?: unknown; error?: string; logs?: ReadonlyArray<string> } | undefined => {
   const settle = log.find((e) => e.type === "CodeSettled" && str((e as { execId?: unknown }).execId) === callId) as
-    | { result?: unknown; error?: unknown; logs?: ReadonlyArray<string> }
+    | { result?: unknown; error?: unknown; logs?: ReadonlyArray<string>; tmp?: unknown; size?: unknown; preview?: unknown; note?: unknown }
     | undefined
   if (settle === undefined) return undefined
   // Captured console output rides along: the model reads what its code printed, beside the
   // result (the print-to-inspect habit; packages/code/src/sandbox.ts, SandboxResult.logs).
   const logs = settle.logs !== undefined && settle.logs.length > 0 ? { logs: settle.logs } : {}
-  return settle.error === undefined ? { result: settle.result, ...logs } : { error: String(settle.error), ...logs }
+  if (settle.error !== undefined) return { error: String(settle.error), ...logs }
+  // A settle over TMP_BYTES carries a pointer instead of the value (packages/code/src/execute.ts).
+  // The pointer IS the result the model reads: its preview and its note name the ref and the
+  // call that loads it. Reading `result` alone answers a spilled call with `{}`, so the model
+  // learns neither what it computed nor that anything is there to fetch, and it re-runs the work
+  // it already did (tools.test.ts, "a spilled settle").
+  if (settle.tmp !== undefined) {
+    return { result: { tmp: settle.tmp, size: settle.size, preview: settle.preview, note: settle.note }, ...logs }
+  }
+  return { result: settle.result, ...logs }
 }
 
 // decisionFor returns the parent's decision on an escalation ask, scoped to the call's turn.

--- a/packages/agent/src/turn.test.ts
+++ b/packages/agent/src/turn.test.ts
@@ -142,6 +142,38 @@ describe("the agent with execute as the only tool", () => {
     expect(toolsReactor(events)).toHaveLength(0)
   })
 
+  test("a spilled settle answers with its pointer, never an empty result", async () => {
+    // Over TMP_BYTES the settle carries a pointer instead of the value. Answering the call from
+    // `result` alone hands the model `{}`: it learns neither what its code computed nor that a
+    // ref holds it, so it re-runs the work. The pointer and its note are the result.
+    const big = "y".repeat(20_000)
+    const spilled: ReadonlyArray<Event> = [
+      { type: "MessageReceived", id: "m1", text: "read the contract", at: 1 },
+      { type: "ToolCalled", callId: "t1", name: "execute", arguments: { code: "return await docs.read()" }, turn: "m1", at: 2 },
+      { type: "CodeDispatched", execId: "t1", code: "return await docs.read()", turn: "m1", at: 3 },
+      {
+        type: "CodeSettled",
+        execId: "t1",
+        tmp: "t1.result",
+        size: big.length,
+        preview: big.slice(0, 500),
+        note: "full value: workspace.read({ref: 't1.result'})",
+        turn: "m1",
+        at: 4
+      }
+    ]
+    const events = await run(readLog, memoryLog(spilled))
+    const [answer] = toolsReactor(events)
+    expect(answer).toBeDefined()
+    const returned = await run(answer!.act(answer!.input as never) as Effect.Effect<ReadonlyArray<Event>>, memoryLog())
+    expect(returned[0]!.type).toBe("ToolReturned")
+    const result = (returned[0] as unknown as { result: { result: Record<string, unknown> } }).result.result
+    expect(result.tmp).toBe("t1.result")
+    expect(result.size).toBe(big.length)
+    expect(result.note).toBe("full value: workspace.read({ref: 't1.result'})")
+    expect(String(result.preview)).toHaveLength(500)
+  })
+
   test("a committed package call replays: the insert is never re-executed", async () => {
     // The shape a crash leaves behind: the insert's pair is committed, the search never ran. The
     // re-settle re-runs the body from the top, replays the insert from the log, and runs only


### PR DESCRIPTION
Compaction has never fired where the context actually grows, so the durability work landed on a path the failing runs do not take. Across a 1,219 cell benchmark sweep exactly one cell compacted, and the degenerate turns that motivated the work ran to their ceiling uncompacted. The guard required a `ReplyDelivered` since the last checkpoint, which is a turn boundary. The shape that grows is a single long turn looping on tool calls, and that shape crosses no turn boundary until it is already over. A guard keyed to the end of a turn cannot bound a turn that has not ended.

The guard now fires at any resolved tool round, meaning any moment the open turn awaits no call. A long turn sheds context while it runs and the request stays bounded near FIRE under any window. A 40 round turn that would render 60,224 tokens now peaks at 15,521 across four mid-turn checkpoints, and the bound holds for any number of rounds.

Two further defects would have made compaction harmful once it did fire. The checkpoint recorded an index into the raw log while the render sliced `trajectoryOf(log)`, a projection that drops queued messages and repositions heads, so one message arriving mid-turn shifted every later render by one event. The result is dropped context or a tool message whose call was sliced away, which providers reject with a 400, which reads as three died attempts and a failed turn. The checkpoint now names its first kept event by identity, and identity means the same event in both sequences. Separately the cut was chosen by token count alone and could land between a `ToolCalled` and its `ToolReturned`, leaving the same orphaned tool result. Cuts now land only on a served turn head or a `ToolCalled`, so a kept tail always renders as a valid conversation.

The guard also measured raw event JSON, counting full tool results the render truncates and lanes the render never sends. It now measures what the request carries, with the render caps stated once and shared by both sides.

The open turn's head renders verbatim ahead of the summary once a checkpoint passes it, so the live task is never reduced to a summary paragraph while the model is still working on it. This is a projection change with no prompt content, and it adds no conditional guidance to any model.

One defect in the same family turned up while verifying this end to end. A code result over `TMP_BYTES` spills to tmp and the settle carries a pointer with a preview and the call that loads the full value, but `settleFor` read only `settle.result`, so the model received `{}`. It learned neither what its code computed nor that a ref held it, and the work was there to be redone. The pointer is now the result the model reads.

Gate green at 16 checks. New coverage: the guard fires inside an open turn and holds while a call is unanswered, a cut keeps a call and its return together, a checkpoint survives the projection with a queued mid-turn message, a head at the cut renders once, and a spilled settle answers with its pointer.
