### PR TITLE
feat(agent): pluggable tool surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,25 @@ import { messageKeys } from "@flamecast/core/message"
 import { codeReactor, codeKeys } from "@flamecast/code"
 import { jsSandbox, memoryTmp } from "@flamecast/code/defaults"
 import { Packages } from "@flamecast/code/packages"
-import { agentKeys, budgetReactor, compactionReactor, inferReactor, replyReactor, toolsReactor } from "@flamecast/agent"
+import { agentKeys, budgetReactor, codeSurface, compactionReactor, inferReactor, replyReactor, toolsReactorFor } from "@flamecast/agent"
 import { realInfer } from "@flamecast/model/model"
 import { createBunHost } from "@flamecast/bun/host"
 
+// The tool surface: code mode is the default. `nativeSurface` presents a fixed table of named
+// tools instead, for an agent measured against another harness's surface.
+const surface = codeSurface("none")
+
 // Adding a capability is adding a reactor to the list.
 const agent = actor(
-  [inferReactor, budgetReactor, toolsReactor, codeReactor, replyReactor, compactionReactor],
+  [inferReactor, budgetReactor, toolsReactorFor(surface), codeReactor, replyReactor, compactionReactor],
   composeKeys(messageKeys, codeKeys, agentKeys)
 )
 
 // The wiring: a real model through platform/model, a sandbox for the agent's code, your packages.
+// The binding renders the same surface the actor serves.
 const wiring = () =>
   Layer.mergeAll(
-    realInfer({ baseUrl: process.env.MODEL_BASE_URL!, apiKey: process.env.MODEL_API_KEY!, model: process.env.MODEL_ID!, provider: "bedrock", packagesInScope: "none", maxOutputTokens: 64_000 }),
+    realInfer({ baseUrl: process.env.MODEL_BASE_URL!, apiKey: process.env.MODEL_API_KEY!, model: process.env.MODEL_ID!, provider: "bedrock", surface, maxOutputTokens: 64_000 }),
     Layer.succeed(Packages, { resolve: () => undefined, list: () => Effect.succeed([]) }),
     jsSandbox,
     memoryTmp()

--- a/knip.json
+++ b/knip.json
@@ -13,6 +13,11 @@
       "project": [
         "src/**/*.ts"
       ]
+    },
+    "platform/*": {
+      "project": [
+        "src/**/*.ts"
+      ]
     }
   }
 }

--- a/packages/agent/src/budget.test.ts
+++ b/packages/agent/src/budget.test.ts
@@ -101,12 +101,13 @@ describe("the tools gate reacts to BudgetExhausted", () => {
     expect(out[0]!.type).toBe("CodeDispatched")
   })
 
-  test("once BudgetExhausted is on the turn, execute is refused with an answer nudge", async () => {
+  test("once BudgetExhausted is on the turn, the work tool is refused with an answer nudge", async () => {
     const log = turn(3, 2, [{ type: "BudgetExhausted", budget: 2, used: 3, turn: "m1", at: 99 }])
     const out = await dispatch(log)
     expect(out[0]!.type).toBe("ToolReturned")
-    expect(String((out[0] as { result?: { error?: string } }).result?.error)).toContain("budget reached".replace("budget reached", "Tool budget reached"))
-    expect(String((out[0] as { result?: { error?: string } }).result?.error)).toContain("answer now")
+    const refusal = String((out[0] as { result?: { error?: string } }).result?.error)
+    expect(refusal).toContain("Tool budget reached")
+    expect(refusal).toContain("Answer now")
   })
 })
 

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test"
 import type { Event } from "@flamecast/core/event"
 import type { Action } from "./events"
+import { Effect } from "effect"
 import { createRlmAgent } from "./index"
+import { nativeSurface } from "./surface"
 
 const ROOT_LANE = "ag.root"
 
@@ -89,5 +91,55 @@ describe("createRlmAgent", () => {
     for (const lane of ["ag.t2.0", "ag.t2.1"]) {
       expect(mind.host.read(lane).some((e) => e.type === "TurnCompleted")).toBe(true)
     }
+  })
+
+  test("a native tool surface runs the same turn loop with no code lane", async () => {
+    // The benchmark shape: a fixed table of named tools, called directly. Code mode is the
+    // default rather than the only surface, so an agent measured against another harness keeps
+    // the turn loop, the budget wall, and the answer contract while presenting that harness's
+    // tools (surface.ts).
+    const reads: string[] = []
+    const surface = nativeSurface([
+      {
+        spec: { name: "read", description: "read a file", inputSchema: { type: "object", properties: { path: { type: "string" } } } },
+        run: (input) => {
+          const path = String((input as { path?: unknown }).path)
+          reads.push(path)
+          return Effect.succeed(`contents of ${path}`)
+        }
+      }
+    ])
+    const mind = createRlmAgent({
+      surface,
+      infer: async (trajectory) => {
+        const returned = trajectory.find((e) => e.type === "ToolReturned") as { result?: unknown } | undefined
+        if (returned !== undefined) return { kind: "complete", output: String(returned.result) }
+        return { kind: "call", callId: "n1", name: "read", arguments: { path: "/contract.md" } }
+      }
+    })
+    const answer = await mind.run("read the contract")
+    expect(answer.output).toBe("contents of /contract.md")
+    expect(reads).toEqual(["/contract.md"])
+    // The tool answered directly: no code was ever dispatched.
+    const log = mind.host.read(ROOT_LANE)
+    expect(log.some((e) => e.type === "CodeDispatched")).toBe(false)
+    expect(log.filter((e) => e.type === "ToolReturned")).toHaveLength(1)
+  })
+
+  test("a call outside the surface comes back as an unknown tool, never a dead turn", async () => {
+    const surface = nativeSurface([
+      { spec: { name: "read", description: "read", inputSchema: {} }, run: () => Effect.succeed("ok") }
+    ])
+    const mind = createRlmAgent({
+      surface,
+      infer: async (trajectory) => {
+        const returned = trajectory.find((e) => e.type === "ToolReturned") as { result?: { error?: string } } | undefined
+        if (returned !== undefined) return { kind: "complete", output: String(returned.result?.error) }
+        return { kind: "call", callId: "x1", name: "execute", arguments: { code: "return 1" } }
+      }
+    })
+    const answer = await mind.run("go")
+    expect(answer.output).toContain("unknown tool: execute")
+    expect(answer.output).toContain("read")
   })
 })

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -4,11 +4,12 @@ import { Router } from "@flamecast/core/router"
 import { Packages, type Package } from "@flamecast/code/packages"
 import { jsSandbox, memoryTmp } from "@flamecast/code/defaults"
 import { createHost, type Host } from "@flamecast/host/host"
-import { agent, type AgentR } from "./turn"
+import { agent, agentFor, type AgentR } from "./turn"
 import { Infer } from "./infer"
 import type { Action } from "./events"
 import { boundaryOf } from "./boundary"
 import { agentsPackage } from "./spawn"
+import type { ToolSurface } from "./surface"
 
 // createRlmAgent is the front door: a Recursive Language Model agent, one hosted,
 // spawn-capable agent over an
@@ -24,13 +25,17 @@ export { agent } from "./turn"
 // The parts the actor is assembled from, for a caller composing their own: the six reactors
 // and the agent's key table. An agent is reactors over one log; adding a capability is adding
 // a reactor to the list.
-export { agentActorKeys } from "./turn"
+export { agentActorKeys, agentFor } from "./turn"
 export { inferReactor, Infer } from "./infer"
 export { budgetReactor } from "./budget"
-export { toolsReactor } from "./tools"
+export { toolsReactor, toolsReactorFor } from "./tools"
 export { replyReactor } from "./reply"
 export { compactionReactor } from "./compaction"
 export { agentKeys } from "./events"
+
+// The tool surface: code mode is the default, and an agent measured against a fixed tool table
+// brings its own (surface.ts).
+export { codeSurface, nativeSurface, type NativeTool, type ToolSurface } from "./surface"
 
 export interface CreateAgentOptions {
   readonly packages?: ReadonlyArray<Package>
@@ -40,6 +45,9 @@ export interface CreateAgentOptions {
   // only state there is. The next run derives from everything here, and work the log still owes
   // settles on the first drive (index.test.ts, "an agent initialises from a log").
   readonly log?: ReadonlyArray<Event>
+  // The tool surface, code mode by default. The same surface must reach the model binding, so a
+  // caller passing one here passes it to `realInfer` too (surface.ts).
+  readonly surface?: ToolSurface<AgentR>
 }
 
 export interface RlmAgent {
@@ -77,9 +85,10 @@ export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
   }
 
   // Every ag. lane runs the full turn loop; anything else is a sink.
+  const assembled = options.surface === undefined ? agent : agentFor(options.surface)
   const host: Host = createHost<AgentR>({
     principal: "mem",
-    actorFor: (lane) => (lane.startsWith("ag.") ? agent : undefined),
+    actorFor: (lane) => (lane.startsWith("ag.") ? assembled : undefined),
     layersFor: layersFor as never
   })
 

--- a/packages/agent/src/request.test.ts
+++ b/packages/agent/src/request.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
 import type { Event } from "@flamecast/core/event"
 import { trajectoryOf } from "@flamecast/code/turns"
 import { modelRequest, renderMessages } from "./request"
+import { codeSurface, nativeSurface } from "./surface"
+
+const CODE = codeSurface("none")
 
 // The request is a pure projection of the trajectory: the message conversation, and the tool and
 // prompt policy. Both live in the domain, so they test without a provider.
@@ -71,14 +75,14 @@ describe("modelRequest tool and prompt policy", () => {
   ]
 
   test("with no schema, offers execute; with a schema, offers execute and answer", () => {
-    expect(modelRequest(head(), undefined as never).tools.map((t) => t.name)).toEqual(["execute"])
+    expect(modelRequest(head(), CODE).tools.map((t) => t.name)).toEqual(["execute"])
     const schema = { type: "object", properties: { a: { type: "string" } } }
-    expect(modelRequest(head([], schema), "").tools.map((t) => t.name)).toEqual(["execute", "answer"])
+    expect(modelRequest(head([], schema), CODE).tools.map((t) => t.name)).toEqual(["execute", "answer"])
   })
 
   test("once the budget is spent, execute is dropped and the nudge is added", () => {
     const spent = head([{ type: "BudgetExhausted", budget: 2, used: 3, turn: "m1", at: 5 }])
-    const req = modelRequest(spent, "")
+    const req = modelRequest(spent, CODE)
     expect(req.tools.map((t) => t.name)).toEqual([]) // no work tool, no schema, so the model answers in prose
     expect(req.system).toContain("tool budget for this turn is spent")
   })
@@ -86,7 +90,7 @@ describe("modelRequest tool and prompt policy", () => {
   test("spent with a schema leaves only the answer tool", () => {
     const schema = { type: "object", properties: { a: { type: "string" } } }
     const spent = head([{ type: "BudgetExhausted", budget: 2, used: 3, turn: "m1", at: 5 }], schema)
-    expect(modelRequest(spent, "").tools.map((t) => t.name)).toEqual(["answer"])
+    expect(modelRequest(spent, CODE).tools.map((t) => t.name)).toEqual(["answer"])
   })
 
   test("a spent wall from an earlier turn does not drop execute in a fresh turn", () => {
@@ -96,6 +100,39 @@ describe("modelRequest tool and prompt policy", () => {
       { type: "TurnCompleted", output: "done", turn: "m1", at: 2 },
       { type: "MessageReceived", id: "m2", text: "new", at: 3 }
     ]
-    expect(modelRequest(trajectory, "").tools.map((t) => t.name)).toEqual(["execute"])
+    expect(modelRequest(trajectory, CODE).tools.map((t) => t.name)).toEqual(["execute"])
+  })
+})
+
+describe("the tool surface decides the tool table", () => {
+  const LAB = nativeSurface([
+    { spec: { name: "read", description: "read a file", inputSchema: {} }, run: () => Effect.succeed("") },
+    { spec: { name: "grep", description: "search files", inputSchema: {} }, run: () => Effect.succeed("") }
+  ])
+  const head = (extra: Event[] = [], output?: unknown): Event[] => [
+    { type: "MessageReceived", id: "m1", text: "go", ...(output === undefined ? {} : { output }), at: 0 },
+    ...extra
+  ]
+
+  test("a native surface offers its own tools and never mentions execute", () => {
+    const req = modelRequest(head(), LAB)
+    expect(req.tools.map((t) => t.name)).toEqual(["read", "grep"])
+    expect(req.system).not.toContain("execute")
+    expect(req.system).toContain("read, grep")
+  })
+
+  test("every policy still folds over a swapped surface", () => {
+    const schema = { type: "object", properties: { a: { type: "string" } } }
+    expect(modelRequest(head([], schema), LAB).tools.map((t) => t.name)).toEqual(["read", "grep", "answer"])
+    const spent = head([{ type: "BudgetExhausted", budget: 2, used: 3, turn: "m1", at: 5 }], schema)
+    // The wall drops the work tools whatever they are, and leaves the answer contract standing.
+    expect(modelRequest(spent, LAB).tools.map((t) => t.name)).toEqual(["answer"])
+    expect(modelRequest(spent, LAB).system).toContain("tool budget for this turn is spent")
+  })
+
+  test("the turn frame is surface independent", () => {
+    for (const surface of [CODE, LAB]) {
+      expect(modelRequest(head(), surface).system).toContain("that reply is your final answer")
+    }
   })
 })

--- a/packages/agent/src/request.ts
+++ b/packages/agent/src/request.ts
@@ -2,6 +2,7 @@ import type { Event } from "@flamecast/core/event"
 import { MESSAGE_RENDER_CAP, RESULT_RENDER_CAP, checkpointOf, keepFromIndex } from "./compaction"
 import { outputSchemaOf } from "./contract"
 import { budgetSpent, canRequestBudget } from "./budget"
+import type { ToolSurface } from "./surface"
 
 // The model request, decided from the trajectory: system prompt, tool surface, message
 // projection. Domain policy lives with the agent; the platform maps these provider-agnostic
@@ -33,20 +34,6 @@ export interface ModelRequest {
   readonly tools: ReadonlyArray<ToolSpec>
 }
 
-// EXECUTE_TOOL is the one work tool: the model acts by writing JavaScript against the packages
-// in scope.
-const EXECUTE_TOOL: ToolSpec = {
-  name: "execute",
-  description:
-    "Run JavaScript against the connected packages. Packages are objects in scope; await their methods and end with `return <value>`. The returned value comes back as this call's result, and console output comes back beside it as `logs` (capped; return the value you need, print to inspect).",
-  inputSchema: {
-    type: "object",
-    properties: { code: { type: "string", description: "The JavaScript body to run." } },
-    required: ["code"],
-    additionalProperties: false
-  }
-}
-
 // answerTool renders the turn's declared output schema as a tool. Calling it ends the turn, and
 // its arguments are the structured answer, parsed JSON by construction.
 const answerTool = (schema: unknown): ToolSpec => ({
@@ -57,7 +44,7 @@ const answerTool = (schema: unknown): ToolSpec => ({
 
 // REQUEST_BUDGET_TOOL is offered only at the wall, and only when the brief made the turn
 // escalatable. The model calls it to ask its parent for more tool calls instead of answering.
-// The call parks the turn until the parent grants or denies; a grant reopens `execute`.
+// The call parks the turn until the parent grants or denies; a grant reopens the work tools.
 const REQUEST_BUDGET_TOOL: ToolSpec = {
   name: "request_budget",
   description:
@@ -73,14 +60,17 @@ const REQUEST_BUDGET_TOOL: ToolSpec = {
   }
 }
 
-const SYSTEM = (packages: string): string =>
-  `You are an agent. You act on the world by calling the execute tool with JavaScript; the packages in scope are:\n${packages}\nWhen the work is done, reply in plain text: that reply is your final answer and ends the turn. Reply plainly without calling execute when no action is needed.`
+// SYSTEM frames the turn around whatever surface is in play: the surface states how the model
+// acts, and the frame states how a turn ends. The two are separate so a surface swap rewrites
+// only its own half.
+const SYSTEM = (surface: string): string =>
+  `You are an agent. ${surface}\nWhen the work is done, reply in plain text: that reply is your final answer and ends the turn. Reply plainly without calling a tool when no action is needed.`
 
 const ANSWER_NUDGE =
   "This turn declares an output schema. Finish by calling the answer tool: its arguments are your final answer and MUST conform to its schema. Never answer in prose."
 
 const BUDGET_NUDGE =
-  "Your tool budget for this turn is spent, so the execute tool is gone. Finish now: answer with your best result from what you have already gathered."
+  "Your tool budget for this turn is spent, so the work tools are gone. Finish now: answer with your best result from what you have already gathered."
 
 const ESCALATE_NUDGE =
   "If the work genuinely needs more and the extra spend is worth it, you may call request_budget with a reason and an amount instead of answering. Ask only when it changes the result; otherwise answer now."
@@ -163,17 +153,19 @@ export const renderMessages = (trajectory: ReadonlyArray<Event>): ReadonlyArray<
   return messages
 }
 
-// modelRequest folds two policies. A declared output schema adds the answer tool and its
-// nudge. A spent budget drops execute and adds the budget nudge, so the model can only answer.
-// Both are pure projections of the log.
-export const modelRequest = (trajectory: ReadonlyArray<Event>, packagesInScope: string): ModelRequest => {
+// modelRequest folds two policies over the surface's tool table. A declared output schema adds
+// the answer tool and its nudge. A spent budget drops the work tools and adds the budget nudge,
+// so the model can only answer. Both are pure projections of the log, and neither knows what the
+// work tools are.
+export const modelRequest = (trajectory: ReadonlyArray<Event>, surface: ToolSurface<never>): ModelRequest => {
   const schema = outputSchemaOf(trajectory)
   const spent = budgetSpent(trajectory)
   const canRequest = canRequestBudget(trajectory)
-  const work = spent ? [] : [EXECUTE_TOOL]
+  const work = spent ? [] : surface.tools
   const withAnswer = schema === undefined ? work : [...work, answerTool(schema)]
   const tools = canRequest ? [...withAnswer, REQUEST_BUDGET_TOOL] : withAnswer
-  const base = schema === undefined ? SYSTEM(packagesInScope) : `${SYSTEM(packagesInScope)}\n${ANSWER_NUDGE}`
+  const framed = SYSTEM(surface.system)
+  const base = schema === undefined ? framed : `${framed}\n${ANSWER_NUDGE}`
   const budgetLine = canRequest ? `${BUDGET_NUDGE}\n${ESCALATE_NUDGE}` : BUDGET_NUDGE
   return { system: spent ? `${base}\n${budgetLine}` : base, messages: renderMessages(trajectory), tools }
 }

--- a/packages/agent/src/surface.ts
+++ b/packages/agent/src/surface.ts
@@ -1,0 +1,153 @@
+import { Clock, Effect } from "effect"
+import { transition, type Transition } from "@flamecast/core/actor"
+import type { Event } from "@flamecast/core/event"
+import { codeDispatched } from "@flamecast/code/events"
+import { toolReturned } from "./events"
+import type { ToolSpec } from "./request"
+
+// A ToolSurface is the agent's work half: the tools the model may call, the system text that
+// explains them, and how one call becomes events. The turn loop, the budget wall, the answer
+// contract, and compaction are policy and stay in the reactors; only the work surface varies.
+//
+// Code mode is the default (`codeSurface`), not the only option. An agent whose worth is being
+// measured against a fixed tool table (a benchmark replicating another harness) hands its own
+// tools to `nativeSurface` and keeps every other behavior, so the surface under test is the one
+// the comparison names rather than the one this library prefers.
+//
+// One surface serves two consumers: the actor takes `serve` (tools.ts), and the model binding
+// takes `system` and `tools` (request.ts). Bundling them keeps a caller from pairing the prompt
+// of one surface with the dispatch of another.
+
+// PendingCall is the call being served: the head unanswered `ToolCalled`.
+export interface PendingCall {
+  readonly callId: string
+  readonly name: string
+  readonly arguments: unknown
+  readonly turn?: string
+}
+
+// Answer mints the transition that ends a call with a result. The reactor owns the key and the
+// turn stamp, so a surface cannot key a tool answer wrongly.
+export type Answer = (result: unknown) => Transition<never, never>
+
+export interface ToolSurface<R = never> {
+  // The system text describing this surface's tools. It joins the agent's own instructions.
+  readonly system: string
+  readonly tools: ReadonlyArray<ToolSpec>
+  // serve returns the transitions this call owes: an empty array while the world is still
+  // working, and undefined when the call names no tool on this surface (the reactor answers
+  // with an unknown-tool error). It is a projection, so it never reads a clock.
+  readonly serve: (
+    call: PendingCall,
+    log: ReadonlyArray<Event>,
+    answer: Answer
+  ) => ReadonlyArray<Transition<never, R>> | undefined
+}
+
+// EXECUTE_TOOL is code mode's one work tool: the model acts by writing JavaScript against the
+// packages in scope.
+const EXECUTE_TOOL: ToolSpec = {
+  name: "execute",
+  description:
+    "Run JavaScript against the connected packages. Packages are objects in scope; await their methods and end with `return <value>`. The returned value comes back as this call's result, and console output comes back beside it as `logs` (capped; return the value you need, print to inspect).",
+  inputSchema: {
+    type: "object",
+    properties: { code: { type: "string", description: "The JavaScript body to run." } },
+    required: ["code"],
+    additionalProperties: false
+  }
+}
+
+const CODE_SYSTEM = (packages: string): string =>
+  `You act on the world by calling the execute tool with JavaScript; the packages in scope are:\n${packages}`
+
+// settleFor reads one execution's outcome, once the code reactor has recorded it.
+const settleFor = (
+  log: ReadonlyArray<Event>,
+  callId: string
+): { result?: unknown; error?: string; logs?: ReadonlyArray<string> } | undefined => {
+  const settle = log.find((e) => e.type === "CodeSettled" && String((e as { execId?: unknown }).execId) === callId) as
+    | { result?: unknown; error?: unknown; logs?: ReadonlyArray<string>; tmp?: unknown; size?: unknown; preview?: unknown; note?: unknown }
+    | undefined
+  if (settle === undefined) return undefined
+  // Captured console output rides along: the model reads what its code printed, beside the
+  // result (the print-to-inspect habit; packages/code/src/sandbox.ts, SandboxResult.logs).
+  const logs = settle.logs !== undefined && settle.logs.length > 0 ? { logs: settle.logs } : {}
+  if (settle.error !== undefined) return { error: String(settle.error), ...logs }
+  // A settle over TMP_BYTES carries a pointer instead of the value (packages/code/src/execute.ts).
+  // The pointer IS the result the model reads: its preview and its note name the ref and the
+  // call that loads it. Reading `result` alone answers a spilled call with `{}`, so the model
+  // learns neither what it computed nor that anything is there to fetch, and it re-runs the work
+  // it already did (turn.test.ts, "a spilled settle").
+  if (settle.tmp !== undefined) {
+    return { result: { tmp: settle.tmp, size: settle.size, preview: settle.preview, note: settle.note }, ...logs }
+  }
+  return { result: settle.result, ...logs }
+}
+
+// codeSurface is the default: one `execute` tool, dispatched to the code reactor and answered
+// from its settle. `packagesInScope` is the rendered package list the system text names.
+export const codeSurface = (packagesInScope = "none"): ToolSurface => ({
+  system: CODE_SYSTEM(packagesInScope),
+  tools: [EXECUTE_TOOL],
+  serve: (call, log, answer) => {
+    if (call.name !== "execute") return undefined
+    const stamp = call.turn === undefined ? {} : { turn: call.turn }
+    // Dispatched already: the answer exists once the code reactor settles the execution.
+    if (log.some((e) => e.type === "CodeDispatched" && String((e as { execId?: unknown }).execId) === call.callId)) {
+      const outcome = settleFor(log, call.callId)
+      return outcome === undefined ? [] : [answer(outcome)]
+    }
+    const code = String((call.arguments as { code?: unknown } | undefined)?.code ?? "")
+    return [
+      transition({
+        key: `cd:${call.callId}`,
+        input: { execId: call.callId, code },
+        act: (input) =>
+          Effect.gen(function* () {
+            const at = yield* Clock.currentTimeMillis
+            return [codeDispatched({ execId: input.execId, code: input.code, ...stamp, at })]
+          })
+      })
+    ]
+  }
+})
+
+// A NativeTool is one named tool the model calls directly: its wire shape, and the effect that
+// runs it. The effect's failures are the tool's own answer, so a tool that throws returns an
+// error the model reads rather than killing the turn.
+export interface NativeTool<R = never> {
+  readonly spec: ToolSpec
+  readonly run: (input: unknown, context: { readonly callId: string; readonly turn?: string }) => Effect.Effect<unknown, never, R>
+}
+
+// nativeSurface serves a fixed table of named tools, the shape every provider's tool calling
+// takes and the shape a replicated harness is measured on. One transition per call: the act runs
+// the tool and records its return, so the surface needs no lane of its own.
+export const nativeSurface = <R = never>(tools: ReadonlyArray<NativeTool<R>>, system = ""): ToolSurface<R> => {
+  const table = new Map(tools.map((t) => [t.spec.name, t]))
+  return {
+    system:
+      system === ""
+        ? `You act on the world by calling the tools available to you: ${tools.map((t) => t.spec.name).join(", ")}.`
+        : system,
+    tools: tools.map((t) => t.spec),
+    serve: (call, _log, _answer) => {
+      const tool = table.get(call.name)
+      if (tool === undefined) return undefined
+      const stamp = call.turn === undefined ? {} : { turn: call.turn }
+      return [
+        transition({
+          key: `tr:${call.callId}`,
+          input: { callId: call.callId, arguments: call.arguments, turn: call.turn },
+          act: (input) =>
+            Effect.gen(function* () {
+              const result = yield* tool.run(input.arguments, { callId: input.callId, ...(input.turn === undefined ? {} : { turn: input.turn }) })
+              const at = yield* Clock.currentTimeMillis
+              return [toolReturned({ callId: input.callId, result, ...stamp, at })]
+            })
+        })
+      ]
+    }
+  }
+}

--- a/packages/agent/src/tools.ts
+++ b/packages/agent/src/tools.ts
@@ -1,28 +1,20 @@
 import { Clock, Effect } from "effect"
 import { transition, type Reactor, type Transition } from "@flamecast/core/actor"
 import { budgetRequested, toolReturned } from "./events"
-import { codeDispatched } from "@flamecast/code/events"
 import type { Event } from "@flamecast/core/event"
 import { turnView } from "@flamecast/code/turns"
 import { budgetSpent } from "./budget"
 import { answerErrors, outputSchemaOf, repairText } from "./contract"
+import { codeSurface, type PendingCall, type ToolSurface } from "./surface"
 
-// The tools reactor: the agent's side of the execute tool. `execute` is the only tool: the model
-// interacts with the real world by writing code, and packages are objects in the code's scope.
-// It translates between the agent's alphabet and the code reactor's: it dispatches the call's
-// code, owes nothing while the code reactor executes, and answers the call with the settle.
-// Neither imports the other.
+// The tools reactor: the agent's side of the tool table. The policy here is the same whatever
+// the tools are: the answer contract, the escalation ask, the budget wall, and the unknown-tool
+// error. The work tools themselves come from a `ToolSurface`, so an agent measured against a
+// fixed tool table swaps the surface and keeps every one of these behaviors (surface.ts).
 //
 // Owed work, derived from the event set: the head pending call (a ToolCalled with no
 // ToolReturned, earliest by its own `at`) owes a routing until its dispatch or ask exists, an
-// answer once its execution settled, and an escalation answer once the parent decided.
-
-interface PendingCall {
-  readonly callId: string
-  readonly name: string
-  readonly arguments: unknown
-  readonly turn?: string
-}
+// answer once its work settled, and an escalation answer once the parent decided.
 
 const str = (v: unknown): string => String(v ?? "")
 
@@ -52,29 +44,6 @@ const pendingCall = (log: ReadonlyArray<Event>): PendingCall | undefined => {
 const has = (log: ReadonlyArray<Event>, type: string, key: string, value: string): boolean =>
   log.some((e) => e.type === type && str((e as Record<string, unknown>)[key]) === value)
 
-const settleFor = (
-  log: ReadonlyArray<Event>,
-  callId: string
-): { result?: unknown; error?: string; logs?: ReadonlyArray<string> } | undefined => {
-  const settle = log.find((e) => e.type === "CodeSettled" && str((e as { execId?: unknown }).execId) === callId) as
-    | { result?: unknown; error?: unknown; logs?: ReadonlyArray<string>; tmp?: unknown; size?: unknown; preview?: unknown; note?: unknown }
-    | undefined
-  if (settle === undefined) return undefined
-  // Captured console output rides along: the model reads what its code printed, beside the
-  // result (the print-to-inspect habit; packages/code/src/sandbox.ts, SandboxResult.logs).
-  const logs = settle.logs !== undefined && settle.logs.length > 0 ? { logs: settle.logs } : {}
-  if (settle.error !== undefined) return { error: String(settle.error), ...logs }
-  // A settle over TMP_BYTES carries a pointer instead of the value (packages/code/src/execute.ts).
-  // The pointer IS the result the model reads: its preview and its note name the ref and the
-  // call that loads it. Reading `result` alone answers a spilled call with `{}`, so the model
-  // learns neither what it computed nor that anything is there to fetch, and it re-runs the work
-  // it already did (tools.test.ts, "a spilled settle").
-  if (settle.tmp !== undefined) {
-    return { result: { tmp: settle.tmp, size: settle.size, preview: settle.preview, note: settle.note }, ...logs }
-  }
-  return { result: settle.result, ...logs }
-}
-
 // decisionFor returns the parent's decision on an escalation ask, scoped to the call's turn.
 const decisionFor = (
   log: ReadonlyArray<Event>,
@@ -89,11 +58,13 @@ const decisionFor = (
   return undefined
 }
 
-// toolsReactor derives one transition per pending call, branch by branch. The records each
-// branch appends carry the keys: an answer tr:<callId>, a dispatch cd:<callId>, an escalation
-// ask br:<callId>. An escalating call with no parental decision derives nothing (the turn is
-// durably paused); the decision's arrival re-derives the answer.
-export const toolsReactor: Reactor<never> = (log) => {
+// toolsReactorFor derives one transition per pending call, branch by branch. The records each
+// branch appends carry the keys: an answer tr:<callId>, an escalation ask br:<callId>, and
+// whatever key the surface's own dispatch mints. An escalating call with no parental decision
+// derives nothing (the turn is durably paused); the decision's arrival re-derives the answer.
+// Every branch here is surface-independent policy; the surface decides only how a work call
+// becomes events.
+export const toolsReactorFor = <R = never>(surface: ToolSurface<R>): Reactor<R> => (log) => {
   const call = pendingCall(log)
   if (call === undefined) return []
   const stamp = call.turn === undefined ? {} : { turn: call.turn }
@@ -119,14 +90,6 @@ export const toolsReactor: Reactor<never> = (log) => {
     ]
   }
 
-  // Executed: answer the call with the settle, once it exists.
-  if (has(log, "CodeDispatched", "execId", call.callId)) {
-    const outcome = settleFor(log, call.callId)
-    if (outcome === undefined) return []
-    return [answering(outcome)]
-  }
-
-  // Route the call.
   // The escalation ask: record the request and rest. No ToolReturned follows, so the turn is
   // durably paused; the parental decision derives the answer above.
   if (call.name === "request_budget") {
@@ -150,27 +113,22 @@ export const toolsReactor: Reactor<never> = (log) => {
     const errors = answerErrors(outputSchemaOf(turnView(log)), call.arguments)
     return [answering({ error: repairText(errors.length > 0 ? errors : ["the answer tool was called with no arguments"]) })]
   }
-  if (call.name !== "execute") {
-    return [answering({ error: `unknown tool: ${call.name}. Write code with execute.` })]
-  }
-  // The budget gate: the wall on the turn refuses the dispatch and keeps the model's work.
+  // The budget gate: the wall on the turn refuses the work and keeps what the model has. It
+  // precedes the surface so a spent turn cannot dispatch, whatever the surface would have done.
   if (budgetSpent(log)) {
     return [
       answering({
-        error: "Tool budget reached. Do not call execute again. Call answer now with your best result from what you have already gathered."
+        error: "Tool budget reached. Do not call this tool again. Answer now with your best result from what you have already gathered."
       })
     ]
   }
-  const code = String((call.arguments as { code?: unknown } | undefined)?.code ?? "")
-  return [
-    transition({
-      key: `cd:${call.callId}`,
-      input: { execId: call.callId, code },
-      act: (input) =>
-        Effect.gen(function* () {
-          const at = yield* Clock.currentTimeMillis
-          return [codeDispatched({ execId: input.execId, code: input.code, ...stamp, at })]
-        })
-    })
-  ]
+  const served = surface.serve(call, log, answering)
+  if (served === undefined) {
+    return [answering({ error: `unknown tool: ${call.name}. Call one of: ${surface.tools.map((t) => t.name).join(", ")}.` })]
+  }
+  return served
 }
+
+// toolsReactor is the default surface's reactor: code mode. An agent on another surface builds
+// its own with `toolsReactorFor`.
+export const toolsReactor: Reactor<never> = toolsReactorFor(codeSurface())

--- a/packages/agent/src/turn.ts
+++ b/packages/agent/src/turn.ts
@@ -12,26 +12,36 @@ import type { Sandbox } from "@flamecast/code/sandbox"
 import type { Router } from "@flamecast/core/router"
 import type { Self } from "@flamecast/core/actor"
 import { Infer, inferReactor } from "./infer"
-import { toolsReactor } from "./tools"
+import { toolsReactorFor } from "./tools"
 import { budgetReactor } from "./budget"
 import { replyReactor } from "./reply"
 import { compactionReactor } from "./compaction"
+import { codeSurface, type ToolSurface } from "./surface"
 
 export { Infer } from "./infer"
 
 // agent is one actor, six reactors over one log. infer decides, budget fires the wall, tools
-// serves the execute tool, code runs bodies durably, reply reports the terminal home, compaction
-// checkpoints the context. None imports another; they compose through event names. budget
-// precedes tools in the list, so BudgetExhausted is on the log when the dispatch gate reads it.
+// serves the surface's tools, code runs bodies durably, reply reports the terminal home,
+// compaction checkpoints the context. None imports another; they compose through event names.
+// budget precedes tools in the list, so BudgetExhausted is on the log when the dispatch gate
+// reads it.
 export type AgentR = Infer | EventLog | Packages | Sandbox | Tmp | Router | Self
 // agentActorKeys is the agent's own key table: its alphabet, the code lane's, and the canonical
 // inbound. A platform composes wider (its app fragments join in) when it builds its own actor;
 // this default serves the library tier and tests.
 export const agentActorKeys = composeKeys(messageKeys, codeKeys, agentKeys)
-export const agent = actor<AgentR>(
-  [inferReactor, budgetReactor, toolsReactor, codeReactor, replyReactor, compactionReactor],
-  agentActorKeys
-)
+
+// agentFor composes the actor around one tool surface. The code lane stays in the list whatever
+// the surface is: it derives work only from `CodeDispatched`, so a surface that never dispatches
+// code leaves it quiet.
+export const agentFor = (surface: ToolSurface<AgentR>) =>
+  actor<AgentR>(
+    [inferReactor, budgetReactor, toolsReactorFor(surface), codeReactor, replyReactor, compactionReactor],
+    agentActorKeys
+  )
+
+// agent is the default assembly: code mode, the surface this library prefers.
+export const agent = agentFor(codeSurface())
 
 // receive sends the inbound to the actor. The message id is the dedup key, so delivery can be
 // at-least-once.

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
+import { codeSurface } from "@flamecast/agent/surface"
 import { Infer } from "@flamecast/agent/infer"
 import { actionOf, ladderOf, modelAskOf, modelIdOf, realInfer, retryAfterMsOf, throttleDelayMs } from "./model"
 
@@ -102,7 +103,7 @@ describe("realInfer end to end", () => {
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "test-model",
-      packagesInScope: "- zohorecruit",
+      surface: codeSurface(),
       fetch: fetchImpl
     })
     const action = await Effect.runPromise(
@@ -124,7 +125,7 @@ describe("realInfer end to end", () => {
         { id: "r2", choices: [{ index: 0, delta: { content: "is 4" } }] },
         { id: "r2", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }
       ])) as unknown as typeof globalThis.fetch
-    const layer = realInfer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "test-model", packagesInScope: "", fetch: fetchImpl })
+    const layer = realInfer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "test-model", surface: codeSurface(), fetch: fetchImpl })
     const action = await Effect.runPromise(
       Effect.flatMap(Infer, (model) => model.react([{ type: "MessageReceived", id: "m1", text: "2+2?", at: 1 }])).pipe(
         Effect.provide(layer)
@@ -143,7 +144,7 @@ describe("realInfer end to end", () => {
         { id: "r3", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }
       ])
     }) as typeof globalThis.fetch
-    const layer = realInfer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "test-model", packagesInScope: "", fetch: fetchImpl })
+    const layer = realInfer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "test-model", surface: codeSurface(), fetch: fetchImpl })
     const trajectory = [{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]
     await Effect.runPromise(
       Effect.flatMap(Infer, (model) => model.react(trajectory, "m1/infer/0")).pipe(Effect.provide(layer)) as Effect.Effect<unknown>
@@ -177,7 +178,7 @@ describe("realInfer: throttle-shaped retry", () => {
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "test-model",
-      packagesInScope: "",
+      surface: codeSurface(),
       fetch: fetchImpl,
       sleep: (ms) => {
         slept.push(ms)
@@ -207,7 +208,7 @@ describe("realInfer: throttle-shaped retry", () => {
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "test-model",
-      packagesInScope: "",
+      surface: codeSurface(),
       fetch: fetchImpl,
       sleep: (ms) => {
         slept.push(ms)
@@ -237,7 +238,7 @@ describe("realInfer: throttle-shaped retry", () => {
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "test-model",
-      packagesInScope: "",
+      surface: codeSurface(),
       fetch: fetchImpl,
       sleep: (ms) => {
         slept.push(ms)
@@ -337,7 +338,7 @@ describe("truncation", () => {
       keys.push(request.headers.get("Idempotency-Key"))
       return calls++ === 0 ? cut("half an ans") : whole("the whole answer")
     }) as unknown as typeof fetch
-    const layer = realInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", packagesInScope: "", fetch: fetchImpl as never })
+    const layer = realInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", surface: codeSurface(), fetch: fetchImpl as never })
     const action = await Effect.runPromise(
       Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }], "t1/infer/0")).pipe(
         Effect.provide(layer)
@@ -355,7 +356,7 @@ describe("truncation", () => {
 
   test("the top rung still truncating fails the turn loudly, never half an answer", async () => {
     const fetchImpl = (async () => cut("half")) as unknown as typeof fetch
-    const layer = realInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", packagesInScope: "", fetch: fetchImpl as never })
+    const layer = realInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", surface: codeSurface(), fetch: fetchImpl as never })
     const action = await Effect.runPromise(
       Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
         Effect.provide(layer)
@@ -385,7 +386,7 @@ describe("declared limits", () => {
         headers: { "content-type": "text/event-stream" }
       })
     }) as unknown as typeof fetch
-    const layer = realInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", packagesInScope: "", maxOutputTokens: 16_384, fetch: fetchImpl as never })
+    const layer = realInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", surface: codeSurface(), maxOutputTokens: 16_384, fetch: fetchImpl as never })
     await Effect.runPromise(
       Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(Effect.provide(layer)) as Effect.Effect<unknown>
     )

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -9,6 +9,7 @@ import type { Action } from "@flamecast/agent/events"
 import type { Event } from "@flamecast/core/event"
 import { answerErrors, outputSchemaOf } from "@flamecast/agent/contract"
 import { modelRequest, type AgentMessage, type ToolSpec } from "@flamecast/agent/request"
+import { codeSurface, type ToolSurface } from "@flamecast/agent/surface"
 
 // The real model binding: one inference per react, streamed through a TanStack adapter and
 // decoded by their StreamProcessor. The reactors never learn this layer exists. Resilience is
@@ -166,7 +167,10 @@ export interface ModelConfig {
   readonly baseUrl: string
   readonly apiKey: string
   readonly model: string
-  readonly packagesInScope: string
+  // The tool surface this binding renders: code mode by default. The actor must be assembled on
+  // the same surface, or the model is offered tools its reactor will not serve
+  // (@flamecast/agent, surface.ts).
+  readonly surface?: ToolSurface<never>
   readonly provider?: string
   // The model's output ceiling, DECLARED by the operator rather than guessed: no wire this
   // binding speaks publishes limits, so the number that bounds the truncation ladder is stated
@@ -358,7 +362,7 @@ export const realInfer = (config: ModelConfig) => {
             ...(fetcher === undefined ? {} : { fetch: fetcher })
           })
     // The domain decides the request; the platform maps it to the wire and streams it.
-    const req = modelRequest(trajectory, config.packagesInScope)
+    const req = modelRequest(trajectory, config.surface ?? codeSurface())
     const schema = outputSchemaOf(trajectory) // the answer parser needs the turn's declared shape
     const stream = adapter.chatStream({
       model: config.model,


### PR DESCRIPTION
Code mode was the only surface the agent could present. `request.ts` hardcoded an `execute` tool and a system prompt naming it, and `tools.ts` answered every other name with "unknown tool: X. Write code with execute." An agent whose worth is measured against a fixed tool table, a benchmark replicating another harness, could not be built on this library without reimplementing the tool surface outside it and carrying that fork.

Code mode stays the default and nothing about it changes. It moves behind a `ToolSurface`: the tools the model may call, the system text describing them, and how one call becomes events. `codeSurface()` is that default. `nativeSurface(tools)` presents a fixed table of named tools instead, dispatched directly, which is the shape every provider's tool calling takes.

The seam is narrow because the surface was the only part that varied. The turn loop, the budget wall, the answer contract and its repair bound, the escalation ask, compaction, and the reply are surface independent policy and stay exactly where they were. Three call sites moved: `toolsReactorFor(surface)` builds the reactor, `agentFor(surface)` builds the actor, and `realInfer({surface})` renders the request. The undecorated `agent`, `toolsReactor`, and a `realInfer` with no surface all resolve to code mode, so an existing assembly reads the same.

One surface object serves both the actor and the model binding. Pairing the prompt of one surface with the dispatch of another would offer the model tools its reactor refuses, so they take the same value rather than two halves that can drift.

Two behaviors became surface independent along the way. The budget refusal said "Do not call execute again. Call answer now", which is wrong on a surface with no execute and wrong for a turn with no schema; it now names neither. The unknown-tool error listed no alternative and now names the surface's own tools.

The code lane stays in the default reactor list whatever the surface is. It derives work only from `CodeDispatched`, so a surface that never dispatches code leaves it quiet, and the assembly does not fork on the surface.

Gate green at 16 checks. New coverage: a native surface offers its own tools and never mentions execute, every policy still folds over a swapped surface, the turn frame is surface independent, a native agent runs a full turn end to end with no code lane, and a call outside the surface comes back as an unknown-tool answer rather than a dead turn.
