### PR TITLE
refactor(agent): split rlm default

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ await host.deliver("bun:main", { type: "MessageReceived", id: "m1", text: "What 
 await host.drive()
 ```
 
-`createRlmAgent` from `@flamecast/agent` is this Recursive Language Model default: the same six reactors, an in-process host, packages, and spawn. The mind is `agentFor` (infer, tools, reply). Add budget, code, or compaction when the harness needs them.
+`createRlmAgent` from `@flamecast/agent` is this Recursive Language Model default: the same six reactors, an in-process host, packages, and spawn. The mind is `agentFor` plus a work surface that the three reactors can serve (`nativeSurface` is the usual thinner case). Code mode is `rlmAgentFor`, because `execute` needs the code reactor.
 
 ## Concepts
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ await host.deliver("bun:main", { type: "MessageReceived", id: "m1", text: "What 
 await host.drive()
 ```
 
-`createRlmAgent` from `@flamecast/agent` is this assembly prebuilt over an in-process host, packages and spawning included.
+`createRlmAgent` from `@flamecast/agent` is this Recursive Language Model default: the same six reactors, an in-process host, packages, and spawn. The mind is `agentFor` (infer, tools, reply). Add budget, code, or compaction when the harness needs them.
 
 ## Concepts
 
@@ -113,7 +113,7 @@ Organized on the Diátaxis grid: learning, tasks, information, understanding.
 packages/
   core/      contracts: Event, EventLog, KeyFragment, Transition, Reactor, Router
   code/      durable code execution
-  agent/     the agent as reactors, and createRlmAgent
+  agent/     reactors, the mind (`agentFor`), and the RLM default (`createRlmAgent`)
   host/      the reference in-memory binding
 platform/
   model/     the Infer binding over TanStack AI

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -11,11 +11,7 @@ import { boundaryOf } from "./boundary"
 import { agentsPackage } from "./spawn"
 import type { ToolSurface } from "./surface"
 
-// createRlmAgent is the library default: a hosted Recursive Language Model over an in-process
-// host, with spawn and a sandbox (tutorials/rlm-agent.md). The mind is agentFor; this function
-// adds budget, code, compaction, host, and the agents package. A caller who wants a thinner
-// harness uses actor([...]) and their own host.
-export { agent, agentFor, rlmAgent, rlmAgentFor, type AgentR, type RlmR } from "./turn"
+export { agentFor, rlmAgent, rlmAgentFor, type AgentR, type RlmR } from "./turn"
 
 // The parts a caller lists: reactors and key tables. An agent is reactors over one log.
 // Adding a capability is adding a reactor to the list.
@@ -51,6 +47,10 @@ export interface RlmAgent {
 
 const ROOT = "ag.root"
 
+// createRlmAgent is the library default: a hosted Recursive Language Model over an in-process
+// host, with spawn and a sandbox (tutorials/rlm-agent.md). The mind is agentFor; this function
+// adds budget, code, compaction, host, and the agents package. A caller who wants a thinner
+// harness uses actor([...]) and their own host.
 export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
   const user = options.packages ?? []
   const infer = Layer.succeed(Infer, {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -4,28 +4,22 @@ import { Router } from "@flamecast/core/router"
 import { Packages, type Package } from "@flamecast/code/packages"
 import { jsSandbox, memoryTmp } from "@flamecast/code/defaults"
 import { createHost, type Host } from "@flamecast/host/host"
-import { agent, agentFor, type AgentR } from "./turn"
+import { rlmAgent, rlmAgentFor, type RlmR } from "./turn"
 import { Infer } from "./infer"
 import type { Action } from "./events"
 import { boundaryOf } from "./boundary"
 import { agentsPackage } from "./spawn"
 import type { ToolSurface } from "./surface"
 
-// createRlmAgent is the front door: a Recursive Language Model agent, one hosted,
-// spawn-capable agent over an
-// ambient in-process host (tutorials/rlm-agent.md). No actor exists outside a host (the Erlang-node
-// shape); the user brings packages and a mind, the graph is whatever
-// their agent's code decides to spawn, and run answers when the ROOT
-// settles, however many lanes exist by then.
+// createRlmAgent is the library default: a hosted Recursive Language Model over an in-process
+// host, with spawn and a sandbox (tutorials/rlm-agent.md). The mind is agentFor; this function
+// adds budget, code, compaction, host, and the agents package. A caller who wants a thinner
+// harness uses actor([...]) and their own host.
+export { agent, agentFor, rlmAgent, rlmAgentFor, type AgentR, type RlmR } from "./turn"
 
-// The root speaks both registers: the composed actor for a platform binding
-// (actorFor: () => agent), and the hosted front door for a one-call start.
-export { agent } from "./turn"
-
-// The parts the actor is assembled from, for a caller composing their own: the six reactors
-// and the agent's key table. An agent is reactors over one log; adding a capability is adding
-// a reactor to the list.
-export { agentActorKeys, agentFor } from "./turn"
+// The parts a caller lists: reactors and key tables. An agent is reactors over one log.
+// Adding a capability is adding a reactor to the list.
+export { agentActorKeys, rlmActorKeys } from "./turn"
 export { inferReactor, Infer } from "./infer"
 export { budgetReactor } from "./budget"
 export { toolsReactor, toolsReactorFor } from "./tools"
@@ -47,7 +41,7 @@ export interface CreateAgentOptions {
   readonly log?: ReadonlyArray<Event>
   // The tool surface, code mode by default. The same surface must reach the model binding, so a
   // caller passing one here passes it to `realInfer` too (surface.ts).
-  readonly surface?: ToolSurface<AgentR>
+  readonly surface?: ToolSurface<RlmR>
 }
 
 export interface RlmAgent {
@@ -66,7 +60,7 @@ export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
 
   // The layers close over the host and are built per serve, so the
   // spawn package always routes and reads through the live host.
-  const layersFor = (lane: string): Layer.Layer<AgentR> => {
+  const layersFor = (lane: string): Layer.Layer<RlmR> => {
     const self = host.self(lane)
     const router = {
       deliver: (address: string, event: Event) => Effect.sync(() => host.deliver(address, event)),
@@ -81,12 +75,12 @@ export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
       resolve: (name: string) => all.find((p) => p.name === name),
       list: () => Effect.succeed(all.map((p) => ({ name: p.name, description: p.description })))
     })
-    return Layer.mergeAll(packages, jsSandbox, tmp, infer, Layer.succeed(Router, router)) as unknown as Layer.Layer<AgentR>
+    return Layer.mergeAll(packages, jsSandbox, tmp, infer, Layer.succeed(Router, router)) as unknown as Layer.Layer<RlmR>
   }
 
-  // Every ag. lane runs the full turn loop; anything else is a sink.
-  const assembled = options.surface === undefined ? agent : agentFor(options.surface)
-  const host: Host = createHost<AgentR>({
+  // Every ag. lane runs the RLM default; anything else is a sink.
+  const assembled = options.surface === undefined ? rlmAgent : rlmAgentFor(options.surface)
+  const host: Host = createHost<RlmR>({
     principal: "mem",
     actorFor: (lane) => (lane.startsWith("ag.") ? assembled : undefined),
     layersFor: layersFor as never

--- a/packages/agent/src/request.ts
+++ b/packages/agent/src/request.ts
@@ -157,7 +157,10 @@ export const renderMessages = (trajectory: ReadonlyArray<Event>): ReadonlyArray<
 // the answer tool and its nudge. A spent budget drops the work tools and adds the budget nudge,
 // so the model can only answer. Both are pure projections of the log, and neither knows what the
 // work tools are.
-export const modelRequest = (trajectory: ReadonlyArray<Event>, surface: ToolSurface<never>): ModelRequest => {
+export const modelRequest = (
+  trajectory: ReadonlyArray<Event>,
+  surface: Pick<ToolSurface, "system" | "tools">
+): ModelRequest => {
   const schema = outputSchemaOf(trajectory)
   const spent = budgetSpent(trajectory)
   const canRequest = canRequestBudget(trajectory)

--- a/packages/agent/src/surface.ts
+++ b/packages/agent/src/surface.ts
@@ -2,8 +2,13 @@ import { Clock, Effect } from "effect"
 import { transition, type Transition } from "@flamecast/core/actor"
 import type { Event } from "@flamecast/core/event"
 import { codeDispatched } from "@flamecast/code/events"
+import type { Packages } from "@flamecast/code/packages"
+import type { Sandbox } from "@flamecast/code/sandbox"
+import type { Tmp } from "@flamecast/code/tmp"
 import { toolReturned } from "./events"
 import type { ToolSpec } from "./request"
+
+export type CodeLaneR = Packages | Sandbox | Tmp
 
 // A ToolSurface is the agent's work half: the tools the model may call, the system text that
 // explains them, and how one call becomes events. The turn loop, the budget wall, the answer
@@ -85,9 +90,10 @@ const settleFor = (
   return { result: settle.result, ...logs }
 }
 
-// codeSurface is the default: one `execute` tool, dispatched to the code reactor and answered
-// from its settle. `packagesInScope` is the rendered package list the system text names.
-export const codeSurface = (packagesInScope = "none"): ToolSurface => ({
+// codeSurface is one `execute` tool, dispatched to the code reactor and answered from its settle.
+// The surface's R is the code lane: `agentFor` cannot wear it, because that actor has no code reactor.
+// `packagesInScope` is the rendered package list the system text names.
+export const codeSurface = (packagesInScope = "none"): ToolSurface<CodeLaneR> => ({
   system: CODE_SYSTEM(packagesInScope),
   tools: [EXECUTE_TOOL],
   serve: (call, log, answer) => {

--- a/packages/agent/src/tools.ts
+++ b/packages/agent/src/tools.ts
@@ -5,7 +5,7 @@ import type { Event } from "@flamecast/core/event"
 import { turnView } from "@flamecast/code/turns"
 import { budgetSpent } from "./budget"
 import { answerErrors, outputSchemaOf, repairText } from "./contract"
-import { codeSurface, type PendingCall, type ToolSurface } from "./surface"
+import { codeSurface, type CodeLaneR, type PendingCall, type ToolSurface } from "./surface"
 
 // The tools reactor: the agent's side of the tool table. The policy here is the same whatever
 // the tools are: the answer contract, the escalation ask, the budget wall, and the unknown-tool
@@ -131,4 +131,4 @@ export const toolsReactorFor = <R = never>(surface: ToolSurface<R>): Reactor<R> 
 
 // toolsReactor is the default surface's reactor: code mode. An agent on another surface builds
 // its own with `toolsReactorFor`.
-export const toolsReactor: Reactor<never> = toolsReactorFor(codeSurface())
+export const toolsReactor: Reactor<CodeLaneR> = toolsReactorFor(codeSurface())

--- a/packages/agent/src/turn.test.ts
+++ b/packages/agent/src/turn.test.ts
@@ -7,9 +7,10 @@ import { Packages, type Package } from "@flamecast/code/packages"
 import { Sandbox, type Bindings } from "@flamecast/code/sandbox"
 import { Router } from "@flamecast/core/router"
 import { Self } from "@flamecast/core/actor"
-import { Infer, agent, rlmAgent, receive } from "./turn"
+import { Infer, agentFor, rlmAgent, receive } from "./turn"
 import { inferReactor } from "./infer"
 import { toolsReactor } from "./tools"
+import { nativeSurface } from "./surface"
 import { Tmp } from "@flamecast/code/tmp"
 const memSpill = () => {
   const store = new Map<string, string>()
@@ -410,9 +411,53 @@ describe("a turn that declares an output schema", () => {
   })
 })
 
-describe("the mind and the RLM default", () => {
-  test("the mind is three reactors; the RLM default adds budget, code, and compaction", () => {
-    expect(agent.reactors).toHaveLength(3)
-    expect(rlmAgent.reactors).toHaveLength(6)
+describe("the mind on a native surface", () => {
+  test("a turn completes with no budget, code, or compaction reactors", async () => {
+    const reads: string[] = []
+    const mind = agentFor(
+      nativeSurface([
+        {
+          spec: { name: "read", description: "read a file", inputSchema: { type: "object", properties: { path: { type: "string" } } } },
+          run: (input) => {
+            const path = String((input as { path?: unknown }).path)
+            reads.push(path)
+            return Effect.succeed(`contents of ${path}`)
+          }
+        }
+      ])
+    )
+    expect(mind.reactors).toHaveLength(3)
+    const layers = Layer.mergeAll(
+      memoryLog(),
+      noRouter,
+      Layer.succeed(Infer, {
+        react: (trajectory: ReadonlyArray<Event>) => {
+          const returned = trajectory.find((e) => e.type === "ToolReturned") as { result?: unknown } | undefined
+          return Effect.succeed(
+            returned !== undefined
+              ? { kind: "complete" as const, output: String(returned.result) }
+              : { kind: "call" as const, callId: "n1", name: "read", arguments: { path: "/contract.md" } }
+          )
+        }
+      })
+    )
+    const events = await run(
+      Effect.gen(function* () {
+        yield* receive(mind, { id: "m1", text: "read the contract" })
+        return yield* readLog
+      }),
+      layers
+    )
+    expect(events.map((e) => e.type)).toEqual([
+      "MessageReceived",
+      "ModelCalled",
+      "ToolCalled",
+      "ToolReturned",
+      "ModelCalled",
+      "TurnCompleted",
+      "ReplyDelivered"
+    ])
+    expect(reads).toEqual(["/contract.md"])
+    expect(events.some((e) => e.type === "CodeDispatched" || e.type === "BudgetExhausted" || e.type === "ContextCompacted")).toBe(false)
   })
 })

--- a/packages/agent/src/turn.test.ts
+++ b/packages/agent/src/turn.test.ts
@@ -7,7 +7,7 @@ import { Packages, type Package } from "@flamecast/code/packages"
 import { Sandbox, type Bindings } from "@flamecast/code/sandbox"
 import { Router } from "@flamecast/core/router"
 import { Self } from "@flamecast/core/actor"
-import { Infer, agent, receive } from "./turn"
+import { Infer, agent, rlmAgent, receive } from "./turn"
 import { inferReactor } from "./infer"
 import { toolsReactor } from "./tools"
 import { Tmp } from "@flamecast/code/tmp"
@@ -114,7 +114,7 @@ describe("the agent with execute as the only tool", () => {
     memoryLog(), codeThenComplete(count), registry([zoho(spies)]), jsSandbox, noRouter)
     const events = await run(
       Effect.gen(function* () {
-        yield* receive({ id: "m1", text: "add the JD and search candidates" })
+        yield* receive(rlmAgent, { id: "m1", text: "add the JD and search candidates" })
         return yield* readLog
       }),
       layers
@@ -190,7 +190,7 @@ describe("the agent with execute as the only tool", () => {
     const layers = Layer.mergeAll(memSpill(), memoryLog(crashed), codeThenComplete(count), registry([zoho(spies)]), jsSandbox, noRouter)
     const events = await run(
       Effect.gen(function* () {
-        yield* settleActor(agent)
+        yield* settleActor(rlmAgent)
         return yield* readLog
       }),
       layers
@@ -222,7 +222,7 @@ describe("the agent with execute as the only tool", () => {
     )
     const events = await run(
       Effect.gen(function* () {
-        yield* receive({ id: "m1", text: "run it" })
+        yield* receive(rlmAgent, { id: "m1", text: "run it" })
         return yield* readLog
       }),
       layers
@@ -252,7 +252,7 @@ describe("the agent with execute as the only tool", () => {
     memoryLog(queued), echoHead, registry([]), jsSandbox, noRouter)
     const events = await run(
       Effect.gen(function* () {
-        yield* settleActor(agent)
+        yield* settleActor(rlmAgent)
         return yield* readLog
       }),
       layers
@@ -279,7 +279,7 @@ describe("the agent with execute as the only tool", () => {
     const layers = Layer.mergeAll(memSpill(), memoryLog(crashed), codeThenComplete(count), registry([]), jsSandbox, noRouter)
     const events = await run(
       Effect.gen(function* () {
-        yield* settleActor(agent)
+        yield* settleActor(rlmAgent)
         return yield* readLog
       }),
       layers
@@ -305,8 +305,8 @@ describe("the agent with execute as the only tool", () => {
     )
     const events = await run(
       Effect.gen(function* () {
-        yield* receive({ id: "m1", text: "hi" })
-        yield* receive({ id: "m1", text: "hi" })
+        yield* receive(rlmAgent, { id: "m1", text: "hi" })
+        yield* receive(rlmAgent, { id: "m1", text: "hi" })
         return yield* readLog
       }),
       layers
@@ -361,7 +361,7 @@ describe("a turn that declares an output schema", () => {
     )
     const events = await run(
       Effect.gen(function* () {
-        yield* receive({ id: "m1", text: "decompose this topic", output: SCOUT_SCHEMA })
+        yield* receive(rlmAgent, { id: "m1", text: "decompose this topic", output: SCOUT_SCHEMA })
         return yield* readLog
       }),
       layers
@@ -398,7 +398,7 @@ describe("a turn that declares an output schema", () => {
     )
     const events = await run(
       Effect.gen(function* () {
-        yield* receive({ id: "m1", text: "decompose this topic", output: SCOUT_SCHEMA })
+        yield* receive(rlmAgent, { id: "m1", text: "decompose this topic", output: SCOUT_SCHEMA })
         return yield* readLog
       }),
       layers
@@ -407,5 +407,12 @@ describe("a turn that declares an output schema", () => {
     expect(failed.error).toContain("did not satisfy the declared schema")
     // Bounded: the corrections are spent, not repeated forever.
     expect(asked).toBeLessThanOrEqual(4)
+  })
+})
+
+describe("the mind and the RLM default", () => {
+  test("the mind is three reactors; the RLM default adds budget, code, and compaction", () => {
+    expect(agent.reactors).toHaveLength(3)
+    expect(rlmAgent.reactors).toHaveLength(6)
   })
 })

--- a/packages/agent/src/turn.ts
+++ b/packages/agent/src/turn.ts
@@ -1,6 +1,6 @@
 import { Clock, Effect } from "effect"
 import { EventLog } from "@flamecast/core/event-log"
-import { actor, send } from "@flamecast/core/actor"
+import { actor, send, type Actor } from "@flamecast/core/actor"
 import { composeKeys } from "@flamecast/core/event-log"
 import { messageKeys } from "@flamecast/core/message"
 import { codeKeys } from "@flamecast/code/events"
@@ -20,43 +20,52 @@ import { codeSurface, type ToolSurface } from "./surface"
 
 export { Infer } from "./infer"
 
-// agent is one actor, six reactors over one log. infer decides, budget fires the wall, tools
-// serves the surface's tools, code runs bodies durably, reply reports the terminal home,
-// compaction checkpoints the context. None imports another; they compose through event names.
-// budget precedes tools in the list, so BudgetExhausted is on the log when the dispatch gate
-// reads it.
-export type AgentR = Infer | EventLog | Packages | Sandbox | Tmp | Router | Self
-// agentActorKeys is the agent's own key table: its alphabet, the code lane's, and the canonical
-// inbound. A platform composes wider (its app fragments join in) when it builds its own actor;
-// this default serves the library tier and tests.
-export const agentActorKeys = composeKeys(messageKeys, codeKeys, agentKeys)
+// AgentR is the mind: infer, a tool surface, and a reply home. Budget, code, and compaction
+// join at the RLM assembly (rlmAgentFor).
+export type AgentR = Infer | EventLog | Router | Self
+export type RlmR = AgentR | Packages | Sandbox | Tmp
 
-// agentFor composes the actor around one tool surface. The code lane stays in the list whatever
-// the surface is: it derives work only from `CodeDispatched`, so a surface that never dispatches
-// code leaves it quiet.
+// agentActorKeys is the mind's key table: its alphabet and the canonical inbound.
+export const agentActorKeys = composeKeys(messageKeys, agentKeys)
+
+// rlmActorKeys adds the code lane's fragment. createRlmAgent uses this table.
+export const rlmActorKeys = composeKeys(messageKeys, codeKeys, agentKeys)
+
+// agentFor is the mind: infer decides, tools serve the surface, reply reports the terminal home.
+// A caller adds budget, code, or compaction by listing those reactors beside this actor's.
 export const agentFor = (surface: ToolSurface<AgentR>) =>
-  actor<AgentR>(
-    [inferReactor, budgetReactor, toolsReactorFor(surface), codeReactor, replyReactor, compactionReactor],
-    agentActorKeys
-  )
+  actor<AgentR>([inferReactor, toolsReactorFor(surface), replyReactor], agentActorKeys)
 
-// agent is the default assembly: code mode, the surface this library prefers.
+// agent is the mind on the library's code-mode surface.
 export const agent = agentFor(codeSurface())
 
-// receive sends the inbound to the actor. The message id is the dedup key, so delivery can be
-// at-least-once.
-export const receive = (
+// rlmAgentFor is the Recursive Language Model default: the mind plus budget, durable code, and
+// compaction. budget precedes tools, so BudgetExhausted is on the log when the dispatch gate
+// reads it. None of the six imports another; they compose through event names.
+export const rlmAgentFor = (surface: ToolSurface<RlmR>) =>
+  actor<RlmR>(
+    [inferReactor, budgetReactor, toolsReactorFor(surface), codeReactor, replyReactor, compactionReactor],
+    rlmActorKeys
+  )
+
+// rlmAgent is that default on code mode. createRlmAgent hosts this actor.
+export const rlmAgent = rlmAgentFor(codeSurface())
+
+// receive sends the inbound to the given actor. The message id is the dedup key, so delivery can
+// be at-least-once.
+export const receive = <R>(
+  a: Actor<R>,
   // `output` is the turn's contract: a message that declares one is answered in that shape,
   // whichever door it arrived through.
   message: { readonly id: string; readonly text: string; readonly input?: unknown; readonly output?: unknown }
-): Effect.Effect<void, never, AgentR> =>
+): Effect.Effect<void, never, EventLog | R> =>
   Effect.gen(function* () {
     const log = yield* EventLog
     const events = yield* log.read
     const seen = events.some((e) => e.type === "MessageReceived" && (e as { id?: unknown }).id === message.id)
     if (seen) return
     const at = yield* Clock.currentTimeMillis
-    yield* send(agent, {
+    yield* send(a, {
       type: "MessageReceived",
       id: message.id,
       text: message.text,

--- a/packages/agent/src/turn.ts
+++ b/packages/agent/src/turn.ts
@@ -20,8 +20,8 @@ import { codeSurface, type ToolSurface } from "./surface"
 
 export { Infer } from "./infer"
 
-// AgentR is the mind: infer, a tool surface, and a reply home. Budget, code, and compaction
-// join at the RLM assembly (rlmAgentFor).
+// AgentR is the mind: Infer for the model, EventLog for settle, Router and Self for reply.
+// Budget, code, and compaction join at the RLM assembly (rlmAgentFor).
 export type AgentR = Infer | EventLog | Router | Self
 export type RlmR = AgentR | Packages | Sandbox | Tmp
 
@@ -32,12 +32,10 @@ export const agentActorKeys = composeKeys(messageKeys, agentKeys)
 export const rlmActorKeys = composeKeys(messageKeys, codeKeys, agentKeys)
 
 // agentFor is the mind: infer decides, tools serve the surface, reply reports the terminal home.
-// A caller adds budget, code, or compaction by listing those reactors beside this actor's.
+// The caller chooses the work half. Code mode is rlmAgentFor(codeSurface()), because execute
+// needs the code reactor.
 export const agentFor = (surface: ToolSurface<AgentR>) =>
   actor<AgentR>([inferReactor, toolsReactorFor(surface), replyReactor], agentActorKeys)
-
-// agent is the mind on the library's code-mode surface.
-export const agent = agentFor(codeSurface())
 
 // rlmAgentFor is the Recursive Language Model default: the mind plus budget, durable code, and
 // compaction. budget precedes tools, so BudgetExhausted is on the log when the dispatch gate

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -170,7 +170,7 @@ export interface ModelConfig {
   // The tool surface this binding renders: code mode by default. The actor must be assembled on
   // the same surface, or the model is offered tools its reactor will not serve
   // (@flamecast/agent, surface.ts).
-  readonly surface?: ToolSurface<never>
+  readonly surface?: Pick<ToolSurface, "system" | "tools">
   readonly provider?: string
   // The model's output ceiling, DECLARED by the operator rather than guessed: no wire this
   // binding speaks publishes limits, so the number that bounds the truncation ladder is stated


### PR DESCRIPTION
## What and why

`agentFor` is the mind (infer, tools, reply) and requires a work surface the three reactors can serve. `createRlmAgent` and `rlmAgentFor` are the Recursive Language Model default on top of that mind: budget, durable code, compaction, host, and spawn. The bare `agent` export is gone so code mode cannot park on a missing code reactor. `receive(actor, message)` is a breaking signature change: the actor is now the first argument.

- [x] `bun run gate` passes locally
- [x] Docs updated if behavior changed
- [x] Tests cover the change