### PR TITLE
feat: span pass and tracer seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Tardigrade
 
+### Log is all you need
+
 Tardigrade is a durable agent harness built with the log as its core, inspired by event sourcing and React. State at any point is a pure function of the log, and the harness is a set of transitions derived from it.
 
 $$\{\mathrm{transitions}\} = f(\mathrm{log})$$
 
 ## Quickstart
 
-An agent is reactors over one log. Assemble one, give it a durable log, send it a message.
+An agent is reactors over one log.
 
 ```ts
 import { Effect, Layer } from "effect"
@@ -51,7 +53,7 @@ await host.drive()
 
 ### Events
 
-An event is a fact, recorded once and never edited. Everything else is derived from the set of them.
+An event is the smallest primitive. It's an immutable fact, recorded once in the event log. You define events based on what's meaningful in your domain. For example, when building an agent, your events could be `MessageReceived`, `ToolCalled` etc.
 
 ```ts
 // An Event is an open record. Concrete events narrow it.
@@ -65,7 +67,7 @@ type TurnCompleted = { type: "TurnCompleted"; output: string }
 
 ### Projections
 
-A projection is a pure function from the event log to a value.
+A projection is a pure function that takes an event log and returns a value. Projections help to slice an event log into different views based on the consumer.
 
 ```ts
 type Projection<T> = (events: ReadonlyArray<Event>) => T
@@ -76,8 +78,10 @@ const done: Projection<boolean> = (events) => events.some((e) => e.type === "Tur
 
 ### Transitions and reactors
 
+A transition is a keyed unit of state change. It takes in state, and returns new events. Reactors compute the transitions enabled by a given event log.
+
 ```ts
-// One keyed unit of work: state in, events out. A retried fire is the same work, absorbed by its key.
+// state in, events out. A retried fire is the same work, absorbed by its key.
 interface Transition<T> {
   readonly key: string
   readonly input: T
@@ -96,8 +100,6 @@ An actor is a set of reactors over one log, plus the key derivation that decides
 </picture>
 
 ## Docs
-
-Organized on the Diátaxis grid: learning, tasks, information, understanding.
 
 - [Quickstart](docs/quickstart.md): the concepts in one page: events, projections, transitions, reactors, an agent in three reactors.
 - [Tutorial: an RLM agent](docs/tutorials/rlm-agent.md): a Recursive Language Model agent with durable code execution, killed mid-recursion.

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "tardigrade",

--- a/docs/assets/reconciler-loop-dark.svg
+++ b/docs/assets/reconciler-loop-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 284.485 542.5" width="284.485" height="542.5" style="--bg:#0d1117;--fg:#e6edf3;--accent:#f59e0b;--muted:#8b949e;background:var(--bg)">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 290.425 542.5" width="290.425" height="542.5" style="--bg:#0d1117;--fg:#e6edf3;--accent:#f59e0b;--muted:#8b949e;background:var(--bg)">
 <style>
   
   text { font-family: 'ui-sans-serif', system-ui, sans-serif; }
@@ -26,44 +26,44 @@
     <polygon points="8 0, 0 2.5, 8 5" fill="var(--_arrow)" stroke="var(--_arrow)" stroke-width="0.75" stroke-linejoin="round" />
   </marker>
 </defs>
-<polyline class="edge" data-from="log" data-to="reactor" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="events" points="184.622,373.3 184.622,477.6000000000001 137.71266666666668,477.6000000000001 137.71266666666668,489.6000000000001" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
-<polyline class="edge" data-from="reactor" data-to="transitions" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="transitions = f(log)" points="108.90933333333334,489.6000000000001 108.90933333333334,477.6000000000001 62,477.6000000000001 62,409.3 105.94533333333334,409.3 105.94533333333334,52.900000000000006" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
-<polyline class="edge" data-from="transitions" data-to="act" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="unrecorded keys fire" points="140.67666666666668,52.900000000000006 140.67666666666668,88.9 184.622,88.9 184.622,169.2" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
-<polyline class="edge" data-from="act" data-to="log" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="events, keyed record last" points="184.622,206.10000000000002 184.622,322.40000000000003" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="log" data-to="reactor" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="events" points="190.562,373.3 190.562,477.6000000000001 142.18266666666668,477.6000000000001 142.18266666666668,489.6000000000001" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="reactor" data-to="transitions" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="{transitions} = f(log)" points="113.37933333333334,489.6000000000001 113.37933333333334,477.6000000000001 65,477.6000000000001 65,409.3 110.41533333333334,409.3 110.41533333333334,52.900000000000006" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="transitions" data-to="act" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="unrecorded keys fire" points="145.14666666666668,52.900000000000006 145.14666666666668,88.9 190.562,88.9 190.562,169.2" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="act" data-to="log" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="events, keyed record last" points="190.562,206.10000000000002 190.562,322.40000000000003" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
 <g class="edge-label" data-from="log" data-to="reactor" data-label="events">
-  <rect x="159.622" y="416.30000000000007" width="49.726000000000006" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="184.485" y="431.45000000000005" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">events</text>
+  <rect x="165.562" y="416.30000000000007" width="49.726000000000006" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="190.425" y="431.45000000000005" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">events</text>
 </g>
-<g class="edge-label" data-from="reactor" data-to="transitions" data-label="transitions = f(log)">
-  <rect x="12" y="416.30000000000007" width="99.62200000000003" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="61.811000000000014" y="431.45000000000005" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">transitions = f(log)</text>
+<g class="edge-label" data-from="reactor" data-to="transitions" data-label="{transitions} = f(log)">
+  <rect x="11.999999999999993" y="416.30000000000007" width="105.56200000000003" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="64.781" y="431.45000000000005" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">{transitions} = f(log)</text>
 </g>
 <g class="edge-label" data-from="transitions" data-to="act" data-label="unrecorded keys fire">
-  <rect x="125.622" y="95.9" width="117.44200000000004" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="184.34300000000002" y="111.05000000000001" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">unrecorded keys fire</text>
+  <rect x="131.562" y="95.9" width="117.44200000000004" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="190.28300000000002" y="111.05000000000001" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">unrecorded keys fire</text>
 </g>
 <g class="edge-label" data-from="act" data-to="log" data-label="events, keyed record last">
-  <rect x="115.62200000000001" y="249.1" width="137.04400000000004" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="184.14400000000003" y="264.25" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">events, keyed record last</text>
+  <rect x="121.56200000000001" y="249.1" width="137.04400000000004" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="190.08400000000003" y="264.25" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">events, keyed record last</text>
 </g>
 <g class="node" data-id="log" data-label="event log" data-shape="cylinder">
-  <rect x="137.34150000000002" y="329.40000000000003" width="94.561" height="36.900000000000006" fill="var(--_node-fill)" stroke="none" />
-  <line x1="137.34150000000002" y1="329.40000000000003" x2="137.34150000000002" y2="366.30000000000007" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <line x1="231.90250000000003" y1="329.40000000000003" x2="231.90250000000003" y2="366.30000000000007" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <ellipse cx="184.622" cy="366.30000000000007" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <ellipse cx="184.622" cy="329.40000000000003" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="184.622" y="347.85" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">event log</text>
+  <rect x="143.28150000000002" y="329.40000000000003" width="94.561" height="36.900000000000006" fill="var(--_node-fill)" stroke="none" />
+  <line x1="143.28150000000002" y1="329.40000000000003" x2="143.28150000000002" y2="366.30000000000007" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <line x1="237.84250000000003" y1="329.40000000000003" x2="237.84250000000003" y2="366.30000000000007" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <ellipse cx="190.562" cy="366.30000000000007" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <ellipse cx="190.562" cy="329.40000000000003" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="190.562" y="347.85" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">event log</text>
 </g>
 <g class="node" data-id="reactor" data-label="reactor" data-shape="rectangle">
-  <rect x="80.10600000000002" y="489.6000000000001" width="86.41" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="123.31100000000002" y="508.05000000000007" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">reactor</text>
+  <rect x="84.57600000000002" y="489.6000000000001" width="86.41" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="127.78100000000002" y="508.05000000000007" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">reactor</text>
 </g>
 <g class="node" data-id="transitions" data-label="transitions" data-shape="rectangle">
-  <rect x="71.214" y="16" width="104.19400000000002" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="123.311" y="34.45" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">transitions</text>
+  <rect x="75.684" y="16" width="104.19400000000002" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="127.781" y="34.45" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">transitions</text>
 </g>
 <g class="node" data-id="act" data-label="act(input)" data-shape="rectangle">
-  <rect x="136.97100000000003" y="169.2" width="95.30199999999999" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="184.622" y="187.64999999999998" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">act(input)</text>
+  <rect x="142.91100000000003" y="169.2" width="95.30199999999999" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="190.562" y="187.64999999999998" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">act(input)</text>
 </g>
 </svg>

--- a/docs/assets/reconciler-loop-light.svg
+++ b/docs/assets/reconciler-loop-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 284.485 542.5" width="284.485" height="542.5" style="--bg:#ffffff;--fg:#1f2328;--accent:#d97706;--muted:#656d76;background:var(--bg)">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 290.425 542.5" width="290.425" height="542.5" style="--bg:#ffffff;--fg:#1f2328;--accent:#d97706;--muted:#656d76;background:var(--bg)">
 <style>
   
   text { font-family: 'ui-sans-serif', system-ui, sans-serif; }
@@ -26,44 +26,44 @@
     <polygon points="8 0, 0 2.5, 8 5" fill="var(--_arrow)" stroke="var(--_arrow)" stroke-width="0.75" stroke-linejoin="round" />
   </marker>
 </defs>
-<polyline class="edge" data-from="log" data-to="reactor" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="events" points="184.622,373.3 184.622,477.6000000000001 137.71266666666668,477.6000000000001 137.71266666666668,489.6000000000001" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
-<polyline class="edge" data-from="reactor" data-to="transitions" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="transitions = f(log)" points="108.90933333333334,489.6000000000001 108.90933333333334,477.6000000000001 62,477.6000000000001 62,409.3 105.94533333333334,409.3 105.94533333333334,52.900000000000006" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
-<polyline class="edge" data-from="transitions" data-to="act" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="unrecorded keys fire" points="140.67666666666668,52.900000000000006 140.67666666666668,88.9 184.622,88.9 184.622,169.2" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
-<polyline class="edge" data-from="act" data-to="log" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="events, keyed record last" points="184.622,206.10000000000002 184.622,322.40000000000003" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="log" data-to="reactor" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="events" points="190.562,373.3 190.562,477.6000000000001 142.18266666666668,477.6000000000001 142.18266666666668,489.6000000000001" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="reactor" data-to="transitions" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="{transitions} = f(log)" points="113.37933333333334,489.6000000000001 113.37933333333334,477.6000000000001 65,477.6000000000001 65,409.3 110.41533333333334,409.3 110.41533333333334,52.900000000000006" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="transitions" data-to="act" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="unrecorded keys fire" points="145.14666666666668,52.900000000000006 145.14666666666668,88.9 190.562,88.9 190.562,169.2" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="act" data-to="log" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="events, keyed record last" points="190.562,206.10000000000002 190.562,322.40000000000003" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
 <g class="edge-label" data-from="log" data-to="reactor" data-label="events">
-  <rect x="159.622" y="416.30000000000007" width="49.726000000000006" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="184.485" y="431.45000000000005" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">events</text>
+  <rect x="165.562" y="416.30000000000007" width="49.726000000000006" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="190.425" y="431.45000000000005" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">events</text>
 </g>
-<g class="edge-label" data-from="reactor" data-to="transitions" data-label="transitions = f(log)">
-  <rect x="12" y="416.30000000000007" width="99.62200000000003" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="61.811000000000014" y="431.45000000000005" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">transitions = f(log)</text>
+<g class="edge-label" data-from="reactor" data-to="transitions" data-label="{transitions} = f(log)">
+  <rect x="11.999999999999993" y="416.30000000000007" width="105.56200000000003" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="64.781" y="431.45000000000005" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">{transitions} = f(log)</text>
 </g>
 <g class="edge-label" data-from="transitions" data-to="act" data-label="unrecorded keys fire">
-  <rect x="125.622" y="95.9" width="117.44200000000004" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="184.34300000000002" y="111.05000000000001" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">unrecorded keys fire</text>
+  <rect x="131.562" y="95.9" width="117.44200000000004" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="190.28300000000002" y="111.05000000000001" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">unrecorded keys fire</text>
 </g>
 <g class="edge-label" data-from="act" data-to="log" data-label="events, keyed record last">
-  <rect x="115.62200000000001" y="249.1" width="137.04400000000004" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
-  <text x="184.14400000000003" y="264.25" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">events, keyed record last</text>
+  <rect x="121.56200000000001" y="249.1" width="137.04400000000004" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="190.08400000000003" y="264.25" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">events, keyed record last</text>
 </g>
 <g class="node" data-id="log" data-label="event log" data-shape="cylinder">
-  <rect x="137.34150000000002" y="329.40000000000003" width="94.561" height="36.900000000000006" fill="var(--_node-fill)" stroke="none" />
-  <line x1="137.34150000000002" y1="329.40000000000003" x2="137.34150000000002" y2="366.30000000000007" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <line x1="231.90250000000003" y1="329.40000000000003" x2="231.90250000000003" y2="366.30000000000007" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <ellipse cx="184.622" cy="366.30000000000007" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <ellipse cx="184.622" cy="329.40000000000003" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="184.622" y="347.85" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">event log</text>
+  <rect x="143.28150000000002" y="329.40000000000003" width="94.561" height="36.900000000000006" fill="var(--_node-fill)" stroke="none" />
+  <line x1="143.28150000000002" y1="329.40000000000003" x2="143.28150000000002" y2="366.30000000000007" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <line x1="237.84250000000003" y1="329.40000000000003" x2="237.84250000000003" y2="366.30000000000007" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <ellipse cx="190.562" cy="366.30000000000007" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <ellipse cx="190.562" cy="329.40000000000003" rx="47.2805" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="190.562" y="347.85" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">event log</text>
 </g>
 <g class="node" data-id="reactor" data-label="reactor" data-shape="rectangle">
-  <rect x="80.10600000000002" y="489.6000000000001" width="86.41" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="123.31100000000002" y="508.05000000000007" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">reactor</text>
+  <rect x="84.57600000000002" y="489.6000000000001" width="86.41" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="127.78100000000002" y="508.05000000000007" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">reactor</text>
 </g>
 <g class="node" data-id="transitions" data-label="transitions" data-shape="rectangle">
-  <rect x="71.214" y="16" width="104.19400000000002" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="123.311" y="34.45" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">transitions</text>
+  <rect x="75.684" y="16" width="104.19400000000002" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="127.781" y="34.45" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">transitions</text>
 </g>
 <g class="node" data-id="act" data-label="act(input)" data-shape="rectangle">
-  <rect x="136.97100000000003" y="169.2" width="95.30199999999999" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
-  <text x="184.622" y="187.64999999999998" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">act(input)</text>
+  <rect x="142.91100000000003" y="169.2" width="95.30199999999999" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="190.562" y="187.64999999999998" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">act(input)</text>
 </g>
 </svg>

--- a/docs/explanations/reactors.md
+++ b/docs/explanations/reactors.md
@@ -1,6 +1,6 @@
 If you're familiar with React, you know the concept of `UI = f(state)`. 
 
-$$\mathrm{transitions} = f(\mathrm{log})$$
+$$\{\mathrm{transitions}\} = f(\mathrm{log})$$
 ### Interface
 
 ```ts

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -57,7 +57,7 @@ An actor is a set of reactors.
 ```mermaid
 flowchart TB
   log[("event log")] -->|"events"| reactor["reactor"]
-  reactor -->|"transitions = f(log)"| transitions["transitions"]
+  reactor -->|"{transitions} = f(log)"| transitions["transitions"]
   transitions -->|"keys the log does not record"| act["act(input)"]
   act -->|"events, keyed record last"| log
 ```

--- a/packages/core/src/actor.ts
+++ b/packages/core/src/actor.ts
@@ -101,7 +101,9 @@ export const settleActor = <R>(a: Actor<R>): Effect.Effect<void, never, EventLog
       let moved = false
       for (const t of fires) {
         const before = yield* log.head
-        const returned = yield* t.act(t.input)
+        // The fire is the reconciler's unit of work, so it is the span: the transition key is
+        // the one attribute that joins a trace to the log. Inert without a tracer.
+        const returned = yield* t.act(t.input).pipe(Effect.withSpan("transition.fire", { attributes: { key: t.key } }))
         if (returned.length > 0) yield* log.append(returned)
         if (recordedKeys(yield* log.read, a.keyOf).has(t.key)) {
           moved = true

--- a/packages/core/src/actor.ts
+++ b/packages/core/src/actor.ts
@@ -101,24 +101,32 @@ export const settleActor = <R>(a: Actor<R>): Effect.Effect<void, never, EventLog
       let moved = false
       for (const t of fires) {
         const before = yield* log.head
-        // The fire is the reconciler's unit of work, so it is the span: the transition key is
-        // the one attribute that joins a trace to the log. Inert without a tracer.
-        const returned = yield* t.act(t.input).pipe(Effect.withSpan("transition.fire", { attributes: { key: t.key } }))
-        if (returned.length > 0) yield* log.append(returned)
-        if (recordedKeys(yield* log.read, a.keyOf).has(t.key)) {
+        // The fire is the reconciler's unit of work, so it is the span: the transition key
+        // joins the trace to the log, and the outcome is the one question every trace query
+        // starts with. Inert without a tracer.
+        const fired = yield* Effect.gen(function* () {
+          const returned = yield* t.act(t.input)
+          if (returned.length > 0) yield* log.append(returned)
+          const committed = recordedKeys(yield* log.read, a.keyOf).has(t.key)
+          const outcome = committed
+            ? "committed"
+            : (yield* log.head) > before
+              ? // Progress without the key: the act recorded evidence (its sends, a BlockedOn)
+                // and stopped. Re-derive: a transient attempt that recorded its send retries in
+                // this settle, and a genuine park's evidence suppresses its own re-derivation
+                // until the world moves.
+                "advanced"
+              : returned.length === 0
+                ? // Blocked with nothing to say: a park already on record, or a transient
+                  // failure with none. Legal; the platform alarm re-drives when the world moves.
+                  "blocked"
+                : "wedged"
+          yield* Effect.annotateCurrentSpan("outcome", outcome)
+          return outcome
+        }).pipe(Effect.withSpan("transition.fire", { attributes: { key: t.key } }))
+        if (fired === "committed" || fired === "advanced") {
           moved = true
-        } else if ((yield* log.head) > before) {
-          // Progress without the key: the act recorded evidence (its
-          // sends, a BlockedOn) and stopped. Re-derive: a transient
-          // attempt that recorded its send retries in this settle,
-          // and a genuine park's evidence suppresses its own
-          // re-derivation until the world moves.
-          moved = true
-        } else if (returned.length === 0) {
-          // Blocked with nothing to say: a park already on record, or
-          // a transient failure with none. Legal; the platform alarm
-          // re-drives when the world moves.
-        } else {
+        } else if (fired === "wedged") {
           return yield* Effect.die(
             new Error(`transition "${t.key}" wedged: its events carry no committing key and none landed`)
           )

--- a/packages/core/src/actor.ts
+++ b/packages/core/src/actor.ts
@@ -130,7 +130,7 @@ export const settleActor = <R>(a: Actor<R>): Effect.Effect<void, never, EventLog
             attributes: { key: t.key },
             // The link to the delivery that woke this work: the cross-lane seam of the trace
             // (packages/core/src/trace.ts, triggerOf).
-            ...(trigger === undefined ? {} : { links: [{ _tag: "SpanLink", span: trigger, attributes: {} } as const] })
+            ...(trigger === undefined ? {} : { links: [{ span: trigger, attributes: {} }] })
           })
         )
         if (fired === "committed" || fired === "advanced") {

--- a/packages/core/src/actor.ts
+++ b/packages/core/src/actor.ts
@@ -1,6 +1,7 @@
 import { Context, Effect } from "effect"
 import { EventLog } from "./event-log"
 import type { Event } from "./event"
+import { triggerOf } from "./trace"
 
 // An actor is the single writer of one log and the reactors over it.
 // All state is a projection of the log: a crash loses nothing, and two
@@ -98,6 +99,7 @@ export const settleActor = <R>(a: Actor<R>): Effect.Effect<void, never, EventLog
       const events = yield* log.read
       const fires = enabled(a, events)
       if (fires.length === 0) return
+      const trigger = triggerOf(events)
       let moved = false
       for (const t of fires) {
         const before = yield* log.head
@@ -123,7 +125,14 @@ export const settleActor = <R>(a: Actor<R>): Effect.Effect<void, never, EventLog
                 : "wedged"
           yield* Effect.annotateCurrentSpan("outcome", outcome)
           return outcome
-        }).pipe(Effect.withSpan("transition.fire", { attributes: { key: t.key } }))
+        }).pipe(
+          Effect.withSpan("transition.fire", {
+            attributes: { key: t.key },
+            // The link to the delivery that woke this work: the cross-lane seam of the trace
+            // (packages/core/src/trace.ts, triggerOf).
+            ...(trigger === undefined ? {} : { links: [{ _tag: "SpanLink", span: trigger, attributes: {} } as const] })
+          })
+        )
         if (fired === "committed" || fired === "advanced") {
           moved = true
         } else if (fired === "wedged") {

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -1,0 +1,34 @@
+import { Tracer } from "effect"
+import type { Event } from "./event"
+
+// The trace seam of the event grammar: a delivered event MAY carry `traceparent`, the W3C
+// header form of the span that sent it (00-<traceId>-<spanId>-01). The PLATFORM stamps it at
+// delivery, where the sending span is current; the packages only read it, so the reconciler can
+// link a fire to the delivery that woke the work and one business event stays one trace across
+// every lane it touches. Links, never parents: one settle serves many deliveries, and the
+// messaging conventions make links the default for exactly that reason (platform/bun's
+// host.test.ts, "one trace across lanes").
+
+export const traceparentOf = (span: { readonly traceId: string; readonly spanId: string }): string =>
+  `00-${span.traceId}-${span.spanId}-01`
+
+// linkOf reads an event's carried context back into a linkable span. An event without one, or
+// with an unreadable one, links nothing.
+export const linkOf = (e: Event): Tracer.ExternalSpan | undefined => {
+  const header = (e as { traceparent?: unknown }).traceparent
+  if (typeof header !== "string") return undefined
+  const parts = header.split("-")
+  if (parts.length !== 4 || parts[1]!.length === 0 || parts[2]!.length === 0) return undefined
+  return Tracer.externalSpan({ traceId: parts[1]!, spanId: parts[2]! })
+}
+
+// triggerOf is the settle's approximation of "what woke this work": the newest carried context
+// on the log. A settle that serves several fresh deliveries links them all to the same trigger;
+// finer attribution needs the derivation to name its inputs, which a projection cannot.
+export const triggerOf = (events: ReadonlyArray<Event>): Tracer.ExternalSpan | undefined => {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const link = linkOf(events[i]!)
+    if (link !== undefined) return link
+  }
+  return undefined
+}

--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -108,9 +108,12 @@ describe("the bun host", () => {
 describe("telemetry seam", () => {
   test("spans flow to a supplied tracer: deliver and the transition fire, keyed", async () => {
     const names: Array<{ name: string; key?: unknown; type?: unknown }> = []
+    const linked: Array<{ name: string; traceId: string }> = []
     const capture = Layer.setTracer(
       Tracer.make({
-        span: (name, parent, context, links, startTime, kind) => ({
+        span: (name, parent, context, links, startTime, kind) => {
+          for (const l of links) linked.push({ name, traceId: l.span.traceId })
+          return {
           _tag: "Span",
           spanId: "s",
           traceId: "t",
@@ -128,7 +131,8 @@ describe("telemetry seam", () => {
           end() {},
           event() {},
           addLinks() {}
-        }),
+          }
+        },
         context: (f) => f()
       })
     )
@@ -137,6 +141,11 @@ describe("telemetry seam", () => {
     await h.drive()
     expect(names.some((s) => s.name === "deliver" && s.type === "MessageReceived")).toBe(true)
     expect(names.some((s) => s.name === "transition.fire" && s.key === "dn:m1")).toBe(true)
+    // The cross-lane seam: the delivered event carries the deliver span's context, and the
+    // fire links back to it: one business event, one trace.
+    const row = (await h.read("echo"))[0] as { traceparent?: string }
+    expect(row.traceparent).toMatch(/^00-t-s-01$/)
+    expect(linked.some((l) => l.name === "transition.fire" && l.traceId === "t")).toBe(true)
     await h.close()
   })
 })

--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { mkdtempSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { Effect } from "effect"
+import { Effect, Layer, Tracer } from "effect"
 import type { Event } from "@tardigrade/core/event"
 import { transition, type Actor, type Reactor } from "@tardigrade/core/actor"
 
@@ -101,6 +101,42 @@ describe("the bun host", () => {
       { type: "Done", id: "c", at: 4 } as Event
     ])
     expect((await h.read("echo")).map((e) => String((e as { id?: unknown }).id))).toEqual(["a", "b", "c"])
+    await h.close()
+  })
+})
+
+describe("telemetry seam", () => {
+  test("spans flow to a supplied tracer: deliver and the transition fire, keyed", async () => {
+    const names: Array<{ name: string; key?: unknown; type?: unknown }> = []
+    const capture = Layer.setTracer(
+      Tracer.make({
+        span: (name, parent, context, links, startTime, kind) => ({
+          _tag: "Span",
+          spanId: "s",
+          traceId: "t",
+          name,
+          parent,
+          context,
+          links,
+          kind,
+          sampled: true,
+          status: { _tag: "Started", startTime },
+          attributes: new Map(),
+          attribute(k: string, v: unknown) {
+            names.push({ name, ...(k === "key" ? { key: v } : {}), ...(k === "type" ? { type: v } : {}) })
+          },
+          end() {},
+          event() {},
+          addLinks() {}
+        }),
+        context: (f) => f()
+      })
+    )
+    const h = await createBunHost({ ...options(freshPath()), telemetry: capture })
+    await h.deliver("bun:echo", { type: "MessageReceived", id: "m1", text: "go", at: 1 } as Event)
+    await h.drive()
+    expect(names.some((s) => s.name === "deliver" && s.type === "MessageReceived")).toBe(true)
+    expect(names.some((s) => s.name === "transition.fire" && s.key === "dn:m1")).toBe(true)
     await h.close()
   })
 })

--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -109,31 +109,30 @@ describe("telemetry seam", () => {
   test("spans flow to a supplied tracer: deliver and the transition fire, keyed", async () => {
     const names: Array<{ name: string; key?: unknown; type?: unknown }> = []
     const linked: Array<{ name: string; traceId: string }> = []
-    const capture = Layer.setTracer(
+    const capture = Layer.succeed(Tracer.Tracer)(
       Tracer.make({
-        span: (name, parent, context, links, startTime, kind) => {
-          for (const l of links) linked.push({ name, traceId: l.span.traceId })
+        span(options) {
+          for (const l of options.links) linked.push({ name: options.name, traceId: l.span.traceId })
+          const record = (k: string, v: unknown) =>
+            names.push({ name: options.name, ...(k === "key" ? { key: v } : {}), ...(k === "type" ? { type: v } : {}) })
           return {
-          _tag: "Span",
-          spanId: "s",
-          traceId: "t",
-          name,
-          parent,
-          context,
-          links,
-          kind,
-          sampled: true,
-          status: { _tag: "Started", startTime },
-          attributes: new Map(),
-          attribute(k: string, v: unknown) {
-            names.push({ name, ...(k === "key" ? { key: v } : {}), ...(k === "type" ? { type: v } : {}) })
-          },
-          end() {},
-          event() {},
-          addLinks() {}
-          }
-        },
-        context: (f) => f()
+            _tag: "Span",
+            spanId: "s",
+            traceId: "t",
+            name: options.name,
+            parent: options.parent,
+            annotations: options.annotations,
+            links: options.links,
+            kind: options.kind,
+            sampled: true,
+            status: { _tag: "Started", startTime: options.startTime },
+            attributes: new Map(),
+            attribute: record,
+            end() {},
+            event() {},
+            addLinks() {}
+          } as never
+        }
       })
     )
     const h = await createBunHost({ ...options(freshPath()), telemetry: capture })

--- a/platform/bun/src/host.ts
+++ b/platform/bun/src/host.ts
@@ -19,6 +19,10 @@ import { deadlocks, victimOf, type EdgesOf } from "@tardigrade/host/deadlock"
 
 export interface BunHostOptions<R> {
   readonly path: string // SQLite file, or ":memory:" for a volatile run
+  // The tracer the spans flow to, when the app brings one (an @effect/opentelemetry layer, a
+  // test capture). Absent, every span is inert: instrumentation lives in the packages, export
+  // is the platform's, and this seam is the whole of it.
+  readonly telemetry?: Layer.Layer<never>
   readonly principal?: string
   readonly actorFor: (lane: string) => Actor<R> | undefined
   readonly layersFor?: (lane: string) => Layer.Layer<unknown, never, EventLog | Router | Self>
@@ -52,7 +56,7 @@ const REFUSED: CallResult = { error: "this host takes no synchronous calls" }
 
 export const createBunHost = async <R>(options: BunHostOptions<R>): Promise<BunHost> => {
   const principal = options.principal ?? "bun"
-  const runtime = ManagedRuntime.make(SqliteClient.layer({ filename: options.path }))
+  const runtime = ManagedRuntime.make(Layer.mergeAll(SqliteClient.layer({ filename: options.path }), options.telemetry ?? Layer.empty))
   // One client, acquired once: every read and every append shares the connection, so ":memory:"
   // is one database and the per-lane writer stays this process.
   const sql = await runtime.runPromise(SqlClient.SqlClient)
@@ -132,7 +136,7 @@ export const createBunHost = async <R>(options: BunHostOptions<R>): Promise<BunH
       }
       yield* appendEffect(lane, [event])
       dirty.add(lane)
-    })
+    }).pipe(Effect.withSpan("deliver", { attributes: { to: address, type: event.type } }))
 
   const router = Layer.succeed(Router, {
     deliver: deliverEffect,

--- a/platform/bun/src/host.ts
+++ b/platform/bun/src/host.ts
@@ -136,7 +136,7 @@ export const createBunHost = async <R>(options: BunHostOptions<R>): Promise<BunH
       }
       yield* appendEffect(lane, [event])
       dirty.add(lane)
-    }).pipe(Effect.withSpan("deliver", { attributes: { to: address, type: event.type } }))
+    }).pipe(Effect.withSpan("deliver", { kind: "producer", attributes: { to: address, type: event.type } }))
 
   const router = Layer.succeed(Router, {
     deliver: deliverEffect,

--- a/platform/bun/src/host.ts
+++ b/platform/bun/src/host.ts
@@ -6,6 +6,7 @@ import { EventLog } from "@tardigrade/core/event-log"
 import { Router, type CallResult } from "@tardigrade/core/router"
 import { Self, restingActor, settleActor, type Actor } from "@tardigrade/core/actor"
 import { deadlocks, victimOf, type EdgesOf } from "@tardigrade/host/deadlock"
+import { traceparentOf } from "@tardigrade/core/trace"
 
 // The bun binding: packages/host's semantics with physics. The log lives in SQLite through
 // @effect/sql-sqlite-bun, so a process death loses nothing and `recover()` re-derives the owed
@@ -126,6 +127,15 @@ export const createBunHost = async <R>(options: BunHostOptions<R>): Promise<BunH
         )
       }
       const lane = laneOf(address)
+      // The platform stamps the sending span's context onto the event it persists (the W3C
+      // header form), so a later settle on the receiving lane links back to this delivery: one
+      // business event, one trace, across lanes (packages/core/src/trace.ts). An event already
+      // carrying a context keeps it: the first stamp is the causal one.
+      const current = yield* Effect.currentSpan.pipe(Effect.option)
+      const stamped =
+        current._tag === "Some" && (event as { traceparent?: unknown }).traceparent === undefined
+          ? ({ ...event, traceparent: traceparentOf(current.value) } as Event)
+          : event
       if (event.type === "MessageReceived") {
         const id = String((event as { id?: unknown }).id)
         const seen = yield* sql<{ n: number }>`SELECT COUNT(*) AS n FROM events
@@ -134,7 +144,7 @@ export const createBunHost = async <R>(options: BunHostOptions<R>): Promise<BunH
         )
         if (Number(seen[0]?.n ?? 0) > 0) return
       }
-      yield* appendEffect(lane, [event])
+      yield* appendEffect(lane, [stamped])
       dirty.add(lane)
     }).pipe(Effect.withSpan("deliver", { kind: "producer", attributes: { to: address, type: event.type } }))
 

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -405,7 +405,7 @@ export const realInfer = (config: ModelConfig) => {
   }
   return Layer.succeed(Infer, {
     react: (trajectory: ReadonlyArray<Event>, key?: string) =>
-      Effect.promise(async () => {
+      Effect.promise<Action>(async () => {
         const ladder = ladderOf(config.maxOutputTokens)
         let rung = 0
         for (let attempt = 0; ; attempt++) {
@@ -427,6 +427,10 @@ export const realInfer = (config: ModelConfig) => {
             await sleep(delay)
           }
         }
-      })
+      }).pipe(
+        // One span per react: the model, the wire, and the ceiling that bounded it. Attempt-level
+        // detail (rungs, throttle waits) stays inside; the log records what landed.
+        Effect.withSpan("llm.react", { attributes: { model: config.model, provider: config.provider ?? "openai-compatible" } })
+      )
   })
 }

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -364,7 +364,7 @@ export const realInfer = (config: ModelConfig) => {
     totalMs: config.stream?.totalMs ?? DEFAULT_STREAM_BOUNDS.totalMs
   }
   const throttleDelays = config.throttleRetryDelaysMs ?? DEFAULT_THROTTLE_RETRY_DELAYS_MS
-  const attemptOnce = async (trajectory: ReadonlyArray<Event>, key: string | undefined, maxTokens: number, rung: number): Promise<Action> => {
+  const attemptOnce = async (trajectory: ReadonlyArray<Event>, key: string | undefined, maxTokens: number, rung: number, stats: { finish?: string }): Promise<Action> => {
     // A changed ceiling is a different request, so it mints a different idempotency key: a
     // provider that dedups would otherwise answer the escalated retry with the cached truncated
      // response, and the ladder would climb nowhere (the removed driver learned this).
@@ -400,17 +400,21 @@ export const realInfer = (config: ModelConfig) => {
       logger: noopLogger
     } as never)
     const result = await new StreamProcessor().process(bounded(stream, bounds))
+    stats.finish = result.finishReason ?? "stop"
     if (result.finishReason === "length") throw new TruncatedError(maxTokens)
     return actionOf(result, schema)
   }
   return Layer.succeed(Infer, {
     react: (trajectory: ReadonlyArray<Event>, key?: string) =>
-      Effect.promise<Action>(async () => {
+      Effect.gen(function* () {
         const ladder = ladderOf(config.maxOutputTokens)
+        const stats: { finish?: string; rung: number; waits: number } = { rung: 0, waits: 0 }
+        const action = yield* Effect.promise<Action>(async () => {
         let rung = 0
         for (let attempt = 0; ; attempt++) {
           try {
-            return await attemptOnce(trajectory, key, ladder[rung]!, rung)
+            stats.rung = rung
+            return await attemptOnce(trajectory, key, ladder[rung]!, rung, stats)
           } catch (e) {
             if (isTruncated(e)) {
               if (rung + 1 < ladder.length) {
@@ -424,13 +428,26 @@ export const realInfer = (config: ModelConfig) => {
             if (!isThrottleShaped(e)) throw e
             const delay = throttleDelayMs(e, attempt, Date.now(), throttleDelays)
             if (delay === undefined) throw e
+            stats.waits += 1
             await sleep(delay)
           }
         }
+        })
+        // The wide-span discipline: everything a failure query filters by rides the one span.
+        // Names follow the GenAI semantic conventions where they exist (registry, 2026).
+        yield* Effect.annotateCurrentSpan("gen_ai.response.finish_reasons", [stats.finish ?? "unknown"])
+        yield* Effect.annotateCurrentSpan("retry.rung", stats.rung)
+        yield* Effect.annotateCurrentSpan("retry.throttle_waits", stats.waits)
+        return action
       }).pipe(
-        // One span per react: the model, the wire, and the ceiling that bounded it. Attempt-level
-        // detail (rungs, throttle waits) stays inside; the log records what landed.
-        Effect.withSpan("llm.react", { attributes: { model: config.model, provider: config.provider ?? "openai-compatible" } })
+        Effect.withSpan("llm.react", {
+          kind: "client",
+          attributes: {
+            "gen_ai.operation.name": "chat",
+            "gen_ai.request.model": config.model,
+            "gen_ai.provider.name": config.provider === "bedrock" ? "aws.bedrock" : "openai"
+          }
+        })
       )
   })
 }

--- a/tools/render-diagrams.ts
+++ b/tools/render-diagrams.ts
@@ -11,7 +11,7 @@ const root = fileURLToPath(new URL("../", import.meta.url))
 const DIAGRAMS: Record<string, string> = {
   "reconciler-loop": `flowchart TB
   log[("event log")] -->|"events"| reactor["reactor"]
-  reactor -->|"transitions = f(log)"| transitions["transitions"]
+  reactor -->|"{transitions} = f(log)"| transitions["transitions"]
   transitions -->|"unrecorded keys fire"| act["act(input)"]
   act -->|"events, keyed record last"| log`
 }


### PR DESCRIPTION
Tracing had two spans (the code lane's), no export seam, and every settle was its own orphan trace. This pass gives the seams the log cannot see their spans, makes the spans wide, joins the traces across lanes, and ships the export batteries.

Spans and width:
- transition.fire in the reconciler: the transition key joins the trace to the log; the outcome (committed, advanced, blocked, wedged) is annotated on the span
- llm.react on the model binding: kind client, gen_ai.operation.name/request.model/provider.name at creation, gen_ai.response.finish_reasons plus retry.rung and retry.throttle_waits annotated after the ladder settles (current registry keys; gen_ai.system is deprecated upstream)
- deliver on the bun host: kind producer, with target and event type

One trace across lanes (the messaging conventions' shape: links by default, context persisted in the message):
- the platform stamps the sending span's context onto the event it persists, as one traceparent string in W3C header form; an event already carrying one keeps it, the first stamp being the causal one
- the fire span links to the newest carried context on the log: the delivery that woke the work
- packages/core/src/trace.ts holds the seam (traceparentOf, linkOf, triggerOf), pure and dependency-free; stamping is platform behavior only

Export:
- createBunHost's telemetry takes any tracer layer; absent, every span stays inert, so packages keep their dependency rule and pay nothing
- otlpTelemetry in platform/bun is the ready-made occupant: effect v4 ships the OTLP exporter in core (unstable/observability), so the convenience costs zero dependencies: baseUrl, serviceName, batched JSON to any collector

The capture-tracer test proves the chain end to end. Rebased through the Effect v4 upgrade and the tardigrade package rename; gate green. Rides along: the README voice pass, and braces on the transitions set everywhere it renders.