### PR TITLE
chore(deps): upgrade Effect v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ packages/
   host/      the reference in-memory binding
 platform/
   model/     the Infer binding over TanStack AI
-  bun/       the durable host binding: SQLite through @effect/sql
+   bun/       the durable host binding: SQLite through @effect/sql-sqlite-bun
 ```
 
 ## Contributing

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "flamecast-core",
@@ -23,7 +22,7 @@
         "@flamecast/code": "workspace:*",
         "@flamecast/core": "workspace:*",
         "@flamecast/host": "workspace:*",
-        "effect": "^3.22.1",
+        "effect": "4.0.0-rc.110",
       },
     },
     "packages/code": {
@@ -31,7 +30,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@flamecast/core": "workspace:*",
-        "effect": "^3.22.1",
+        "effect": "4.0.0-rc.110",
       },
       "devDependencies": {
         "fast-check": "^4.9.0",
@@ -41,7 +40,7 @@
       "name": "@flamecast/core",
       "version": "0.0.0",
       "dependencies": {
-        "effect": "^3.22.1",
+        "effect": "4.0.0-rc.110",
       },
     },
     "packages/host": {
@@ -49,7 +48,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@flamecast/core": "workspace:*",
-        "effect": "^3.22.1",
+        "effect": "4.0.0-rc.110",
       },
       "devDependencies": {
         "fast-check": "^4.9.0",
@@ -59,13 +58,10 @@
       "name": "@flamecast/bun",
       "version": "0.0.0",
       "dependencies": {
-        "@effect/experimental": "^0.61.1",
-        "@effect/platform": "^0.97.1",
-        "@effect/sql": "^0.52.1",
-        "@effect/sql-sqlite-bun": "^0.53.0",
+        "@effect/sql-sqlite-bun": "4.0.0-rc.110",
         "@flamecast/core": "workspace:*",
         "@flamecast/host": "workspace:*",
-        "effect": "^3.22.1",
+        "effect": "4.0.0-rc.110",
       },
     },
     "platform/model": {
@@ -79,7 +75,7 @@
         "@tanstack/ai": "0.44.0",
         "@tanstack/ai-bedrock": "0.2.1",
         "@tanstack/ai-openai": "0.19.0",
-        "effect": "^3.22.1",
+        "effect": "4.0.0-rc.110",
       },
     },
   },
@@ -134,13 +130,7 @@
 
     "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
 
-    "@effect/experimental": ["@effect/experimental@0.61.1", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/platform": "^0.97.1", "effect": "^3.22.1", "ioredis": "^5", "lmdb": "^3" }, "optionalPeers": ["ioredis", "lmdb"] }, "sha512-+P+PgGQeE2fXmsm63YoyENNcQIc7OiCkY4/HLkEdTvq93syfGIpwDfQD8u3xODMHJhZ5ZtRZHH4+UedFO0tLiA=="],
-
-    "@effect/platform": ["@effect/platform@0.97.1", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.10", "multipasta": "^0.2.8" }, "peerDependencies": { "effect": "^3.22.1" } }, "sha512-IevWxwmrxCdeXxbXDx/hiOstHtERRigd1nhZSuHgiFEl7NkBmS/5GVWsRacq4NfJN2uCXqggETKNwij15VEpew=="],
-
-    "@effect/sql": ["@effect/sql@0.52.1", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/experimental": "^0.61.1", "@effect/platform": "^0.97.1", "effect": "^3.22.1" } }, "sha512-dUVPjlUgpga6sDa/MtYipHAqzHx2St41hxI00nXTBt4IBBJaf2lTGaOvlEoBg/q6PHVAgSoKnxe19pWUvabC9g=="],
-
-    "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@0.53.0", "", { "peerDependencies": { "@effect/experimental": "^0.61.0", "@effect/platform": "^0.97.0", "@effect/sql": "^0.52.0", "effect": "^3.22.0" } }, "sha512-duY1ePTP1W44E1hJ/GS/s7Zhs9xVv3mok41ShSa4pPaISw6Vn1vDGLEqH1VDa9Ffck2/YnWywB8Ise+nOk+6ew=="],
+    "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@4.0.0-rc.110", "", { "peerDependencies": { "effect": "^4.0.0-rc.110" } }, "sha512-Lam3gY1xszjQS/cebdLbWbtR21FtQI4ke7QHqbBQ6AyVJF0CGUtS/ePL9zNq6wHNmJ95FUDGS6W+Qx/l6RPSzA=="],
 
     "@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
 
@@ -338,7 +328,7 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "effect": ["effect@3.22.1", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-TNoXushmPOBAjJlthF5d2QwnX2xBPEtcNJr5XKNKbRLbDvBcOYkXlYDfvGfSA0zriwLFuCll5MDtNMAdZL17PQ=="],
+    "effect": ["effect@4.0.0-rc.110", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "msgpackr": "^2.0.4" } }, "sha512-ega6FTJ8CS2of7tHZiADvgyJyV999Q6tZ9juE56V81O0jw6flRwydaPNtyfvP2a5LL9PZrse8A1jnNUD5sWVHg=="],
 
     "elkjs": ["elkjs@0.11.1", "", {}, "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg=="],
 
@@ -350,8 +340,6 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
-
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 
     "get-tsconfig": ["get-tsconfig@4.14.1", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A=="],
@@ -360,11 +348,9 @@
 
     "knip": ["knip@6.32.2", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.1", "jiti": "^2.7.0", "oxc-parser": "^0.143.0", "oxc-resolver": "11.24.2", "picomatch": "^4.0.5", "smol-toml": "^1.7.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.17", "unbash": "^4.0.9", "yaml": "^2.9.0", "zod": "^4.4.3" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-WXTXbmocrw7gqm1A1TQvFN0OgJ7hUSU6E1g6SPRIzzHFogUBhXByc7cYeOFVtJ2uODg7DP4VbESYBYnfbtBYsg=="],
 
-    "msgpackr": ["msgpackr@1.12.1", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ=="],
+    "msgpackr": ["msgpackr@2.0.5", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA=="],
 
     "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
-
-    "multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
@@ -398,8 +384,6 @@
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
-    "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
-
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
@@ -407,9 +391,5 @@
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1111.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.8", "@aws-sdk/nested-clients": "^3.997.43", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A=="],
-
-    "effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
-
-    "effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
   }
 }

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -11,7 +11,7 @@
     "@flamecast/core": "workspace:*",
     "@flamecast/code": "workspace:*",
     "@cfworker/json-schema": "^4.1.1",
-    "effect": "^3.22.1",
+    "effect": "4.0.0-rc.110",
     "@flamecast/host": "workspace:*"
   },
   "scripts": {

--- a/packages/agent/src/events.ts
+++ b/packages/agent/src/events.ts
@@ -121,7 +121,7 @@ export const BudgetDenied = Schema.Struct({
   at: Schema.Number
 })
 
-export const AgentEvent = Schema.Union(
+export const AgentEvent = Schema.Union([
   MessageReceived,
   ModelCalled,
   TextReturned,
@@ -134,7 +134,7 @@ export const AgentEvent = Schema.Union(
   BudgetRequested,
   BudgetGranted,
   BudgetDenied
-)
+])
 export type AgentEvent = typeof AgentEvent.Type
 
 // Action is what the model reacts with: ask the world, or end the turn. `text` is the prose the

--- a/packages/agent/src/infer.ts
+++ b/packages/agent/src/infer.ts
@@ -32,10 +32,10 @@ const REPAIR_AT_MOST = 2
 // Contract on the action: a call's callId must be fresh per call, never reused across turns
 // (providers mint tool-use ids; a stub must too). A reused id collides with the earlier call's
 // recorded pair and the dispatch dedup absorbs the new work.
-export class Infer extends Context.Tag("agent/Infer")<
+export class Infer extends Context.Service<
   Infer,
   { readonly react: (trajectory: ReadonlyArray<Event>, key?: string) => Effect.Effect<Action> }
->() {}
+>()("agent/Infer") {}
 
 // consequenceOf returns the action's recorded answer: the model responds by acting. Every
 // consequence carries the turn it serves.

--- a/packages/agent/src/spawn.ts
+++ b/packages/agent/src/spawn.ts
@@ -38,7 +38,7 @@ import { replyId } from "@flamecast/core/reply"
 // park on until the child is done asking. An escalatable spawn holds its call open; a plain one
 // parks.
 export const agentsPackage = (
-  router: Context.Tag.Service<typeof Router>,
+  router: Context.Service.Shape<typeof Router>,
   self: string,
   place: (callId: string) => string,
   reader: AgentReader,

--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@flamecast/core": "workspace:*",
-    "effect": "^3.22.1"
+    "effect": "4.0.0-rc.110"
   },
   "devDependencies": {
     "fast-check": "^4.9.0"

--- a/packages/code/src/events.ts
+++ b/packages/code/src/events.ts
@@ -61,13 +61,13 @@ export const CodeSettled = Schema.Struct({
   at: Schema.Number
 })
 
-export const CodeEvent = Schema.Union(
+export const CodeEvent = Schema.Union([
   CodeDispatched,
   BlockedOn,
   PackageCalled,
   PackageReturned,
   CodeSettled
-)
+])
 export type CodeEvent = typeof CodeEvent.Type
 
 // codeKeys is the code lane's dedup key fragment, owned beside its alphabet. cd/cs name the

--- a/packages/code/src/execute.ts
+++ b/packages/code/src/execute.ts
@@ -1,4 +1,4 @@
-import { Clock, Deferred, Effect, Fiber, Runtime } from "effect"
+import { Clock, Deferred, Effect, Fiber } from "effect"
 import { EventLog } from "@flamecast/core/event-log"
 import type { Event } from "@flamecast/core/event"
 import { transition, type Reactor } from "@flamecast/core/actor"
@@ -46,7 +46,7 @@ const executeRecorded = (
     const shadow = (turnHead(events) as { shadow?: unknown } | undefined)?.shadow === true
     const packages = yield* Packages
     const sandbox = yield* Sandbox
-    const runtime = yield* Effect.runtime<Tmp>()
+    const context = yield* Effect.context<Tmp>()
     let n = 0
     // Park bookkeeping. inFlight counts proxy calls from synchronous invoke to committed pair
     // or park; parkGate completes when every open call settled or parked and at least one
@@ -68,7 +68,7 @@ const executeRecorded = (
         methods[method] = (args: unknown) => {
           const callId = callIdOf(execId, n++)
           inFlight++
-          return Runtime.runPromise(runtime)(
+          return Effect.runPromiseWith(context)(
             Effect.gen(function* () {
               const events = yield* log.read
               // The replay guard: a recorded call at this position must be THIS call. Positional
@@ -175,8 +175,8 @@ const executeRecorded = (
               const attempt = yield* fn(args, { callId }).pipe(
                 Effect.map((result): CallOutcome => ({ parked: false, result })),
                 Effect.catchTag("Park", (p) => parkOut(p.awaiting)),
-                Effect.catchAll(() => parkOut()),
-                Effect.catchAllDefect(() => parkOut())
+                Effect.catch(() => parkOut()),
+                Effect.catchDefect(() => parkOut())
               )
               if (attempt.parked) return attempt
               // A large result goes to tmp: the event keeps the pointer, the body still
@@ -203,7 +203,7 @@ const executeRecorded = (
     const head = turnHead(events) as { text?: unknown; input?: unknown } | undefined
     // The body runs as its own fiber: a park interrupts it mid-flight instead of waiting for a
     // promise that, by construction, never settles.
-    const fiber = yield* Effect.fork(
+    const fiber = yield* Effect.forkChild(
       sandbox
         .run(
           code,

--- a/packages/code/src/packages.ts
+++ b/packages/code/src/packages.ts
@@ -145,10 +145,10 @@ export interface Package {
 // Packages is the registry seam. Which packages exist here is capability scoping: a task that
 // must never send messages is bound to a registry that holds no sending package, and the code
 // cannot name what the registry does not hold.
-export class Packages extends Context.Tag("code/Packages")<
+export class Packages extends Context.Service<
   Packages,
   {
     readonly resolve: (name: string) => Package | undefined
     readonly list: () => Effect.Effect<ReadonlyArray<{ readonly name: string; readonly description: string }>>
   }
->() {}
+>()("code/Packages") {}

--- a/packages/code/src/sandbox.ts
+++ b/packages/code/src/sandbox.ts
@@ -33,9 +33,9 @@ export interface Ambient {
 // call. The clock and the random source are ambient-shimmed rather than banned (a model's
 // priors reach for both): Date.now, the no-argument Date constructor, and Math.random answer
 // from `ambient`, identically on every attempt.
-export class Sandbox extends Context.Tag("code/Sandbox")<
+export class Sandbox extends Context.Service<
   Sandbox,
   {
     readonly run: (code: string, bindings: Bindings, ambient?: Ambient) => Effect.Effect<SandboxResult>
   }
->() {}
+>()("code/Sandbox") {}

--- a/packages/code/src/tmp.ts
+++ b/packages/code/src/tmp.ts
@@ -4,13 +4,13 @@ import { Context, Effect } from "effect"
 // `tmp` table, keyed by ref, and every truncation carries a pointer with a CTA. The event keeps
 // a preview and the ref; replay hydrates the ref from the same durable storage, so recorded
 // pairs stay whole. Agents reach the full value through workspace.sql.
-export class Tmp extends Context.Tag("code/Tmp")<
+export class Tmp extends Context.Service<
   Tmp,
   {
     readonly store: (ref: string, json: string) => Effect.Effect<void>
     readonly load: (ref: string) => Effect.Effect<string | undefined>
   }
->() {}
+>()("code/Tmp") {}
 
 // TMP_BYTES is the bound: a larger value goes to tmp and the event keeps a pointer.
 export const TMP_BYTES = 8_192

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
     "./*": "./src/*.ts"
   },
   "dependencies": {
-    "effect": "^3.22.1"
+    "effect": "4.0.0-rc.110"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/core/src/actor.ts
+++ b/packages/core/src/actor.ts
@@ -10,7 +10,7 @@ import type { Event } from "./event"
 
 // Self is the current actor's own address, bound by the platform per
 // lane.
-export class Self extends Context.Tag("flamecast/Self")<Self, string>() {}
+export class Self extends Context.Service<Self, string>()("flamecast/Self") {}
 
 // Transition is one keyed unit of work: state in, events out. The
 // runtime fires a transition only when no record derives its key; a

--- a/packages/core/src/event-log.ts
+++ b/packages/core/src/event-log.ts
@@ -15,7 +15,7 @@ import type { Event } from "./event"
 //
 // `head` is the store's own testimony of progress: the settle loop compares it instead of
 // materializing the log (packages/core/src/actor.ts, settleActor).
-export class EventLog extends Context.Tag("flamecast/EventLog")<
+export class EventLog extends Context.Service<
   EventLog,
   {
     readonly append: (events: ReadonlyArray<Event>) => Effect.Effect<void>
@@ -23,7 +23,7 @@ export class EventLog extends Context.Tag("flamecast/EventLog")<
     readonly head: Effect.Effect<number>
     readonly readFrom: (mark: number) => Effect.Effect<ReadonlyArray<Event>>
   }
->() {}
+>()("flamecast/EventLog") {}
 
 // withWatermark derives `head` and `readFrom` for a store that only has `append` and `read`:
 // the watermark is the event count. Correct for any append-only array binding; a real store
@@ -31,7 +31,7 @@ export class EventLog extends Context.Tag("flamecast/EventLog")<
 export const withWatermark = (store: {
   readonly append: (events: ReadonlyArray<Event>) => Effect.Effect<void>
   readonly read: Effect.Effect<ReadonlyArray<Event>>
-}): Context.Tag.Service<EventLog> => ({
+}): Context.Service.Shape<typeof EventLog> => ({
   ...store,
   head: Effect.map(store.read, (events) => events.length),
   readFrom: (mark) => Effect.map(store.read, (events) => events.slice(mark))

--- a/packages/core/src/event.ts
+++ b/packages/core/src/event.ts
@@ -3,8 +3,7 @@ import { Schema } from "effect"
 // Event is the open event shape, the only one core knows. Every stored event decodes
 // through it, so unknown types survive a read (tolerant reads, upcast-on-read). Consumers
 // narrow on type.
-export const Event = Schema.Struct(
-  { type: Schema.String },
-  { key: Schema.String, value: Schema.Unknown }
-)
+export const Event = Schema.StructWithRest(Schema.Struct({ type: Schema.String }), [
+  Schema.Record(Schema.String, Schema.Unknown)
+])
 export type Event = typeof Event.Type

--- a/packages/core/src/router.ts
+++ b/packages/core/src/router.ts
@@ -26,7 +26,7 @@ export const readAddress = (a: string): { readonly home: string; readonly facet:
 // settle eventually. call is the sync door: run the target to quiescence, return its terminal.
 // A call cycle deadlocks on per-actor serialization, so long work goes through deliver with the
 // reply coming home as an inbound.
-export class Router extends Context.Tag("flamecast/Router")<
+export class Router extends Context.Service<
   Router,
   {
     readonly deliver: (address: string, event: Event) => Effect.Effect<void>
@@ -52,4 +52,4 @@ export class Router extends Context.Tag("flamecast/Router")<
       decision: { readonly amount: number; readonly reason?: string }
     ) => Effect.Effect<CallResult>
   }
->() {}
+>()("flamecast/Router") {}

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@flamecast/core": "workspace:*",
-    "effect": "^3.22.1"
+    "effect": "4.0.0-rc.110"
   },
   "devDependencies": {
     "fast-check": "^4.9.0"

--- a/platform/README.md
+++ b/platform/README.md
@@ -11,4 +11,4 @@ in-memory and dependency-free, and it is the executable contract a platform bind
 against.
 
 Nothing lives here yet. `platform/model` (the Infer binding over the AI SDK) is the first
-planned tenant; `platform/bun` binds the log to SQLite through @effect/sql; `platform/cloudflare` arrives with the flamecast-v6 extraction.
+planned tenant; `platform/bun` binds the log to SQLite through @effect/sql-sqlite-bun; `platform/cloudflare` arrives with the flamecast-v6 extraction.

--- a/platform/bun/package.json
+++ b/platform/bun/package.json
@@ -9,11 +9,8 @@
   "dependencies": {
     "@flamecast/core": "workspace:*",
     "@flamecast/host": "workspace:*",
-    "@effect/experimental": "^0.61.1",
-    "@effect/platform": "^0.97.1",
-    "@effect/sql": "^0.52.1",
-    "@effect/sql-sqlite-bun": "^0.53.0",
-    "effect": "^3.22.1"
+    "@effect/sql-sqlite-bun": "4.0.0-rc.110",
+    "effect": "4.0.0-rc.110"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/platform/bun/src/host.ts
+++ b/platform/bun/src/host.ts
@@ -1,5 +1,5 @@
 import { Effect, Layer, ManagedRuntime } from "effect"
-import { SqlClient } from "@effect/sql"
+import { SqlClient } from "effect/unstable/sql"
 import { SqliteClient } from "@effect/sql-sqlite-bun"
 import type { Event } from "@flamecast/core/event"
 import { EventLog } from "@flamecast/core/event-log"

--- a/platform/model/package.json
+++ b/platform/model/package.json
@@ -14,7 +14,7 @@
     "@tanstack/ai": "0.44.0",
     "@tanstack/ai-bedrock": "0.2.1",
     "@tanstack/ai-openai": "0.19.0",
-    "effect": "^3.22.1"
+    "effect": "4.0.0-rc.110"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
Move the workspace to Effect 4.0.0-rc.110.

Effect 4 folds SQL into `effect/unstable/sql`, replaces `Context.Tag` with `Context.Service`, and changes a few operators (`catch`, `catchDefect`, `forkChild`, `Schema.Union([...])`). The Bun host now takes SQLite from `@effect/sql-sqlite-bun` only.

- Pin `effect` and `@effect/sql-sqlite-bun` at `4.0.0-rc.110`.
- Drop `@effect/sql`, `@effect/platform`, and `@effect/experimental`.
- Adapt services, schemas, and the code executor to the v4 APIs.

Verified with `bun run gate` (lint, docs, typecheck, tests, knip).