### PR TITLE
feat(model): tunable stream bounds

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -16,7 +16,7 @@ export { agentFor, rlmAgent, rlmAgentFor, type AgentR, type RlmR } from "./turn"
 // The parts a caller lists: reactors and key tables. An agent is reactors over one log.
 // Adding a capability is adding a reactor to the list.
 export { agentActorKeys, rlmActorKeys } from "./turn"
-export { inferReactor, Infer } from "./infer"
+export { inferReactor, inferReactorFor, Infer, DEFAULT_INFER_POLICY, type InferPolicy } from "./infer"
 export { budgetReactor } from "./budget"
 export { toolsReactor, toolsReactorFor } from "./tools"
 export { replyReactor } from "./reply"

--- a/packages/agent/src/infer.ts
+++ b/packages/agent/src/infer.ts
@@ -12,16 +12,14 @@ import { trajectoryOf, turnView } from "@flamecast/code/turns"
 // is unanswered the turn owes nothing here: the tools and code reactors carry it. The pieces
 // compose over one log through event names alone.
 //
-// `ModelCalled` is appended before the inference, so a died attempt leaves its mark. Consecutive
-// marks with nothing between them are the crash-loop evidence, and the give-up guard turns three
-// of them into the failure terminal instead of a fourth attempt.
-const GIVE_UP_AFTER = 3
+// InferPolicy is the give-up and repair ceilings. The defaults match the old constants; a
+// caller who wants a longer crash loop or more schema repairs lists inferReactorFor.
+export interface InferPolicy {
+  readonly giveUpAfter: number
+  readonly repairAtMost: number
+}
 
-// REPAIR_AT_MOST bounds schema repairs, separately from the died-attempt guard: a model that
-// keeps answering off-schema would repair forever, because each rejected answer is a real tool
-// round trip and reads as progress. Two corrections is generous for an encoding mistake; a third
-// means the model cannot meet the schema, and a named failure beats an endless turn.
-const REPAIR_AT_MOST = 2
+export const DEFAULT_INFER_POLICY: InferPolicy = { giveUpAfter: 3, repairAtMost: 2 }
 
 // Infer is the model seam: one inference over the trajectory, one action out. The platform binds this to
 // a provider. Tests bind it to a stub. `key` is the attempt's identity, the same string the
@@ -69,18 +67,20 @@ const awaitingTool = (slice: ReadonlyArray<Event>): boolean => {
 const terminated = (slice: ReadonlyArray<Event>): boolean =>
   slice.some((e) => e.type === "TurnCompleted" || e.type === "TurnFailed")
 
-export const inferReactor: Reactor<Infer | EventLog> = (log) => {
+export const inferReactorFor = (policy: Partial<InferPolicy> = {}): Reactor<Infer | EventLog> => (log) => {
+  const giveUpAfter = policy.giveUpAfter ?? DEFAULT_INFER_POLICY.giveUpAfter
+  const repairAtMost = policy.repairAtMost ?? DEFAULT_INFER_POLICY.repairAtMost
   const slice = turnView(log)
   if (slice.length === 0 || awaitingTool(slice) || terminated(slice)) return []
   const head = slice[0] as { id?: unknown }
   const turn = String(head.id)
   // The give-up and repair bounds are derivations, so each derives its own terminal
   // transition: one terminal per turn (tn:<turn>), and a duplicate of either kind absorbs.
-  if (diedAttempts(slice) >= GIVE_UP_AFTER) {
+  if (diedAttempts(slice) >= giveUpAfter) {
     return [
       transition({
         key: `tn:${turn}`,
-        input: { turn, error: `the model attempt died ${GIVE_UP_AFTER} times in a row` },
+        input: { turn, error: `the model attempt died ${giveUpAfter} times in a row` },
         act: (input) =>
           Effect.gen(function* () {
             const at = yield* Clock.currentTimeMillis
@@ -90,11 +90,11 @@ export const inferReactor: Reactor<Infer | EventLog> = (log) => {
     ]
   }
   const rejections = slice.filter((e) => e.type === "ToolCalled" && String((e as { name?: unknown }).name) === "answer").length
-  if (rejections > REPAIR_AT_MOST) {
+  if (rejections > repairAtMost) {
     return [
       transition({
         key: `tn:${turn}`,
-        input: { turn, error: `the model's answer did not satisfy the declared schema after ${REPAIR_AT_MOST} corrections` },
+        input: { turn, error: `the model's answer did not satisfy the declared schema after ${repairAtMost} corrections` },
         act: (input) =>
           Effect.gen(function* () {
             const at = yield* Clock.currentTimeMillis
@@ -134,3 +134,5 @@ export const inferReactor: Reactor<Infer | EventLog> = (log) => {
     })
   ]
 }
+
+export const inferReactor: Reactor<Infer | EventLog> = inferReactorFor()

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -309,6 +309,13 @@ describe("retry-after", () => {
     expect(fallback).toBeLessThanOrEqual(8_000)
     expect(throttleDelayMs({ headers: { "retry-after": "1" } }, 3, NOW)).toBeUndefined()
   })
+
+  test("a caller-supplied ladder sets the retry count and the Retry-After ceiling", () => {
+    const short = [100]
+    expect(throttleDelayMs({}, 0, NOW, short)).toBeLessThanOrEqual(100)
+    expect(throttleDelayMs({}, 1, NOW, short)).toBeUndefined()
+    expect(throttleDelayMs({ headers: { "retry-after": "1" } }, 0, NOW, short)).toBeUndefined()
+  })
 })
 
 

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -54,19 +54,27 @@ export const modelAskOf = (trajectory: ReadonlyArray<Event>): string | undefined
   return name
 }
 
-// The unrecorded stream bounds (v5's stream-idle lesson): time to first chunk, idle between
-// chunks, and the whole stream. Each timeout throws; the attempt dies and the marks count it.
-const FIRST_CHUNK_MS = 90_000
-const IDLE_MS = 90_000
-const TOTAL_MS = 300_000
+// StreamBounds is time to first chunk, idle between chunks, and the whole stream. Each timeout
+// throws; the attempt dies and the marks count it (v5's stream-idle lesson).
+export interface StreamBounds {
+  readonly firstChunkMs: number
+  readonly idleMs: number
+  readonly totalMs: number
+}
 
-const bounded = (stream: AsyncIterable<StreamChunk>): AsyncIterable<StreamChunk> => ({
+export const DEFAULT_STREAM_BOUNDS: StreamBounds = {
+  firstChunkMs: 90_000,
+  idleMs: 90_000,
+  totalMs: 300_000
+}
+
+const bounded = (stream: AsyncIterable<StreamChunk>, bounds: StreamBounds): AsyncIterable<StreamChunk> => ({
   async *[Symbol.asyncIterator]() {
     const startedAt = Date.now()
     const iterator = stream[Symbol.asyncIterator]()
     let first = true
     while (true) {
-      const budget = Math.min(first ? FIRST_CHUNK_MS : IDLE_MS, TOTAL_MS - (Date.now() - startedAt))
+      const budget = Math.min(first ? bounds.firstChunkMs : bounds.idleMs, bounds.totalMs - (Date.now() - startedAt))
       if (budget <= 0) throw new Error("model stream exceeded its total bound")
       let timer: ReturnType<typeof setTimeout> | undefined
       const timeout = new Promise<never>((_, reject) => {
@@ -177,27 +185,32 @@ export interface ModelConfig {
   // configuration. Absent, the ladder falls back to its built-in guesses and the compatible leg
   // sends its rung explicitly rather than trusting a provider default.
   readonly maxOutputTokens?: number
+  // Stream wall times. Absent fields take DEFAULT_STREAM_BOUNDS. A long healthy generation
+  // that outlives totalMs dies the same way a hung stream does, so set this for the work you run.
+  readonly stream?: Partial<StreamBounds>
+  // In-act backoff bases for throttle-shaped failures. Length is the retry count.
+  readonly throttleRetryDelaysMs?: ReadonlyArray<number>
   readonly fetch?: FetchImpl // test seam
   readonly sleep?: (ms: number) => Promise<void> // test seam: swap the backoff wait for an instant one
 }
 
 // Throttle-shaped failures die fast under fan-out: many agents firing at once trip the gateway's
 // rate limit, and three back-to-back attempts with no wait between them exhaust
-// `GIVE_UP_AFTER` (`src/agent/infer.ts`) before the throttle even clears. `inferMachine`'s
+// infer's give-up ceiling (`inferReactorFor`) before the throttle even clears. `inferMachine`'s
 // attempt/give-up fold has no notion of time: settleActor (src/core/actor.ts) re-serves owed
 // work on the very next event, and a delayed re-serve would need the lane to rest until an
 // alarm keyed off the attempt count wakes it — a real change to the reactor
 // framework's vocabulary, not a local one. The seam that IS local and honest: retry the
 // throttle-shaped failure inside this one act, before it ever becomes a died mark, so the
 // attempt counter only counts failures that were not a gateway saying "slow down". Retries stay
-// bounded (`THROTTLE_RETRY_DELAYS_MS.length`, at most 3) so a genuinely wedged provider still
+// bounded (the configured delay list's length) so a genuinely wedged provider still
 // dies and gives up in time.
 //
 // The openai SDK client `chatStream` runs on (`@tanstack/openai-base`) throws its `APIError`
 // subclasses with a numeric `.status`: 429 is the gateway's rate limit, 5xx is its own upstream
 // trouble. `bounded()` below throws plain `Error`s for the same shape of failure (a stream that
 // never starts or stalls), so the message is checked too.
-const THROTTLE_RETRY_DELAYS_MS = [2_000, 8_000, 30_000]
+export const DEFAULT_THROTTLE_RETRY_DELAYS_MS: ReadonlyArray<number> = [2_000, 8_000, 30_000]
 
 const isThrottleShaped = (e: unknown): boolean => {
   const err = e as { status?: unknown; statusCode?: unknown; message?: unknown }
@@ -244,12 +257,17 @@ export const retryAfterMsOf = (e: unknown, now: number): number | undefined => {
 // re-trip the limit), the jittered ladder otherwise, and undefined for a stated wait past the
 // ceiling: holding a turn open longer than the ladder ever would is worse than dying, and a
 // died attempt's mark lets the platform alarm re-drive after the queue clears.
-export const throttleDelayMs = (e: unknown, attempt: number, now: number): number | undefined => {
-  if (attempt >= THROTTLE_RETRY_DELAYS_MS.length) return undefined
-  const ceiling = THROTTLE_RETRY_DELAYS_MS[THROTTLE_RETRY_DELAYS_MS.length - 1]!
+export const throttleDelayMs = (
+  e: unknown,
+  attempt: number,
+  now: number,
+  delays: ReadonlyArray<number> = DEFAULT_THROTTLE_RETRY_DELAYS_MS
+): number | undefined => {
+  if (attempt >= delays.length) return undefined
+  const ceiling = delays[delays.length - 1]!
   const stated = retryAfterMsOf(e, now)
   if (stated !== undefined) return stated > ceiling ? undefined : stated + Math.random() * 1_000
-  return jittered(THROTTLE_RETRY_DELAYS_MS[attempt]!)
+  return jittered(delays[attempt]!)
 }
 
 const realSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
@@ -340,6 +358,12 @@ const withKey = (base: FetchImpl | undefined, key: string | undefined): FetchImp
 
 export const realInfer = (config: ModelConfig) => {
   const sleep = config.sleep ?? realSleep
+  const bounds: StreamBounds = {
+    firstChunkMs: config.stream?.firstChunkMs ?? DEFAULT_STREAM_BOUNDS.firstChunkMs,
+    idleMs: config.stream?.idleMs ?? DEFAULT_STREAM_BOUNDS.idleMs,
+    totalMs: config.stream?.totalMs ?? DEFAULT_STREAM_BOUNDS.totalMs
+  }
+  const throttleDelays = config.throttleRetryDelaysMs ?? DEFAULT_THROTTLE_RETRY_DELAYS_MS
   const attemptOnce = async (trajectory: ReadonlyArray<Event>, key: string | undefined, maxTokens: number, rung: number): Promise<Action> => {
     // A changed ceiling is a different request, so it mints a different idempotency key: a
     // provider that dedups would otherwise answer the escalated retry with the cached truncated
@@ -375,7 +399,7 @@ export const realInfer = (config: ModelConfig) => {
       modelOptions: { max_tokens: maxTokens } as never,
       logger: noopLogger
     } as never)
-    const result = await new StreamProcessor().process(bounded(stream))
+    const result = await new StreamProcessor().process(bounded(stream, bounds))
     if (result.finishReason === "length") throw new TruncatedError(maxTokens)
     return actionOf(result, schema)
   }
@@ -398,7 +422,7 @@ export const realInfer = (config: ModelConfig) => {
               return { kind: "fail", error: `${e.message}; the answer does not fit the largest ceiling, so the task must produce less at once` }
             }
             if (!isThrottleShaped(e)) throw e
-            const delay = throttleDelayMs(e, attempt, Date.now())
+            const delay = throttleDelayMs(e, attempt, Date.now(), throttleDelays)
             if (delay === undefined) throw e
             await sleep(delay)
           }


### PR DESCRIPTION
## What and why

Stream walls and throttle backoff are now `ModelConfig` fields (`stream`, `throttleRetryDelaysMs`) with the previous numbers as defaults, so a long healthy generation can outlive the 300s wall. Died-attempt and schema-repair ceilings are `inferReactorFor` options for the same reason.

- [x] `bun run gate` passes locally
- [x] Docs updated if behavior changed
- [x] Tests cover the change