### PR TITLE
fix(host): type lane layers

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,9 +1,10 @@
 import { Effect, Layer } from "effect"
 import type { Event } from "@flamecast/core/event"
 import { Router } from "@flamecast/core/router"
+import { Self } from "@flamecast/core/actor"
 import { Packages, type Package } from "@flamecast/code/packages"
 import { jsSandbox, memoryTmp } from "@flamecast/code/defaults"
-import { createHost, type Host } from "@flamecast/host/host"
+import { createHost, type Host, type LaneEnv } from "@flamecast/host/host"
 import { rlmAgent, rlmAgentFor, type RlmR } from "./turn"
 import { Infer } from "./infer"
 import type { Action } from "./events"
@@ -58,24 +59,25 @@ export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
   })
   const tmp = memoryTmp()
 
-  // The layers close over the host and are built per serve, so the
-  // spawn package always routes and reads through the live host.
-  const layersFor = (lane: string): Layer.Layer<RlmR> => {
-    const self = host.self(lane)
-    const router = {
-      deliver: (address: string, event: Event) => Effect.sync(() => host.deliver(address, event)),
-      call: () => Effect.succeed({ error: "escalatable spawns need a binding with synchronous calls" }),
-      resume: () => Effect.succeed({ error: "escalatable spawns need a binding with synchronous calls" })
-    }
-    const spawn = agentsPackage(router, self, (callId) => host.self(`ag.${callId}`), {
-      events: (facet: string) => Promise.resolve(host.read(facet))
-    })
-    const all = [...user, spawn]
-    const packages = Layer.succeed(Packages, {
-      resolve: (name: string) => all.find((p) => p.name === name),
-      list: () => Effect.succeed(all.map((p) => ({ name: p.name, description: p.description })))
-    })
-    return Layer.mergeAll(packages, jsSandbox, tmp, infer, Layer.succeed(Router, router)) as unknown as Layer.Layer<RlmR>
+  // Packages is built from the host's Router and Self. place and the
+  // facet reader still close over the host: they name other lanes.
+  const layersFor = (_lane: string): LaneEnv<RlmR> => {
+    const packages = Layer.effect(
+      Packages,
+      Effect.gen(function* () {
+        const router = yield* Router
+        const self = yield* Self
+        const spawn = agentsPackage(router, self, (callId) => host.self(`ag.${callId}`), {
+          events: (facet: string) => Promise.resolve(host.read(facet))
+        })
+        const all = [...user, spawn]
+        return Packages.of({
+          resolve: (name) => all.find((p) => p.name === name),
+          list: () => Effect.succeed(all.map((p) => ({ name: p.name, description: p.description })))
+        })
+      })
+    )
+    return Layer.mergeAll(packages, jsSandbox, tmp, infer)
   }
 
   // Every ag. lane runs the RLM default; anything else is a sink.
@@ -83,7 +85,7 @@ export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
   const host: Host = createHost<RlmR>({
     principal: "mem",
     actorFor: (lane) => (lane.startsWith("ag.") ? assembled : undefined),
-    layersFor: layersFor as never
+    layersFor
   })
 
   if (options.log !== undefined && options.log.length > 0) host.seed(ROOT, options.log)

--- a/packages/host/src/host.test.ts
+++ b/packages/host/src/host.test.ts
@@ -96,7 +96,7 @@ describe("the host", () => {
 
 describe("the router membrane", () => {
   test("an unkeyed cross-lane event refuses loudly; a keyed one travels", () => {
-    const host = createHost({
+    const host = createHost<never>({
       actorFor: () => undefined,
       keyOf: (e) => (e.type === "MessageReceived" || e.type === "Keyed" ? `k:${String((e as { id?: unknown }).id)}` : undefined)
     })

--- a/packages/host/src/host.ts
+++ b/packages/host/src/host.ts
@@ -11,16 +11,28 @@ import { deadlocks, victimOf, type EdgesOf } from "./deadlock"
 // earns a qualified name and must keep every guarantee here; the
 // conformance contract is packages/core/tla (Driver, Delivery).
 
+// HostPorts are the services every host binds per lane: the log, the
+// router, and this lane's address. layersFor may require them and must
+// not provide them.
+export type HostPorts = EventLog | Router | Self
+
+// LaneEnv is the rest of an actor's R: what the host does not bind.
+// Construction may require HostPorts; Layer.provideMerge discharges them.
+export type LaneEnv<R> = Layer.Layer<Exclude<R, HostPorts>, never, HostPorts>
+
+type LayersFor<R> = [Exclude<R, HostPorts>] extends [never]
+  ? { readonly layersFor?: (lane: string) => LaneEnv<R> }
+  : { readonly layersFor: (lane: string) => LaneEnv<R> }
+
 // HostOptions binds a host to its owner's world. actorFor names a
 // lane's reactors; a lane with none is a sink (a registry, a mirror)
-// and delivery still lands. layersFor supplies the lane's environment
-// beyond what the host provides (EventLog, Router, Self); packages and
-// inference live there. call and resume are the synchronous doors; a
-// host without them refuses synchronous calls with an error result.
-export interface HostOptions<R> {
+// and delivery still lands. layersFor supplies the rest of R; the host
+// binds EventLog, Router, and Self. A missing Infer is a type error.
+// call and resume are the synchronous doors; a host without them
+// refuses synchronous calls with an error result.
+export type HostOptions<R> = {
   readonly principal?: string
   readonly actorFor: (lane: string) => Actor<R> | undefined
-  readonly layersFor?: (lane: string) => Layer.Layer<unknown, never, EventLog | Router | Self>
   readonly call?: Parameters<typeof Router.of>[0]["call"]
   readonly resume?: Parameters<typeof Router.of>[0]["resume"]
   // edgesOf arms the deadlock sentinel: after a drive drains, the host
@@ -38,7 +50,7 @@ export interface HostOptions<R> {
   // cross-lane delivery loudly. MessageReceived is exempt only because
   // its key is its own id, deduped by `seen` here.
   readonly keyOf?: (e: Event) => string | undefined
-}
+} & LayersFor<R>
 
 export interface Host {
   // seed appends without waking the lane: test and bootstrap ingress.
@@ -76,7 +88,7 @@ const seen = (events: ReadonlyArray<Event>, event: Event): boolean => {
 
 const REFUSED: CallResult = { error: "this host takes no synchronous calls" }
 
-export const createHost = <R>(options: HostOptions<R>): Host => {
+export const createHost = <R = never>(options: HostOptions<R>): Host => {
   const principal = options.principal ?? "mem"
   const lanes = new Map<string, ReadonlyArray<Event>>()
   const dirty = new Set<string>()
@@ -134,7 +146,7 @@ export const createHost = <R>(options: HostOptions<R>): Host => {
 
   const self = (lane: string): string => `${principal}:${lane}`
 
-  const layersOf = (lane: string) =>
+  const portsOf = (lane: string) =>
     Layer.mergeAll(
       Layer.succeed(
         EventLog,
@@ -144,9 +156,15 @@ export const createHost = <R>(options: HostOptions<R>): Host => {
         })
       ),
       router,
-      Layer.succeed(Self, self(lane)),
-      options.layersFor?.(lane) ?? Layer.empty
+      Layer.succeed(Self, self(lane))
     )
+
+  // Exclude is not distributive over a generic R, so the merge is named
+  // here as the env settleActor requires (tla/Driver.tla, EventuallyServed).
+  const layersOf = (lane: string): Layer.Layer<R | EventLog> => {
+    const extra = (options.layersFor ?? (() => Layer.empty as unknown as LaneEnv<R>))(lane)
+    return extra.pipe(Layer.provideMerge(portsOf(lane))) as Layer.Layer<R | EventLog>
+  }
 
   const drain = async (): Promise<void> => {
     while (dirty.size > 0) {
@@ -154,9 +172,7 @@ export const createHost = <R>(options: HostOptions<R>): Host => {
       dirty.delete(lane)
       const actor = options.actorFor(lane)
       if (actor === undefined) continue
-      await Effect.runPromise(
-        settleActor(actor).pipe(Effect.provide(layersOf(lane))) as Effect.Effect<void>
-      )
+      await Effect.runPromise(settleActor(actor).pipe(Effect.provide(layersOf(lane))))
     }
   }
 

--- a/platform/bun/src/host.ts
+++ b/platform/bun/src/host.ts
@@ -6,6 +6,7 @@ import { EventLog } from "@flamecast/core/event-log"
 import { Router, type CallResult } from "@flamecast/core/router"
 import { Self, restingActor, settleActor, type Actor } from "@flamecast/core/actor"
 import { deadlocks, victimOf, type EdgesOf } from "@flamecast/host/deadlock"
+import type { HostPorts, LaneEnv } from "@flamecast/host/host"
 
 // The bun binding: packages/host's semantics with physics. The log lives in SQLite through
 // @effect/sql-sqlite-bun, so a process death loses nothing and `recover()` re-derives the owed
@@ -17,17 +18,20 @@ import { deadlocks, victimOf, type EdgesOf } from "@flamecast/host/deadlock"
 // tests, plus the two only physics can show (a reopen keeps the log; a reopen recovers owed
 // work).
 
-export interface BunHostOptions<R> {
+type LayersFor<R> = [Exclude<R, HostPorts>] extends [never]
+  ? { readonly layersFor?: (lane: string) => LaneEnv<R> }
+  : { readonly layersFor: (lane: string) => LaneEnv<R> }
+
+export type BunHostOptions<R> = {
   readonly path: string // SQLite file, or ":memory:" for a volatile run
   readonly principal?: string
   readonly actorFor: (lane: string) => Actor<R> | undefined
-  readonly layersFor?: (lane: string) => Layer.Layer<unknown, never, EventLog | Router | Self>
   readonly call?: Parameters<typeof Router.of>[0]["call"]
   readonly resume?: Parameters<typeof Router.of>[0]["resume"]
   readonly edgesOf?: EdgesOf
   readonly pick?: (dirty: ReadonlySet<string>) => string
   readonly keyOf?: (e: Event) => string | undefined
-}
+} & LayersFor<R>
 
 export interface BunHost {
   readonly seed: (lane: string, events: ReadonlyArray<Event>) => Promise<void>
@@ -50,7 +54,7 @@ const laneOf = (address: string): string => {
 
 const REFUSED: CallResult = { error: "this host takes no synchronous calls" }
 
-export const createBunHost = async <R>(options: BunHostOptions<R>): Promise<BunHost> => {
+export const createBunHost = async <R = never>(options: BunHostOptions<R>): Promise<BunHost> => {
   const principal = options.principal ?? "bun"
   const runtime = ManagedRuntime.make(SqliteClient.layer({ filename: options.path }))
   // One client, acquired once: every read and every append shares the connection, so ":memory:"
@@ -142,7 +146,7 @@ export const createBunHost = async <R>(options: BunHostOptions<R>): Promise<BunH
 
   const self = (lane: string): string => `${principal}:${lane}`
 
-  const layersOf = (lane: string) =>
+  const portsOf = (lane: string) =>
     Layer.mergeAll(
       Layer.succeed(EventLog, {
         append: (events: ReadonlyArray<Event>) => appendEffect(lane, events),
@@ -151,9 +155,13 @@ export const createBunHost = async <R>(options: BunHostOptions<R>): Promise<BunH
         readFrom: (mark: number) => readFromEffect(lane, mark)
       }),
       router,
-      Layer.succeed(Self, self(lane)),
-      options.layersFor?.(lane) ?? Layer.empty
+      Layer.succeed(Self, self(lane))
     )
+
+  const layersOf = (lane: string): Layer.Layer<R | EventLog> => {
+    const extra = (options.layersFor ?? (() => Layer.empty as unknown as LaneEnv<R>))(lane)
+    return extra.pipe(Layer.provideMerge(portsOf(lane))) as Layer.Layer<R | EventLog>
+  }
 
   const drain = async (): Promise<void> => {
     while (dirty.size > 0) {
@@ -161,7 +169,7 @@ export const createBunHost = async <R>(options: BunHostOptions<R>): Promise<BunH
       dirty.delete(lane)
       const actor = options.actorFor(lane)
       if (actor === undefined) continue
-      await runtime.runPromise(settleActor(actor).pipe(Effect.provide(layersOf(lane))) as Effect.Effect<void>)
+      await runtime.runPromise(settleActor(actor).pipe(Effect.provide(layersOf(lane))))
     }
   }
 


### PR DESCRIPTION
Restore the compile-time check that a host supplies every service its actor requires.

`layersFor` is now `LaneEnv<R>`: it must provide `Exclude<R, EventLog | Router | Self>` and it can require those host ports. The host binds the ports, then `Layer.provideMerge` feeds them into the extra env. `createHost<RlmR>` without Infer or Packages is a type error. `createRlmAgent` builds `Packages` from `Router` and `Self` instead of closing over a hand-built router.

Verified with `bun run gate`.