### PR TITLE
docs: observe a running agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Log is all you need
 
-Tardigrade is a durable agent harness built with the log as its core, inspired by event sourcing and React. State at any point is a pure function of the log, and the harness is a set of transitions derived from it.
+Tardigrade is a durable agent harness built with the log as its core. State at any point is a pure function of the log, and the harness is a set of transitions derived from it.
 
 $$\{\mathrm{transitions}\} = f(\mathrm{log})$$
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Organized on the Diátaxis grid: learning, tasks, information, understanding.
   - [rlm-agent.md](tutorials/rlm-agent.md): a Recursive Language Model agent with durable code execution. Ends by killing it mid-recursion.
 - [how-to/](how-to/): task-shaped recipes.
   - [gate-tools.md](how-to/gate-tools.md): hide, reveal, or revoke tools from the log.
+  - [observe.md](how-to/observe.md): wire a tracer, the one-trace contract, the outcome vocabulary.
 - [reference/](reference/): neutral per-symbol contracts, no analogies.
   - [api.md](reference/api.md): Event, Projection, Transition, Reactor, Actor, send, settle, resting.
 - [explanations/](explanations/): the why and the mental model.

--- a/docs/assets/one-trace-dark.svg
+++ b/docs/assets/one-trace-dark.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 388.8285 389.3" width="388.8285" height="389.3" style="--bg:#0d1117;--fg:#e6edf3;--accent:#f59e0b;--muted:#8b949e;background:var(--bg)">
+<style>
+  
+  text { font-family: 'ui-sans-serif', system-ui, sans-serif; }
+  svg {
+    /* Derived from --bg and --fg (overridable via --line, --accent, etc.) */
+    --_text:          var(--fg);
+    --_text-sec:      var(--muted, color-mix(in srgb, var(--fg) 60%, var(--bg)));
+    --_text-muted:    var(--muted, color-mix(in srgb, var(--fg) 40%, var(--bg)));
+    --_text-faint:    color-mix(in srgb, var(--fg) 25%, var(--bg));
+    --_line:          var(--line, color-mix(in srgb, var(--fg) 50%, var(--bg)));
+    --_arrow:         var(--accent, color-mix(in srgb, var(--fg) 85%, var(--bg)));
+    --_node-fill:     var(--surface, color-mix(in srgb, var(--fg) 3%, var(--bg)));
+    --_node-stroke:   var(--border, color-mix(in srgb, var(--fg) 20%, var(--bg)));
+    --_group-fill:    var(--bg);
+    --_group-hdr:     color-mix(in srgb, var(--fg) 5%, var(--bg));
+    --_inner-stroke:  color-mix(in srgb, var(--fg) 12%, var(--bg));
+    --_key-badge:     color-mix(in srgb, var(--fg) 10%, var(--bg));
+  }
+</style>
+<defs>
+  <marker id="arrowhead" markerWidth="8" markerHeight="5" refX="7" refY="2.5" orient="auto">
+    <polygon points="0 0, 8 2.5, 0 5" fill="var(--_arrow)" stroke="var(--_arrow)" stroke-width="0.75" stroke-linejoin="round" />
+  </marker>
+  <marker id="arrowhead-start" markerWidth="8" markerHeight="5" refX="1" refY="2.5" orient="auto-start-reverse">
+    <polygon points="8 0, 0 2.5, 8 5" fill="var(--_arrow)" stroke="var(--_arrow)" stroke-width="0.75" stroke-linejoin="round" />
+  </marker>
+</defs>
+<polyline class="edge" data-from="send" data-to="event" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="stamps traceparent, first stamp wins" points="174.31708333333336,52.900000000000006 174.31708333333336,88.9 103.5,88.9 103.5,169.2" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="event" data-to="fire" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="newest carried context" points="103.5,220.10000000000002 103.5,324.40000000000003 174.68758333333335,324.40000000000003 174.68758333333335,336.40000000000003" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="fire" data-to="send" data-style="dotted" data-arrow-start="false" data-arrow-end="true" data-label="link: the delivery that woke this work" points="214.3589166666667,336.40000000000003 214.3589166666667,324.40000000000003 285.54650000000004,324.40000000000003 285.54650000000004,256.1 214.72941666666668,256.1 214.72941666666668,52.900000000000006" fill="none" stroke="var(--_line)" stroke-width="1" stroke-dasharray="4 4" marker-end="url(#arrowhead)" />
+<g class="edge-label" data-from="send" data-to="event" data-label="stamps traceparent, first stamp wins">
+  <rect x="12" y="95.9" width="182.78199999999998" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="103.39099999999999" y="111.05000000000001" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">stamps traceparent, first stamp wins</text>
+</g>
+<g class="edge-label" data-from="event" data-to="fire" data-label="newest carried context">
+  <rect x="40.99999999999999" y="263.1" width="124.57000000000001" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="103.285" y="278.25" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">newest carried context</text>
+</g>
+<g class="edge-label" data-from="fire" data-to="send" data-label="link: the delivery that woke this work">
+  <rect x="194.04649999999998" y="263.1" width="182.782" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="285.4375" y="278.25" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">link: the delivery that woke this work</text>
+</g>
+<g class="node" data-id="send" data-label="sending span" data-shape="rectangle">
+  <rect x="133.90475" y="16" width="121.237" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="194.52325000000002" y="34.45" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">sending span</text>
+</g>
+<g class="node" data-id="event" data-label="persisted event" data-shape="cylinder">
+  <rect x="36.95349999999999" y="176.2" width="133.09300000000002" height="36.900000000000006" fill="var(--_node-fill)" stroke="none" />
+  <line x1="36.95349999999999" y1="176.2" x2="36.95349999999999" y2="213.1" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <line x1="170.0465" y1="176.2" x2="170.0465" y2="213.1" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <ellipse cx="103.5" cy="213.1" rx="66.54650000000001" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <ellipse cx="103.5" cy="176.2" rx="66.54650000000001" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="103.5" y="194.64999999999998" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">persisted event</text>
+</g>
+<g class="node" data-id="fire" data-label="transition.fire" data-shape="rectangle">
+  <rect x="135.01625" y="336.40000000000003" width="119.01400000000001" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="194.52325000000002" y="354.85" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">transition.fire</text>
+</g>
+</svg>

--- a/docs/assets/one-trace-light.svg
+++ b/docs/assets/one-trace-light.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 388.8285 389.3" width="388.8285" height="389.3" style="--bg:#ffffff;--fg:#1f2328;--accent:#d97706;--muted:#656d76;background:var(--bg)">
+<style>
+  
+  text { font-family: 'ui-sans-serif', system-ui, sans-serif; }
+  svg {
+    /* Derived from --bg and --fg (overridable via --line, --accent, etc.) */
+    --_text:          var(--fg);
+    --_text-sec:      var(--muted, color-mix(in srgb, var(--fg) 60%, var(--bg)));
+    --_text-muted:    var(--muted, color-mix(in srgb, var(--fg) 40%, var(--bg)));
+    --_text-faint:    color-mix(in srgb, var(--fg) 25%, var(--bg));
+    --_line:          var(--line, color-mix(in srgb, var(--fg) 50%, var(--bg)));
+    --_arrow:         var(--accent, color-mix(in srgb, var(--fg) 85%, var(--bg)));
+    --_node-fill:     var(--surface, color-mix(in srgb, var(--fg) 3%, var(--bg)));
+    --_node-stroke:   var(--border, color-mix(in srgb, var(--fg) 20%, var(--bg)));
+    --_group-fill:    var(--bg);
+    --_group-hdr:     color-mix(in srgb, var(--fg) 5%, var(--bg));
+    --_inner-stroke:  color-mix(in srgb, var(--fg) 12%, var(--bg));
+    --_key-badge:     color-mix(in srgb, var(--fg) 10%, var(--bg));
+  }
+</style>
+<defs>
+  <marker id="arrowhead" markerWidth="8" markerHeight="5" refX="7" refY="2.5" orient="auto">
+    <polygon points="0 0, 8 2.5, 0 5" fill="var(--_arrow)" stroke="var(--_arrow)" stroke-width="0.75" stroke-linejoin="round" />
+  </marker>
+  <marker id="arrowhead-start" markerWidth="8" markerHeight="5" refX="1" refY="2.5" orient="auto-start-reverse">
+    <polygon points="8 0, 0 2.5, 8 5" fill="var(--_arrow)" stroke="var(--_arrow)" stroke-width="0.75" stroke-linejoin="round" />
+  </marker>
+</defs>
+<polyline class="edge" data-from="send" data-to="event" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="stamps traceparent, first stamp wins" points="174.31708333333336,52.900000000000006 174.31708333333336,88.9 103.5,88.9 103.5,169.2" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="event" data-to="fire" data-style="solid" data-arrow-start="false" data-arrow-end="true" data-label="newest carried context" points="103.5,220.10000000000002 103.5,324.40000000000003 174.68758333333335,324.40000000000003 174.68758333333335,336.40000000000003" fill="none" stroke="var(--_line)" stroke-width="1" marker-end="url(#arrowhead)" />
+<polyline class="edge" data-from="fire" data-to="send" data-style="dotted" data-arrow-start="false" data-arrow-end="true" data-label="link: the delivery that woke this work" points="214.3589166666667,336.40000000000003 214.3589166666667,324.40000000000003 285.54650000000004,324.40000000000003 285.54650000000004,256.1 214.72941666666668,256.1 214.72941666666668,52.900000000000006" fill="none" stroke="var(--_line)" stroke-width="1" stroke-dasharray="4 4" marker-end="url(#arrowhead)" />
+<g class="edge-label" data-from="send" data-to="event" data-label="stamps traceparent, first stamp wins">
+  <rect x="12" y="95.9" width="182.78199999999998" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="103.39099999999999" y="111.05000000000001" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">stamps traceparent, first stamp wins</text>
+</g>
+<g class="edge-label" data-from="event" data-to="fire" data-label="newest carried context">
+  <rect x="40.99999999999999" y="263.1" width="124.57000000000001" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="103.285" y="278.25" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">newest carried context</text>
+</g>
+<g class="edge-label" data-from="fire" data-to="send" data-label="link: the delivery that woke this work">
+  <rect x="194.04649999999998" y="263.1" width="182.782" height="30.3" rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1" />
+  <text x="285.4375" y="278.25" text-anchor="middle" font-size="11" font-weight="400" fill="var(--_text-sec)" dy="3.8499999999999996">link: the delivery that woke this work</text>
+</g>
+<g class="node" data-id="send" data-label="sending span" data-shape="rectangle">
+  <rect x="133.90475" y="16" width="121.237" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="194.52325000000002" y="34.45" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">sending span</text>
+</g>
+<g class="node" data-id="event" data-label="persisted event" data-shape="cylinder">
+  <rect x="36.95349999999999" y="176.2" width="133.09300000000002" height="36.900000000000006" fill="var(--_node-fill)" stroke="none" />
+  <line x1="36.95349999999999" y1="176.2" x2="36.95349999999999" y2="213.1" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <line x1="170.0465" y1="176.2" x2="170.0465" y2="213.1" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <ellipse cx="103.5" cy="213.1" rx="66.54650000000001" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <ellipse cx="103.5" cy="176.2" rx="66.54650000000001" ry="7" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="103.5" y="194.64999999999998" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">persisted event</text>
+</g>
+<g class="node" data-id="fire" data-label="transition.fire" data-shape="rectangle">
+  <rect x="135.01625" y="336.40000000000003" width="119.01400000000001" height="36.900000000000006" rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="0.75" />
+  <text x="194.52325000000002" y="354.85" text-anchor="middle" font-size="13" font-weight="500" fill="var(--_text)" dy="4.55">transition.fire</text>
+</g>
+</svg>

--- a/docs/how-to/observe.md
+++ b/docs/how-to/observe.md
@@ -26,6 +26,11 @@ One business event stays one trace across every lane it touches, and that proper
 
 The reconciler's side of the contract is a link: `transition.fire` links to the newest carried context on the log, which reads as "the delivery that woke this work". It is an approximation: a settle serving several fresh deliveries links them to the same trigger, because a derivation reads the whole log and cannot name which events enabled it. Links, never parents: one settle serves many deliveries, and a span has one parent.
 
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="../assets/one-trace-dark.svg">
+  <img alt="The one-trace contract: the sending span stamps a traceparent on the persisted event, and transition.fire links back to it as the delivery that woke this work" src="../assets/one-trace-light.svg">
+</picture>
+
 ## The outcome vocabulary
 
 Every `transition.fire` span carries an `outcome` attribute, and it is the first filter a trace query wants:

--- a/docs/how-to/observe.md
+++ b/docs/how-to/observe.md
@@ -1,0 +1,36 @@
+# Observe a running agent
+
+The log is the primary record: every call, park, and terminal is an event you can read back. Spans carry what the log cannot: wall-clock time, retries that landed no event, and the shape of a slow turn. This page wires the spans to a collector and states the two contracts a reader cannot discover from the trace data alone.
+
+## Wire a tracer
+
+`createBunHost` takes any tracer as a Layer through `telemetry`. The ready-made occupant is `otlpTelemetry`, built on the OTLP exporter effect v4 ships in core:
+
+```ts
+import { createBunHost } from "@tardigrade/bun/host"
+import { otlpTelemetry } from "@tardigrade/bun/otlp"
+
+const host = await createBunHost({
+  path: "agents.sqlite",
+  actorFor,
+  layersFor,
+  telemetry: otlpTelemetry({ baseUrl: "http://localhost:4318", serviceName: "my-agent" })
+})
+```
+
+Absent `telemetry`, every span is inert and costs nothing. The span inventory needs no page: point a backend at the stream and the names and attributes enumerate themselves (`transition.fire`, `deliver`, `llm.react`, `package.call`, `code.run`, with GenAI semantic-convention keys on the model span).
+
+## The one-trace contract
+
+One business event stays one trace across every lane it touches, and that property rests on a rule every platform binding must uphold: the platform stamps the sending span's context onto each event it persists, as one `traceparent` string in W3C header form, and an event already carrying one keeps it, because the first stamp is the causal one. A binding that does not stamp fragments every cross-lane trace, and nothing will say why: the traces simply arrive orphaned.
+
+The reconciler's side of the contract is a link: `transition.fire` links to the newest carried context on the log, which reads as "the delivery that woke this work". It is an approximation: a settle serving several fresh deliveries links them to the same trigger, because a derivation reads the whole log and cannot name which events enabled it. Links, never parents: one settle serves many deliveries, and a span has one parent.
+
+## The outcome vocabulary
+
+Every `transition.fire` span carries an `outcome` attribute, and it is the first filter a trace query wants:
+
+- `committed`: an event now derives the transition's key; the work is done and absorbed against retries.
+- `advanced`: no key landed, but the log grew: the act recorded evidence (a send, a BlockedOn) and stopped; the settle re-derives.
+- `blocked`: nothing landed and nothing was said: a park already on record or a transient failure; the platform alarm re-drives.
+- `wedged`: events returned, none derives the key, none landed: the actor dies naming the transition, because a silent spin is worse than a crash.

--- a/docs/how-to/observe.md
+++ b/docs/how-to/observe.md
@@ -1,6 +1,6 @@
-# Observe a running agent
+How to observe a running agent: wire its spans to a collector and keep one trace across lanes.
 
-The log is the primary record: every call, park, and terminal is an event you can read back. Spans carry what the log cannot: wall-clock time, retries that landed no event, and the shape of a slow turn. This page wires the spans to a collector and states the two contracts a reader cannot discover from the trace data alone.
+The log is the primary record: every call, park, and terminal is an event you can read back. Spans carry what the log cannot: wall-clock time, retries that landed no event, and the shape of a slow turn. To collect the spans, hand the host a tracer. To read one trace across lanes, hold two contracts the trace data does not state: the platform stamps each persisted event with the sending span, and the reconciler links each fire to the delivery that woke it.
 
 ## Wire a tracer
 
@@ -18,7 +18,7 @@ const host = await createBunHost({
 })
 ```
 
-Absent `telemetry`, every span is inert and costs nothing. The span inventory needs no page: point a backend at the stream and the names and attributes enumerate themselves (`transition.fire`, `deliver`, `llm.react`, `package.call`, `code.run`, with GenAI semantic-convention keys on the model span).
+Absent `telemetry`, every span is inert and costs nothing. Point a backend at the stream and the span inventory enumerates itself (`transition.fire`, `deliver`, `llm.react`, `package.call`, `code.run`, with GenAI semantic-convention keys on the model span).
 
 ## The one-trace contract
 

--- a/docs/how-to/observe.md
+++ b/docs/how-to/observe.md
@@ -1,10 +1,10 @@
 How to observe a running agent: wire its spans to a collector and keep one trace across lanes.
 
-The log is the primary record: every call, park, and terminal is an event you can read back. Spans carry what the log cannot: wall-clock time, retries that landed no event, and the shape of a slow turn. To collect the spans, hand the host a tracer. To read one trace across lanes, hold two contracts the trace data does not state: the platform stamps each persisted event with the sending span, and the reconciler links each fire to the delivery that woke it.
+The log is the primary record: every call, park, and terminal is an event you can read back. Spans carry what the log cannot: wall-clock time, retries that landed no event, and the shape of a slow turn. To collect them, hand the host a tracer.
 
 ## Wire a tracer
 
-`createBunHost` takes any tracer as a Layer through `telemetry`. The ready-made occupant is `otlpTelemetry`, built on the OTLP exporter effect v4 ships in core:
+`createBunHost` takes any tracer as a Layer through `telemetry`. The ready-made layer is `otlpTelemetry`, on the OTLP exporter effect v4 ships in core:
 
 ```ts
 import { createBunHost } from "@tardigrade/bun/host"
@@ -22,9 +22,9 @@ Absent `telemetry`, every span is inert and costs nothing. Point a backend at th
 
 ## The one-trace contract
 
-One business event stays one trace across every lane it touches, and that property rests on a rule every platform binding must uphold: the platform stamps the sending span's context onto each event it persists, as one `traceparent` string in W3C header form, and an event already carrying one keeps it, because the first stamp is the causal one. A binding that does not stamp fragments every cross-lane trace, and nothing will say why: the traces simply arrive orphaned.
+One business event stays one trace across every lane it touches. The rule that holds it: every platform binding stamps the sending span's context onto each event it persists, as one `traceparent` string in W3C header form. An event that already carries one keeps it; the first stamp is the causal one. A binding that skips the stamp fragments every cross-lane trace, and nothing says why: the traces arrive orphaned.
 
-The reconciler's side of the contract is a link: `transition.fire` links to the newest carried context on the log, which reads as "the delivery that woke this work". It is an approximation: a settle serving several fresh deliveries links them to the same trigger, because a derivation reads the whole log and cannot name which events enabled it. Links, never parents: one settle serves many deliveries, and a span has one parent.
+The reconciler's side is a link: `transition.fire` links to the newest carried context on the log, which reads as "the delivery that woke this work". This is an approximation: a settle that serves several fresh deliveries links them all to the same trigger, because a derivation reads the whole log and cannot name which events enabled it. Links, never parents: one settle serves many deliveries, and a span has one parent.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="../assets/one-trace-dark.svg">

--- a/platform/README.md
+++ b/platform/README.md
@@ -4,7 +4,7 @@ The packages state contracts and semantics: the log, the reconciler, the code la
 and the ports they leave open (EventLog, Router, Sandbox, Infer). A package depends on effect
 and on other packages, and on nothing else. That invariant is the line between the two trees.
 
-A platform binds one port to the world. Storage and delivery on Cloudflare, a model provider
+A platform binds one port to the world. A binding that delivers events also stamps the sending span's context onto each event it persists (one traceparent string, first stamp wins), or every cross-lane trace it serves arrives fragmented (docs/how-to/observe.md). Storage and delivery on Cloudflare, a model provider
 behind Infer, a Bun process: each binding is one subdirectory here, and it owns its own
 dependencies. `packages/host` stays a package by the same rule: the reference runtime is
 in-memory and dependency-free, and it is the executable contract a platform binding is tested

--- a/tools/render-diagrams.ts
+++ b/tools/render-diagrams.ts
@@ -13,7 +13,11 @@ const DIAGRAMS: Record<string, string> = {
   log[("event log")] -->|"events"| reactor["reactor"]
   reactor -->|"{transitions} = f(log)"| transitions["transitions"]
   transitions -->|"unrecorded keys fire"| act["act(input)"]
-  act -->|"events, keyed record last"| log`
+  act -->|"events, keyed record last"| log`,
+  "one-trace": `flowchart TB
+  send["sending span"] -->|"stamps traceparent, first stamp wins"| event[("persisted event")]
+  event -->|"newest carried context"| fire["transition.fire"]
+  fire -.->|"link: the delivery that woke this work"| send`
 }
 
 const LIGHT = { bg: "#ffffff", fg: "#1f2328", accent: "#d97706", muted: "#656d76" }


### PR DESCRIPTION
The how-to the tracing work owes: wiring a tracer in five lines (otlpTelemetry over the seam), and the two contracts a reader cannot discover from trace data: the stamp rule every platform binding must uphold (traceparent on each persisted event, first stamp wins, or cross-lane traces silently fragment) and the trigger link's honest semantics (the delivery that woke the settle, an approximation by design). The outcome vocabulary (committed, advanced, blocked, wedged) is defined where queries will reach for it. The span inventory itself is deliberately undocumented: the data enumerates itself in any backend, and inventories rot. Index links it; platform/README gains the obligation sentence.