### PR TITLE
feat(agent): record cost provenance

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Organized on the Diátaxis grid: learning, tasks, information, understanding.
 - [how-to/](how-to/): task-shaped recipes.
   - [gate-tools.md](how-to/gate-tools.md): hide, reveal, or revoke tools from the log.
 - [reference/](reference/): neutral per-symbol contracts, no analogies.
-  - [api.md](reference/api.md): Event, Projection, Transition, Reactor, Actor, send, settle, resting.
+  - [api.md](reference/api.md): Event, Projection, Transition, Reactor, Actor, send, settle, resting, Usage.
 - [explanations/](explanations/): the why and the mental model.
   - [why.md](explanations/why.md): state = memo { f(log) }, the convergence of durable systems, agents as the new users, the last inversion.
   - [reactors.md](explanations/reactors.md): the reactor model, with the React analogy and the math.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -89,4 +89,4 @@ const usageIn: (events: Event[], turn: string) => Usage
 
 Usage is what one model attempt spent. `ModelReturned` records it. `costUsd` is present when the figure is known: a provider bill, including zero, or a price table fill from token counts. Absence is unknown. `costSource` says which of those two produced the figure, so a billed dollar and a catalog estimate cannot be mistaken for each other. `provider` and `model` name who was called.
 
-`usageIn(log, turn)` sums `ModelReturned` for that turn. Unknown is sticky: if any part omitted cost, the total omits `costUsd`. Mixed sources take `table`, the weaker label.
+`usageIn(log, turn)` sums `ModelReturned` for that turn. Unknown is sticky: if any part omitted cost, including a return that carried no usage field, the total omits `costUsd`. Mixed sources take `table`, the weaker label. A died attempt leaves no return and does not invent a cost.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -69,3 +69,24 @@ const resting: (actor: Actor, events: Event[]) => boolean
 ```
 
 resting reports quiescence: no reactor enables a transition. The platform alarm may be deleted only on a true answer (tla/Driver.tla, Accounting).
+
+### Usage
+
+```ts
+type CostSource = "provider" | "table"
+
+type Usage = {
+  promptTokens: number
+  completionTokens: number
+  costUsd?: number
+  costSource?: CostSource
+  provider?: string
+  model?: string
+}
+
+const usageIn: (events: Event[], turn: string) => Usage
+```
+
+Usage is what one model attempt spent. `ModelReturned` records it. `costUsd` is present when the figure is known: a provider bill, including zero, or a price table fill from token counts. Absence is unknown. `costSource` says which of those two produced the figure, so a billed dollar and a catalog estimate cannot be mistaken for each other. `provider` and `model` name who was called.
+
+`usageIn(log, turn)` sums `ModelReturned` for that turn. Unknown is sticky: if any part omitted cost, the total omits `costUsd`. Mixed sources take `table`, the weaker label.

--- a/packages/agent/src/events.ts
+++ b/packages/agent/src/events.ts
@@ -10,7 +10,7 @@ import type { Usage } from "./usage"
 // answer lives on `TurnCompleted` alone.
 //
 // The union projects onto OpenEnv RFC 005's HarnessEvent stream: `ModelCalled` -> LLM_REQUEST,
-// `ModelReturned` carries spend, `TextReturned` -> LLM_RESPONSE, `ToolCalled` -> TOOL_CALL,
+// `ModelReturned` -> no RFC 005 event, `TextReturned` -> LLM_RESPONSE, `ToolCalled` -> TOOL_CALL,
 // `ToolReturned` -> TOOL_RESULT, `TurnCompleted` -> TURN_COMPLETE with TEXT_OUTPUT as payload,
 // `TurnFailed` -> ERROR. `MessageReceived` is the step() input on their side of the wire.
 

--- a/packages/agent/src/events.ts
+++ b/packages/agent/src/events.ts
@@ -2,6 +2,7 @@ import { Schema } from "effect"
 import { MessageReceived } from "@tardigrade/core/message"
 import type { Event } from "@tardigrade/core/event"
 import type { KeyFragment } from "@tardigrade/core/event-log"
+import type { Usage } from "./usage"
 
 // The agent's domain events. This alphabet belongs to the agent, and core never learns it: core
 // sees only the open envelope. The model responds by acting: its recorded decision is the
@@ -9,9 +10,9 @@ import type { KeyFragment } from "@tardigrade/core/event-log"
 // answer lives on `TurnCompleted` alone.
 //
 // The union projects onto OpenEnv RFC 005's HarnessEvent stream: `ModelCalled` -> LLM_REQUEST,
-// `TextReturned` -> LLM_RESPONSE, `ToolCalled` -> TOOL_CALL, `ToolReturned` -> TOOL_RESULT,
-// `TurnCompleted` -> TURN_COMPLETE with TEXT_OUTPUT as payload, `TurnFailed` -> ERROR.
-// `MessageReceived` is the step() input on their side of the wire.
+// `ModelReturned` carries spend, `TextReturned` -> LLM_RESPONSE, `ToolCalled` -> TOOL_CALL,
+// `ToolReturned` -> TOOL_RESULT, `TurnCompleted` -> TURN_COMPLETE with TEXT_OUTPUT as payload,
+// `TurnFailed` -> ERROR. `MessageReceived` is the step() input on their side of the wire.
 
 // MessageReceived is the canonical inbound (core/message.ts), shared with every other actor
 // kind.
@@ -36,14 +37,27 @@ export const ToolReturned = Schema.Struct({
 })
 
 // ModelCalled is the ask to the model and the attempt mark in one, appended before the inference
-// runs. A committed consequence after it is the answer. Consecutive `ModelCalled` with nothing
-// between them are attempts that died, and the give-up guard reads that count.
+// runs. ModelReturned is the spend of that attempt. A committed acting consequence after it is
+// the answer. Consecutive `ModelCalled` with nothing between them are attempts that died, and
+// the give-up guard reads that count.
 export const ModelCalled = Schema.Struct({
   type: Schema.Literal("ModelCalled"),
   callId: Schema.String,
   // The occurrence: distinct per physical attempt, the dedup key's scope. callId stays the
   // provider idempotency key, shared across retries of one logical attempt.
   ordinal: Schema.optional(Schema.Number),
+  turn: Schema.optional(Schema.String),
+  at: Schema.Number
+})
+
+// ModelReturned is the spend of one attempt: tokens, a cost when known, and who was called.
+// costSource on usage says whether the dollar came from the provider or a price table
+// (packages/agent/src/usage.ts). A died attempt leaves no return, so usageIn invents nothing.
+export const ModelReturned = Schema.Struct({
+  type: Schema.Literal("ModelReturned"),
+  callId: Schema.String,
+  ordinal: Schema.optional(Schema.Number),
+  usage: Schema.optional(Schema.Unknown),
   turn: Schema.optional(Schema.String),
   at: Schema.Number
 })
@@ -124,6 +138,7 @@ export const BudgetDenied = Schema.Struct({
 export const AgentEvent = Schema.Union([
   MessageReceived,
   ModelCalled,
+  ModelReturned,
   TextReturned,
   ToolCalled,
   ToolReturned,
@@ -140,16 +155,16 @@ export type AgentEvent = typeof AgentEvent.Type
 // Action is what the model reacts with: ask the world, or end the turn. `text` is the prose the
 // model emitted alongside a call; it records as `TextReturned`.
 export type Action =
-  | { readonly kind: "call"; readonly callId: string; readonly name: string; readonly arguments: unknown; readonly text?: string }
-  | { readonly kind: "complete"; readonly output: string }
-  | { readonly kind: "fail"; readonly error: string }
+  | { readonly kind: "call"; readonly callId: string; readonly name: string; readonly arguments: unknown; readonly text?: string; readonly usage?: Usage }
+  | { readonly kind: "complete"; readonly output: string; readonly usage?: Usage }
+  | { readonly kind: "fail"; readonly error: string; readonly usage?: Usage }
 
 // agentKeys is the agent lane's dedup fragment, owned beside its alphabet. tr names the tool call's recorded
 // pair; bg/bd name the budget request a decision answers (a grant is SUMMED into the ceiling,
 // src/budget.ts, so a redelivered decision landing twice would double it). A decision that
 // carries no callId predates the stamp and lands unkeyed; the fold tolerates it.
 export const agentKeys: KeyFragment = {
-  prefixes: ["tr:", "bg:", "bd:", "rd:", "tn:", "mc:", "bw:", "br:", "cc:"],
+  prefixes: ["tr:", "bg:", "bd:", "rd:", "tn:", "mc:", "mr:", "bw:", "br:", "cc:"],
   keyOf: (e) => {
     const v = e as Record<string, unknown>
     switch (e.type) {
@@ -171,6 +186,8 @@ export const agentKeys: KeyFragment = {
         // repetition that evidences died attempts is preserved. A mark predating the ordinal
         // lands unkeyed, which the folds tolerate.
         return v.ordinal === undefined ? undefined : `mc:${String(v.turn)}/${String(v.ordinal)}`
+      case "ModelReturned":
+        return v.ordinal === undefined ? undefined : `mr:${String(v.turn)}/${String(v.ordinal)}`
       case "BudgetExhausted":
         // The wall's occurrence is the ceiling it fired at: a grant raises it, so a second
         // crossing keys anew.
@@ -201,6 +218,10 @@ export const toolReturned = (fields: { readonly callId: string; readonly result:
 export const modelCalled = (
   fields: { readonly callId: string; readonly ordinal?: number } & Stamp
 ): Event => ({ type: "ModelCalled", ...fields }) as Event
+
+export const modelReturned = (
+  fields: { readonly callId: string; readonly ordinal?: number; readonly usage?: Usage } & Stamp
+): Event => ({ type: "ModelReturned", ...fields }) as Event
 
 export const textReturned = (fields: { readonly text: string } & Stamp): Event =>
   ({ type: "TextReturned", ...fields }) as Event

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -22,6 +22,18 @@ export { toolsReactor, toolsReactorFor } from "./tools"
 export { replyReactor } from "./reply"
 export { compactionReactor } from "./compaction"
 export { agentKeys } from "./events"
+export {
+  usageIn,
+  usageOf,
+  usageFrom,
+  priced,
+  costOf,
+  sumUsage,
+  ZERO_USAGE,
+  type Usage,
+  type CostSource,
+  type ModelPricing
+} from "./usage"
 
 // The tool surface: code mode is the default, and an agent measured against a fixed tool table
 // brings its own (surface.ts).

--- a/packages/agent/src/infer.ts
+++ b/packages/agent/src/infer.ts
@@ -1,7 +1,7 @@
 import { Clock, Context, Effect } from "effect"
 import { EventLog } from "@tardigrade/core/event-log"
 import { transition, type Reactor } from "@tardigrade/core/actor"
-import { modelCalled, textReturned, turnFailed } from "./events"
+import { modelCalled, modelReturned, textReturned, turnFailed } from "./events"
 import type { Event } from "@tardigrade/core/event"
 import type { Action } from "./events"
 import { trajectoryOf, turnView } from "@tardigrade/code/turns"
@@ -125,6 +125,13 @@ export const inferReactorFor = (policy: Partial<InferPolicy> = {}): Reactor<Infe
           const action = yield* (yield* Infer).react(input.trajectory, input.attempt)
           const after = yield* Clock.currentTimeMillis
           return [
+            modelReturned({
+              callId: input.attempt,
+              ordinal: input.ordinal,
+              turn: input.turn,
+              at: after,
+              ...(action.usage === undefined ? {} : { usage: action.usage })
+            }),
             ...(action.kind === "call" && action.text !== undefined && action.text !== ""
               ? [textReturned({ text: action.text, turn: input.turn, at: after })]
               : []),

--- a/packages/agent/src/turn.test.ts
+++ b/packages/agent/src/turn.test.ts
@@ -123,6 +123,7 @@ describe("the agent with execute as the only tool", () => {
     expect(events.map((e) => e.type)).toEqual([
       "MessageReceived",
       "ModelCalled",
+      "ModelReturned",
       "ToolCalled",
       "CodeDispatched",
       "PackageCalled",
@@ -132,11 +133,12 @@ describe("the agent with execute as the only tool", () => {
       "CodeSettled",
       "ToolReturned",
       "ModelCalled",
+      "ModelReturned",
       "TurnCompleted",
       "ReplyDelivered"
     ])
-    expect(events[4]).toMatchObject({ callId: "t1.0", name: "zohorecruit.insert_record" })
-    expect(events[8]).toMatchObject({ result: { jd_record_id: "jd-91", hits: 3 } })
+    expect(events[5]).toMatchObject({ callId: "t1.0", name: "zohorecruit.insert_record" })
+    expect(events[9]).toMatchObject({ result: { jd_record_id: "jd-91", hits: 3 } })
     expect(spies).toEqual({ insert: 1, search: 1 })
     expect(count.calls).toBe(2)
     expect(inferReactor(events)).toHaveLength(0)
@@ -315,6 +317,47 @@ describe("the agent with execute as the only tool", () => {
     expect(events.filter((e) => e.type === "MessageReceived").length).toBe(1)
     expect(count.calls).toBe(1)
   })
+
+  test("ModelReturned records the action's spend and who was called", async () => {
+    const spent = {
+      promptTokens: 10,
+      completionTokens: 4,
+      costUsd: 0.01,
+      costSource: "provider" as const,
+      provider: "vercel-ai-gateway",
+      model: "anthropic/claude-sonnet-4.6"
+    }
+    const layers = Layer.mergeAll(
+      memSpill(),
+      memoryLog(),
+      Layer.succeed(Infer, {
+        react: () => Effect.succeed({ kind: "complete" as const, output: "ok", usage: spent })
+      }),
+      registry([]),
+      jsSandbox,
+      noRouter
+    )
+    const events = await run(
+      Effect.gen(function* () {
+        yield* receive(rlmAgent, { id: "m1", text: "hi" })
+        return yield* readLog
+      }),
+      layers
+    )
+    expect(events.map((e) => e.type)).toEqual([
+      "MessageReceived",
+      "ModelCalled",
+      "ModelReturned",
+      "TurnCompleted",
+      "ReplyDelivered"
+    ])
+    expect(events.find((e) => e.type === "ModelReturned")).toMatchObject({
+      callId: "m1/infer/0",
+      ordinal: 0,
+      turn: "m1",
+      usage: spent
+    })
+  })
 })
 
 // The scout schema from a research task, and the two answers a model gives: the double-encoded
@@ -451,9 +494,11 @@ describe("the mind on a native surface", () => {
     expect(events.map((e) => e.type)).toEqual([
       "MessageReceived",
       "ModelCalled",
+      "ModelReturned",
       "ToolCalled",
       "ToolReturned",
       "ModelCalled",
+      "ModelReturned",
       "TurnCompleted",
       "ReplyDelivered"
     ])

--- a/packages/agent/src/usage.test.ts
+++ b/packages/agent/src/usage.test.ts
@@ -99,6 +99,29 @@ describe("usageIn", () => {
     expect(usageIn(log, "m2")).toEqual(ZERO_USAGE)
   })
 
+  test("a return with no usage poisons the total, and an unstamped return still belongs by callId", () => {
+    const billed = {
+      promptTokens: 10,
+      completionTokens: 4,
+      costUsd: 0.01,
+      costSource: "provider" as const,
+      provider: "openai",
+      model: "m"
+    }
+    const log: Event[] = [
+      { type: "MessageReceived", id: "m1", text: "go", at: 0 },
+      { type: "ModelReturned", callId: "m1/infer/0", ordinal: 0, turn: "m1", at: 1 },
+      { type: "ModelReturned", callId: "m1/infer/1", ordinal: 1, turn: "m1", usage: billed, at: 2 }
+    ]
+    expect(usageIn(log, "m1")).toEqual({ promptTokens: 10, completionTokens: 4 })
+    expect(
+      usageIn(
+        [{ type: "ModelReturned", callId: "m1/infer/0", ordinal: 0, usage: billed, at: 1 }],
+        "m1"
+      )
+    ).toEqual(billed)
+  })
+
   test("usageOf keeps a labeled figure and drops a source with no cost", () => {
     expect(usageOf({ promptTokens: 3, completionTokens: 1, costUsd: 0, costSource: "provider" })).toEqual({
       promptTokens: 3,

--- a/packages/agent/src/usage.test.ts
+++ b/packages/agent/src/usage.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test"
+import type { Event } from "@tardigrade/core/event"
+import { costNumber, priced, sumUsage, usageFrom, usageIn, usageOf, ZERO_USAGE } from "./usage"
+
+const table = { promptUsdPerToken: 0.001, completionUsdPerToken: 0.002 }
+
+describe("priced and usageFrom", () => {
+  test("a reported cost keeps its source, including zero, and a price table fills an omitted cost", () => {
+    const billed = usageFrom({ promptTokens: 10, completionTokens: 4, cost: 0 }, table, {
+      provider: "vercel-ai-gateway",
+      model: "anthropic/claude-sonnet-4.6"
+    })
+    expect(billed).toEqual({
+      promptTokens: 10,
+      completionTokens: 4,
+      costUsd: 0,
+      costSource: "provider",
+      provider: "vercel-ai-gateway",
+      model: "anthropic/claude-sonnet-4.6"
+    })
+    const filled = usageFrom({ prompt_tokens: 10, completion_tokens: 4 }, table, { provider: "openai", model: "test" })
+    expect(filled).toEqual({
+      promptTokens: 10,
+      completionTokens: 4,
+      costUsd: 10 * 0.001 + 4 * 0.002,
+      costSource: "table",
+      provider: "openai",
+      model: "test"
+    })
+    const unknown = usageFrom({ promptTokens: 10, completionTokens: 4 })
+    expect(unknown).toEqual({ promptTokens: 10, completionTokens: 4 })
+    expect(usageFrom(undefined)).toBeUndefined()
+  })
+
+  test("priced does not relabel a figure that already has a cost", () => {
+    const reported = { promptTokens: 1, completionTokens: 1, costUsd: 9, costSource: "provider" as const }
+    expect(priced(reported, table)).toEqual(reported)
+    expect(priced({ promptTokens: 10, completionTokens: 4 }, table).costSource).toBe("table")
+  })
+
+  test("costNumber reads the seats a gateway actually writes", () => {
+    expect(costNumber({ cost: 0.01 })).toBe(0.01)
+    expect(costNumber({ costUsd: "0.2" })).toBe(0.2)
+    expect(costNumber({ gateway: { cost: 0 } })).toBe(0)
+    expect(costNumber({ prompt_tokens: 3 })).toBeUndefined()
+  })
+})
+
+describe("sumUsage", () => {
+  test("unknown is sticky, and mixed sources take the weaker label", () => {
+    const billed = { promptTokens: 1, completionTokens: 1, costUsd: 0.25, costSource: "provider" as const, provider: "a", model: "m" }
+    const filled = { promptTokens: 2, completionTokens: 2, costUsd: 0.5, costSource: "table" as const, provider: "a", model: "m" }
+    const mixed = sumUsage([billed, filled])
+    expect(mixed).toEqual({
+      promptTokens: 3,
+      completionTokens: 3,
+      costUsd: 0.75,
+      costSource: "table",
+      provider: "a",
+      model: "m"
+    })
+    expect(sumUsage([billed, { promptTokens: 1, completionTokens: 0 }]).costUsd).toBeUndefined()
+    expect(sumUsage([billed, { ...billed, provider: "b" }]).provider).toBeUndefined()
+    expect(sumUsage([])).toEqual(ZERO_USAGE)
+  })
+})
+
+describe("usageIn", () => {
+  test("a turn sums ModelReturned, and a died attempt invents nothing", () => {
+    const log: Event[] = [
+      { type: "MessageReceived", id: "m1", text: "go", at: 0 },
+      { type: "ModelCalled", callId: "m1/infer/0", ordinal: 0, turn: "m1", at: 1 },
+      {
+        type: "ModelReturned",
+        callId: "m1/infer/0",
+        ordinal: 0,
+        turn: "m1",
+        usage: {
+          promptTokens: 10,
+          completionTokens: 4,
+          costUsd: 0.01,
+          costSource: "provider",
+          provider: "openai",
+          model: "m"
+        },
+        at: 2
+      },
+      { type: "ModelCalled", callId: "m1/infer/1", ordinal: 1, turn: "m1", at: 3 },
+      { type: "TurnCompleted", output: "ok", turn: "m1", at: 4 }
+    ]
+    expect(usageIn(log, "m1")).toEqual({
+      promptTokens: 10,
+      completionTokens: 4,
+      costUsd: 0.01,
+      costSource: "provider",
+      provider: "openai",
+      model: "m"
+    })
+    expect(usageIn(log, "m2")).toEqual(ZERO_USAGE)
+  })
+
+  test("usageOf keeps a labeled figure and drops a source with no cost", () => {
+    expect(usageOf({ promptTokens: 3, completionTokens: 1, costUsd: 0, costSource: "provider" })).toEqual({
+      promptTokens: 3,
+      completionTokens: 1,
+      costUsd: 0,
+      costSource: "provider"
+    })
+    expect(usageOf({ promptTokens: 1, completionTokens: 0, costSource: "table" }).costSource).toBeUndefined()
+  })
+})

--- a/packages/agent/src/usage.ts
+++ b/packages/agent/src/usage.ts
@@ -1,0 +1,183 @@
+import type { Event } from "@tardigrade/core/event"
+import { turnOf } from "@tardigrade/code/turns"
+
+// Usage is what one model attempt spent. costUsd is present when the figure is known.
+// costSource is how that figure was obtained: the provider billed it, or a price table
+// filled it from token counts. A reported zero is free. Absence of costUsd is unknown.
+// provider and model name who was called, so a later switch cannot rewrite the stamp
+// (usage.test.ts, "a reported cost keeps its source").
+
+export type CostSource = "provider" | "table"
+
+export interface Usage {
+  readonly promptTokens: number
+  readonly completionTokens: number
+  readonly costUsd?: number
+  readonly costSource?: CostSource
+  readonly provider?: string
+  readonly model?: string
+}
+
+export interface ModelPricing {
+  readonly promptUsdPerToken: number
+  readonly completionUsdPerToken: number
+}
+
+export const ZERO_USAGE: Usage = { promptTokens: 0, completionTokens: 0 }
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  value !== null && typeof value === "object" ? (value as Record<string, unknown>) : undefined
+
+const numberOf = (value: unknown): number | undefined => {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "string" && value !== "") {
+    const n = Number(value)
+    return Number.isFinite(n) ? n : undefined
+  }
+  return undefined
+}
+
+const firstNumber = (rec: Record<string, unknown>, keys: ReadonlyArray<string>): number | undefined => {
+  for (const key of keys) {
+    const n = numberOf(rec[key])
+    if (n !== undefined) return n
+  }
+  return undefined
+}
+
+// costNumber reads a provider-billed dollar amount from a usage object. Gateways disagree on
+// the field name, so every common seat is checked; a table fill never writes these keys.
+export const costNumber = (value: unknown): number | undefined => {
+  const rec = asRecord(value)
+  if (rec === undefined) return undefined
+  const direct = firstNumber(rec, ["cost", "costUsd", "total_cost", "cost_usd"])
+  if (direct !== undefined) return direct
+  return costNumber(rec.gateway)
+}
+
+const tokensOf = (value: unknown): { readonly promptTokens: number; readonly completionTokens: number } | undefined => {
+  const rec = asRecord(value)
+  if (rec === undefined) return undefined
+  const prompt = firstNumber(rec, ["promptTokens", "prompt_tokens", "inputTokens", "input_tokens"])
+  const completion = firstNumber(rec, ["completionTokens", "completion_tokens", "outputTokens", "output_tokens"])
+  if (prompt === undefined && completion === undefined) return undefined
+  return { promptTokens: prompt ?? 0, completionTokens: completion ?? 0 }
+}
+
+export const costOf = (
+  pricing: ModelPricing | undefined,
+  promptTokens: number,
+  completionTokens: number
+): number | undefined =>
+  pricing === undefined
+    ? undefined
+    : promptTokens * pricing.promptUsdPerToken + completionTokens * pricing.completionUsdPerToken
+
+// priced keeps a cost that is already present, including zero, and fills from the table only
+// when nobody billed a figure. The fill is labeled table so a later reader can tell it from a
+// provider bill (usage.test.ts, "a price table fills an omitted cost").
+export const priced = (usage: Usage, pricing?: ModelPricing): Usage => {
+  if (usage.costUsd !== undefined) return usage
+  const costUsd = costOf(pricing, usage.promptTokens, usage.completionTokens)
+  return costUsd === undefined ? usage : { ...usage, costUsd, costSource: "table" }
+}
+
+// usageFrom builds spend from a provider reply. A billed dollar, including zero, is provider.
+// Token counts with no bill are filled from the table when one exists, and left without a
+// cost when none does. Nothing at all (no tokens, no bill) is undefined: unknown, not zero.
+export const usageFrom = (
+  reported: unknown,
+  pricing?: ModelPricing,
+  stamp?: { readonly provider?: string; readonly model?: string }
+): Usage | undefined => {
+  const parts = Array.isArray(reported) ? reported : [reported]
+  let tokens: { readonly promptTokens: number; readonly completionTokens: number } | undefined
+  let billed: number | undefined
+  for (const part of parts) {
+    const next = tokensOf(part)
+    if (next !== undefined) tokens = next
+    const cost = costNumber(part)
+    if (cost !== undefined) billed = cost
+  }
+  if (tokens === undefined && billed === undefined) return undefined
+  return priced(
+    {
+      promptTokens: tokens?.promptTokens ?? 0,
+      completionTokens: tokens?.completionTokens ?? 0,
+      ...(stamp?.provider === undefined ? {} : { provider: stamp.provider }),
+      ...(stamp?.model === undefined ? {} : { model: stamp.model }),
+      ...(billed === undefined ? {} : { costUsd: billed, costSource: "provider" as const })
+    },
+    pricing
+  )
+}
+
+export const usageOf = (value: unknown): Usage => {
+  const carried = asRecord(value)
+  const costUsd = numberOf(carried?.costUsd)
+  const source = carried?.costSource
+  const provider = carried?.provider
+  const model = carried?.model
+  return {
+    promptTokens: numberOf(carried?.promptTokens) ?? 0,
+    completionTokens: numberOf(carried?.completionTokens) ?? 0,
+    ...(costUsd === undefined ? {} : { costUsd }),
+    ...(costUsd !== undefined && (source === "provider" || source === "table") ? { costSource: source } : {}),
+    ...(typeof provider === "string" && provider !== "" ? { provider } : {}),
+    ...(typeof model === "string" && model !== "" ? { model } : {})
+  }
+}
+
+const weaker = (a: CostSource | undefined, b: CostSource | undefined): CostSource | undefined => {
+  if (a === undefined || b === undefined) return undefined
+  return a === "provider" && b === "provider" ? "provider" : "table"
+}
+
+const same = (a: string | undefined, b: string | undefined): string | undefined =>
+  a !== undefined && a === b ? a : undefined
+
+export const sumUsage = (parts: ReadonlyArray<Usage>): Usage => {
+  if (parts.length === 0) return ZERO_USAGE
+  let promptTokens = 0
+  let completionTokens = 0
+  let costUsd = 0
+  let known = true
+  let source: CostSource | undefined
+  let provider: string | undefined
+  let model: string | undefined
+  let first = true
+  for (const part of parts) {
+    promptTokens += part.promptTokens
+    completionTokens += part.completionTokens
+    if (part.costUsd === undefined) known = false
+    else costUsd += part.costUsd
+    if (first) {
+      source = part.costSource
+      provider = part.provider
+      model = part.model
+      first = false
+    } else {
+      source = weaker(source, part.costSource)
+      provider = same(provider, part.provider)
+      model = same(model, part.model)
+    }
+  }
+  return {
+    promptTokens,
+    completionTokens,
+    ...(known ? { costUsd, ...(source === undefined ? {} : { costSource: source }) } : {}),
+    ...(provider === undefined ? {} : { provider }),
+    ...(model === undefined ? {} : { model })
+  }
+}
+
+// usageIn sums what one turn spent on the model. Settled figures come from ModelReturned.
+// An attempt that died after ModelCalled has no return, so it does not invent a cost.
+export const usageIn = (log: ReadonlyArray<Event>, turn: string): Usage =>
+  sumUsage(
+    log.flatMap((event) => {
+      if (event.type !== "ModelReturned" || turnOf(event) !== turn) return []
+      const carried = asRecord(event)?.usage
+      return carried === undefined ? [] : [usageOf(carried)]
+    })
+  )

--- a/packages/agent/src/usage.ts
+++ b/packages/agent/src/usage.ts
@@ -19,6 +19,8 @@ export interface Usage {
 }
 
 export interface ModelPricing {
+  // Per-token rates for a table fill. Cached prompt tokens have no cheaper seat here, so a
+  // fill prices them at the full input rate (usage.test.ts, "a price table fills an omitted cost").
   readonly promptUsdPerToken: number
   readonly completionUsdPerToken: number
 }
@@ -85,6 +87,7 @@ export const priced = (usage: Usage, pricing?: ModelPricing): Usage => {
 // usageFrom builds spend from a provider reply. A billed dollar, including zero, is provider.
 // Token counts with no bill are filled from the table when one exists, and left without a
 // cost when none does. Nothing at all (no tokens, no bill) is undefined: unknown, not zero.
+// Later parts win on tokens, so the adapter's counts (held last) beat the raw SSE object.
 export const usageFrom = (
   reported: unknown,
   pricing?: ModelPricing,
@@ -171,13 +174,22 @@ export const sumUsage = (parts: ReadonlyArray<Usage>): Usage => {
   }
 }
 
+const ofTurn = (event: Event, turn: string): boolean => {
+  const stamped = turnOf(event)
+  if (stamped === turn) return true
+  if (stamped !== undefined) return false
+  const callId = String(asRecord(event)?.callId ?? "")
+  return callId === turn || callId.startsWith(`${turn}/`)
+}
+
 // usageIn sums what one turn spent on the model. Settled figures come from ModelReturned.
-// An attempt that died after ModelCalled has no return, so it does not invent a cost.
+// A return with no usage is unknown cost, so it poisons the total (usage.test.ts, "unknown is
+// sticky"). An attempt that died after ModelCalled has no return, so it does not invent a cost.
 export const usageIn = (log: ReadonlyArray<Event>, turn: string): Usage =>
   sumUsage(
     log.flatMap((event) => {
-      if (event.type !== "ModelReturned" || turnOf(event) !== turn) return []
+      if (event.type !== "ModelReturned" || !ofTurn(event, turn)) return []
       const carried = asRecord(event)?.usage
-      return carried === undefined ? [] : [usageOf(carried)]
+      return [carried === undefined ? ZERO_USAGE : usageOf(carried)]
     })
   )

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -406,15 +406,17 @@ describe("truncation", () => {
       headers: { "content-type": "text/event-stream" }
     })
 
-  const cut = (text: string) =>
+  const cut = (text: string, usage?: Record<string, unknown>) =>
     sse([
       { choices: [{ delta: { content: text }, index: 0 }] },
-      { choices: [{ delta: {}, finish_reason: "length", index: 0 }] }
+      { choices: [{ delta: {}, finish_reason: "length", index: 0 }] },
+      ...(usage === undefined ? [] : [{ choices: [], usage }])
     ])
-  const whole = (text: string) =>
+  const whole = (text: string, usage?: Record<string, unknown>) =>
     sse([
       { choices: [{ delta: { content: text }, index: 0 }] },
-      { choices: [{ delta: {}, finish_reason: "stop", index: 0 }] }
+      { choices: [{ delta: {}, finish_reason: "stop", index: 0 }] },
+      ...(usage === undefined ? [] : [{ choices: [], usage }])
     ])
 
   test("a cut answer retries up the ladder under a fresh idempotency key, and completes", async () => {
@@ -441,6 +443,33 @@ describe("truncation", () => {
     expect(keys[1]).not.toBe(keys[0])
   })
 
+  test("every truncated rung's bill rides the action, not only the winner's", async () => {
+    let calls = 0
+    const fetchImpl = (async () =>
+      calls++ === 0
+        ? cut("half an ans", { prompt_tokens: 10, completion_tokens: 32768, cost: 5 })
+        : whole("the whole answer", { prompt_tokens: 10, completion_tokens: 4, cost: 1 })) as unknown as typeof fetch
+    const layer = realInfer({
+      provider: "openai",
+      model: "m",
+      baseUrl: "https://x",
+      apiKey: "k",
+      surface: codeSurface(),
+      fetch: fetchImpl as never
+    })
+    const action = await Effect.runPromise(
+      Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
+        Effect.provide(layer)
+      ) as Effect.Effect<Action>
+    )
+    expect(calls).toBe(2)
+    expect(action).toMatchObject({
+      kind: "complete",
+      output: "the whole answer",
+      usage: { promptTokens: 20, completionTokens: 32772, costUsd: 6, costSource: "provider" }
+    })
+  })
+
   test("the top rung still truncating fails the turn loudly, never half an answer", async () => {
     const fetchImpl = (async () => cut("half")) as unknown as typeof fetch
     const layer = realInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", surface: codeSurface(), fetch: fetchImpl as never })
@@ -451,6 +480,47 @@ describe("truncation", () => {
     )
     expect(action.kind).toBe("fail")
     expect(action.error).toContain("output ceiling")
+  })
+
+  test("a mid-stream drop does not leak an unhandled rejection from the usage tee", async () => {
+    const leaked: unknown[] = []
+    const onLeak = (reason: unknown) => {
+      leaked.push(reason)
+    }
+    process.on("unhandledRejection", onLeak)
+    try {
+      const fetchImpl = (async () =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('data: {"choices":[{"delta":{"content":"x"},"index":0}]}\n\n'))
+              controller.error(new Error("ECONNRESET mid-stream"))
+            }
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } }
+        )) as unknown as typeof fetch
+      const layer = realInfer({
+        provider: "openai",
+        model: "m",
+        baseUrl: "https://x",
+        apiKey: "k",
+        surface: codeSurface(),
+        fetch: fetchImpl as never,
+        throttleRetryDelaysMs: [0],
+        sleep: () => Promise.resolve()
+      })
+      await expect(
+        Effect.runPromise(
+          Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
+            Effect.provide(layer)
+          ) as Effect.Effect<unknown>
+        )
+      ).rejects.toBeTruthy()
+      await Promise.resolve()
+      expect(leaked).toEqual([])
+    } finally {
+      process.off("unhandledRejection", onLeak)
+    }
   })
 })
 

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -3,6 +3,7 @@ import { Effect } from "effect"
 import { codeSurface } from "@tardigrade/agent/surface"
 import { Infer } from "@tardigrade/agent/infer"
 import { actionOf, ladderOf, modelAskOf, modelIdOf, realInfer, retryAfterMsOf, throttleDelayMs } from "./model"
+import type { Action } from "@tardigrade/agent/events"
 
 // The model binding: the trajectory renders into the provider conversation, the streamed reply
 // decodes into one Action, and the whole loop round-trips through a fake OpenAI-compatible SSE
@@ -153,6 +154,85 @@ describe("realInfer end to end", () => {
       Effect.flatMap(Infer, (model) => model.react(trajectory)).pipe(Effect.provide(layer)) as Effect.Effect<unknown>
     )
     expect(seen).toEqual(["m1/infer/0", null])
+  })
+})
+
+const usageChunk = (usage: Record<string, unknown>) => ({ id: "u", choices: [], usage })
+
+describe("realInfer: cost provenance", () => {
+  const okText = [
+    { id: "r", choices: [{ index: 0, delta: { role: "assistant", content: "ok" } }] },
+    { id: "r", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }
+  ]
+  const table = { promptUsdPerToken: 0.001, completionUsdPerToken: 0.002 }
+
+  test("a billed cost is provider, an omitted cost is table or unknown", async () => {
+    const billed = await Effect.runPromise(
+      Effect.flatMap(Infer, (model) => model.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
+        Effect.provide(
+          realInfer({
+            baseUrl: "https://model.test/v1",
+            apiKey: "k",
+            model: "test-model",
+            provider: "openai",
+            surface: codeSurface(),
+            pricing: table,
+            fetch: (async () => sse([...okText, usageChunk({ prompt_tokens: 10, completion_tokens: 4, cost: 0 })])) as unknown as typeof globalThis.fetch
+          })
+        )
+      ) as Effect.Effect<Action>
+    )
+    expect(billed).toMatchObject({
+      kind: "complete",
+      output: "ok",
+      usage: {
+        promptTokens: 10,
+        completionTokens: 4,
+        costUsd: 0,
+        costSource: "provider",
+        provider: "openai",
+        model: "test-model"
+      }
+    })
+
+    const filled = await Effect.runPromise(
+      Effect.flatMap(Infer, (model) => model.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
+        Effect.provide(
+          realInfer({
+            baseUrl: "https://model.test/v1",
+            apiKey: "k",
+            model: "test-model",
+            provider: "openai",
+            surface: codeSurface(),
+            pricing: table,
+            fetch: (async () => sse([...okText, usageChunk({ prompt_tokens: 10, completion_tokens: 4 })])) as unknown as typeof globalThis.fetch
+          })
+        )
+      ) as Effect.Effect<Action>
+    )
+    expect(filled.usage).toEqual({
+      promptTokens: 10,
+      completionTokens: 4,
+      costUsd: 10 * 0.001 + 4 * 0.002,
+      costSource: "table",
+      provider: "openai",
+      model: "test-model"
+    })
+
+    const unknown = await Effect.runPromise(
+      Effect.flatMap(Infer, (model) => model.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
+        Effect.provide(
+          realInfer({
+            baseUrl: "https://model.test/v1",
+            apiKey: "k",
+            model: "test-model",
+            surface: codeSurface(),
+            fetch: (async () => sse(okText)) as unknown as typeof globalThis.fetch
+          })
+        )
+      ) as Effect.Effect<Action>
+    )
+    expect(unknown).toEqual({ kind: "complete", output: "ok" })
   })
 })
 

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -10,7 +10,7 @@ import type { Event } from "@tardigrade/core/event"
 import { answerErrors, outputSchemaOf } from "@tardigrade/agent/contract"
 import { modelRequest, type AgentMessage, type ToolSpec } from "@tardigrade/agent/request"
 import { codeSurface, type ToolSurface } from "@tardigrade/agent/surface"
-import { usageFrom, type ModelPricing, type Usage } from "@tardigrade/agent/usage"
+import { sumUsage, usageFrom, type ModelPricing, type Usage } from "@tardigrade/agent/usage"
 
 // The real model binding: one inference per react, streamed through a TanStack adapter and
 // decoded by their StreamProcessor. The reactors never learn this layer exists. Resilience is
@@ -191,7 +191,7 @@ export interface ModelConfig {
   readonly stream?: Partial<StreamBounds>
   // What the model costs, when a catalog or a caller has said. A billed figure from the
   // provider is preferred; this table fills only a cost the provider omitted
-  // (packages/agent/src/usage.ts, priced).
+  // (packages/agent/src/usage.ts, priced). Cached prompt tokens price at the full input rate.
   readonly pricing?: ModelPricing
   // In-act backoff bases for throttle-shaped failures. Length is the retry count.
   readonly throttleRetryDelaysMs?: ReadonlyArray<number>
@@ -363,11 +363,37 @@ const withKey = (base: FetchImpl | undefined, key: string | undefined): FetchImp
   }
 }
 
+const concatBytes = (chunks: ReadonlyArray<Uint8Array>): Uint8Array => {
+  const total = chunks.reduce((n, c) => n + c.byteLength, 0)
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const c of chunks) {
+    out.set(c, offset)
+    offset += c.byteLength
+  }
+  return out
+}
+
+type BodyReader = {
+  read: () => Promise<{ done: boolean; value?: Uint8Array }>
+  cancel: () => Promise<unknown>
+}
+
 // captureRawUsage reads the last `usage` object off an SSE (or JSON) body. The OpenAI-compat
 // adapter normalizes tokens and drops extra keys; a gateway's billed dollar lives on those keys
 // (packages/agent/src/usage.ts, costNumber).
-const captureRawUsage = async (stream: ReadableStream<Uint8Array>): Promise<unknown> => {
-  const text = await new Response(stream).text()
+const captureRawUsage = async (reader: BodyReader): Promise<unknown> => {
+  const chunks: Uint8Array[] = []
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (value !== undefined) chunks.push(value)
+    }
+  } catch {
+    // the live branch already failed; bytes read so far may still hold a usage chunk
+  }
+  const text = new TextDecoder().decode(concatBytes(chunks))
   let last: unknown
   for (const line of text.split(/\r?\n/)) {
     const payload = line.startsWith("data:") ? line.slice(5).trim() : ""
@@ -391,14 +417,16 @@ const captureRawUsage = async (stream: ReadableStream<Uint8Array>): Promise<unkn
 const withCapture = (
   base: FetchImpl | undefined,
   key: string | undefined,
-  sink: { promise: Promise<unknown> }
+  sink: { promise: Promise<unknown>; reader?: BodyReader }
 ): FetchImpl => {
   const inner = withKey(base, key) ?? ((input, init) => globalThis.fetch(input, init))
   return async (input, init) => {
     const res = await inner(input, init)
     if (res.body === null) return res
     const [live, copy] = res.body.tee()
-    sink.promise = captureRawUsage(copy)
+    const reader = copy.getReader()
+    sink.reader = reader
+    sink.promise = captureRawUsage(reader).catch(() => undefined)
     return new Response(live, { status: res.status, statusText: res.statusText, headers: res.headers })
   }
 }
@@ -424,6 +452,21 @@ const stampOf = (config: ModelConfig) => ({
   model: config.model
 })
 
+const usageOn = (e: unknown): Usage | undefined =>
+  e !== null && typeof e === "object" && "usage" in e ? (e as { usage?: Usage }).usage : undefined
+
+const spentOf = (parts: ReadonlyArray<Usage>, missed: boolean): Usage | undefined => {
+  if (parts.length === 0) return undefined
+  const summed = sumUsage(parts)
+  if (!missed) return summed
+  return {
+    promptTokens: summed.promptTokens,
+    completionTokens: summed.completionTokens,
+    ...(summed.provider === undefined ? {} : { provider: summed.provider }),
+    ...(summed.model === undefined ? {} : { model: summed.model })
+  }
+}
+
 export const realInfer = (config: ModelConfig) => {
   const sleep = config.sleep ?? realSleep
   const bounds: StreamBounds = {
@@ -439,7 +482,9 @@ export const realInfer = (config: ModelConfig) => {
      // Rung zero keeps the bare key, so crash-retries of the same request still
     // collapse.
     const keyForRung = key === undefined ? undefined : rung === 0 ? key : `${key}/mt${maxTokens}`
-    const sink: { promise: Promise<unknown> } = { promise: Promise.resolve(undefined) }
+    const sink: { promise: Promise<unknown>; reader?: BodyReader } = {
+      promise: Promise.resolve(undefined)
+    }
     const held: { tokens?: { readonly promptTokens: number; readonly completionTokens: number; readonly cost?: number } } = {}
     const fetcher = withCapture(config.fetch, keyForRung, sink)
     const adapter =
@@ -469,12 +514,22 @@ export const realInfer = (config: ModelConfig) => {
       modelOptions: { max_tokens: maxTokens } as never,
       logger: noopLogger
     } as never)
-    const result = await new StreamProcessor().process(tapTokens(bounded(stream, bounds), held))
-    const raw = await sink.promise
-    const usage = usageFrom([held.tokens, raw], config.pricing, stampOf(config))
-    stats.finish = result.finishReason ?? "stop"
-    if (result.finishReason === "length") throw new TruncatedError(maxTokens, usage)
-    return withSpend(actionOf(result, schema), usage)
+    const spendOf = async (): Promise<Usage | undefined> =>
+      usageFrom([await sink.promise, held.tokens], config.pricing, stampOf(config))
+    try {
+      const result = await new StreamProcessor().process(tapTokens(bounded(stream, bounds), held))
+      const usage = await spendOf()
+      stats.finish = result.finishReason ?? "stop"
+      if (result.finishReason === "length") throw new TruncatedError(maxTokens, usage)
+      return withSpend(actionOf(result, schema), usage)
+    } catch (e) {
+      await sink.reader?.cancel().catch(() => undefined)
+      if (isTruncated(e)) throw e
+      const usage = await spendOf()
+      if (usage === undefined) throw e
+      if (e !== null && typeof e === "object") throw Object.assign(e, { usage })
+      throw Object.assign(new Error(String(e)), { usage })
+    }
   }
   return Layer.succeed(Infer, {
     react: (trajectory: ReadonlyArray<Event>, key?: string) =>
@@ -483,11 +538,21 @@ export const realInfer = (config: ModelConfig) => {
         const stats: { finish?: string; rung: number; waits: number } = { rung: 0, waits: 0 }
         const action = yield* Effect.promise<Action>(async () => {
         let rung = 0
+        const parts: Usage[] = []
+        let missed = false
+        const remember = (usage: Usage | undefined, billed: boolean) => {
+          if (usage !== undefined) parts.push(usage)
+          else if (billed) missed = true
+        }
         for (let attempt = 0; ; attempt++) {
           try {
             stats.rung = rung
-            return await attemptOnce(trajectory, key, ladder[rung]!, rung, stats)
+            const action = await attemptOnce(trajectory, key, ladder[rung]!, rung, stats)
+            remember(action.usage, true)
+            return withSpend(action, spentOf(parts, missed))
           } catch (e) {
+            const usage = isTruncated(e) ? e.usage : usageOn(e)
+            remember(usage, isTruncated(e) || usage !== undefined)
             if (isTruncated(e)) {
               if (rung + 1 < ladder.length) {
                 rung += 1
@@ -500,7 +565,7 @@ export const realInfer = (config: ModelConfig) => {
                   kind: "fail",
                   error: `${e.message}; the answer does not fit the largest ceiling, so the task must produce less at once`
                 },
-                e.usage
+                spentOf(parts, missed)
               )
             }
             if (!isThrottleShaped(e)) throw e

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -10,6 +10,7 @@ import type { Event } from "@tardigrade/core/event"
 import { answerErrors, outputSchemaOf } from "@tardigrade/agent/contract"
 import { modelRequest, type AgentMessage, type ToolSpec } from "@tardigrade/agent/request"
 import { codeSurface, type ToolSurface } from "@tardigrade/agent/surface"
+import { usageFrom, type ModelPricing, type Usage } from "@tardigrade/agent/usage"
 
 // The real model binding: one inference per react, streamed through a TanStack adapter and
 // decoded by their StreamProcessor. The reactors never learn this layer exists. Resilience is
@@ -188,6 +189,10 @@ export interface ModelConfig {
   // Stream wall times. Absent fields take DEFAULT_STREAM_BOUNDS. A long healthy generation
   // that outlives totalMs dies the same way a hung stream does, so set this for the work you run.
   readonly stream?: Partial<StreamBounds>
+  // What the model costs, when a catalog or a caller has said. A billed figure from the
+  // provider is preferred; this table fills only a cost the provider omitted
+  // (packages/agent/src/usage.ts, priced).
+  readonly pricing?: ModelPricing
   // In-act backoff bases for throttle-shaped failures. Length is the retry count.
   readonly throttleRetryDelaysMs?: ReadonlyArray<number>
   readonly fetch?: FetchImpl // test seam
@@ -292,8 +297,10 @@ export const ladderOf = (declared?: number): ReadonlyArray<number> => {
 
 class TruncatedError extends Error {
   readonly truncated = true
-  constructor(ceiling: number) {
+  readonly usage: Usage | undefined
+  constructor(ceiling: number, usage: Usage | undefined) {
     super(`the model's answer was cut at the ${ceiling}-token output ceiling`)
+    this.usage = usage
   }
 }
 
@@ -356,6 +363,67 @@ const withKey = (base: FetchImpl | undefined, key: string | undefined): FetchImp
   }
 }
 
+// captureRawUsage reads the last `usage` object off an SSE (or JSON) body. The OpenAI-compat
+// adapter normalizes tokens and drops extra keys; a gateway's billed dollar lives on those keys
+// (packages/agent/src/usage.ts, costNumber).
+const captureRawUsage = async (stream: ReadableStream<Uint8Array>): Promise<unknown> => {
+  const text = await new Response(stream).text()
+  let last: unknown
+  for (const line of text.split(/\r?\n/)) {
+    const payload = line.startsWith("data:") ? line.slice(5).trim() : ""
+    if (payload === "" || payload === "[DONE]") continue
+    try {
+      const parsed = JSON.parse(payload) as { usage?: unknown }
+      if (parsed.usage !== undefined) last = parsed.usage
+    } catch {
+      // a keep-alive or a malformed line is not usage
+    }
+  }
+  if (last !== undefined) return last
+  try {
+    const parsed = JSON.parse(text) as { usage?: unknown }
+    return parsed.usage
+  } catch {
+    return undefined
+  }
+}
+
+const withCapture = (
+  base: FetchImpl | undefined,
+  key: string | undefined,
+  sink: { promise: Promise<unknown> }
+): FetchImpl => {
+  const inner = withKey(base, key) ?? ((input, init) => globalThis.fetch(input, init))
+  return async (input, init) => {
+    const res = await inner(input, init)
+    if (res.body === null) return res
+    const [live, copy] = res.body.tee()
+    sink.promise = captureRawUsage(copy)
+    return new Response(live, { status: res.status, statusText: res.statusText, headers: res.headers })
+  }
+}
+
+const tapTokens = (
+  stream: AsyncIterable<StreamChunk>,
+  into: { tokens?: { readonly promptTokens: number; readonly completionTokens: number; readonly cost?: number } }
+): AsyncIterable<StreamChunk> => ({
+  async *[Symbol.asyncIterator]() {
+    for await (const chunk of stream) {
+      const tokens = (chunk as { usage?: { promptTokens: number; completionTokens: number; cost?: number } }).usage
+      if (tokens !== undefined) into.tokens = tokens
+      yield chunk
+    }
+  }
+})
+
+const withSpend = (action: Action, usage: Usage | undefined): Action =>
+  usage === undefined ? action : { ...action, usage }
+
+const stampOf = (config: ModelConfig) => ({
+  ...(config.provider === undefined ? {} : { provider: config.provider }),
+  model: config.model
+})
+
 export const realInfer = (config: ModelConfig) => {
   const sleep = config.sleep ?? realSleep
   const bounds: StreamBounds = {
@@ -371,7 +439,9 @@ export const realInfer = (config: ModelConfig) => {
      // Rung zero keeps the bare key, so crash-retries of the same request still
     // collapse.
     const keyForRung = key === undefined ? undefined : rung === 0 ? key : `${key}/mt${maxTokens}`
-    const fetcher = withKey(config.fetch, keyForRung)
+    const sink: { promise: Promise<unknown> } = { promise: Promise.resolve(undefined) }
+    const held: { tokens?: { readonly promptTokens: number; readonly completionTokens: number; readonly cost?: number } } = {}
+    const fetcher = withCapture(config.fetch, keyForRung, sink)
     const adapter =
       config.provider === "bedrock"
         ? bedrockAdapter(config, maxTokens)
@@ -383,7 +453,7 @@ export const realInfer = (config: ModelConfig) => {
             // default (`maxRetries: 2`, real waits it does not expose to us). Turned off here so
             // a 429 or a 5xx surfaces to `react`'s own retry loop once, on our own backoff.
             maxRetries: 0,
-            ...(fetcher === undefined ? {} : { fetch: fetcher })
+            fetch: fetcher
           })
     // The domain decides the request; the platform maps it to the wire and streams it.
     const req = modelRequest(trajectory, config.surface ?? codeSurface())
@@ -399,10 +469,12 @@ export const realInfer = (config: ModelConfig) => {
       modelOptions: { max_tokens: maxTokens } as never,
       logger: noopLogger
     } as never)
-    const result = await new StreamProcessor().process(bounded(stream, bounds))
+    const result = await new StreamProcessor().process(tapTokens(bounded(stream, bounds), held))
+    const raw = await sink.promise
+    const usage = usageFrom([held.tokens, raw], config.pricing, stampOf(config))
     stats.finish = result.finishReason ?? "stop"
-    if (result.finishReason === "length") throw new TruncatedError(maxTokens)
-    return actionOf(result, schema)
+    if (result.finishReason === "length") throw new TruncatedError(maxTokens, usage)
+    return withSpend(actionOf(result, schema), usage)
   }
   return Layer.succeed(Infer, {
     react: (trajectory: ReadonlyArray<Event>, key?: string) =>
@@ -423,7 +495,13 @@ export const realInfer = (config: ModelConfig) => {
               }
               // The top rung still truncates: the turn fails loudly instead of shipping half an
               // answer, and the error names the remedy.
-              return { kind: "fail", error: `${e.message}; the answer does not fit the largest ceiling, so the task must produce less at once` }
+              return withSpend(
+                {
+                  kind: "fail",
+                  error: `${e.message}; the answer does not fit the largest ceiling, so the task must produce less at once`
+                },
+                e.usage
+              )
             }
             if (!isThrottleShaped(e)) throw e
             const delay = throttleDelayMs(e, attempt, Date.now(), throttleDelays)
@@ -438,6 +516,16 @@ export const realInfer = (config: ModelConfig) => {
         yield* Effect.annotateCurrentSpan("gen_ai.response.finish_reasons", [stats.finish ?? "unknown"])
         yield* Effect.annotateCurrentSpan("retry.rung", stats.rung)
         yield* Effect.annotateCurrentSpan("retry.throttle_waits", stats.waits)
+        if (action.usage !== undefined) {
+          yield* Effect.annotateCurrentSpan("gen_ai.usage.input_tokens", action.usage.promptTokens)
+          yield* Effect.annotateCurrentSpan("gen_ai.usage.output_tokens", action.usage.completionTokens)
+          if (action.usage.costUsd !== undefined) {
+            yield* Effect.annotateCurrentSpan("gen_ai.usage.cost", action.usage.costUsd)
+            if (action.usage.costSource !== undefined) {
+              yield* Effect.annotateCurrentSpan("gen_ai.usage.cost_source", action.usage.costSource)
+            }
+          }
+        }
         return action
       }).pipe(
         Effect.withSpan("llm.react", {


### PR DESCRIPTION
## What and why

A model call's dollar figure is a fact about that attempt: who was called, what they billed, and how the number was obtained. ModelReturned records spend on the log. costSource is provider when the gateway billed the call, including zero, and table when a price list filled an omitted cost from token counts. Absence of costUsd stays unknown. usageIn sums one turn and keeps unknown sticky; mixed sources take the weaker table label.

- Usage carries tokens, optional cost, costSource, provider, and model.
- The infer reactor emits ModelReturned after each live attempt.
- The model binding reads billed cost from the stream and SSE usage, and fills from pricing only when the provider omitted a figure.
- Docs: docs/reference/api.md Usage.

## Test plan

- [x] bun run gate passes locally
- [x] Docs updated
- [x] Tests cover billed zero, table fill, unknown, mixed-source sums, and ModelReturned on the log