### PR TITLE
docs: quickstart trace path

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,12 @@ await host.deliver("bun:main", { type: "MessageReceived", id: "m1", text: "What 
 await host.drive()
 ```
 
-The snippet already emits spans to `localhost:4318`. To land them in ClickHouse, front it with the [OTel Collector](https://github.com/open-telemetry/opentelemetry-collector-releases/releases):
+The snippet already emits spans to `localhost:4318`. To land them in ClickHouse, front it with the OTel Collector:
 
 ```bash
 brew install clickhouse && clickhouse server
-otelcol-contrib --config=collector.yaml
+curl -sL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.159.0/otelcol-contrib_0.159.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz | tar xz otelcol-contrib
+./otelcol-contrib --config=collector.yaml
 ```
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ await host.deliver("bun:main", { type: "MessageReceived", id: "m1", text: "What 
 await host.drive()
 ```
 
-`createRlmAgent` from `@tardigrade/agent` is this Recursive Language Model default: the same six reactors, an in-process host, packages, and spawn. The mind is `agentFor` plus a work surface that the three reactors can serve (`nativeSurface` is the usual thinner case). Code mode is `rlmAgentFor`, because `execute` needs the code reactor.
-
 The snippet already emits spans to `localhost:4318`. To land them in ClickHouse, front it with the OTel Collector (the contrib distribution from the [collector releases](https://github.com/open-telemetry/opentelemetry-collector-releases/releases); the core one lacks the `clickhouse` exporter):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ $$\{\mathrm{transitions}\} = f(\mathrm{log})$$
 
 ## Quickstart
 
+Prerequisites: bun 1.1 or later, and a model endpoint.
+
 An agent is reactors over one log.
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ await host.deliver("bun:main", { type: "MessageReceived", id: "m1", text: "What 
 await host.drive()
 ```
 
-The snippet already emits spans to `localhost:4318`. To land them in ClickHouse, front it with the OTel Collector (the contrib distribution from the [collector releases](https://github.com/open-telemetry/opentelemetry-collector-releases/releases); the core one lacks the `clickhouse` exporter):
+The snippet already emits spans to `localhost:4318`. To land them in ClickHouse, front it with the [OTel Collector](https://github.com/open-telemetry/opentelemetry-collector-releases/releases):
 
 ```bash
 brew install clickhouse && clickhouse server

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ const wiring = () =>
     memoryTmp()
   )
 
-// Spans go to any OTLP listener; absent one they cost nothing (docs/how-to/observe.md).
+// Spans go to any OTLP listener (docs/how-to/observe.md).
 const host = await createBunHost({
   path: "agents.sqlite",
   actorFor: () => agent,
@@ -113,6 +113,7 @@ An actor is a set of reactors over one log, plus the key derivation that decides
 - [Quickstart](docs/quickstart.md): the concepts in one page: events, projections, transitions, reactors, an agent in three reactors.
 - [Tutorial: an RLM agent](docs/tutorials/rlm-agent.md): a Recursive Language Model agent with durable code execution, killed mid-recursion.
 - [How-to: gate tools](docs/how-to/gate-tools.md): hide, reveal, or revoke tools from the log.
+- [How-to: observe](docs/how-to/observe.md): wire a tracer, traces in ClickHouse, the one-trace contract, the outcome vocabulary.
 - [Reference: API](docs/reference/api.md): Event, Projection, Transition, Reactor, Actor, send, settle, resting.
 - [Why tardigrade](docs/explanations/why.md): state = f(log), the convergence of durable systems, agents as the new users.
 - [Reactors](docs/explanations/reactors.md): the reactor model, with the React analogy and the math.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import { Packages } from "@tardigrade/code/packages"
 import { agentKeys, budgetReactor, codeSurface, compactionReactor, inferReactor, replyReactor, toolsReactorFor } from "@tardigrade/agent"
 import { realInfer } from "@tardigrade/model/model"
 import { createBunHost } from "@tardigrade/bun/host"
-import { otlpTelemetry } from "@tardigrade/bun/otlp"
+import { fileTelemetry } from "@tardigrade/bun/file"
 
 // The tool surface: code mode is the default. `nativeSurface` presents a fixed table of named
 // tools instead, for an agent measured against another harness's surface.
@@ -45,39 +45,25 @@ const wiring = () =>
     memoryTmp()
   )
 
-// Spans go to any OTLP listener (docs/how-to/observe.md).
+// One NDJSON row per span (docs/how-to/observe.md); `otlpTelemetry` reaches real backends.
 const host = await createBunHost({
   path: "agents.sqlite",
   actorFor: () => agent,
   layersFor: wiring,
-  telemetry: otlpTelemetry({ baseUrl: "http://localhost:4318", serviceName: "quickstart" })
+  telemetry: fileTelemetry("spans.ndjson")
 })
 await host.deliver("bun:main", { type: "MessageReceived", id: "m1", text: "What changed in the deploy?", at: Date.now() })
 await host.drive()
 ```
 
-The snippet already emits spans to `localhost:4318`. To land them in ClickHouse, front it with the OTel Collector:
+The run leaves its spans in `spans.ndjson`. The ClickHouse binary (`brew install clickhouse`) queries the file in place, no server:
 
 ```bash
-brew install clickhouse && clickhouse server
-curl -sL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.159.0/otelcol-contrib_0.159.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz | tar xz otelcol-contrib
-./otelcol-contrib --config=collector.yaml
-```
-
-```yaml
-# collector.yaml
-receivers:
-  otlp: { protocols: { http: { endpoint: 0.0.0.0:4318 } } }
-exporters:
-  clickhouse: { endpoint: tcp://localhost:9000, database: otel, create_schema: true }
-service:
-  pipelines:
-    traces: { receivers: [otlp], exporters: [clickhouse] }
-```
-
-```sql
-SELECT SpanName, SpanAttributes['outcome'] AS outcome, Duration / 1e6 AS ms
-FROM otel.otel_traces ORDER BY Timestamp
+clickhouse local -q "
+  SELECT SpanName, SpanAttributes['outcome'] AS outcome, Duration / 1e6 AS ms
+  FROM file('spans.ndjson', JSONEachRow,
+    'Timestamp String, SpanName String, Duration UInt64, SpanAttributes Map(String, String)')
+  ORDER BY Timestamp"
 ```
 
 ## Concepts

--- a/README.md
+++ b/README.md
@@ -58,6 +58,29 @@ await host.drive()
 
 `createRlmAgent` from `@tardigrade/agent` is this Recursive Language Model default: the same six reactors, an in-process host, packages, and spawn. The mind is `agentFor` plus a work surface that the three reactors can serve (`nativeSurface` is the usual thinner case). Code mode is `rlmAgentFor`, because `execute` needs the code reactor.
 
+The snippet already emits spans to `localhost:4318`. To land them in ClickHouse, front it with the OTel Collector (the contrib distribution from the [collector releases](https://github.com/open-telemetry/opentelemetry-collector-releases/releases); the core one lacks the `clickhouse` exporter):
+
+```bash
+brew install clickhouse && clickhouse server
+otelcol-contrib --config=collector.yaml
+```
+
+```yaml
+# collector.yaml
+receivers:
+  otlp: { protocols: { http: { endpoint: 0.0.0.0:4318 } } }
+exporters:
+  clickhouse: { endpoint: tcp://localhost:9000, database: otel, create_schema: true }
+service:
+  pipelines:
+    traces: { receivers: [otlp], exporters: [clickhouse] }
+```
+
+```sql
+SELECT SpanName, SpanAttributes['outcome'] AS outcome, Duration / 1e6 AS ms
+FROM otel.otel_traces ORDER BY Timestamp
+```
+
 ## Concepts
 
 ### Events

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ import { Packages } from "@tardigrade/code/packages"
 import { agentKeys, budgetReactor, codeSurface, compactionReactor, inferReactor, replyReactor, toolsReactorFor } from "@tardigrade/agent"
 import { realInfer } from "@tardigrade/model/model"
 import { createBunHost } from "@tardigrade/bun/host"
+import { otlpTelemetry } from "@tardigrade/bun/otlp"
 
 // The tool surface: code mode is the default. `nativeSurface` presents a fixed table of named
 // tools instead, for an agent measured against another harness's surface.
@@ -44,7 +45,13 @@ const wiring = () =>
     memoryTmp()
   )
 
-const host = await createBunHost({ path: "agents.sqlite", actorFor: () => agent, layersFor: wiring })
+// Spans go to any OTLP listener; absent one they cost nothing (docs/how-to/observe.md).
+const host = await createBunHost({
+  path: "agents.sqlite",
+  actorFor: () => agent,
+  layersFor: wiring,
+  telemetry: otlpTelemetry({ baseUrl: "http://localhost:4318", serviceName: "quickstart" })
+})
 await host.deliver("bun:main", { type: "MessageReceived", id: "m1", text: "What changed in the deploy?", at: Date.now() })
 await host.drive()
 ```

--- a/docs/how-to/observe.md
+++ b/docs/how-to/observe.md
@@ -24,7 +24,7 @@ Absent `telemetry`, every span is inert and costs nothing. Point a backend at th
 
 ## Traces in ClickHouse
 
-Jaeger reads one trace; questions across many take SQL. ClickHouse does not ingest OTLP itself: the OTel Collector fronts it, and the collector's `clickhouse` exporter writes the tables. Run `clickhouse server` and `otelcol-contrib --config=collector.yaml`, and point `otlpTelemetry` at the same 4318:
+Questions across many traces take SQL. ClickHouse does not ingest OTLP itself: the OTel Collector fronts it, and the collector's `clickhouse` exporter writes the tables. Run `clickhouse server` and `otelcol-contrib --config=collector.yaml`, and point `otlpTelemetry` at the same 4318:
 
 ```yaml
 # collector.yaml

--- a/docs/how-to/observe.md
+++ b/docs/how-to/observe.md
@@ -4,6 +4,12 @@ The log is the primary record: every call, park, and terminal is an event you ca
 
 ## Wire a tracer
 
+The one prerequisite is a listener that speaks OTLP over HTTP; the exporter ships in effect core, so there is nothing to install. For a local look, Jaeger is one container: spans arrive on port 4318, the UI reads on 16686.
+
+```bash
+docker run --rm -p 16686:16686 -p 4318:4318 jaegertracing/jaeger:2
+```
+
 `createBunHost` takes any tracer as a Layer through `telemetry`. The ready-made layer is `otlpTelemetry`, on the OTLP exporter effect v4 ships in core:
 
 ```ts

--- a/docs/how-to/observe.md
+++ b/docs/how-to/observe.md
@@ -24,7 +24,7 @@ Absent `telemetry`, every span is inert and costs nothing. Point a backend at th
 
 ## Traces in ClickHouse
 
-Questions across many traces take SQL. ClickHouse does not ingest OTLP itself: the OTel Collector fronts it, and the collector's `clickhouse` exporter writes the tables. Install both as single binaries: `brew install clickhouse`, and `otelcol-contrib` from the [collector releases](https://github.com/open-telemetry/opentelemetry-collector-releases/releases). Take the contrib distribution; the core one lacks the `clickhouse` exporter. Then run `clickhouse server` and `otelcol-contrib --config=collector.yaml`, and point `otlpTelemetry` at the same 4318:
+Questions across many traces take SQL. ClickHouse does not ingest OTLP itself: the OTel Collector fronts it, and the collector's `clickhouse` exporter writes the tables. Install both as single binaries: `brew install clickhouse`, and `otelcol-contrib` from the [collector releases](https://github.com/open-telemetry/opentelemetry-collector-releases/releases). Then run `clickhouse server` and `otelcol-contrib --config=collector.yaml`, and point `otlpTelemetry` at the same 4318:
 
 ```yaml
 # collector.yaml

--- a/docs/how-to/observe.md
+++ b/docs/how-to/observe.md
@@ -26,6 +26,33 @@ const host = await createBunHost({
 
 Absent `telemetry`, every span is inert and costs nothing. Point a backend at the stream and the span inventory enumerates itself (`transition.fire`, `deliver`, `llm.react`, `package.call`, `code.run`, with GenAI semantic-convention keys on the model span).
 
+## Traces in ClickHouse
+
+Jaeger reads one trace; questions across many take SQL. ClickHouse does not ingest OTLP itself: the OTel Collector fronts it, and the collector's `clickhouse` exporter writes the tables. Run `clickhouse server` and `otelcol-contrib --config=collector.yaml`, and point `otlpTelemetry` at the same 4318:
+
+```yaml
+# collector.yaml
+receivers:
+  otlp: { protocols: { http: { endpoint: 0.0.0.0:4318 } } }
+exporters:
+  clickhouse:
+    endpoint: tcp://localhost:9000
+    database: otel
+    create_schema: true
+service:
+  pipelines:
+    traces: { receivers: [otlp], exporters: [clickhouse] }
+```
+
+Every attribute is then one query away (`Duration` is nanoseconds; `SpanAttributes` is a Map):
+
+```sql
+SELECT SpanAttributes['key'] AS key, count() AS fires
+FROM otel.otel_traces
+WHERE SpanName = 'transition.fire' AND SpanAttributes['outcome'] = 'wedged'
+GROUP BY key
+```
+
 ## The one-trace contract
 
 One business event stays one trace across every lane it touches. The rule that holds it: every platform binding stamps the sending span's context onto each event it persists, as one `traceparent` string in W3C header form. An event that already carries one keeps it; the first stamp is the causal one. A binding that skips the stamp fragments every cross-lane trace, and nothing says why: the traces arrive orphaned.

--- a/docs/how-to/observe.md
+++ b/docs/how-to/observe.md
@@ -24,7 +24,7 @@ Absent `telemetry`, every span is inert and costs nothing. Point a backend at th
 
 ## Traces in ClickHouse
 
-Questions across many traces take SQL. ClickHouse does not ingest OTLP itself: the OTel Collector fronts it, and the collector's `clickhouse` exporter writes the tables. Run `clickhouse server` and `otelcol-contrib --config=collector.yaml`, and point `otlpTelemetry` at the same 4318:
+Questions across many traces take SQL. ClickHouse does not ingest OTLP itself: the OTel Collector fronts it, and the collector's `clickhouse` exporter writes the tables. Install both as single binaries: `brew install clickhouse`, and `otelcol-contrib` from the [collector releases](https://github.com/open-telemetry/opentelemetry-collector-releases/releases). Take the contrib distribution; the core one lacks the `clickhouse` exporter. Then run `clickhouse server` and `otelcol-contrib --config=collector.yaml`, and point `otlpTelemetry` at the same 4318:
 
 ```yaml
 # collector.yaml

--- a/docs/how-to/observe.md
+++ b/docs/how-to/observe.md
@@ -4,7 +4,7 @@ The log is the primary record: every call, park, and terminal is an event you ca
 
 ## Wire a tracer
 
-The one prerequisite is a listener that speaks OTLP over HTTP (Jaeger, an OTel Collector, a hosted backend); the exporter ships in effect core, so there is nothing to install.
+The one prerequisite is a listener that speaks OTLP over HTTP; the exporter ships in effect core, so there is nothing to install.
 
 `createBunHost` takes any tracer as a Layer through `telemetry`. The ready-made layer is `otlpTelemetry`, on the OTLP exporter effect v4 ships in core:
 

--- a/docs/how-to/observe.md
+++ b/docs/how-to/observe.md
@@ -4,11 +4,7 @@ The log is the primary record: every call, park, and terminal is an event you ca
 
 ## Wire a tracer
 
-The one prerequisite is a listener that speaks OTLP over HTTP; the exporter ships in effect core, so there is nothing to install. For a local look, Jaeger is one container: spans arrive on port 4318, the UI reads on 16686.
-
-```bash
-docker run --rm -p 16686:16686 -p 4318:4318 jaegertracing/jaeger:2
-```
+The one prerequisite is a listener that speaks OTLP over HTTP (Jaeger, an OTel Collector, a hosted backend); the exporter ships in effect core, so there is nothing to install.
 
 `createBunHost` takes any tracer as a Layer through `telemetry`. The ready-made layer is `otlpTelemetry`, on the OTLP exporter effect v4 ships in core:
 

--- a/docs/how-to/observe.md
+++ b/docs/how-to/observe.md
@@ -4,27 +4,40 @@ The log is the primary record: every call, park, and terminal is an event you ca
 
 ## Wire a tracer
 
-The one prerequisite is a listener that speaks OTLP over HTTP; the exporter ships in effect core, so there is nothing to install.
-
-`createBunHost` takes any tracer as a Layer through `telemetry`. The ready-made layer is `otlpTelemetry`, on the OTLP exporter effect v4 ships in core:
+`createBunHost` takes any tracer as a Layer through `telemetry`. Two ready-made layers cover the usual cases: `fileTelemetry` writes spans to a local file with no infrastructure at all, and `otlpTelemetry` (on the OTLP exporter effect v4 ships in core) exports to any listener that speaks OTLP over HTTP:
 
 ```ts
 import { createBunHost } from "@tardigrade/bun/host"
+import { fileTelemetry } from "@tardigrade/bun/file"
 import { otlpTelemetry } from "@tardigrade/bun/otlp"
 
 const host = await createBunHost({
   path: "agents.sqlite",
   actorFor,
   layersFor,
-  telemetry: otlpTelemetry({ baseUrl: "http://localhost:4318", serviceName: "my-agent" })
+  telemetry: fileTelemetry("spans.ndjson")
+  // telemetry: otlpTelemetry({ baseUrl: "http://localhost:4318", serviceName: "my-agent" })
 })
 ```
 
 Absent `telemetry`, every span is inert and costs nothing. Point a backend at the stream and the span inventory enumerates itself (`transition.fire`, `deliver`, `llm.react`, `package.call`, `code.run`, with GenAI semantic-convention keys on the model span).
 
+## Query the file
+
+`fileTelemetry` appends one flat row per finished span, and the ClickHouse binary (`brew install clickhouse`) queries the file in place with full SQL, no server. Declare the schema to read `SpanAttributes` as a Map (`Duration` is nanoseconds):
+
+```sql
+SELECT SpanName, SpanAttributes['outcome'] AS outcome, Duration / 1e6 AS ms
+FROM file('spans.ndjson', JSONEachRow,
+  'Timestamp String, SpanName String, Duration UInt64, SpanAttributes Map(String, String)')
+ORDER BY Timestamp
+```
+
+The file grows while the agent runs, and the same file feeds DuckDB, grep, or a later bulk insert into a real deployment.
+
 ## Traces in ClickHouse
 
-Questions across many traces take SQL. ClickHouse does not ingest OTLP itself: the OTel Collector fronts it, and the collector's `clickhouse` exporter writes the tables. Install both as single binaries: `brew install clickhouse`, and `otelcol-contrib` from the [collector releases](https://github.com/open-telemetry/opentelemetry-collector-releases/releases). Then run `clickhouse server` and `otelcol-contrib --config=collector.yaml`, and point `otlpTelemetry` at the same 4318:
+For a running deployment, `otlpTelemetry` feeds the standard pipeline: the OTel Collector fronts a ClickHouse server, and the collector's `clickhouse` exporter writes the tables. Install both as single binaries: `brew install clickhouse`, and `otelcol-contrib` from the [collector releases](https://github.com/open-telemetry/opentelemetry-collector-releases/releases). Then run `clickhouse server` and `otelcol-contrib --config=collector.yaml`, and point `otlpTelemetry` at the same 4318:
 
 ```yaml
 # collector.yaml


### PR DESCRIPTION
The quickstart assumed setup it never stated and pointed at no way to see a run. It now carries the whole trace path: the snippet writes spans to a file, and one query reads them, with no server and no collector. Merge #63 first; the quickstart imports `@tardigrade/bun/file` from it.

- README: a prerequisites line (bun 1.1 or later, a model endpoint) ahead of the snippet
- README: the snippet wires `telemetry: fileTelemetry("spans.ndjson")`, and a `clickhouse local` query with the declared Map schema reads the file in place
- observe.md: both ready-made layers at the seam (`fileTelemetry` for the local file, `otlpTelemetry` for OTLP backends), a Query the file section, and the collector-fronted ClickHouse server pipeline kept as the deployment path
- README docs list gains the observe how-to
- docs gate green; the file path verified live (a bun host wrote the file, `clickhouse local` answered outcome and link)