### PR TITLE
feat(bun): file telemetry layer

### DIFF
--- a/platform/bun/src/file.ts
+++ b/platform/bun/src/file.ts
@@ -1,0 +1,45 @@
+import { appendFileSync } from "node:fs"
+import { Layer, Option, Tracer } from "effect"
+import type { Exit } from "effect"
+
+// fileTelemetry is the zero-infrastructure occupant of the telemetry seam: one flat NDJSON row
+// per finished span, appended to `path`. The file is live while the agent runs and needs no
+// listener; `clickhouse local` queries it in place with the same column names a collector's
+// otel_traces table uses, so queries transfer between the two
+// (host.test.ts, "fileTelemetry lands queryable rows").
+//
+//   clickhouse local -q "SELECT SpanName, SpanAttributes['outcome'] FROM file('spans.ndjson',
+//     JSONEachRow, 'SpanName String, SpanAttributes Map(String, String)')"
+
+class FileSpan extends Tracer.NativeSpan {
+  readonly #path: string
+
+  constructor(options: ConstructorParameters<typeof Tracer.NativeSpan>[0], path: string) {
+    super(options)
+    this.#path = path
+  }
+
+  override end(endTime: bigint, exit: Exit.Exit<unknown, unknown>): void {
+    super.end(endTime, exit)
+    const attributes: Record<string, string> = {}
+    for (const [key, value] of this.attributes) attributes[key] = String(value)
+    appendFileSync(
+      this.#path,
+      JSON.stringify({
+        Timestamp: new Date(Number(this.startTime / 1_000_000n)).toISOString(),
+        TraceId: this.traceId,
+        SpanId: this.spanId,
+        ParentSpanId: Option.getOrUndefined(this.parent)?.spanId ?? "",
+        SpanName: this.name,
+        SpanKind: this.kind,
+        Duration: Number(endTime - this.startTime),
+        StatusCode: exit._tag === "Success" ? "Ok" : "Error",
+        SpanAttributes: attributes,
+        Links: this.links.map((l) => ({ TraceId: l.span.traceId, SpanId: l.span.spanId }))
+      }) + "\n"
+    )
+  }
+}
+
+export const fileTelemetry = (path: string): Layer.Layer<never> =>
+  Layer.succeed(Tracer.Tracer)(Tracer.make({ span: (options) => new FileSpan(options, path) }))

--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { mkdtempSync } from "node:fs"
+import { mkdtempSync, readFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { Effect, Layer, Tracer } from "effect"
@@ -7,6 +7,7 @@ import type { Event } from "@tardigrade/core/event"
 import { transition, type Actor, type Reactor } from "@tardigrade/core/actor"
 
 import { createBunHost, type BunHostOptions } from "./host"
+import { fileTelemetry } from "./file"
 
 // The bun binding against the reference host's contract, plus the two behaviors only physics
 // can show: a reopened database keeps the log, and recover() settles work a death interrupted.
@@ -146,5 +147,24 @@ describe("telemetry seam", () => {
     expect(row.traceparent).toMatch(/^00-t-s-01$/)
     expect(linked.some((l) => l.name === "transition.fire" && l.traceId === "t")).toBe(true)
     await h.close()
+  })
+
+  test("fileTelemetry lands queryable rows: the fire carries its outcome and links to the deliver", async () => {
+    const path = join(dir, `spans-${n++}.ndjson`)
+    const h = await createBunHost({ ...options(freshPath()), telemetry: fileTelemetry(path) })
+    await h.deliver("bun:echo", { type: "MessageReceived", id: "m1", text: "go", at: 1 } as Event)
+    await h.drive()
+    await h.close()
+    const rows = readFileSync(path, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { SpanName: string; TraceId: string; Duration: number; StatusCode: string; SpanAttributes: Record<string, string>; Links: Array<{ TraceId: string }> })
+    const delivered = rows.find((r) => r.SpanName === "deliver")
+    const fired = rows.find((r) => r.SpanName === "transition.fire")
+    expect(delivered?.SpanAttributes["type"]).toBe("MessageReceived")
+    expect(fired?.SpanAttributes["outcome"]).toBe("committed")
+    expect(fired?.StatusCode).toBe("Ok")
+    expect(fired?.Duration).toBeGreaterThan(0)
+    expect(fired?.Links[0]?.TraceId).toBe(delivered?.TraceId)
   })
 })


### PR DESCRIPTION
Local observability today takes a collector and a ClickHouse server before the first span is visible. This adds the zero-infrastructure occupant of the telemetry seam: `fileTelemetry(path)` appends one flat NDJSON row per finished span, and `clickhouse local` queries the file in place with full SQL, no listener and no server.

- `fileTelemetry` in platform/bun/src/file.ts: a NativeSpan subclass whose `end` appends the row, so ids, parent-trace inheritance, and attributes stay effect's own
- row columns mirror a collector's otel_traces (SpanName, Duration, SpanAttributes as a map, Links), so queries transfer to a real deployment unchanged
- `otlpTelemetry` stays the door to real backends; the seam still takes any tracer
- new host test: the fire row carries outcome=committed, StatusCode Ok, and a link to the deliver's trace; full gate green
- verified live: a bun host wrote /tmp spans and `clickhouse local` answered outcome and link with no process running