### PR TITLE
feat(code): default seam services

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,12 @@ Prerequisites: bun 1.1 or later, and a model endpoint.
 An agent is reactors over one log.
 
 ```ts
-import { Effect, Layer } from "effect"
 import { actor } from "@tardigrade/core/actor"
 import { composeKeys } from "@tardigrade/core/event-log"
 import { messageKeys } from "@tardigrade/core/message"
 import { codeReactor, codeKeys } from "@tardigrade/code"
-import { jsSandbox, memoryTmp } from "@tardigrade/code/defaults"
-import { Packages } from "@tardigrade/code/packages"
 import { agentKeys, budgetReactor, codeSurface, compactionReactor, inferReactor, replyReactor, toolsReactorFor } from "@tardigrade/agent"
-import { realInfer } from "@tardigrade/model/model"
+import { infer } from "@tardigrade/model/model"
 import { createBunHost } from "@tardigrade/bun/host"
 import { fileTelemetry } from "@tardigrade/bun/file"
 
@@ -35,21 +32,13 @@ const agent = actor(
   composeKeys(messageKeys, codeKeys, agentKeys)
 )
 
-// The wiring: a real model through platform/model, a sandbox for the agent's code, your packages.
-// The binding renders the same surface the actor serves.
-const wiring = () =>
-  Layer.mergeAll(
-    realInfer({ baseUrl: process.env.MODEL_BASE_URL!, apiKey: process.env.MODEL_API_KEY!, model: process.env.MODEL_ID!, provider: "bedrock", surface, maxOutputTokens: 64_000 }),
-    Layer.succeed(Packages, { resolve: () => undefined, list: () => Effect.succeed([]) }),
-    jsSandbox,
-    memoryTmp()
-  )
-
-// One NDJSON row per span (docs/how-to/observe.md); `otlpTelemetry` reaches real backends.
+// The model is the one seam with no default: sandbox, tmp, and packages (an empty registry)
+// bind themselves until a layer overrides them. The binding renders the same surface the
+// actor serves. Telemetry is one NDJSON row per span (docs/how-to/observe.md).
 const host = await createBunHost({
   path: "agents.sqlite",
   actorFor: () => agent,
-  layersFor: wiring,
+  layersFor: () => infer({ baseUrl: process.env.MODEL_BASE_URL!, apiKey: process.env.MODEL_API_KEY!, model: process.env.MODEL_ID!, provider: "bedrock", surface, maxOutputTokens: 64_000 }),
   telemetry: fileTelemetry("spans.ndjson")
 })
 await host.deliver("bun:main", { type: "MessageReceived", id: "m1", text: "What changed in the deploy?", at: Date.now() })

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ import { fileTelemetry } from "@tardigrade/bun/file"
 
 // The tool surface: code mode is the default. `nativeSurface` presents a fixed table of named
 // tools instead, for an agent measured against another harness's surface.
-const surface = codeSurface("none")
+const surface = codeSurface()
 
 // Adding a capability is adding a reactor to the list.
 const agent = actor(
@@ -33,12 +33,13 @@ const agent = actor(
 )
 
 // The model is the one seam with no default: sandbox, tmp, and packages (an empty registry)
-// bind themselves until a layer overrides them. The binding renders the same surface the
-// actor serves. Telemetry is one NDJSON row per span (docs/how-to/observe.md).
+// bind themselves until a layer overrides them. The binding also defaults to the code surface;
+// a changed surface goes to both the actor and `infer`, so the model is offered the tools the
+// reactors serve. Telemetry is one NDJSON row per span (docs/how-to/observe.md).
 const host = await createBunHost({
   path: "agents.sqlite",
   actorFor: () => agent,
-  layersFor: () => infer({ baseUrl: process.env.MODEL_BASE_URL!, apiKey: process.env.MODEL_API_KEY!, model: process.env.MODEL_ID!, provider: "bedrock", surface, maxOutputTokens: 64_000 }),
+  layersFor: () => infer({ baseUrl: process.env.MODEL_BASE_URL!, apiKey: process.env.MODEL_API_KEY!, model: process.env.MODEL_ID!, provider: "bedrock" }),
   telemetry: fileTelemetry("spans.ndjson")
 })
 await host.deliver("bun:main", { type: "MessageReceived", id: "m1", text: "What changed in the deploy?", at: Date.now() })

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -49,7 +49,7 @@ export interface CreateAgentOptions {
   // settles on the first drive (index.test.ts, "an agent initialises from a log").
   readonly log?: ReadonlyArray<Event>
   // The tool surface, code mode by default. The same surface must reach the model binding, so a
-  // caller passing one here passes it to `realInfer` too (surface.ts).
+  // caller passing one here passes it to `infer` too (surface.ts).
   readonly surface?: ToolSurface<RlmR>
 }
 

--- a/packages/agent/src/surface.ts
+++ b/packages/agent/src/surface.ts
@@ -2,13 +2,10 @@ import { Clock, Effect } from "effect"
 import { transition, type Transition } from "@tardigrade/core/actor"
 import type { Event } from "@tardigrade/core/event"
 import { codeDispatched } from "@tardigrade/code/events"
-import type { Packages } from "@tardigrade/code/packages"
-import type { Sandbox } from "@tardigrade/code/sandbox"
-import type { Tmp } from "@tardigrade/code/tmp"
 import { toolReturned } from "./events"
 import type { ToolSpec } from "./request"
 
-export type CodeLaneR = Packages | Sandbox | Tmp
+export type CodeLaneR = never
 
 // A ToolSurface is the agent's work half: the tools the model may call, the system text that
 // explains them, and how one call becomes events. The turn loop, the budget wall, the answer

--- a/packages/agent/src/turn.ts
+++ b/packages/agent/src/turn.ts
@@ -6,9 +6,6 @@ import { messageKeys } from "@tardigrade/core/message"
 import { codeKeys } from "@tardigrade/code/events"
 import { agentKeys } from "./events"
 import { codeReactor } from "@tardigrade/code/execute"
-import type { Tmp } from "@tardigrade/code/tmp"
-import type { Packages } from "@tardigrade/code/packages"
-import type { Sandbox } from "@tardigrade/code/sandbox"
 import type { Router } from "@tardigrade/core/router"
 import type { Self } from "@tardigrade/core/actor"
 import { Infer, inferReactor } from "./infer"
@@ -23,7 +20,7 @@ export { Infer } from "./infer"
 // AgentR is the mind: Infer for the model, EventLog for settle, Router and Self for reply.
 // Budget, code, and compaction join at the RLM assembly (rlmAgentFor).
 export type AgentR = Infer | EventLog | Router | Self
-export type RlmR = AgentR | Packages | Sandbox | Tmp
+export type RlmR = AgentR
 
 // agentActorKeys is the mind's key table: its alphabet and the canonical inbound.
 export const agentActorKeys = composeKeys(messageKeys, agentKeys)

--- a/packages/code/src/defaults.ts
+++ b/packages/code/src/defaults.ts
@@ -1,104 +1,13 @@
-import { Effect, Layer } from "effect"
-import { Sandbox, type Ambient, type Bindings } from "./sandbox"
-import { Tmp } from "./tmp"
+import { Layer } from "effect"
+import { jsSandboxService, Sandbox } from "./sandbox"
+import { memoryTmpService, Tmp } from "./tmp"
 
-// The code lane's default seam bindings: a plain async-function sandbox
-// and a memory tmp store. The platform binds isolates and durable
-// storage instead; tests and the memory host bind these.
+// The code lane's explicit seam bindings. Both services default to these implementations
+// (Sandbox and Tmp are References), so a caller only provides a layer to override, or to get a
+// tmp store that is fresh rather than the process-shared default.
 
-const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as new (
-  ...args: ReadonlyArray<string>
-) => (...bindings: ReadonlyArray<unknown>) => Promise<unknown>
+export { LOG_CAP_BYTES } from "./sandbox"
 
-// consoleShim captures a body's console output into `lines`, capped in bytes so a print loop
-// stays harmless. Past the cap, lines drop silently: prints are telemetry, never control flow.
-export const LOG_CAP_BYTES = 8192
-const consoleShim = (lines: string[]) => {
-  let bytes = 0
-  const push = (args: ReadonlyArray<unknown>) => {
-    if (bytes >= LOG_CAP_BYTES) return
-    const line = args.map(String).join(" ")
-    lines.push(line)
-    bytes += line.length
-  }
-  return {
-    log: (...args: unknown[]) => push(args),
-    warn: (...args: unknown[]) => push(args),
-    error: (...args: unknown[]) => push(args),
-    info: (...args: unknown[]) => push(args),
-    debug: (...args: unknown[]) => push(args)
-  }
-}
+export const jsSandbox: Layer.Layer<never> = Layer.succeed(Sandbox)(jsSandboxService)
 
-// seededRandom is mulberry32 over an fnv-1a hash of the seed string: the
-// same seed answers the same stream, which is the whole point.
-const seededRandom = (seed: string): (() => number) => {
-  let h = 0x811c9dc5
-  for (let i = 0; i < seed.length; i++) {
-    h ^= seed.charCodeAt(i)
-    h = Math.imul(h, 0x01000193)
-  }
-  let state = h >>> 0
-  return () => {
-    state = (state + 0x6d2b79f5) >>> 0
-    let t = state
-    t = Math.imul(t ^ (t >>> 15), t | 1)
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
-  }
-}
-
-// ambientShims pins the body's clock and randomness to the execution's
-// recorded ambient: Date.now and the no-argument Date constructor answer
-// the dispatch instant, Math.random walks a seeded stream. Identical on
-// every attempt by construction (packages/code/src/sandbox.ts, Ambient;
-// the shims are bindings, so they shadow the globals inside the body).
-const ambientShims = (ambient: Ambient): Record<string, unknown> => {
-  const PinnedDate = class extends Date {
-    constructor(...args: ReadonlyArray<unknown>) {
-      if (args.length === 0) super(ambient.at)
-      else super(...(args as ConstructorParameters<typeof Date>))
-    }
-    static override now(): number {
-      return ambient.at
-    }
-  }
-  const random = seededRandom(ambient.seed)
-  const PinnedMath = Object.create(Math, { random: { value: random } }) as Math
-  return { Date: PinnedDate, Math: PinnedMath }
-}
-
-// jsSandbox runs the body as a plain async function. The body must stay
-// deterministic between package calls (packages/code/src/sandbox.ts);
-// nothing here enforces it. `console` is shadowed by a capturing shim
-// (printed lines come back on the result's `logs`), and with an ambient,
-// Date and Math are shadowed by replay-stable pins.
-export const jsSandbox: Layer.Layer<Sandbox> = Layer.succeed(Sandbox, {
-  run: (code: string, bindings: Bindings, ambient?: Ambient) =>
-    Effect.promise(async () => {
-      const lines: string[] = []
-      const logs = () => (lines.length === 0 ? {} : { logs: lines })
-      const scope: Bindings = {
-        ...bindings,
-        console: consoleShim(lines),
-        ...(ambient === undefined ? {} : ambientShims(ambient))
-      }
-      try {
-        const names = Object.keys(scope)
-        const body = new AsyncFunction(...names, code)
-        return { result: await body(...names.map((name) => scope[name])), ...logs() }
-      } catch (e) {
-        return { error: String(e), ...logs() }
-      }
-    })
-})
-
-// memoryTmp holds spilled values in a Map: replay hydrates from it for
-// the life of the process.
-export const memoryTmp = (): Layer.Layer<Tmp> => {
-  const store = new Map<string, string>()
-  return Layer.succeed(Tmp, {
-    store: (ref: string, json: string) => Effect.sync(() => void store.set(ref, json)),
-    load: (ref: string) => Effect.sync(() => store.get(ref))
-  })
-}
+export const memoryTmp = (): Layer.Layer<never> => Layer.succeed(Tmp)(memoryTmpService())

--- a/packages/code/src/execute.ts
+++ b/packages/code/src/execute.ts
@@ -36,7 +36,7 @@ const executeRecorded = (
   code: string,
   turn?: string,
   dispatchedAt?: number
-): Effect.Effect<ReadonlyArray<Event>, never, EventLog | Packages | Sandbox | Tmp> =>
+): Effect.Effect<ReadonlyArray<Event>, never, EventLog> =>
   Effect.gen(function* () {
     const stamp = turn === undefined ? {} : { turn }
     const log = yield* EventLog
@@ -46,7 +46,7 @@ const executeRecorded = (
     const shadow = (turnHead(events) as { shadow?: unknown } | undefined)?.shadow === true
     const packages = yield* Packages
     const sandbox = yield* Sandbox
-    const context = yield* Effect.context<Tmp>()
+    const context = yield* Effect.context<never>()
     let n = 0
     // Park bookkeeping. inFlight counts proxy calls from synchronous invoke to committed pair
     // or park; parkGate completes when every open call settled or parked and at least one
@@ -263,7 +263,7 @@ const executeRecorded = (
 // a blocked head (open BlockedOn calls, no awaited reply home) derives nothing, so the lane
 // rests honestly and a landing reply re-derives it. An attempt that parks mid-act returns
 // BlockedOn evidence instead of the settle; the reconciler reads that as blocked, never wedged.
-export const codeReactor: Reactor<Packages | Sandbox | Tmp> = (events) => {
+export const codeReactor: Reactor = (events) => {
   const owed = workOwed(events)
   if (owed === undefined) return []
   const dispatch = events.find(
@@ -272,7 +272,7 @@ export const codeReactor: Reactor<Packages | Sandbox | Tmp> = (events) => {
   if (dispatch === undefined) return []
   const d = dispatch as { code?: unknown; at?: unknown }
   return [
-    transition({
+    transition<{ execId: string; code: string; turn: string | undefined; at: number | undefined }, never>({
       key: `cs:${owed.execId}`,
       input: {
         execId: owed.execId,

--- a/packages/code/src/packages.ts
+++ b/packages/code/src/packages.ts
@@ -144,11 +144,13 @@ export interface Package {
 
 // Packages is the registry seam. Which packages exist here is capability scoping: a task that
 // must never send messages is bound to a registry that holds no sending package, and the code
-// cannot name what the registry does not hold.
-export class Packages extends Context.Service<
-  Packages,
-  {
-    readonly resolve: (name: string) => Package | undefined
-    readonly list: () => Effect.Effect<ReadonlyArray<{ readonly name: string; readonly description: string }>>
-  }
->()("code/Packages") {}
+// cannot name what the registry does not hold. The default registry holds nothing, so the
+// unwired case is the powerless one.
+export interface PackagesService {
+  readonly resolve: (name: string) => Package | undefined
+  readonly list: () => Effect.Effect<ReadonlyArray<{ readonly name: string; readonly description: string }>>
+}
+
+export const Packages: Context.Reference<PackagesService> = Context.Reference("code/Packages", {
+  defaultValue: (): PackagesService => ({ resolve: () => undefined, list: () => Effect.succeed([]) })
+})

--- a/packages/code/src/sandbox.ts
+++ b/packages/code/src/sandbox.ts
@@ -33,9 +33,96 @@ export interface Ambient {
 // call. The clock and the random source are ambient-shimmed rather than banned (a model's
 // priors reach for both): Date.now, the no-argument Date constructor, and Math.random answer
 // from `ambient`, identically on every attempt.
-export class Sandbox extends Context.Service<
-  Sandbox,
-  {
-    readonly run: (code: string, bindings: Bindings, ambient?: Ambient) => Effect.Effect<SandboxResult>
+export interface SandboxService {
+  readonly run: (code: string, bindings: Bindings, ambient?: Ambient) => Effect.Effect<SandboxResult>
+}
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as new (
+  ...args: ReadonlyArray<string>
+) => (...bindings: ReadonlyArray<unknown>) => Promise<unknown>
+
+// consoleShim captures a body's console output into `lines`, capped in bytes so a print loop
+// stays harmless. Past the cap, lines drop silently: prints are telemetry, never control flow.
+export const LOG_CAP_BYTES = 8192
+const consoleShim = (lines: string[]) => {
+  let bytes = 0
+  const push = (args: ReadonlyArray<unknown>) => {
+    if (bytes >= LOG_CAP_BYTES) return
+    const line = args.map(String).join(" ")
+    lines.push(line)
+    bytes += line.length
   }
->()("code/Sandbox") {}
+  return {
+    log: (...args: unknown[]) => push(args),
+    warn: (...args: unknown[]) => push(args),
+    error: (...args: unknown[]) => push(args),
+    info: (...args: unknown[]) => push(args),
+    debug: (...args: unknown[]) => push(args)
+  }
+}
+
+// seededRandom is mulberry32 over an fnv-1a hash of the seed string: the
+// same seed answers the same stream, which is the whole point.
+const seededRandom = (seed: string): (() => number) => {
+  let h = 0x811c9dc5
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  let state = h >>> 0
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0
+    let t = state
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+// ambientShims pins the body's clock and randomness to the execution's
+// recorded ambient: Date.now and the no-argument Date constructor answer
+// the dispatch instant, Math.random walks a seeded stream. Identical on
+// every attempt by construction (Ambient above; the shims are bindings,
+// so they shadow the globals inside the body).
+const ambientShims = (ambient: Ambient): Record<string, unknown> => {
+  const PinnedDate = class extends Date {
+    constructor(...args: ReadonlyArray<unknown>) {
+      if (args.length === 0) super(ambient.at)
+      else super(...(args as ConstructorParameters<typeof Date>))
+    }
+    static override now(): number {
+      return ambient.at
+    }
+  }
+  const random = seededRandom(ambient.seed)
+  const PinnedMath = Object.create(Math, { random: { value: random } }) as Math
+  return { Date: PinnedDate, Math: PinnedMath }
+}
+
+// jsSandboxService runs the body as a plain async function. The body must stay deterministic
+// between package calls (the contract above); nothing here enforces it. `console` is shadowed
+// by a capturing shim (printed lines come back on the result's `logs`), and with an ambient,
+// Date and Math are shadowed by replay-stable pins.
+export const jsSandboxService: SandboxService = {
+  run: (code: string, bindings: Bindings, ambient?: Ambient) =>
+    Effect.promise(async () => {
+      const lines: string[] = []
+      const logs = () => (lines.length === 0 ? {} : { logs: lines })
+      const scope: Bindings = {
+        ...bindings,
+        console: consoleShim(lines),
+        ...(ambient === undefined ? {} : ambientShims(ambient))
+      }
+      try {
+        const names = Object.keys(scope)
+        const body = new AsyncFunction(...names, code)
+        return { result: await body(...names.map((name) => scope[name])), ...logs() }
+      } catch (e) {
+        return { error: String(e), ...logs() }
+      }
+    })
+}
+
+export const Sandbox: Context.Reference<SandboxService> = Context.Reference("code/Sandbox", {
+  defaultValue: () => jsSandboxService
+})

--- a/packages/code/src/tmp.ts
+++ b/packages/code/src/tmp.ts
@@ -4,13 +4,25 @@ import { Context, Effect } from "effect"
 // `tmp` table, keyed by ref, and every truncation carries a pointer with a CTA. The event keeps
 // a preview and the ref; replay hydrates the ref from the same durable storage, so recorded
 // pairs stay whole. Agents reach the full value through workspace.sql.
-export class Tmp extends Context.Service<
-  Tmp,
-  {
-    readonly store: (ref: string, json: string) => Effect.Effect<void>
-    readonly load: (ref: string) => Effect.Effect<string | undefined>
+export interface TmpService {
+  readonly store: (ref: string, json: string) => Effect.Effect<void>
+  readonly load: (ref: string) => Effect.Effect<string | undefined>
+}
+
+// memoryTmpService holds spilled values in a Map: replay hydrates from it for the life of the
+// process. Each call is a fresh store; the Reference default below is one shared store, so two
+// hosts in one process share it (refs are unique, so rows never collide).
+export const memoryTmpService = (): TmpService => {
+  const store = new Map<string, string>()
+  return {
+    store: (ref: string, json: string) => Effect.sync(() => void store.set(ref, json)),
+    load: (ref: string) => Effect.sync(() => store.get(ref))
   }
->()("code/Tmp") {}
+}
+
+export const Tmp: Context.Reference<TmpService> = Context.Reference("code/Tmp", {
+  defaultValue: memoryTmpService
+})
 
 // TMP_BYTES is the bound: a larger value goes to tmp and the event keeps a pointer.
 export const TMP_BYTES = 8_192

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { codeSurface } from "@tardigrade/agent/surface"
 import { Infer } from "@tardigrade/agent/infer"
-import { actionOf, ladderOf, modelAskOf, modelIdOf, realInfer, retryAfterMsOf, throttleDelayMs } from "./model"
+import { actionOf, ladderOf, modelAskOf, modelIdOf, infer, retryAfterMsOf, throttleDelayMs } from "./model"
 import type { Action } from "@tardigrade/agent/events"
 
 // The model binding: the trajectory renders into the provider conversation, the streamed reply
@@ -76,7 +76,7 @@ const sse = (events: ReadonlyArray<unknown>): Response => {
   return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } })
 }
 
-describe("realInfer end to end", () => {
+describe("infer end to end", () => {
   test("a streamed tool call becomes a call action", async () => {
     let requested: { url: string; body: unknown } | null = null
     const fetchImpl = (async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
@@ -100,7 +100,7 @@ describe("realInfer end to end", () => {
         { id: "r1", choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] }
       ])
     }) as typeof globalThis.fetch
-    const layer = realInfer({
+    const layer = infer({
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "test-model",
@@ -126,7 +126,7 @@ describe("realInfer end to end", () => {
         { id: "r2", choices: [{ index: 0, delta: { content: "is 4" } }] },
         { id: "r2", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }
       ])) as unknown as typeof globalThis.fetch
-    const layer = realInfer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "test-model", surface: codeSurface(), fetch: fetchImpl })
+    const layer = infer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "test-model", surface: codeSurface(), fetch: fetchImpl })
     const action = await Effect.runPromise(
       Effect.flatMap(Infer, (model) => model.react([{ type: "MessageReceived", id: "m1", text: "2+2?", at: 1 }])).pipe(
         Effect.provide(layer)
@@ -145,7 +145,7 @@ describe("realInfer end to end", () => {
         { id: "r3", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }
       ])
     }) as typeof globalThis.fetch
-    const layer = realInfer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "test-model", surface: codeSurface(), fetch: fetchImpl })
+    const layer = infer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "test-model", surface: codeSurface(), fetch: fetchImpl })
     const trajectory = [{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]
     await Effect.runPromise(
       Effect.flatMap(Infer, (model) => model.react(trajectory, "m1/infer/0")).pipe(Effect.provide(layer)) as Effect.Effect<unknown>
@@ -159,7 +159,7 @@ describe("realInfer end to end", () => {
 
 const usageChunk = (usage: Record<string, unknown>) => ({ id: "u", choices: [], usage })
 
-describe("realInfer: cost provenance", () => {
+describe("infer: cost provenance", () => {
   const okText = [
     { id: "r", choices: [{ index: 0, delta: { role: "assistant", content: "ok" } }] },
     { id: "r", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }
@@ -170,7 +170,7 @@ describe("realInfer: cost provenance", () => {
     const billed = await Effect.runPromise(
       Effect.flatMap(Infer, (model) => model.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
         Effect.provide(
-          realInfer({
+          infer({
             baseUrl: "https://model.test/v1",
             apiKey: "k",
             model: "test-model",
@@ -198,7 +198,7 @@ describe("realInfer: cost provenance", () => {
     const filled = await Effect.runPromise(
       Effect.flatMap(Infer, (model) => model.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
         Effect.provide(
-          realInfer({
+          infer({
             baseUrl: "https://model.test/v1",
             apiKey: "k",
             model: "test-model",
@@ -222,7 +222,7 @@ describe("realInfer: cost provenance", () => {
     const unknown = await Effect.runPromise(
       Effect.flatMap(Infer, (model) => model.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
         Effect.provide(
-          realInfer({
+          infer({
             baseUrl: "https://model.test/v1",
             apiKey: "k",
             model: "test-model",
@@ -240,7 +240,7 @@ describe("realInfer: cost provenance", () => {
 // give-up fold in src/agent/infer.ts only ever counts a died attempt when the retries themselves
 // are exhausted. `sleep` is the test seam that swaps the real backoff wait for an instant one, so
 // these run in milliseconds instead of tens of seconds.
-describe("realInfer: throttle-shaped retry", () => {
+describe("infer: throttle-shaped retry", () => {
   const okStream = () =>
     sse([
       { id: "r1", choices: [{ index: 0, delta: { role: "assistant", content: "ok" } }] },
@@ -254,7 +254,7 @@ describe("realInfer: throttle-shaped retry", () => {
       return calls === 1 ? new Response(JSON.stringify({ error: { message: "rate limited" } }), { status: 429 }) : okStream()
     }) as unknown as typeof globalThis.fetch
     const slept: Array<number> = []
-    const layer = realInfer({
+    const layer = infer({
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "test-model",
@@ -284,7 +284,7 @@ describe("realInfer: throttle-shaped retry", () => {
       return new Response(JSON.stringify({ error: { message: "upstream trouble" } }), { status: 503 })
     }) as unknown as typeof globalThis.fetch
     const slept: Array<number> = []
-    const layer = realInfer({
+    const layer = infer({
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "test-model",
@@ -314,7 +314,7 @@ describe("realInfer: throttle-shaped retry", () => {
       return new Response(JSON.stringify({ error: { message: "bad request" } }), { status: 400 })
     }) as unknown as typeof globalThis.fetch
     const slept: Array<number> = []
-    const layer = realInfer({
+    const layer = infer({
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "test-model",
@@ -427,7 +427,7 @@ describe("truncation", () => {
       keys.push(request.headers.get("Idempotency-Key"))
       return calls++ === 0 ? cut("half an ans") : whole("the whole answer")
     }) as unknown as typeof fetch
-    const layer = realInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", surface: codeSurface(), fetch: fetchImpl as never })
+    const layer = infer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", surface: codeSurface(), fetch: fetchImpl as never })
     const action = await Effect.runPromise(
       Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }], "t1/infer/0")).pipe(
         Effect.provide(layer)
@@ -449,7 +449,7 @@ describe("truncation", () => {
       calls++ === 0
         ? cut("half an ans", { prompt_tokens: 10, completion_tokens: 32768, cost: 5 })
         : whole("the whole answer", { prompt_tokens: 10, completion_tokens: 4, cost: 1 })) as unknown as typeof fetch
-    const layer = realInfer({
+    const layer = infer({
       provider: "openai",
       model: "m",
       baseUrl: "https://x",
@@ -472,7 +472,7 @@ describe("truncation", () => {
 
   test("the top rung still truncating fails the turn loudly, never half an answer", async () => {
     const fetchImpl = (async () => cut("half")) as unknown as typeof fetch
-    const layer = realInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", surface: codeSurface(), fetch: fetchImpl as never })
+    const layer = infer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", surface: codeSurface(), fetch: fetchImpl as never })
     const action = await Effect.runPromise(
       Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
         Effect.provide(layer)
@@ -499,7 +499,7 @@ describe("truncation", () => {
           }),
           { status: 200, headers: { "content-type": "text/event-stream" } }
         )) as unknown as typeof fetch
-      const layer = realInfer({
+      const layer = infer({
         provider: "openai",
         model: "m",
         baseUrl: "https://x",
@@ -543,7 +543,7 @@ describe("declared limits", () => {
         headers: { "content-type": "text/event-stream" }
       })
     }) as unknown as typeof fetch
-    const layer = realInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", surface: codeSurface(), maxOutputTokens: 16_384, fetch: fetchImpl as never })
+    const layer = infer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", surface: codeSurface(), maxOutputTokens: 16_384, fetch: fetchImpl as never })
     await Effect.runPromise(
       Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(Effect.provide(layer)) as Effect.Effect<unknown>
     )

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -330,7 +330,7 @@ const bedrockAdapter = (config: ModelConfig, maxTokens: number) => {
       endpoint: string | undefined
     ) {
       // maxAttempts: 1 turns off the AWS SDK's own retry (it counts the first try as attempt
-      // one), so a throttle-shaped failure surfaces to `realInfer`'s own retry loop instead of
+      // one), so a throttle-shaped failure surfaces to `infer`'s own retry loop instead of
       // being retried twice, once inside the SDK on its own schedule and once outside on ours.
       return { ...super.buildClientConfig(resolved, resolvedRegion, endpoint), requestHandler: handler, maxAttempts: 1 }
     }
@@ -467,7 +467,7 @@ const spentOf = (parts: ReadonlyArray<Usage>, missed: boolean): Usage | undefine
   }
 }
 
-export const realInfer = (config: ModelConfig) => {
+export const infer = (config: ModelConfig) => {
   const sleep = config.sleep ?? realSleep
   const bounds: StreamBounds = {
     firstChunkMs: config.stream?.firstChunkMs ?? DEFAULT_STREAM_BOUNDS.firstChunkMs,


### PR DESCRIPTION
The quickstart wiring was four lines of ceremony: an empty Packages stub, jsSandbox, memoryTmp, and the Layer.mergeAll around them, all identical for every default agent. Sandbox, Tmp, and Packages are now Context.References with those implementations as defaults, so the unwired case works and the wiring collapses to the one seam with real config: the model.

- Sandbox, Tmp, Packages become Context.Reference keys; the js sandbox, the memory tmp store, and the empty registry are their defaults, defined beside each seam
- the default registry holds nothing, so the unwired case stays the powerless one; capability still comes only from a provided registry
- the Reference default Tmp is one process-shared store; memoryTmp() stays the fresh-per-call form, and jsSandbox stays the explicit override
- requirement unions shrink: codeReactor is Reactor, RlmR collapses to AgentR
- realInfer becomes infer: the production binding takes the plain name, the service seam stays Infer
- quickstart drops five imports and the wiring const; layersFor is one infer(...) call
- full gate green