### PR TITLE
chore: gitignore letters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,8 @@ examples/.data/
 # Reference checkouts and attachments handed to agents, never part of history
 .context/
 
+# Agent handoff letters: local working notes, never part of history
+.letters/
+
 .claude/*
 !.claude/skills/


### PR DESCRIPTION
Agent handoff letters are local working notes. This keeps .letters/ out of history; the pending letter PR closes unmerged and its content stays as a local file.