### PR TITLE
refactor(agent): usage rides consequences

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ Organized on the Diátaxis grid: learning, tasks, information, understanding.
   - [gate-tools.md](how-to/gate-tools.md): hide, reveal, or revoke tools from the log.
   - [observe.md](how-to/observe.md): wire a tracer, the one-trace contract, the outcome vocabulary.
 - [reference/](reference/): neutral per-symbol contracts, no analogies.
-  - [api.md](reference/api.md): Event, Projection, Transition, Reactor, Actor, send, settle, resting, Usage.
+  - [api.md](reference/api.md): Event, Projection, Transition, Reactor, Actor, send, settle, resting.
 - [explanations/](explanations/): the why and the mental model.
   - [why.md](explanations/why.md): state = memo { f(log) }, the convergence of durable systems, agents as the new users, the last inversion.
   - [reactors.md](explanations/reactors.md): the reactor model, with the React analogy and the math.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -87,6 +87,6 @@ type Usage = {
 const usageIn: (events: Event[], turn: string) => Usage
 ```
 
-Usage is what one model attempt spent. `ModelReturned` records it. `costUsd` is present when the figure is known: a provider bill, including zero, or a price table fill from token counts. Absence is unknown. `costSource` says which of those two produced the figure, so a billed dollar and a catalog estimate cannot be mistaken for each other. `provider` and `model` name who was called.
+Usage is what one model attempt spent. The attempt's consequence records it: `ToolCalled`, `TurnCompleted`, or `TurnFailed` carries a `usage` field, and an attempt with unreported spend carries an empty one. `costUsd` is present when the figure is known: a provider bill, including zero, or a price table fill from token counts. Absence is unknown. `costSource` says which of those two produced the figure, so a billed dollar and a catalog estimate cannot be mistaken for each other. `provider` and `model` name who was called.
 
-`usageIn(log, turn)` sums `ModelReturned` for that turn. Unknown is sticky: if any part omitted cost, including a return that carried no usage field, the total omits `costUsd`. Mixed sources take `table`, the weaker label. A died attempt leaves no return and does not invent a cost.
+`usageIn(log, turn)` sums the `usage` fields on that turn's events. Unknown is sticky: if any part omitted cost, including an empty usage, the total omits `costUsd`. Mixed sources take `table`, the weaker label. An event with no usage field is no attempt: a died `ModelCalled` and the give-up `TurnFailed` invent nothing.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -70,23 +70,3 @@ const resting: (actor: Actor, events: Event[]) => boolean
 
 resting reports quiescence: no reactor enables a transition. The platform alarm may be deleted only on a true answer (tla/Driver.tla, Accounting).
 
-### Usage
-
-```ts
-type CostSource = "provider" | "table"
-
-type Usage = {
-  promptTokens: number
-  completionTokens: number
-  costUsd?: number
-  costSource?: CostSource
-  provider?: string
-  model?: string
-}
-
-const usageIn: (events: Event[], turn: string) => Usage
-```
-
-Usage is what one model attempt spent. The attempt's consequence records it: `ToolCalled`, `TurnCompleted`, or `TurnFailed` carries a `usage` field, and an attempt with unreported spend carries an empty one. `costUsd` is present when the figure is known: a provider bill, including zero, or a price table fill from token counts. Absence is unknown. `costSource` says which of those two produced the figure, so a billed dollar and a catalog estimate cannot be mistaken for each other. `provider` and `model` name who was called.
-
-`usageIn(log, turn)` sums the `usage` fields on that turn's events. Unknown is sticky: if any part omitted cost, including an empty usage, the total omits `costUsd`. Mixed sources take `table`, the weaker label. An event with no usage field is no attempt: a died `ModelCalled` and the give-up `TurnFailed` invent nothing.

--- a/packages/agent/src/events.ts
+++ b/packages/agent/src/events.ts
@@ -10,9 +10,9 @@ import type { Usage } from "./usage"
 // answer lives on `TurnCompleted` alone.
 //
 // The union projects onto OpenEnv RFC 005's HarnessEvent stream: `ModelCalled` -> LLM_REQUEST,
-// `ModelReturned` -> no RFC 005 event, `TextReturned` -> LLM_RESPONSE, `ToolCalled` -> TOOL_CALL,
-// `ToolReturned` -> TOOL_RESULT, `TurnCompleted` -> TURN_COMPLETE with TEXT_OUTPUT as payload,
-// `TurnFailed` -> ERROR. `MessageReceived` is the step() input on their side of the wire.
+// `TextReturned` -> LLM_RESPONSE, `ToolCalled` -> TOOL_CALL, `ToolReturned` -> TOOL_RESULT,
+// `TurnCompleted` -> TURN_COMPLETE with TEXT_OUTPUT as payload, `TurnFailed` -> ERROR.
+// `MessageReceived` is the step() input on their side of the wire.
 
 // MessageReceived is the canonical inbound (core/message.ts), shared with every other actor
 // kind.
@@ -24,6 +24,9 @@ export const ToolCalled = Schema.Struct({
   callId: Schema.String,
   name: Schema.String,
   arguments: Schema.Unknown,
+  // The spend of the attempt this call answered (packages/agent/src/usage.ts). An empty object
+  // is an attempt with unreported spend; an absent field is an event no attempt produced.
+  usage: Schema.optional(Schema.Unknown),
   at: Schema.Number
 })
 
@@ -37,27 +40,15 @@ export const ToolReturned = Schema.Struct({
 })
 
 // ModelCalled is the ask to the model and the attempt mark in one, appended before the inference
-// runs. ModelReturned is the spend of that attempt. A committed acting consequence after it is
-// the answer. Consecutive `ModelCalled` with nothing between them are attempts that died, and
-// the give-up guard reads that count.
+// runs. A committed acting consequence after it is the answer, and that consequence's `usage`
+// field is the attempt's spend. Consecutive `ModelCalled` with nothing between them are
+// attempts that died, and the give-up guard reads that count.
 export const ModelCalled = Schema.Struct({
   type: Schema.Literal("ModelCalled"),
   callId: Schema.String,
   // The occurrence: distinct per physical attempt, the dedup key's scope. callId stays the
   // provider idempotency key, shared across retries of one logical attempt.
   ordinal: Schema.optional(Schema.Number),
-  turn: Schema.optional(Schema.String),
-  at: Schema.Number
-})
-
-// ModelReturned is the spend of one attempt: tokens, a cost when known, and who was called.
-// costSource on usage says whether the dollar came from the provider or a price table
-// (packages/agent/src/usage.ts). A died attempt leaves no return, so usageIn invents nothing.
-export const ModelReturned = Schema.Struct({
-  type: Schema.Literal("ModelReturned"),
-  callId: Schema.String,
-  ordinal: Schema.optional(Schema.Number),
-  usage: Schema.optional(Schema.Unknown),
   turn: Schema.optional(Schema.String),
   at: Schema.Number
 })
@@ -74,6 +65,7 @@ export const TextReturned = Schema.Struct({
 export const TurnCompleted = Schema.Struct({
   type: Schema.Literal("TurnCompleted"),
   output: Schema.String,
+  usage: Schema.optional(Schema.Unknown),
   at: Schema.Number
 })
 
@@ -81,6 +73,8 @@ export const TurnCompleted = Schema.Struct({
 export const TurnFailed = Schema.Struct({
   type: Schema.Literal("TurnFailed"),
   error: Schema.String,
+  // Present only on the fail a live attempt answered; the give-up terminal carries none.
+  usage: Schema.optional(Schema.Unknown),
   at: Schema.Number
 })
 
@@ -138,7 +132,6 @@ export const BudgetDenied = Schema.Struct({
 export const AgentEvent = Schema.Union([
   MessageReceived,
   ModelCalled,
-  ModelReturned,
   TextReturned,
   ToolCalled,
   ToolReturned,
@@ -164,7 +157,7 @@ export type Action =
 // src/budget.ts, so a redelivered decision landing twice would double it). A decision that
 // carries no callId predates the stamp and lands unkeyed; the fold tolerates it.
 export const agentKeys: KeyFragment = {
-  prefixes: ["tr:", "bg:", "bd:", "rd:", "tn:", "mc:", "mr:", "bw:", "br:", "cc:"],
+  prefixes: ["tr:", "bg:", "bd:", "rd:", "tn:", "mc:", "bw:", "br:", "cc:"],
   keyOf: (e) => {
     const v = e as Record<string, unknown>
     switch (e.type) {
@@ -186,8 +179,6 @@ export const agentKeys: KeyFragment = {
         // repetition that evidences died attempts is preserved. A mark predating the ordinal
         // lands unkeyed, which the folds tolerate.
         return v.ordinal === undefined ? undefined : `mc:${String(v.turn)}/${String(v.ordinal)}`
-      case "ModelReturned":
-        return v.ordinal === undefined ? undefined : `mr:${String(v.turn)}/${String(v.ordinal)}`
       case "BudgetExhausted":
         // The wall's occurrence is the ceiling it fired at: a grant raises it, so a second
         // crossing keys anew.
@@ -218,10 +209,6 @@ export const toolReturned = (fields: { readonly callId: string; readonly result:
 export const modelCalled = (
   fields: { readonly callId: string; readonly ordinal?: number } & Stamp
 ): Event => ({ type: "ModelCalled", ...fields }) as Event
-
-export const modelReturned = (
-  fields: { readonly callId: string; readonly ordinal?: number; readonly usage?: Usage } & Stamp
-): Event => ({ type: "ModelReturned", ...fields }) as Event
 
 export const textReturned = (fields: { readonly text: string } & Stamp): Event =>
   ({ type: "TextReturned", ...fields }) as Event

--- a/packages/agent/src/infer.ts
+++ b/packages/agent/src/infer.ts
@@ -1,7 +1,7 @@
 import { Clock, Context, Effect } from "effect"
 import { EventLog } from "@tardigrade/core/event-log"
 import { transition, type Reactor } from "@tardigrade/core/actor"
-import { modelCalled, modelReturned, textReturned, turnFailed } from "./events"
+import { modelCalled, textReturned, turnFailed } from "./events"
 import type { Event } from "@tardigrade/core/event"
 import type { Action } from "./events"
 import { trajectoryOf, turnView } from "@tardigrade/code/turns"
@@ -36,13 +36,17 @@ export class Infer extends Context.Service<
 >()("agent/Infer") {}
 
 // consequenceOf returns the action's recorded answer: the model responds by acting. Every
-// consequence carries the turn it serves.
-const consequenceOf = (action: Action, turn: string, at: number): Event =>
-  action.kind === "call"
-    ? { type: "ToolCalled", callId: action.callId, name: action.name, arguments: action.arguments, turn, at }
+// consequence carries the turn it serves and the attempt's spend: `usage` is always stamped,
+// and an attempt whose binding reported nothing stamps an empty object, so usageIn reads the
+// spend as unknown rather than absent (usage.test.ts, "unknown is sticky").
+const consequenceOf = (action: Action, turn: string, at: number): Event => {
+  const usage = action.usage ?? {}
+  return action.kind === "call"
+    ? { type: "ToolCalled", callId: action.callId, name: action.name, arguments: action.arguments, usage, turn, at }
     : action.kind === "complete"
-      ? { type: "TurnCompleted", output: action.output, turn, at }
-      : { type: "TurnFailed", error: action.error, turn, at }
+      ? { type: "TurnCompleted", output: action.output, usage, turn, at }
+      : { type: "TurnFailed", error: action.error, usage, turn, at }
+}
 
 // diedAttempts counts the `ModelCalled` marks at the end of the turn's slice, with nothing after
 // them. Any committed event after a mark is progress and resets the count. Counting inside the
@@ -125,13 +129,6 @@ export const inferReactorFor = (policy: Partial<InferPolicy> = {}): Reactor<Infe
           const action = yield* (yield* Infer).react(input.trajectory, input.attempt)
           const after = yield* Clock.currentTimeMillis
           return [
-            modelReturned({
-              callId: input.attempt,
-              ordinal: input.ordinal,
-              turn: input.turn,
-              at: after,
-              ...(action.usage === undefined ? {} : { usage: action.usage })
-            }),
             ...(action.kind === "call" && action.text !== undefined && action.text !== ""
               ? [textReturned({ text: action.text, turn: input.turn, at: after })]
               : []),

--- a/packages/agent/src/turn.test.ts
+++ b/packages/agent/src/turn.test.ts
@@ -123,7 +123,6 @@ describe("the agent with execute as the only tool", () => {
     expect(events.map((e) => e.type)).toEqual([
       "MessageReceived",
       "ModelCalled",
-      "ModelReturned",
       "ToolCalled",
       "CodeDispatched",
       "PackageCalled",
@@ -133,12 +132,11 @@ describe("the agent with execute as the only tool", () => {
       "CodeSettled",
       "ToolReturned",
       "ModelCalled",
-      "ModelReturned",
       "TurnCompleted",
       "ReplyDelivered"
     ])
-    expect(events[5]).toMatchObject({ callId: "t1.0", name: "zohorecruit.insert_record" })
-    expect(events[9]).toMatchObject({ result: { jd_record_id: "jd-91", hits: 3 } })
+    expect(events[4]).toMatchObject({ callId: "t1.0", name: "zohorecruit.insert_record" })
+    expect(events[8]).toMatchObject({ result: { jd_record_id: "jd-91", hits: 3 } })
     expect(spies).toEqual({ insert: 1, search: 1 })
     expect(count.calls).toBe(2)
     expect(inferReactor(events)).toHaveLength(0)
@@ -318,7 +316,7 @@ describe("the agent with execute as the only tool", () => {
     expect(count.calls).toBe(1)
   })
 
-  test("ModelReturned records the action's spend and who was called", async () => {
+  test("the consequence records the action's spend and who was called", async () => {
     const spent = {
       promptTokens: 10,
       completionTokens: 4,
@@ -347,13 +345,10 @@ describe("the agent with execute as the only tool", () => {
     expect(events.map((e) => e.type)).toEqual([
       "MessageReceived",
       "ModelCalled",
-      "ModelReturned",
       "TurnCompleted",
       "ReplyDelivered"
     ])
-    expect(events.find((e) => e.type === "ModelReturned")).toMatchObject({
-      callId: "m1/infer/0",
-      ordinal: 0,
+    expect(events.find((e) => e.type === "TurnCompleted")).toMatchObject({
       turn: "m1",
       usage: spent
     })
@@ -494,11 +489,9 @@ describe("the mind on a native surface", () => {
     expect(events.map((e) => e.type)).toEqual([
       "MessageReceived",
       "ModelCalled",
-      "ModelReturned",
       "ToolCalled",
       "ToolReturned",
       "ModelCalled",
-      "ModelReturned",
       "TurnCompleted",
       "ReplyDelivered"
     ])

--- a/packages/agent/src/usage.test.ts
+++ b/packages/agent/src/usage.test.ts
@@ -66,14 +66,15 @@ describe("sumUsage", () => {
 })
 
 describe("usageIn", () => {
-  test("a turn sums ModelReturned, and a died attempt invents nothing", () => {
+  test("a turn sums the consequences' usage, and a died attempt invents nothing", () => {
     const log: Event[] = [
       { type: "MessageReceived", id: "m1", text: "go", at: 0 },
       { type: "ModelCalled", callId: "m1/infer/0", ordinal: 0, turn: "m1", at: 1 },
       {
-        type: "ModelReturned",
-        callId: "m1/infer/0",
-        ordinal: 0,
+        type: "ToolCalled",
+        callId: "c1",
+        name: "execute",
+        arguments: {},
         turn: "m1",
         usage: {
           promptTokens: 10,
@@ -99,7 +100,7 @@ describe("usageIn", () => {
     expect(usageIn(log, "m2")).toEqual(ZERO_USAGE)
   })
 
-  test("a return with no usage poisons the total, and an unstamped return still belongs by callId", () => {
+  test("an empty usage poisons the total, a usage-less terminal invents nothing, and an unstamped consequence still belongs by callId", () => {
     const billed = {
       promptTokens: 10,
       completionTokens: 4,
@@ -110,13 +111,14 @@ describe("usageIn", () => {
     }
     const log: Event[] = [
       { type: "MessageReceived", id: "m1", text: "go", at: 0 },
-      { type: "ModelReturned", callId: "m1/infer/0", ordinal: 0, turn: "m1", at: 1 },
-      { type: "ModelReturned", callId: "m1/infer/1", ordinal: 1, turn: "m1", usage: billed, at: 2 }
+      { type: "ToolCalled", callId: "c1", name: "execute", arguments: {}, usage: {}, turn: "m1", at: 1 },
+      { type: "TurnCompleted", output: "ok", usage: billed, turn: "m1", at: 2 },
+      { type: "TurnFailed", error: "gave up", turn: "m1", at: 3 }
     ]
     expect(usageIn(log, "m1")).toEqual({ promptTokens: 10, completionTokens: 4 })
     expect(
       usageIn(
-        [{ type: "ModelReturned", callId: "m1/infer/0", ordinal: 0, usage: billed, at: 1 }],
+        [{ type: "ToolCalled", callId: "m1/infer/0", name: "execute", arguments: {}, usage: billed, at: 1 }],
         "m1"
       )
     ).toEqual(billed)

--- a/packages/agent/src/usage.ts
+++ b/packages/agent/src/usage.ts
@@ -182,14 +182,16 @@ const ofTurn = (event: Event, turn: string): boolean => {
   return callId === turn || callId.startsWith(`${turn}/`)
 }
 
-// usageIn sums what one turn spent on the model. Settled figures come from ModelReturned.
-// A return with no usage is unknown cost, so it poisons the total (usage.test.ts, "unknown is
-// sticky"). An attempt that died after ModelCalled has no return, so it does not invent a cost.
+// usageIn sums what one turn spent on the model. A live attempt's consequence carries the
+// spend as its `usage` field, so the sum reads fields, never event types. An empty usage is an
+// attempt with unreported spend, and it keeps the total unknown (usage.test.ts, "unknown is
+// sticky"). An event with no usage field is no attempt: a died ModelCalled and the give-up
+// TurnFailed invent nothing.
 export const usageIn = (log: ReadonlyArray<Event>, turn: string): Usage =>
   sumUsage(
     log.flatMap((event) => {
-      if (event.type !== "ModelReturned" || !ofTurn(event, turn)) return []
+      if (!ofTurn(event, turn)) return []
       const carried = asRecord(event)?.usage
-      return [carried === undefined ? ZERO_USAGE : usageOf(carried)]
+      return carried === undefined ? [] : [usageOf(carried)]
     })
   )


### PR DESCRIPTION
ModelReturned duplicated a fact its neighbor already carried: every return was appended in the same act as the attempt's consequence, one to one, and it projected onto no RFC 005 event. The spend now rides the consequence itself.

- ToolCalled, TurnCompleted, and TurnFailed gain an optional `usage` field; consequenceOf always stamps it, and an attempt with unreported spend stamps an empty object
- usageIn sums usage fields instead of an event type, so the sticky-unknown, billed-zero, and mixed-source semantics from the cost provenance change survive unchanged
- an event with no usage field is no attempt: the give-up TurnFailed and died ModelCalled marks invent nothing, so a give-up cannot poison a turn whose live attempts all billed
- ModelReturned, its `mr:` key prefix, and its constructor are erased; the alphabet and RFC 005 mapping shrink back
- the Usage section leaves docs/reference/api.md: that page is the core contract, and Usage is agent-package detail, its contract stated where the code is
- full gate green