### PR TITLE
refactor: policy values are overridable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ State each fact in one place. If `docs/` contains a fact, link to it from this f
 
 Keep the docs conceptual. Use diagrams, invariants, and links to explain concepts. Write what a thing is and why it has its shape. Do not include file maps or descriptions of documents.
 
+## Design
+
+No silent hardcoding. When the framework applies a policy value, such as a cap, a threshold, a timeout, or a limit, the consumer must be able to see it and set it. Export the default, accept an override at the call site or on the surface that applies it, and make the effect visible in the output when the policy changes what the model sees. A constant a consumer can read but cannot change is a leaky abstraction; be explicit instead.
+
 ## Pull requests
 
 - Title a pull request in the commit format, the same as any commit: `type(scope?): message`, 3 to 5 words. The title becomes the squash commit subject, so it lands in the log as written.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Organized on the Diátaxis grid: learning, tasks, information, understanding.
 - [how-to/](how-to/): task-shaped recipes.
   - [gate-tools.md](how-to/gate-tools.md): hide, reveal, or revoke tools from the log.
   - [observe.md](how-to/observe.md): wire a tracer, the one-trace contract, the outcome vocabulary.
+  - [policy.md](how-to/policy.md): read and set the caps, ceilings, and bounds the framework applies.
 - [reference/](reference/): neutral per-symbol contracts, no analogies.
   - [api.md](reference/api.md): Event, Projection, Transition, Reactor, Actor, send, settle, resting.
 - [explanations/](explanations/): the why and the mental model.

--- a/docs/how-to/policy.md
+++ b/docs/how-to/policy.md
@@ -1,0 +1,35 @@
+How to set a policy value: a cap, a ceiling, a threshold, or a bound the framework applies on your behalf.
+
+A policy value is a number nobody in the domain chose. How much of a tool result the model reads, how many tool calls a turn gets before it must answer, how large a value must be before it spills to storage: each one is a guess that fits some consumers and not others. The framework states a default for every one of them, and every default is a value you can read and a value you can change. A constant you can read but cannot change is a leaky abstraction, so there are none.
+
+### The shape
+
+Every policy follows the same three-part shape, so knowing one is knowing all of them.
+
+A type names the values and what each one bounds. A `DEFAULT_` constant states the framework's answer. The surface that applies the policy takes a partial override and fills the rest from the default, so you state the one number you care about and inherit the rest.
+
+```ts
+// The reactor that applies the policy takes it; the default reactor is the same call with none.
+const compact = compactionReactorFor({ fireTokens: 60_000, keepTokens: 12_000 })
+const agent = rlmAgentFor(codeSurface(), { budget: { defaultToolBudget: 120 } })
+```
+
+The third part is visibility. When a policy changes what the model sees, the output says so. A truncated message names the cap it was cut at and the length it was cut from, and cut console output ends with a line saying it was cut. A model that reads a silent cut treats a fragment as the whole value, and the summary or the answer it writes then states a partial fact as complete.
+
+### Where the values live
+
+The agent applies four policies, gathered as `AgentPolicy` at the assembly so one call sets them all. `context` is the render's truncation caps and compaction's fire and keep lines. `budget` is the tool-call ceiling a brief that states none takes. `infer` is the give-up and repair ceilings. `code` is the size at which a result spills to tmp and leaves a pointer.
+
+The sandbox and the model binding hold the rest. The sandbox bounds captured console output. The model binding bounds the stream (time to first chunk, idle, total), the throttle backoff ladder, and the output-token ladder a truncated answer climbs.
+
+### The one coupling
+
+`context` is the only policy two places apply. Compaction's guard must measure the request the model actually sees, so it counts characters exactly where the render truncates. The reactor runs in the agent; the render runs in the model binding. State the same `context` policy to both, the same way you pass one tool surface to both.
+
+```ts
+const context = { messageRenderCap: 40_000, resultRenderCap: 20_000 }
+const mind = infer({ baseUrl, apiKey, model, context })   // the binding renders the request with it
+const agent = rlmAgentFor(codeSurface(), { context })     // the guard measures with the same one
+```
+
+A policy stated in one place and not the other leaves the guard firing against a size no request ever reaches, or never firing while the request grows past the window.

--- a/packages/agent/src/budget.test.ts
+++ b/packages/agent/src/budget.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { Effect, Layer } from "effect"
 import type { Event } from "@tardigrade/core/event"
 import { EventLog, withWatermark } from "@tardigrade/core/event-log"
-import { budgetReactor, budgetOf, usedOf, budgetPhase, budgetSpent, canRequestBudget } from "./budget"
+import { budgetReactor, budgetReactorFor, budgetOf, usedOf, budgetPhase, budgetSpent, canRequestBudget } from "./budget"
 import { toolsReactor } from "./tools"
 
 // A turn: a `MessageReceived` head carrying `budget`, then `calls` execute tool-calls (each answered
@@ -43,6 +43,14 @@ describe("the budget reactor", () => {
 
   test("with no budget it rests up to the generous default", () => {
     expect(budgetReactor(turn(5))).toHaveLength(0)
+  })
+
+  test("the default is the consumer's: a stated ceiling walls a brief that states none", () => {
+    expect(budgetReactorFor({ defaultToolBudget: 2 })(turn(3))).toHaveLength(1)
+    expect(budgetReactorFor({ defaultToolBudget: 2 })(turn(2))).toHaveLength(0)
+    expect(budgetOf(turn(1), { defaultToolBudget: 2 })).toBe(2)
+    // A brief that states its own budget still outranks the default.
+    expect(budgetOf(turn(1, 9), { defaultToolBudget: 2 })).toBe(9)
   })
 
   test("serving fires BudgetExhausted once, with the counts", async () => {

--- a/packages/agent/src/budget.ts
+++ b/packages/agent/src/budget.ts
@@ -8,16 +8,29 @@ import { turnHead, turnView } from "@tardigrade/code/turns"
 // passes the brief's budget. Detection lives here; enforcement lives with the tools reactor,
 // which reads the wall and refuses the next execute. See docs/agent-budgets.md.
 
-// DEFAULT_TOOL_BUDGET is the ceiling a brief with no budget takes, so an unbounded agent is
-// never an accident.
-export const DEFAULT_TOOL_BUDGET = 40
+// BudgetPolicy is the ceiling a brief with no stated budget takes, so an unbounded agent is
+// never an accident. A brief that states its own `budget` overrides it per turn; this is what a
+// silent brief gets, and a consumer sets it on the reactor (`budgetReactorFor`) and on the spawn
+// package, which draws the same default for a child (spawn.ts).
+export interface BudgetPolicy {
+  readonly defaultToolBudget: number
+}
+
+export const DEFAULT_BUDGET_POLICY: BudgetPolicy = { defaultToolBudget: 40 }
+
+export const budgetPolicyOf = (policy: Partial<BudgetPolicy> = {}): BudgetPolicy => ({
+  defaultToolBudget: policy.defaultToolBudget ?? DEFAULT_BUDGET_POLICY.defaultToolBudget
+})
 
 // budgetOf returns the turn's budget: the head's `budget` plus every grant the escalation has
-// added, or the default. The budget rides the brief envelope and is read off the raw event. A
-// `BudgetGranted` raises the ceiling, which is what lets a granted turn resume.
-export const budgetOf = (view: ReadonlyArray<Event>): number => {
+// added, or the policy's default. The budget rides the brief envelope and is read off the raw
+// event. A `BudgetGranted` raises the ceiling, which is what lets a granted turn resume.
+export const budgetOf = (view: ReadonlyArray<Event>, policy: Partial<BudgetPolicy> = {}): number => {
   const head = turnHead(view) as { budget?: unknown } | undefined
-  const base = typeof head?.budget === "number" && head.budget > 0 ? Math.floor(head.budget) : DEFAULT_TOOL_BUDGET
+  const base =
+    typeof head?.budget === "number" && head.budget > 0
+      ? Math.floor(head.budget)
+      : budgetPolicyOf(policy).defaultToolBudget
   const granted = view.reduce((n, e) => (e.type === "BudgetGranted" ? n + Number((e as { amount?: unknown }).amount ?? 0) : n), 0)
   return base + granted
 }
@@ -81,18 +94,19 @@ export const canRequestBudget = (trajectory: ReadonlyArray<Event>): boolean =>
 // so replay re-folds to the same state: it reads only the log and calls no clock and no random
 // source. It is off by exactly one on purpose: `used > budget` fires on the call after the last
 // allowed one, so the agent gets `budget` dispatched calls and the next is refused.
-const overBudget = (log: ReadonlyArray<Event>): boolean => usedOf(log) > budgetOf(log)
+const overBudget = (log: ReadonlyArray<Event>, policy: BudgetPolicy): boolean => usedOf(log) > budgetOf(log, policy)
 
-// budgetReactor derives the wall when the spend has crossed the ceiling and no wall marker
+// budgetReactorFor derives the wall when the spend has crossed the ceiling and no wall marker
 // stands. The act records `BudgetExhausted` once; the tools reactor reads it and refuses the
 // next `execute`, so enforcement stays where dispatch lives and this reactor only detects. The
 // wall's key is the ceiling it fired at: a grant raises the ceiling, so a second crossing is a
 // new occurrence with a new key, and a redelivered wall absorbs.
-export const budgetReactor: Reactor<never> = (log) => {
+export const budgetReactorFor = (policy: Partial<BudgetPolicy> = {}): Reactor<never> => (log) => {
+  const resolved = budgetPolicyOf(policy)
   const view = turnView(log)
-  if (view.length === 0 || !overBudget(view) || budgetPhase(view) !== "spending") return []
+  if (view.length === 0 || !overBudget(view, resolved) || budgetPhase(view) !== "spending") return []
   const head = turnHead(view) as { id?: unknown } | undefined
-  const budget = budgetOf(view)
+  const budget = budgetOf(view, resolved)
   return [
     transition({
       key: `bw:${String(head?.id ?? "")}/${budget}`,
@@ -112,3 +126,6 @@ export const budgetReactor: Reactor<never> = (log) => {
     })
   ]
 }
+
+// budgetReactor is that reactor on the default ceiling.
+export const budgetReactor: Reactor<never> = budgetReactorFor()

--- a/packages/agent/src/compaction.test.ts
+++ b/packages/agent/src/compaction.test.ts
@@ -6,11 +6,10 @@ import { send, actor } from "@tardigrade/core/actor"
 import { Infer } from "./infer"
 import { agentActorKeys } from "./turn"
 import {
-  COMPACTION_FIRE_TOKENS,
-  COMPACTION_KEEP_TOKENS,
-  RESULT_RENDER_CAP,
+  DEFAULT_CONTEXT_POLICY,
   checkpointOf,
   compactionReactor,
+  compactionReactorFor,
   estimateTokens,
   keepFromIndex,
   suffixOf
@@ -38,13 +37,13 @@ const openTurn = (rounds: number): Event[] => {
 describe("the compaction measure and guard", () => {
   test("the measure counts what a render sends: capped results, skipped lanes", () => {
     const big: Event = { type: "ToolReturned", callId: "c", result: { data: "x".repeat(40_000) }, at: 1 }
-    expect(estimateTokens([big])).toBe(Math.ceil(RESULT_RENDER_CAP / 4))
+    expect(estimateTokens([big])).toBe(Math.ceil(DEFAULT_CONTEXT_POLICY.resultRenderCap / 4))
     const lane: Event = { type: "CodeSettled", execId: "c", result: 1, at: 2 } as Event
     expect(estimateTokens([lane])).toBe(0)
   })
 
   test("the guard fires inside an open turn once a resolved round passes FIRE", () => {
-    expect(estimateTokens(suffixOf(openTurn(16)))).toBeGreaterThan(COMPACTION_FIRE_TOKENS)
+    expect(estimateTokens(suffixOf(openTurn(16)))).toBeGreaterThan(DEFAULT_CONTEXT_POLICY.fireTokens)
     expect(compactionReactor(openTurn(16))).toHaveLength(1) // no reply anywhere, the turn is live
     expect(compactionReactor(openTurn(2))).toHaveLength(0) // under FIRE
   })
@@ -55,6 +54,14 @@ describe("the compaction measure and guard", () => {
       { type: "ToolCalled", callId: "c99", name: "execute", arguments: {}, turn: "m0", at: 99 }
     ]
     expect(compactionReactor(awaiting)).toHaveLength(0)
+  })
+
+  test("the policy is the consumer's: a raised FIRE holds the guard, a lowered one fires early", () => {
+    expect(compactionReactorFor({ fireTokens: 1_000_000 })(openTurn(16))).toHaveLength(0)
+    expect(compactionReactorFor({ fireTokens: 100 })(openTurn(2))).toHaveLength(1)
+    // The measure moves with the render cap, because one policy states both.
+    const big: Event = { type: "ToolReturned", callId: "c", result: { data: "x".repeat(40_000) }, at: 1 }
+    expect(estimateTokens([big], { resultRenderCap: 40 })).toBe(10)
   })
 
   test("the guard is pure: the fold runs with the clock and randomness rigged to throw", () => {
@@ -109,7 +116,7 @@ describe("the compaction pass", () => {
     expect(keepFromIndex(log, checkpoint.keepFrom)).toBeGreaterThan(0)
     // The retained tail fits KEEP plus at most one round of boundary slack.
     const roundTokens = estimateTokens(round(1))
-    expect(estimateTokens(suffixOf(log))).toBeLessThanOrEqual(COMPACTION_KEEP_TOKENS + 2 * roundTokens)
+    expect(estimateTokens(suffixOf(log))).toBeLessThanOrEqual(DEFAULT_CONTEXT_POLICY.keepTokens + 2 * roundTokens)
     expect(briefed()).toContain("extract the covenants")
     expect(briefed()).toContain("run 1")
   })

--- a/packages/agent/src/compaction.ts
+++ b/packages/agent/src/compaction.ts
@@ -25,26 +25,58 @@ import { Infer } from "./infer"
 // Nothing is deleted; the full log stays for the rubric and replay. Consecutive fires with no
 // completion between them are a crash-looping summarizer, and the usual give-up evidence applies.
 
-// The render's truncation caps, stated once beside the measure that must agree with them;
-// request.ts renders with these.
-export const MESSAGE_RENDER_CAP = 12_000
-export const RESULT_RENDER_CAP = 6_000
+// ContextPolicy is every number that decides how much of the log the model sees: the render's
+// truncation caps, the fire and keep lines, and the per-event cap on a summary brief's lines.
+// They are one object because the render and the measure must agree; two policies would let a
+// consumer raise the render's cap and leave the guard firing against a size no request reaches.
+// The same policy therefore goes to the reactor and to the render (request.ts, modelRequest).
+export interface ContextPolicy {
+  // Chars of one inbound message the render sends; past it the message truncates with a pointer.
+  readonly messageRenderCap: number
+  // Chars of one tool result the render sends; past it the result truncates.
+  readonly resultRenderCap: number
+  // Rendered suffix size, in estimated tokens, that fires a compaction pass.
+  readonly fireTokens: number
+  // Estimated tokens of the tail a pass keeps verbatim. Below fireTokens, which is the
+  // hysteresis (module comment).
+  readonly keepTokens: number
+  // Chars of one event's line in the summary brief a pass sends its summarizer.
+  readonly summaryLineCap: number
+}
+
+export const DEFAULT_CONTEXT_POLICY: ContextPolicy = {
+  messageRenderCap: 12_000,
+  resultRenderCap: 6_000,
+  fireTokens: 16_000,
+  keepTokens: 4_000,
+  summaryLineCap: 200
+}
+
+// contextPolicyOf fills an override with the defaults. Every surface that applies context policy
+// takes `Partial<ContextPolicy>` and resolves it here, so a caller states only what it changes.
+export const contextPolicyOf = (policy: Partial<ContextPolicy> = {}): ContextPolicy => ({
+  messageRenderCap: policy.messageRenderCap ?? DEFAULT_CONTEXT_POLICY.messageRenderCap,
+  resultRenderCap: policy.resultRenderCap ?? DEFAULT_CONTEXT_POLICY.resultRenderCap,
+  fireTokens: policy.fireTokens ?? DEFAULT_CONTEXT_POLICY.fireTokens,
+  keepTokens: policy.keepTokens ?? DEFAULT_CONTEXT_POLICY.keepTokens,
+  summaryLineCap: policy.summaryLineCap ?? DEFAULT_CONTEXT_POLICY.summaryLineCap
+})
 
 // renderedChars counts the characters a render sends for one event: capped where the render
 // caps, zero for an event the render skips. The guard must measure the request the model sees;
 // a measure over raw event JSON counts tool results the render truncates and lanes the render
 // never shows, and fires against a size no request ever reaches.
-const renderedChars = (e: Event): number => {
+const renderedChars = (e: Event, policy: ContextPolicy): number => {
   const v = e as Record<string, unknown>
   switch (e.type) {
     case "MessageReceived":
-      return Math.min(String(v.text ?? "").length, MESSAGE_RENDER_CAP)
+      return Math.min(String(v.text ?? "").length, policy.messageRenderCap)
     case "TextReturned":
       return String(v.text ?? "").length
     case "ToolCalled":
       return JSON.stringify(v.arguments ?? {}).length
     case "ToolReturned":
-      return Math.min(JSON.stringify(v.result ?? null).length, RESULT_RENDER_CAP)
+      return Math.min(JSON.stringify(v.result ?? null).length, policy.resultRenderCap)
     case "TurnCompleted":
       return String(v.output ?? "").length
     case "TurnFailed":
@@ -57,13 +89,10 @@ const renderedChars = (e: Event): number => {
 // estimateTokens estimates the span's rendered tokens as chars over four. A real tokenizer would
 // be a dependency and an impure path, and every budget decision must fold the same on replay, so
 // the estimate is a pure function of the recorded events (compaction.test.ts, "the measure").
-export const estimateTokens = (events: ReadonlyArray<Event>): number =>
-  Math.ceil(events.reduce((n, e) => n + renderedChars(e), 0) / 4)
-
-// COMPACTION_FIRE_TOKENS is the rendered suffix size that fires a pass; COMPACTION_KEEP_TOKENS
-// bounds the retained tail the pass summarizes down to.
-export const COMPACTION_FIRE_TOKENS = 16_000
-export const COMPACTION_KEEP_TOKENS = 4_000
+export const estimateTokens = (events: ReadonlyArray<Event>, policy: Partial<ContextPolicy> = {}): number => {
+  const resolved = contextPolicyOf(policy)
+  return Math.ceil(events.reduce((n, e) => n + renderedChars(e, resolved), 0) / 4)
+}
 
 // checkpointOf returns the last checkpoint: the identity the next span starts from, and the
 // summary to date.
@@ -100,7 +129,8 @@ export const suffixOf = (log: ReadonlyArray<Event>): ReadonlyArray<Event> =>
 // overContext reports whether the suffix has passed FIRE tokens. It is pure and total over the
 // log, so the fire decision re-folds identically on replay: it reads only the log, no clock and
 // no random source.
-const overContext = (log: ReadonlyArray<Event>): boolean => estimateTokens(suffixOf(log)) > COMPACTION_FIRE_TOKENS
+const overContext = (log: ReadonlyArray<Event>, policy: ContextPolicy): boolean =>
+  estimateTokens(suffixOf(log), policy) > policy.fireTokens
 
 // atRoundBoundary gates the guard: a pass may land whenever the open turn awaits no tool call,
 // between turns included. A checkpoint landing mid-round would cut a call from the return the
@@ -128,14 +158,17 @@ const boundaryIdOf = (e: Event, served: ReadonlySet<string>): string | undefined
 // that the first boundary past the KEEP line, so the checkpoint always advances when a boundary
 // exists at all. The checkpoint never moves backward; no boundary past the prior one means no
 // cut, and the fire waits for the next round to offer one.
-const cutOf = (log: ReadonlyArray<Event>): { readonly keepFrom: string; readonly index: number } | undefined => {
+const cutOf = (
+  log: ReadonlyArray<Event>,
+  policy: ContextPolicy
+): { readonly keepFrom: string; readonly index: number } | undefined => {
   const priorIndex = keepFromIndex(log, checkpointOf(log).keepFrom)
   const served = new Set(log.map(turnOf).filter((t): t is string => t !== undefined))
   let tokens = 0
   let raw = priorIndex
   for (let i = log.length - 1; i >= priorIndex; i--) {
-    tokens += estimateTokens([log[i]!])
-    if (tokens > COMPACTION_KEEP_TOKENS) {
+    tokens += estimateTokens([log[i]!], policy)
+    if (tokens > policy.keepTokens) {
       raw = i + 1
       break
     }
@@ -151,7 +184,13 @@ const cutOf = (log: ReadonlyArray<Event>): { readonly keepFrom: string; readonly
   return undefined
 }
 
-const lineOf = (e: Event): string | null => {
+// clip cuts one summary line to the policy's cap and says so where it cut. A silent cut reads to
+// the summarizer as the whole value, and the summary it writes then states a truncated fact as
+// complete.
+const clip = (text: string, cap: number): string =>
+  text.length > cap ? `${text.slice(0, cap)}…[cut at ${cap} of ${text.length} chars]` : text
+
+const lineOf = (e: Event, policy: ContextPolicy): string | null => {
   const v = e as Record<string, unknown>
   switch (e.type) {
     case "MessageReceived":
@@ -159,9 +198,9 @@ const lineOf = (e: Event): string | null => {
     case "TextReturned":
       return `agent (working): ${String(v.text ?? "")}`
     case "ToolCalled":
-      return `agent ran: ${JSON.stringify(v.arguments ?? {}).slice(0, 200)}`
+      return `agent ran: ${clip(JSON.stringify(v.arguments ?? {}), policy.summaryLineCap)}`
     case "ToolReturned":
-      return `result: ${JSON.stringify(v.result ?? null).slice(0, 200)}`
+      return `result: ${clip(JSON.stringify(v.result ?? null), policy.summaryLineCap)}`
     case "TurnCompleted":
       return `agent: ${String(v.output ?? "")}`
     case "TurnFailed":
@@ -183,16 +222,20 @@ const firedUncovered = (log: ReadonlyArray<Event>): boolean => {
   return fires > passes
 }
 
-// compactionReactor derives a pass when the suffix has crossed FIRE at a round boundary, or an
+// compactionReactorFor derives a pass when the suffix has crossed FIRE at a round boundary, or an
 // explicit `CompactionFired` stands uncovered. The act always advances the checkpoint (the
 // retained tail is bounded by KEEP < FIRE), so a served pass quiets the derivation instead of
 // re-firing. The checkpoint's key is the identity it keeps from: cc:<keepFrom>. Its input is the
 // span to fold, a projection, so a retried fire summarizes the same span. A crash-looping
 // summarizer re-derives the same key and its retries absorb, while a later fire reaches further
 // and keys anew.
-export const compactionReactor: Reactor<Infer> = (log) => {
-  if (!(firedUncovered(log) || (overContext(log) && atRoundBoundary(log)))) return []
-  const cut = cutOf(log)
+//
+// The policy this takes must be the one the render takes, or the guard measures a request the
+// model never sees (ContextPolicy above).
+export const compactionReactorFor = (policy: Partial<ContextPolicy> = {}): Reactor<Infer> => (log) => {
+  const resolved = contextPolicyOf(policy)
+  if (!(firedUncovered(log) || (overContext(log, resolved) && atRoundBoundary(log)))) return []
+  const cut = cutOf(log, resolved)
   if (cut === undefined) return []
   const prior = checkpointOf(log)
   const span = log.slice(keepFromIndex(log, prior.keepFrom), cut.index)
@@ -203,7 +246,7 @@ export const compactionReactor: Reactor<Infer> = (log) => {
       act: (input) =>
         Effect.gen(function* () {
           const at = yield* Clock.currentTimeMillis
-          const lines = input.span.map(lineOf).filter((l): l is string => l !== null)
+          const lines = input.span.map((e) => lineOf(e, resolved)).filter((l): l is string => l !== null)
           if (lines.length === 0) {
             return [compactionCompleted({ keepFrom: input.keepFrom, summary: input.summary, at })]
           }
@@ -222,3 +265,7 @@ export const compactionReactor: Reactor<Infer> = (log) => {
     })
   ]
 }
+
+// compactionReactor is that reactor on the default policy. An agent on another policy builds its
+// own with `compactionReactorFor` and hands the same policy to its render.
+export const compactionReactor: Reactor<Infer> = compactionReactorFor()

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3,25 +3,26 @@ import type { Event } from "@tardigrade/core/event"
 import { Router } from "@tardigrade/core/router"
 import { Self } from "@tardigrade/core/actor"
 import { Packages, type Package } from "@tardigrade/code/packages"
-import { jsSandbox, memoryTmp } from "@tardigrade/code/defaults"
+import { jsSandboxFor, memoryTmp } from "@tardigrade/code/defaults"
+import type { SandboxPolicy } from "@tardigrade/code/sandbox"
 import { createHost, type Host, type LaneEnv } from "@tardigrade/host/host"
-import { rlmAgent, rlmAgentFor, type RlmR } from "./turn"
+import { rlmAgentFor, type AgentPolicy, type RlmR } from "./turn"
 import { Infer } from "./infer"
 import type { Action } from "./events"
 import { boundaryOf } from "./boundary"
 import { agentsPackage } from "./spawn"
-import type { ToolSurface } from "./surface"
+import { codeSurface, type ToolSurface } from "./surface"
 
-export { agentFor, rlmAgent, rlmAgentFor, type AgentR, type RlmR } from "./turn"
+export { agentFor, rlmAgent, rlmAgentFor, type AgentPolicy, type AgentR, type RlmR } from "./turn"
 
 // The parts a caller lists: reactors and key tables. An agent is reactors over one log.
 // Adding a capability is adding a reactor to the list.
 export { agentActorKeys, rlmActorKeys } from "./turn"
 export { inferReactor, inferReactorFor, Infer, DEFAULT_INFER_POLICY, type InferPolicy } from "./infer"
-export { budgetReactor } from "./budget"
+export { budgetReactor, budgetReactorFor, DEFAULT_BUDGET_POLICY, type BudgetPolicy } from "./budget"
 export { toolsReactor, toolsReactorFor } from "./tools"
 export { replyReactor } from "./reply"
-export { compactionReactor } from "./compaction"
+export { compactionReactor, compactionReactorFor, DEFAULT_CONTEXT_POLICY, type ContextPolicy } from "./compaction"
 export { agentKeys } from "./events"
 export {
   usageIn,
@@ -51,6 +52,15 @@ export interface CreateAgentOptions {
   // The tool surface, code mode by default. The same surface must reach the model binding, so a
   // caller passing one here passes it to `infer` too (surface.ts).
   readonly surface?: ToolSurface<RlmR>
+  // Every policy value the assembled agent applies: the give-up and repair ceilings, the default
+  // tool budget, the context caps, and the spill bound. Absent fields take the exported defaults.
+  // `policy.context` rides the same rule the surface does, because the render lives in the model
+  // binding: a caller stating one here states it to `infer` too (turn.ts, AgentPolicy).
+  readonly policy?: Partial<AgentPolicy>
+  // The console cap of the sandbox this function binds. It is separate from `policy` because the
+  // sandbox is a seam, not a reactor: an assembly that brings its own Sandbox layer sets the cap
+  // there instead (packages/code/src/sandbox.ts, SandboxPolicy).
+  readonly sandbox?: Partial<SandboxPolicy>
 }
 
 export interface RlmAgent {
@@ -70,6 +80,7 @@ export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
     react: (trajectory: ReadonlyArray<Event>, key?: string) => Effect.promise(() => options.infer(trajectory, key))
   })
   const tmp = memoryTmp()
+  const sandbox = jsSandboxFor(options.sandbox ?? {})
 
   // Packages is built from the host's Router and Self. place and the
   // facet reader still close over the host: they name other lanes.
@@ -79,9 +90,14 @@ export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
       Effect.gen(function* () {
         const router = yield* Router
         const self = yield* Self
-        const spawn = agentsPackage(router, self, (callId) => host.self(`ag.${callId}`), {
-          events: (facet: string) => Promise.resolve(host.read(facet))
-        })
+        const spawn = agentsPackage(
+          router,
+          self,
+          (callId) => host.self(`ag.${callId}`),
+          { events: (facet: string) => Promise.resolve(host.read(facet)) },
+          // A child with no stated budget takes the same ceiling this agent's own wall reads.
+          { budget: options.policy?.budget ?? {} }
+        )
         const all = [...user, spawn]
         return Packages.of({
           resolve: (name) => all.find((p) => p.name === name),
@@ -89,11 +105,11 @@ export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
         })
       })
     )
-    return Layer.mergeAll(packages, jsSandbox, tmp, infer)
+    return Layer.mergeAll(packages, sandbox, tmp, infer)
   }
 
   // Every ag. lane runs the RLM default; anything else is a sink.
-  const assembled = options.surface === undefined ? rlmAgent : rlmAgentFor(options.surface)
+  const assembled = rlmAgentFor(options.surface ?? codeSurface(), options.policy ?? {})
   const host: Host = createHost<RlmR>({
     principal: "mem",
     actorFor: (lane) => (lane.startsWith("ag.") ? assembled : undefined),

--- a/packages/agent/src/request.test.ts
+++ b/packages/agent/src/request.test.ts
@@ -66,6 +66,20 @@ describe("renderMessages", () => {
     expect(String(messages[0]!.content)).toContain("Summary of earlier work")
     expect(messages[1]).toMatchObject({ content: "new task" })
   })
+
+  test("the truncation caps are the consumer's, and the render says where it cut", () => {
+    const trajectory: ReadonlyArray<Event> = [
+      { type: "MessageReceived", id: "m1", text: "y".repeat(50), at: 0 },
+      { type: "ToolCalled", callId: "c1", name: "execute", arguments: {}, turn: "m1", at: 1 },
+      { type: "ToolReturned", callId: "c1", result: "z".repeat(50), turn: "m1", at: 2 }
+    ]
+    const tight = renderMessages(trajectory, { messageRenderCap: 10, resultRenderCap: 10 })
+    expect(String(tight[0]!.content)).toContain("truncated at 10 of 50 chars")
+    expect(String(tight[2]!.content)).toContain("truncated at 10 of 52 chars")
+    // The default caps are far above this trajectory, so nothing truncates.
+    const whole = renderMessages(trajectory)
+    expect(whole[0]!.content).toBe("y".repeat(50))
+  })
 })
 
 describe("modelRequest tool and prompt policy", () => {

--- a/packages/agent/src/request.ts
+++ b/packages/agent/src/request.ts
@@ -1,5 +1,5 @@
 import type { Event } from "@tardigrade/core/event"
-import { MESSAGE_RENDER_CAP, RESULT_RENDER_CAP, checkpointOf, keepFromIndex } from "./compaction"
+import { checkpointOf, contextPolicyOf, keepFromIndex, type ContextPolicy } from "./compaction"
 import { outputSchemaOf } from "./contract"
 import { budgetSpent, canRequestBudget } from "./budget"
 import type { ToolSurface } from "./surface"
@@ -75,14 +75,17 @@ const BUDGET_NUDGE =
 const ESCALATE_NUDGE =
   "If the work genuinely needs more and the extra spend is worth it, you may call request_budget with a reason and an amount instead of answering. Ask only when it changes the result; otherwise answer now."
 
-const userMessageOf = (e: Event): AgentMessage => {
+// A truncation names the cap it cut at as well as the size it cut from: the model reads why the
+// text stops, and a consumer who moved the cap sees the new number in the request itself
+// (request.test.ts, "the truncation caps are the consumer's").
+const userMessageOf = (e: Event, policy: ContextPolicy): AgentMessage => {
   const v = e as Record<string, unknown>
   const text = String(v.text ?? "")
   return {
     role: "user",
     content:
-      text.length > MESSAGE_RENDER_CAP
-        ? `${text.slice(0, MESSAGE_RENDER_CAP)}…[truncated ${text.length} chars; read the full message with logs.events on this facet, id ${String(v.id)}]`
+      text.length > policy.messageRenderCap
+        ? `${text.slice(0, policy.messageRenderCap)}…[truncated at ${policy.messageRenderCap} of ${text.length} chars; read the full message with logs.events on this facet, id ${String(v.id)}]`
         : text
   }
 }
@@ -94,7 +97,14 @@ const userMessageOf = (e: Event): AgentMessage => {
 // (request.test.ts, "a checkpoint survives the projection"). The open turn's head renders
 // verbatim ahead of the summary when the checkpoint passed it: the live task never shrinks to a
 // summary paragraph mid-turn. Unknown event types fall through: tolerant reads.
-export const renderMessages = (trajectory: ReadonlyArray<Event>): ReadonlyArray<AgentMessage> => {
+//
+// `policy` sets the truncation caps. It must be the policy the compaction reactor took, or the
+// guard fires against a size this render never sends (compaction.ts, ContextPolicy).
+export const renderMessages = (
+  trajectory: ReadonlyArray<Event>,
+  policy: Partial<ContextPolicy> = {}
+): ReadonlyArray<AgentMessage> => {
+  const resolved = contextPolicyOf(policy)
   const messages: AgentMessage[] = []
   const checkpoint = checkpointOf(trajectory)
   const from = keepFromIndex(trajectory, checkpoint.keepFrom)
@@ -106,14 +116,14 @@ export const renderMessages = (trajectory: ReadonlyArray<Event>): ReadonlyArray<
   const openHead = trajectory.findIndex(
     (e) => e.type === "MessageReceived" && !terminated.has(String((e as { id?: unknown }).id))
   )
-  if (openHead !== -1 && openHead < from) messages.push(userMessageOf(trajectory[openHead]!))
+  if (openHead !== -1 && openHead < from) messages.push(userMessageOf(trajectory[openHead]!, resolved))
   if (checkpoint.summary !== "") messages.push({ role: "user", content: `Summary of earlier work:\n${checkpoint.summary}` })
   let pendingText: string | null = null
   for (const e of trajectory.slice(from)) {
     const v = e as Record<string, unknown>
     switch (e.type) {
       case "MessageReceived": {
-        messages.push(userMessageOf(e))
+        messages.push(userMessageOf(e, resolved))
         break
       }
       case "TextReturned": {
@@ -134,7 +144,10 @@ export const renderMessages = (trajectory: ReadonlyArray<Event>): ReadonlyArray<
         messages.push({
           role: "tool",
           toolCallId: String(v.callId),
-          content: body.length > RESULT_RENDER_CAP ? `${body.slice(0, RESULT_RENDER_CAP)}…[truncated ${body.length} chars]` : body
+          content:
+            body.length > resolved.resultRenderCap
+              ? `${body.slice(0, resolved.resultRenderCap)}…[truncated at ${resolved.resultRenderCap} of ${body.length} chars]`
+              : body
         })
         break
       }
@@ -157,9 +170,14 @@ export const renderMessages = (trajectory: ReadonlyArray<Event>): ReadonlyArray<
 // the answer tool and its nudge. A spent budget drops the work tools and adds the budget nudge,
 // so the model can only answer. Both are pure projections of the log, and neither knows what the
 // work tools are.
+//
+// `context` sets what the render truncates. It rides the same rule the surface does: the actor's
+// compaction reactor must hold the same policy, so the caller that states one here states it
+// there too (compaction.ts, ContextPolicy).
 export const modelRequest = (
   trajectory: ReadonlyArray<Event>,
-  surface: Pick<ToolSurface, "system" | "tools">
+  surface: Pick<ToolSurface, "system" | "tools">,
+  context: Partial<ContextPolicy> = {}
 ): ModelRequest => {
   const schema = outputSchemaOf(trajectory)
   const spent = budgetSpent(trajectory)
@@ -170,5 +188,5 @@ export const modelRequest = (
   const framed = SYSTEM(surface.system)
   const base = schema === undefined ? framed : `${framed}\n${ANSWER_NUDGE}`
   const budgetLine = canRequest ? `${BUDGET_NUDGE}\n${ESCALATE_NUDGE}` : BUDGET_NUDGE
-  return { system: spent ? `${base}\n${budgetLine}` : base, messages: renderMessages(trajectory), tools }
+  return { system: spent ? `${base}\n${budgetLine}` : base, messages: renderMessages(trajectory, context), tools }
 }

--- a/packages/agent/src/spawn.ts
+++ b/packages/agent/src/spawn.ts
@@ -2,7 +2,7 @@ import { Clock, Context, Effect } from "effect"
 import { Router } from "@tardigrade/core/router"
 import type { Package } from "@tardigrade/code/packages"
 import type { Event } from "@tardigrade/core/event"
-import { DEFAULT_TOOL_BUDGET } from "./budget"
+import { budgetPolicyOf, type BudgetPolicy } from "./budget"
 import { Park } from "@tardigrade/code/errors"
 import { readAddress } from "@tardigrade/core/router"
 import { replyId } from "@tardigrade/core/reply"
@@ -37,105 +37,161 @@ import { replyId } from "@tardigrade/core/reply"
 // carries that ask as a message the child could otherwise send home, so there is no reply row to
 // park on until the child is done asking. An escalatable spawn holds its call open; a plain one
 // parks.
+
+// SpawnOptions is the placement's environment: who the family works as, how a child's budget is
+// drawn from the run, and the isolation labels a brief carries down. Every field has a default,
+// and `budget` is one of them rather than a constant this module reads: a spawn with no stated
+// budget takes the same ceiling the child's own reactor would, and a consumer that moved that
+// ceiling moves both (budget.ts, BudgetPolicy).
+export interface SpawnOptions {
+  readonly actorOf?: () => string | undefined
+  readonly reserve?: (callId: string, want: number) => Promise<number>
+  readonly shadowOf?: () => boolean
+  // The parent's explicit world label, when its own fire named a shared world instead of taking
+  // the anonymous one (docs/worlds.md). Forwarded onto every spawn's brief the same way `shadow`
+  // is, so a whole family stays on one shared world's facets.
+  readonly worldOf?: () => string | undefined
+  readonly budget?: Partial<BudgetPolicy>
+}
+
 export const agentsPackage = (
   router: Context.Service.Shape<typeof Router>,
   self: string,
   place: (callId: string) => string,
   reader: AgentReader,
-  actorOf: () => string | undefined = () => undefined,
-  reserve: (callId: string, want: number) => Promise<number> = async (_callId, want) => want,
-  shadowOf: () => boolean = () => false,
-  // The parent's explicit world label, when its own fire named a shared world instead of taking
-  // the anonymous one (docs/worlds.md). Forwarded onto every spawn's brief the same way `shadow`
-  // is, so a whole family stays on one shared world's facets.
-  worldOf: () => string | undefined = () => undefined
-): Package => ({
-  name: "agents",
-  description: "Ad-hoc agents. run({text}) starts a fresh agent with the brief and waits for its answer; add background: true for a long job, and result({id}) awaits the reply later. An escalatable run can ask for more budget at its wall; continue() answers the ask.",
-  annotations: {
-    run: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
-    result: { readOnlyHint: true, openWorldHint: false },
-    continue: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false }
-  },
-  docs: {
-    run: {
-      description: "Brief a fresh agent. `output` (a JSON schema) makes the answer structured and parsed. `model` picks the mind: haiku for quick, cheap work like scouting; sonnet (default) for most work; opus for the hardest judgment. `budget` caps the agent's tool calls: at the cap it answers with its best result, so a research agent can not run forever. `background: true` returns `{ callId }` at once; result({id: callId}) awaits the reply later. `escalatable: true` lets the agent ask for more budget at the cap instead of answering; the run then returns `{ requesting, reason, amount, handle }`, and you decide with continue().",
-      input: {
-        type: "object",
-        properties: {
-          text: { type: "string", description: "the brief" },
-          background: { type: "boolean", description: "true: return { callId } at once, the reply arrives later via result()" },
-          output: { type: "object", description: "JSON schema for a structured answer" },
-          model: { type: "string", enum: ["haiku", "sonnet", "opus"], description: "which model runs the agent; default sonnet" },
-          budget: { type: "number", description: "max tool calls before the agent must answer; keeps a research agent bounded" },
-          escalatable: { type: "boolean", description: "true: at its budget the agent may ask for more instead of answering; the run returns a request you resolve with continue()" }
-        },
-        required: ["text"]
-      },
-      output: { type: "object", properties: { output: { description: "the agent's answer; parsed when a schema was given" } } }
+  options: SpawnOptions = {}
+): Package => {
+  const actorOf = options.actorOf ?? (() => undefined)
+  const reserve = options.reserve ?? (async (_callId: string, want: number) => want)
+  const shadowOf = options.shadowOf ?? (() => false)
+  const worldOf = options.worldOf ?? (() => undefined)
+  const defaultBudget = budgetPolicyOf(options.budget).defaultToolBudget
+  return {
+    name: "agents",
+    description: "Ad-hoc agents. run({text}) starts a fresh agent with the brief and waits for its answer; add background: true for a long job, and result({id}) awaits the reply later. An escalatable run can ask for more budget at its wall; continue() answers the ask.",
+    annotations: {
+      run: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+      result: { readOnlyHint: true, openWorldHint: false },
+      continue: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false }
     },
-    result: {
-      description: "Await a run fired with `background: true`. Answers its terminal once the reply lands; parks the execution until then. `output` re-applies a JSON schema to a structured answer.",
-      input: {
-        type: "object",
-        properties: { id: { type: "string", description: "the callId a background run answered" }, output: { type: "object", description: "JSON schema for a structured answer" } },
-        required: ["id"]
-      },
-      output: { type: "object", properties: { output: { description: "the agent's answer; parsed when a schema was given" } } }
-    },
-    continue: {
-      description: "Resolve a budget request from an escalatable run. Pass the request's `handle` and a `grant` of extra tool calls; a grant of 0 or less denies, and the agent finishes with what it has. A grant draws the run's shared budget, so a spent budget denies whatever you pass. Returns the agent's next boundary: another request, or its final answer, in the same shape run() returns.",
-      input: {
-        type: "object",
-        properties: {
-          handle: { type: "object", description: "the handle from a requesting run" },
-          grant: { type: "number", description: "extra tool calls to grant; 0 or less denies" }
+    docs: {
+      run: {
+        description: "Brief a fresh agent. `output` (a JSON schema) makes the answer structured and parsed. `model` picks the mind: haiku for quick, cheap work like scouting; sonnet (default) for most work; opus for the hardest judgment. `budget` caps the agent's tool calls: at the cap it answers with its best result, so a research agent can not run forever. `background: true` returns `{ callId }` at once; result({id: callId}) awaits the reply later. `escalatable: true` lets the agent ask for more budget at the cap instead of answering; the run then returns `{ requesting, reason, amount, handle }`, and you decide with continue().",
+        input: {
+          type: "object",
+          properties: {
+            text: { type: "string", description: "the brief" },
+            background: { type: "boolean", description: "true: return { callId } at once, the reply arrives later via result()" },
+            output: { type: "object", description: "JSON schema for a structured answer" },
+            model: { type: "string", enum: ["haiku", "sonnet", "opus"], description: "which model runs the agent; default sonnet" },
+            budget: { type: "number", description: "max tool calls before the agent must answer; keeps a research agent bounded" },
+            escalatable: { type: "boolean", description: "true: at its budget the agent may ask for more instead of answering; the run returns a request you resolve with continue()" }
+          },
+          required: ["text"]
         },
-        required: ["handle", "grant"]
+        output: { type: "object", properties: { output: { description: "the agent's answer; parsed when a schema was given" } } }
       },
-      output: { type: "object", properties: { output: { description: "the agent's answer, or a further request" } } }
-    }
-  },
-  methods: {
-    run: (args, ctx) =>
-      Effect.gen(function* () {
-        const a = args as
-          | { text?: unknown; background?: unknown; output?: unknown; outputSchema?: unknown; model?: unknown; budget?: unknown; escalatable?: unknown }
-          | undefined
-        const text = String(a?.text ?? "")
-        if (text === "") return { error: "agents.run needs { text }" }
-        // The schema parameter is `output`, and a near-miss spelling fails silently: no schema
-        // means a prose answer, so the caller's field reads come back undefined and the run
-        // returns something plausible and wrong. Say so instead.
-        if (a?.output === undefined && a?.outputSchema !== undefined) {
-          return { error: "agents.run takes the schema as `output`, not `outputSchema`" }
-        }
-        const output = a?.output
-        // The model name rides the brief's envelope: the child's log records the choice, so its
-        // Infer resolves it from trajectory and replay agrees by construction.
-        const model = a?.model === "haiku" || a?.model === "sonnet" || a?.model === "opus" ? a.model : undefined
-        // The tool-call budget rides the brief like the model does; the child's budget reactor reads
-        // it from its own trajectory. A run without a stated budget wants the per-agent default.
-        const want = typeof a?.budget === "number" && a.budget > 0 ? Math.floor(a.budget) : DEFAULT_TOOL_BUDGET
-        // Draw from the run's single budget before the child spawns, so the whole tree is bounded by
-        // it whatever the fan-out. A partial budget grants what is left; a spent budget grants 0, and
-        // then no agent spawns, which is how the tree stops. The draw is keyed on this call's id, so
-        // a re-driven code body reuses its grant and never draws twice.
-        const budget = yield* Effect.promise(() => reserve(ctx.callId, want))
-        if (budget <= 0) return { error: "the run's budget is exhausted; no budget to spawn this agent" }
-        // The child works as the same member the parent does: the actor rides every brief in the
-        // family, so a run's whole tree resolves connections identically.
-        const actor = actorOf()
-        // The parent's own shadow reading, never the tool args: an agent cannot set or unset it, so
-        // a whole run family is shadow by construction from the fire alone. `world` rides along
-        // the same way, when the fire named an explicit shared one.
-        const shadow = shadowOf()
-        const world = worldOf()
-        const address = place(ctx.callId)
-        if (a?.background === true) {
-          // A background run has no synchronous parent to decide an escalation, so it never asks:
-          // the brief carries no `escalatable`, and the reply comes home as an inbound, awaited
-          // later by `agents.result({ id: callId })`.
+      result: {
+        description: "Await a run fired with `background: true`. Answers its terminal once the reply lands; parks the execution until then. `output` re-applies a JSON schema to a structured answer.",
+        input: {
+          type: "object",
+          properties: { id: { type: "string", description: "the callId a background run answered" }, output: { type: "object", description: "JSON schema for a structured answer" } },
+          required: ["id"]
+        },
+        output: { type: "object", properties: { output: { description: "the agent's answer; parsed when a schema was given" } } }
+      },
+      continue: {
+        description: "Resolve a budget request from an escalatable run. Pass the request's `handle` and a `grant` of extra tool calls; a grant of 0 or less denies, and the agent finishes with what it has. A grant draws the run's shared budget, so a spent budget denies whatever you pass. Returns the agent's next boundary: another request, or its final answer, in the same shape run() returns.",
+        input: {
+          type: "object",
+          properties: {
+            handle: { type: "object", description: "the handle from a requesting run" },
+            grant: { type: "number", description: "extra tool calls to grant; 0 or less denies" }
+          },
+          required: ["handle", "grant"]
+        },
+        output: { type: "object", properties: { output: { description: "the agent's answer, or a further request" } } }
+      }
+    },
+    methods: {
+      run: (args, ctx) =>
+        Effect.gen(function* () {
+          const a = args as
+            | { text?: unknown; background?: unknown; output?: unknown; outputSchema?: unknown; model?: unknown; budget?: unknown; escalatable?: unknown }
+            | undefined
+          const text = String(a?.text ?? "")
+          if (text === "") return { error: "agents.run needs { text }" }
+          // The schema parameter is `output`, and a near-miss spelling fails silently: no schema
+          // means a prose answer, so the caller's field reads come back undefined and the run
+          // returns something plausible and wrong. Say so instead.
+          if (a?.output === undefined && a?.outputSchema !== undefined) {
+            return { error: "agents.run takes the schema as `output`, not `outputSchema`" }
+          }
+          const output = a?.output
+          // The model name rides the brief's envelope: the child's log records the choice, so its
+          // Infer resolves it from trajectory and replay agrees by construction.
+          const model = a?.model === "haiku" || a?.model === "sonnet" || a?.model === "opus" ? a.model : undefined
+          // The tool-call budget rides the brief like the model does; the child's budget reactor reads
+          // it from its own trajectory. A run without a stated budget wants the per-agent default.
+          const want = typeof a?.budget === "number" && a.budget > 0 ? Math.floor(a.budget) : defaultBudget
+          // Draw from the run's single budget before the child spawns, so the whole tree is bounded by
+          // it whatever the fan-out. A partial budget grants what is left; a spent budget grants 0, and
+          // then no agent spawns, which is how the tree stops. The draw is keyed on this call's id, so
+          // a re-driven code body reuses its grant and never draws twice.
+          const budget = yield* Effect.promise(() => reserve(ctx.callId, want))
+          if (budget <= 0) return { error: "the run's budget is exhausted; no budget to spawn this agent" }
+          // The child works as the same member the parent does: the actor rides every brief in the
+          // family, so a run's whole tree resolves connections identically.
+          const actor = actorOf()
+          // The parent's own shadow reading, never the tool args: an agent cannot set or unset it, so
+          // a whole run family is shadow by construction from the fire alone. `world` rides along
+          // the same way, when the fire named an explicit shared one.
+          const shadow = shadowOf()
+          const world = worldOf()
+          const address = place(ctx.callId)
+          if (a?.background === true) {
+            // A background run has no synchronous parent to decide an escalation, so it never asks:
+            // the brief carries no `escalatable`, and the reply comes home as an inbound, awaited
+            // later by `agents.result({ id: callId })`.
+            const at = yield* Clock.currentTimeMillis
+            yield* router.deliver(address, {
+              type: "MessageReceived",
+              id: ctx.callId,
+              text,
+              ...(output === undefined ? {} : { output }),
+              ...(model === undefined ? {} : { model }),
+              budget,
+              ...(actor === undefined ? {} : { actor }),
+              ...(shadow ? { shadow: true } : {}),
+              ...(world === undefined ? {} : { world }),
+              replyTo: self,
+              from: self,
+              at
+            })
+            return { dispatched: true, callId: ctx.callId }
+          }
+          // Escalation is a foreground affordance, and the one shape that still holds its call
+          // open: see the module comment for why. Every other foreground run parks below.
+          if (a?.escalatable === true) {
+            const answer = yield* router.call(address, {
+              id: ctx.callId,
+              text,
+              ...(output === undefined ? {} : { output }),
+              ...(model === undefined ? {} : { model }),
+              budget,
+              escalatable: true,
+              ...(actor === undefined ? {} : { actor }),
+              ...(shadow ? { shadow: true } : {}),
+              ...(world === undefined ? {} : { world })
+            })
+            return shape(answer, address, ctx.callId, output !== undefined)
+          }
+          // Plain foreground: the same park logic `tasks.fire` uses. A reply already on the lane
+          // (a replayed attempt) answers at once, with no re-delivery; otherwise the brief goes
+          // out with `replyTo` this lane, exactly the background delivery above, and the host
+          // parks this call until the reply lands.
+          const already = yield* awaitedReply(reader, self, ctx.callId)
+          if (already !== undefined) return shape(answerOf(already), address, ctx.callId, output !== undefined)
           const at = yield* Clock.currentTimeMillis
           yield* router.deliver(address, {
             type: "MessageReceived",
@@ -151,78 +207,40 @@ export const agentsPackage = (
             from: self,
             at
           })
-          return { dispatched: true, callId: ctx.callId }
-        }
-        // Escalation is a foreground affordance, and the one shape that still holds its call
-        // open: see the module comment for why. Every other foreground run parks below.
-        if (a?.escalatable === true) {
-          const answer = yield* router.call(address, {
-            id: ctx.callId,
-            text,
-            ...(output === undefined ? {} : { output }),
-            ...(model === undefined ? {} : { model }),
-            budget,
-            escalatable: true,
-            ...(actor === undefined ? {} : { actor }),
-            ...(shadow ? { shadow: true } : {}),
-            ...(world === undefined ? {} : { world })
-          })
-          return shape(answer, address, ctx.callId, output !== undefined)
-        }
-        // Plain foreground: the same park logic `tasks.fire` uses. A reply already on the lane
-        // (a replayed attempt) answers at once, with no re-delivery; otherwise the brief goes
-        // out with `replyTo` this lane, exactly the background delivery above, and the host
-        // parks this call until the reply lands.
-        const already = yield* awaitedReply(reader, self, ctx.callId)
-        if (already !== undefined) return shape(answerOf(already), address, ctx.callId, output !== undefined)
-        const at = yield* Clock.currentTimeMillis
-        yield* router.deliver(address, {
-          type: "MessageReceived",
-          id: ctx.callId,
-          text,
-          ...(output === undefined ? {} : { output }),
-          ...(model === undefined ? {} : { model }),
-          budget,
-          ...(actor === undefined ? {} : { actor }),
-          ...(shadow ? { shadow: true } : {}),
-          ...(world === undefined ? {} : { world }),
-          replyTo: self,
-          from: self,
-          at
+          return yield* Effect.fail(new Park({ callId: ctx.callId, awaiting: replyId(ctx.callId) }))
+        }),
+      // Await a run already fired in the background: no delivery, the same reply-or-park read the
+      // plain foreground branch of `run` takes. `id` is the `callId` an earlier `background: true`
+      // run answered.
+      result: (args, ctx) =>
+        Effect.gen(function* () {
+          const a = args as { id?: unknown; output?: unknown } | undefined
+          const id = String(a?.id ?? "")
+          if (id === "") return { error: "agents.result needs { id }" }
+          const reply = yield* awaitedReply(reader, self, id)
+          if (reply !== undefined) return shape(answerOf(reply), "", id, a?.output !== undefined)
+          return yield* Effect.fail(new Park({ callId: ctx.callId, awaiting: replyId(id) }))
+        }),
+      // Resume a child parked on a budget ask. `grant` is the tool calls to add; a non-positive grant,
+      // or a spent run budget, denies and the child finishes. The grant draws the run's budget like a
+      // fresh spawn does, so escalation stays inside the same whole-run bound. Returns the child's next
+      // boundary, another request or its final answer, in the same shape `run` returns.
+      continue: (args, ctx) =>
+        Effect.gen(function* () {
+          const a = args as { handle?: unknown; grant?: unknown } | undefined
+          const handle = a?.handle as { address?: unknown; turn?: unknown; structured?: unknown } | undefined
+          const address = String(handle?.address ?? "")
+          const turn = String(handle?.turn ?? "")
+          if (address === "" || turn === "") return { error: "agents.continue needs { handle, grant }; the handle comes from a run that is requesting" }
+          const want = typeof a?.grant === "number" ? Math.floor(a.grant) : 0
+          const granted = want > 0 ? yield* Effect.promise(() => reserve(ctx.callId, want)) : 0
+          const decision = granted > 0 ? { amount: granted } : { amount: 0, reason: "the parent declined the request" }
+          const answer = yield* router.resume(address, turn, decision)
+          return shape(answer, address, turn, handle?.structured === true)
         })
-        return yield* Effect.fail(new Park({ callId: ctx.callId, awaiting: replyId(ctx.callId) }))
-      }),
-    // Await a run already fired in the background: no delivery, the same reply-or-park read the
-    // plain foreground branch of `run` takes. `id` is the `callId` an earlier `background: true`
-    // run answered.
-    result: (args, ctx) =>
-      Effect.gen(function* () {
-        const a = args as { id?: unknown; output?: unknown } | undefined
-        const id = String(a?.id ?? "")
-        if (id === "") return { error: "agents.result needs { id }" }
-        const reply = yield* awaitedReply(reader, self, id)
-        if (reply !== undefined) return shape(answerOf(reply), "", id, a?.output !== undefined)
-        return yield* Effect.fail(new Park({ callId: ctx.callId, awaiting: replyId(id) }))
-      }),
-    // Resume a child parked on a budget ask. `grant` is the tool calls to add; a non-positive grant,
-    // or a spent run budget, denies and the child finishes. The grant draws the run's budget like a
-    // fresh spawn does, so escalation stays inside the same whole-run bound. Returns the child's next
-    // boundary, another request or its final answer, in the same shape `run` returns.
-    continue: (args, ctx) =>
-      Effect.gen(function* () {
-        const a = args as { handle?: unknown; grant?: unknown } | undefined
-        const handle = a?.handle as { address?: unknown; turn?: unknown; structured?: unknown } | undefined
-        const address = String(handle?.address ?? "")
-        const turn = String(handle?.turn ?? "")
-        if (address === "" || turn === "") return { error: "agents.continue needs { handle, grant }; the handle comes from a run that is requesting" }
-        const want = typeof a?.grant === "number" ? Math.floor(a.grant) : 0
-        const granted = want > 0 ? yield* Effect.promise(() => reserve(ctx.callId, want)) : 0
-        const decision = granted > 0 ? { amount: granted } : { amount: 0, reason: "the parent declined the request" }
-        const answer = yield* router.resume(address, turn, decision)
-        return shape(answer, address, turn, handle?.structured === true)
-      })
+    }
   }
-})
+}
 
 // AgentReader reads one facet's committed events. `run` (awaiting) and `result` use it to check
 // whether a spawned child's reply has already landed, before ever parking: the same shape

--- a/packages/agent/src/surface.ts
+++ b/packages/agent/src/surface.ts
@@ -76,7 +76,8 @@ const settleFor = (
   // result (the print-to-inspect habit; packages/code/src/sandbox.ts, SandboxResult.logs).
   const logs = settle.logs !== undefined && settle.logs.length > 0 ? { logs: settle.logs } : {}
   if (settle.error !== undefined) return { error: String(settle.error), ...logs }
-  // A settle over TMP_BYTES carries a pointer instead of the value (packages/code/src/execute.ts).
+  // A settle over the spill bound carries a pointer instead of the value (packages/code/src/tmp.ts,
+  // SpillPolicy).
   // The pointer IS the result the model reads: its preview and its note name the ref and the
   // call that loads it. Reading `result` alone answers a spilled call with `{}`, so the model
   // learns neither what it computed nor that anything is there to fetch, and it re-runs the work

--- a/packages/agent/src/turn.test.ts
+++ b/packages/agent/src/turn.test.ts
@@ -144,7 +144,7 @@ describe("the agent with execute as the only tool", () => {
   })
 
   test("a spilled settle answers with its pointer, never an empty result", async () => {
-    // Over TMP_BYTES the settle carries a pointer instead of the value. Answering the call from
+    // Over the spill bound the settle carries a pointer instead of the value. Answering the call from
     // `result` alone hands the model `{}`: it learns neither what its code computed nor that a
     // ref holds it, so it re-runs the work. The pointer and its note are the result.
     const big = "y".repeat(20_000)

--- a/packages/agent/src/turn.ts
+++ b/packages/agent/src/turn.ts
@@ -5,14 +5,14 @@ import { composeKeys } from "@tardigrade/core/event-log"
 import { messageKeys } from "@tardigrade/core/message"
 import { codeKeys } from "@tardigrade/code/events"
 import { agentKeys } from "./events"
-import { codeReactor } from "@tardigrade/code/execute"
+import { codeReactorFor, type CodePolicy } from "@tardigrade/code/execute"
 import type { Router } from "@tardigrade/core/router"
 import type { Self } from "@tardigrade/core/actor"
-import { Infer, inferReactor } from "./infer"
+import { Infer, inferReactorFor, type InferPolicy } from "./infer"
 import { toolsReactorFor } from "./tools"
-import { budgetReactor } from "./budget"
+import { budgetReactorFor, type BudgetPolicy } from "./budget"
 import { replyReactor } from "./reply"
-import { compactionReactor } from "./compaction"
+import { compactionReactorFor, type ContextPolicy } from "./compaction"
 import { codeSurface, type ToolSurface } from "./surface"
 
 export { Infer } from "./infer"
@@ -28,18 +28,41 @@ export const agentActorKeys = composeKeys(messageKeys, agentKeys)
 // rlmActorKeys adds the code lane's fragment. createRlmAgent uses this table.
 export const rlmActorKeys = composeKeys(messageKeys, codeKeys, agentKeys)
 
+// AgentPolicy is every policy value an assembled agent applies, one field per reactor that
+// applies one, so a caller sets a single number without rebuilding the reactor list. Each field
+// is itself partial and fills from its own exported default (infer.ts, budget.ts, compaction.ts,
+// packages/code/src/execute.ts). An assembly takes only the fields its reactors apply, so a
+// stated policy is never a silently ignored one.
+//
+// `context` also decides what the model's request renders, and the render happens in the model
+// binding, not here. A caller that states one states the same one to `modelRequest`, exactly as
+// it does with the surface (compaction.ts, ContextPolicy).
+export interface AgentPolicy {
+  readonly infer: Partial<InferPolicy>
+  readonly budget: Partial<BudgetPolicy>
+  readonly context: Partial<ContextPolicy>
+  readonly code: Partial<CodePolicy>
+}
+
 // agentFor is the mind: infer decides, tools serve the surface, reply reports the terminal home.
 // The caller chooses the work half. Code mode is rlmAgentFor(codeSurface()), because execute
-// needs the code reactor.
-export const agentFor = (surface: ToolSurface<AgentR>) =>
-  actor<AgentR>([inferReactor, toolsReactorFor(surface), replyReactor], agentActorKeys)
+// needs the code reactor. The mind applies one policy, the model loop's own ceilings.
+export const agentFor = (surface: ToolSurface<AgentR>, policy: Partial<Pick<AgentPolicy, "infer">> = {}) =>
+  actor<AgentR>([inferReactorFor(policy.infer), toolsReactorFor(surface), replyReactor], agentActorKeys)
 
 // rlmAgentFor is the Recursive Language Model default: the mind plus budget, durable code, and
 // compaction. budget precedes tools, so BudgetExhausted is on the log when the dispatch gate
 // reads it. None of the six imports another; they compose through event names.
-export const rlmAgentFor = (surface: ToolSurface<RlmR>) =>
+export const rlmAgentFor = (surface: ToolSurface<RlmR>, policy: Partial<AgentPolicy> = {}) =>
   actor<RlmR>(
-    [inferReactor, budgetReactor, toolsReactorFor(surface), codeReactor, replyReactor, compactionReactor],
+    [
+      inferReactorFor(policy.infer),
+      budgetReactorFor(policy.budget),
+      toolsReactorFor(surface),
+      codeReactorFor(policy.code),
+      replyReactor,
+      compactionReactorFor(policy.context)
+    ],
     rlmActorKeys
   )
 

--- a/packages/code/src/contract.ts
+++ b/packages/code/src/contract.ts
@@ -48,13 +48,18 @@ const objectBody = (node: SchemaNode, depth: number): string => {
   return `{${fields.join(", ")}}`
 }
 
+// DEFAULT_SIGNATURE_DEPTH is how far a rendered signature nests before an object stands for its
+// own contents. It bounds the line a wrong call reads back, so a caller with deeper schemas
+// raises it at the call site rather than losing the fields that would teach the fix.
+export const DEFAULT_SIGNATURE_DEPTH = 2
+
 // renderSignature folds a method's declared input schema into one calling line:
 // `put({name: string, body: string, title?: string})`. A method with no usable object schema
 // renders bare: `list()`.
-export const renderSignature = (method: string, input: unknown): string => {
+export const renderSignature = (method: string, input: unknown, depth = DEFAULT_SIGNATURE_DEPTH): string => {
   const node = asNode(input)
   if (node === undefined || node.type !== "object" || node.properties === undefined) return `${method}()`
-  const body = objectBody(node, 2)
+  const body = objectBody(node, depth)
   return body === "{}" ? `${method}()` : `${method}(${body})`
 }
 

--- a/packages/code/src/defaults.test.ts
+++ b/packages/code/src/defaults.test.ts
@@ -4,8 +4,8 @@ import type { Event } from "@tardigrade/core/event"
 import { composeKeys, EventLog, withWatermark } from "@tardigrade/core/event-log"
 import { settleActor } from "@tardigrade/core/actor"
 import { messageKeys } from "@tardigrade/core/message"
-import { Sandbox } from "./sandbox"
-import { jsSandbox, memoryTmp, LOG_CAP_BYTES } from "./defaults"
+import { DEFAULT_SANDBOX_POLICY, Sandbox } from "./sandbox"
+import { jsSandbox, jsSandboxFor, memoryTmp } from "./defaults"
 import { codeReactor } from "./execute"
 import { codeKeys } from "./events"
 import { Packages } from "./packages"
@@ -41,12 +41,25 @@ describe("jsSandbox console capture", () => {
     expect(outcome.logs).toEqual(["before the fall"])
   })
 
-  test("the cap bounds a print loop", async () => {
+  test("the cap bounds a print loop and says where it cut", async () => {
     const outcome = await run('for (let i = 0; i < 1000; i++) console.log("x".repeat(100)); return "done"')
     expect(outcome.result).toBe("done")
     const total = (outcome.logs ?? []).reduce((n, l) => n + l.length, 0)
-    expect(total).toBeLessThanOrEqual(LOG_CAP_BYTES + 100)
+    expect(total).toBeLessThanOrEqual(DEFAULT_SANDBOX_POLICY.logCapBytes + 200)
     expect((outcome.logs ?? []).length).toBeLessThan(1000)
+    expect((outcome.logs ?? []).at(-1)).toContain(`cut at ${DEFAULT_SANDBOX_POLICY.logCapBytes} bytes`)
+  })
+
+  test("the cap is the consumer's: a stated one bounds the same loop lower", async () => {
+    const outcome = await Effect.runPromise(
+      Effect.gen(function* () {
+        const sandbox = yield* Sandbox
+        return yield* sandbox.run('for (let i = 0; i < 100; i++) console.log("x".repeat(100)); return "done"', {})
+      }).pipe(Effect.provide(jsSandboxFor({ logCapBytes: 500 })))
+    )
+    const total = (outcome.logs ?? []).reduce((n, l) => n + l.length, 0)
+    expect(total).toBeLessThanOrEqual(500 + 200)
+    expect((outcome.logs ?? []).at(-1)).toContain("cut at 500 bytes")
   })
 })
 

--- a/packages/code/src/defaults.ts
+++ b/packages/code/src/defaults.ts
@@ -1,13 +1,15 @@
 import { Layer } from "effect"
-import { jsSandboxService, Sandbox } from "./sandbox"
+import { jsSandboxService, jsSandboxServiceFor, Sandbox, type SandboxPolicy } from "./sandbox"
 import { memoryTmpService, Tmp } from "./tmp"
 
 // The code lane's explicit seam bindings. Both services default to these implementations
 // (Sandbox and Tmp are References), so a caller only provides a layer to override, or to get a
 // tmp store that is fresh rather than the process-shared default.
 
-export { LOG_CAP_BYTES } from "./sandbox"
-
 export const jsSandbox: Layer.Layer<never> = Layer.succeed(Sandbox)(jsSandboxService)
+
+// jsSandboxFor is the same layer on a stated console cap (sandbox.ts, SandboxPolicy).
+export const jsSandboxFor = (policy: Partial<SandboxPolicy>): Layer.Layer<never> =>
+  Layer.succeed(Sandbox)(jsSandboxServiceFor(policy))
 
 export const memoryTmp = (): Layer.Layer<never> => Layer.succeed(Tmp)(memoryTmpService())

--- a/packages/code/src/execute.test.ts
+++ b/packages/code/src/execute.test.ts
@@ -7,7 +7,7 @@ import { messageKeys } from "@tardigrade/core/message"
 import { Packages, type Package } from "./packages"
 import { Sandbox, type Bindings } from "./sandbox"
 import { Tmp } from "./tmp"
-import { codeReactor } from "./execute"
+import { codeReactor, codeReactorFor } from "./execute"
 import { codeKeys } from "./events"
 
 // The shadow router rule, over the one funnel every package call crosses: `executeRecorded`. A
@@ -217,5 +217,34 @@ describe("the shadow router rule", () => {
       c: { ok: "openWrite" },
       d: { ok: "mystery" }
     })
+  })
+})
+
+describe("the spill bound", () => {
+  // The bound is the consumer's: a settle over it carries a pointer instead of the value, and the
+  // preview length is stated the same way (tmp.ts, SpillPolicy).
+  test("a stated bound spills a value the default would have kept whole", async () => {
+    const log: Event[] = [
+      { type: "MessageReceived", id: "t1", text: "go", at: 1 },
+      { type: "CodeDispatched", execId: "e1", code: 'return "q".repeat(60)', turn: "t1", at: 2 }
+    ]
+    const drive = (reactor: typeof codeReactor) =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          yield* settleActor({ reactors: [reactor], keyOf: composeKeys(messageKeys, codeKeys) })
+          return yield* Effect.flatMap(EventLog, (l) => l.read)
+        }).pipe(Effect.provide(Layer.mergeAll(memoryLog(log), packagesLayer, jsSandbox, memSpill()))) as Effect.Effect<
+          ReadonlyArray<Event>
+        >
+      )
+    const spilled = (await drive(codeReactorFor({ spill: { spillBytes: 10, previewChars: 4 } }))).find(
+      (e) => e.type === "CodeSettled"
+    ) as { tmp?: string; size?: number; preview?: string; result?: unknown }
+    expect(spilled.tmp).toBe("e1.result")
+    expect(spilled.size).toBe(62)
+    expect(spilled.preview).toBe('"qqq')
+    const whole = (await drive(codeReactor)).find((e) => e.type === "CodeSettled") as { tmp?: string; result?: unknown }
+    expect(whole.tmp).toBeUndefined()
+    expect(whole.result).toBe("q".repeat(60))
   })
 })

--- a/packages/code/src/execute.ts
+++ b/packages/code/src/execute.ts
@@ -7,7 +7,7 @@ import { annotationsOf, Packages } from "./packages"
 import { checkInput, renderSignature } from "./contract"
 import { Sandbox, type Bindings } from "./sandbox"
 import { turnHead, turnOf } from "./turns"
-import { Tmp, TMP_BYTES, tmpPointer } from "./tmp"
+import { Tmp, spillPolicyOf, tmpPointer, type SpillPolicy } from "./tmp"
 import { callId as callIdOf } from "./ids"
 import { blockedOn, codeSettled, packageCalled, packageReturned } from "./events"
 
@@ -34,6 +34,7 @@ type CallOutcome = { readonly parked: true } | { readonly parked: false; readonl
 const executeRecorded = (
   execId: string,
   code: string,
+  spill: SpillPolicy,
   turn?: string,
   dispatchedAt?: number
 ): Effect.Effect<ReadonlyArray<Event>, never, EventLog> =>
@@ -183,10 +184,15 @@ const executeRecorded = (
               // receives the whole value, and replay hydrates the ref.
               const answeredAt = yield* Clock.currentTimeMillis
               const json = JSON.stringify(attempt.result ?? null)
-              if (json.length > TMP_BYTES) {
+              if (json.length > spill.spillBytes) {
                 yield* (yield* Tmp).store(callId, json)
                 yield* log.append([
-                  packageReturned({ callId, ...tmpPointer(callId, json.length, json.slice(0, 500)), ...stamp, at: answeredAt })
+                  packageReturned({
+                    callId,
+                    ...tmpPointer(callId, json.length, json.slice(0, spill.previewChars)),
+                    ...stamp,
+                    at: answeredAt
+                  })
                 ])
               } else {
                 yield* log.append([packageReturned({ callId, result: attempt.result, ...stamp, at: answeredAt })])
@@ -248,22 +254,31 @@ const executeRecorded = (
       // The settle is what the model will read: a large one goes to tmp and the settle carries
       // the pointer, so no result can nuke the turn context.
       const json = JSON.stringify(outcome.result ?? null)
-      if (json.length > TMP_BYTES) {
+      if (json.length > spill.spillBytes) {
         const ref = `${execId}.result`
         yield* (yield* Tmp).store(ref, json)
-        return [codeSettled({ execId, ...tmpPointer(ref, json.length, json.slice(0, 500)), ...logs, ...stamp, at })]
+        return [
+          codeSettled({ execId, ...tmpPointer(ref, json.length, json.slice(0, spill.previewChars)), ...logs, ...stamp, at })
+        ]
       }
       return [codeSettled({ execId, result: outcome.result, ...logs, ...stamp, at })]
     }
     return [{ type: "CodeSettled", execId, error: outcome.error, ...logs, ...stamp, at }]
   })
 
-// codeReactor derives the executable head as one transition: the settle is the record
+// CodePolicy is the lane's policy: where a result stops fitting in an agent's context and
+// spills to tmp instead (tmp.ts, SpillPolicy).
+export interface CodePolicy {
+  readonly spill: Partial<SpillPolicy>
+}
+
+// codeReactorFor derives the executable head as one transition: the settle is the record
 // (`cs:<execId>` through codeKeys), one attempt is the act. `workOwed` is the readiness gate:
 // a blocked head (open BlockedOn calls, no awaited reply home) derives nothing, so the lane
 // rests honestly and a landing reply re-derives it. An attempt that parks mid-act returns
 // BlockedOn evidence instead of the settle; the reconciler reads that as blocked, never wedged.
-export const codeReactor: Reactor = (events) => {
+export const codeReactorFor = (policy: Partial<CodePolicy> = {}): Reactor => (events) => {
+  const spill = spillPolicyOf(policy.spill)
   const owed = workOwed(events)
   if (owed === undefined) return []
   const dispatch = events.find(
@@ -280,7 +295,10 @@ export const codeReactor: Reactor = (events) => {
         turn: turnOf(dispatch),
         at: typeof d.at === "number" ? d.at : undefined
       },
-      act: (input) => executeRecorded(input.execId, input.code, input.turn, input.at)
+      act: (input) => executeRecorded(input.execId, input.code, spill, input.turn, input.at)
     })
   ]
 }
+
+// codeReactor is that reactor on the default spill bound.
+export const codeReactor: Reactor = codeReactorFor()

--- a/packages/code/src/sandbox.ts
+++ b/packages/code/src/sandbox.ts
@@ -41,13 +41,28 @@ const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as
   ...args: ReadonlyArray<string>
 ) => (...bindings: ReadonlyArray<unknown>) => Promise<unknown>
 
-// consoleShim captures a body's console output into `lines`, capped in bytes so a print loop
-// stays harmless. Past the cap, lines drop silently: prints are telemetry, never control flow.
-export const LOG_CAP_BYTES = 8192
-const consoleShim = (lines: string[]) => {
+// SandboxPolicy bounds what one execution's console output costs: past `logCapBytes` a print
+// loop stays harmless. The cap decides how much of its own output a model reads back, so
+// `jsSandboxServiceFor` takes an override rather than this file deciding for every consumer.
+export interface SandboxPolicy {
+  readonly logCapBytes: number
+}
+
+export const DEFAULT_SANDBOX_POLICY: SandboxPolicy = { logCapBytes: 8_192 }
+
+// consoleShim captures a body's console output into `lines`, capped in bytes. At the cap it
+// pushes one line naming the cap and drops the rest: a silent drop reads as a body that stopped
+// printing, and the model then trusts a partial log as the whole of it.
+const consoleShim = (lines: string[], policy: SandboxPolicy) => {
   let bytes = 0
+  let cut = false
   const push = (args: ReadonlyArray<unknown>) => {
-    if (bytes >= LOG_CAP_BYTES) return
+    if (bytes >= policy.logCapBytes) {
+      if (cut) return
+      cut = true
+      lines.push(`…[console output cut at ${policy.logCapBytes} bytes; later lines dropped]`)
+      return
+    }
     const line = args.map(String).join(" ")
     lines.push(line)
     bytes += line.length
@@ -99,29 +114,35 @@ const ambientShims = (ambient: Ambient): Record<string, unknown> => {
   return { Date: PinnedDate, Math: PinnedMath }
 }
 
-// jsSandboxService runs the body as a plain async function. The body must stay deterministic
+// jsSandboxServiceFor runs the body as a plain async function. The body must stay deterministic
 // between package calls (the contract above); nothing here enforces it. `console` is shadowed
 // by a capturing shim (printed lines come back on the result's `logs`), and with an ambient,
 // Date and Math are shadowed by replay-stable pins.
-export const jsSandboxService: SandboxService = {
-  run: (code: string, bindings: Bindings, ambient?: Ambient) =>
-    Effect.promise(async () => {
-      const lines: string[] = []
-      const logs = () => (lines.length === 0 ? {} : { logs: lines })
-      const scope: Bindings = {
-        ...bindings,
-        console: consoleShim(lines),
-        ...(ambient === undefined ? {} : ambientShims(ambient))
-      }
-      try {
-        const names = Object.keys(scope)
-        const body = new AsyncFunction(...names, code)
-        return { result: await body(...names.map((name) => scope[name])), ...logs() }
-      } catch (e) {
-        return { error: String(e), ...logs() }
-      }
-    })
+export const jsSandboxServiceFor = (policy: Partial<SandboxPolicy> = {}): SandboxService => {
+  const resolved: SandboxPolicy = { logCapBytes: policy.logCapBytes ?? DEFAULT_SANDBOX_POLICY.logCapBytes }
+  return {
+    run: (code: string, bindings: Bindings, ambient?: Ambient) =>
+      Effect.promise(async () => {
+        const lines: string[] = []
+        const logs = () => (lines.length === 0 ? {} : { logs: lines })
+        const scope: Bindings = {
+          ...bindings,
+          console: consoleShim(lines, resolved),
+          ...(ambient === undefined ? {} : ambientShims(ambient))
+        }
+        try {
+          const names = Object.keys(scope)
+          const body = new AsyncFunction(...names, code)
+          return { result: await body(...names.map((name) => scope[name])), ...logs() }
+        } catch (e) {
+          return { error: String(e), ...logs() }
+        }
+      })
+  }
 }
+
+// jsSandboxService is that sandbox on the default cap.
+export const jsSandboxService: SandboxService = jsSandboxServiceFor()
 
 export const Sandbox: Context.Reference<SandboxService> = Context.Reference("code/Sandbox", {
   defaultValue: () => jsSandboxService

--- a/packages/code/src/tmp.ts
+++ b/packages/code/src/tmp.ts
@@ -24,10 +24,24 @@ export const Tmp: Context.Reference<TmpService> = Context.Reference("code/Tmp", 
   defaultValue: memoryTmpService
 })
 
-// TMP_BYTES is the bound: a larger value goes to tmp and the event keeps a pointer.
-export const TMP_BYTES = 8_192
+// SpillPolicy is the bound and what a bounded value shows: a JSON value longer than
+// `spillBytes` goes to tmp and the event keeps a pointer with the first `previewChars` of it.
+// The reactor that applies it takes an override (execute.ts, codeReactorFor), because the right
+// bound is the consumer's context window and storage, not this module's guess.
+export interface SpillPolicy {
+  readonly spillBytes: number
+  readonly previewChars: number
+}
 
-// tmpPointer is the pointer a bounded value leaves behind.
+export const DEFAULT_SPILL_POLICY: SpillPolicy = { spillBytes: 8_192, previewChars: 500 }
+
+export const spillPolicyOf = (policy: Partial<SpillPolicy> = {}): SpillPolicy => ({
+  spillBytes: policy.spillBytes ?? DEFAULT_SPILL_POLICY.spillBytes,
+  previewChars: policy.previewChars ?? DEFAULT_SPILL_POLICY.previewChars
+})
+
+// tmpPointer is the pointer a bounded value leaves behind. `size` is the whole value's length,
+// so the reader sees how much the preview left out.
 export const tmpPointer = (ref: string, size: number, preview: string) => ({
   tmp: ref,
   size,

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -9,6 +9,7 @@ import type { Action } from "@tardigrade/agent/events"
 import type { Event } from "@tardigrade/core/event"
 import { answerErrors, outputSchemaOf } from "@tardigrade/agent/contract"
 import { modelRequest, type AgentMessage, type ToolSpec } from "@tardigrade/agent/request"
+import type { ContextPolicy } from "@tardigrade/agent/compaction"
 import { codeSurface, type ToolSurface } from "@tardigrade/agent/surface"
 import { sumUsage, usageFrom, type ModelPricing, type Usage } from "@tardigrade/agent/usage"
 
@@ -180,12 +181,20 @@ export interface ModelConfig {
   // the same surface, or the model is offered tools its reactor will not serve
   // (@tardigrade/agent, surface.ts).
   readonly surface?: Pick<ToolSurface, "system" | "tools">
+  // What this binding's render truncates, and where. It rides the same rule the surface does:
+  // the agent's compaction reactor must hold the same policy, or its guard fires against a size
+  // the request never reaches (@tardigrade/agent, compaction.ts, ContextPolicy).
+  readonly context?: Partial<ContextPolicy>
   readonly provider?: string
   // The model's output ceiling, DECLARED by the operator rather than guessed: no wire this
   // binding speaks publishes limits, so the number that bounds the truncation ladder is stated
   // configuration. Absent, the ladder falls back to its built-in guesses and the compatible leg
   // sends its rung explicitly rather than trusting a provider default.
   readonly maxOutputTokens?: number
+  // The rungs the truncation ladder climbs, smallest first. Absent, MAX_TOKENS_LADDER. A model
+  // whose useful answers start above the first rung wastes an attempt on every turn, so the
+  // rungs are the operator's to state, bounded by `maxOutputTokens` either way (ladderOf).
+  readonly maxTokensLadder?: ReadonlyArray<number>
   // Stream wall times. Absent fields take DEFAULT_STREAM_BOUNDS. A long healthy generation
   // that outlives totalMs dies the same way a hung stream does, so set this for the work you run.
   readonly stream?: Partial<StreamBounds>
@@ -288,11 +297,11 @@ export const MAX_TOKENS_LADDER = [32_768, 65_536]
 
 // ladderOf bounds the retry ladder by the declared ceiling: never a rung above what the model
 // can produce, and the declared cap is always the last rung, so the loud failure names the
-// model's true limit (model.test.ts, "declared limits").
-export const ladderOf = (declared?: number): ReadonlyArray<number> => {
-  if (declared === undefined) return MAX_TOKENS_LADDER
-  const rungs = MAX_TOKENS_LADDER.filter((r) => r < declared)
-  return [...rungs, declared]
+// model's true limit (model.test.ts, "declared limits"). `rungs` is the ladder to bound,
+// MAX_TOKENS_LADDER when the caller states none.
+export const ladderOf = (declared?: number, rungs: ReadonlyArray<number> = MAX_TOKENS_LADDER): ReadonlyArray<number> => {
+  if (declared === undefined) return rungs
+  return [...rungs.filter((r) => r < declared), declared]
 }
 
 class TruncatedError extends Error {
@@ -501,7 +510,7 @@ export const infer = (config: ModelConfig) => {
             fetch: fetcher
           })
     // The domain decides the request; the platform maps it to the wire and streams it.
-    const req = modelRequest(trajectory, config.surface ?? codeSurface())
+    const req = modelRequest(trajectory, config.surface ?? codeSurface(), config.context ?? {})
     const schema = outputSchemaOf(trajectory) // the answer parser needs the turn's declared shape
     const stream = adapter.chatStream({
       model: config.model,
@@ -534,7 +543,7 @@ export const infer = (config: ModelConfig) => {
   return Layer.succeed(Infer, {
     react: (trajectory: ReadonlyArray<Event>, key?: string) =>
       Effect.gen(function* () {
-        const ladder = ladderOf(config.maxOutputTokens)
+        const ladder = ladderOf(config.maxOutputTokens, config.maxTokensLadder)
         const stats: { finish?: string; rung: number; waits: number } = { rung: 0, waits: 0 }
         const action = yield* Effect.promise<Action>(async () => {
         let rung = 0


### PR DESCRIPTION
## What and why

The framework applied several policy values that a consumer could read but not change: the render truncation caps, the compaction fire and keep lines, the default tool budget, the tmp spill bound and its preview length, the sandbox console cap, the output-token ladder, and the signature render depth. Each is a guess that fits some consumers and not others, and a constant nobody can set is a leaky abstraction. The render caps are the case that motivated this: they silently cut a trace manifest path out of a reflection prompt, and nothing on `modelRequest` or the surface let the caller widen them.

Every one of those values now follows one shape: a named policy type, an exported `DEFAULT_` constant, and a partial override on the surface that applies it. AGENTS.md gains the rule under Design, and `docs/how-to/policy.md` states the shape, where the values live, and the one coupling.

### The context policy

`MESSAGE_RENDER_CAP`, `RESULT_RENDER_CAP`, `COMPACTION_FIRE_TOKENS`, and `COMPACTION_KEEP_TOKENS` become one `ContextPolicy`, which also absorbs the previously unnamed 200-char cut on summary-brief lines. They are one object on purpose: the compaction guard counts characters exactly where the render truncates, so two policies would let a consumer raise the cap and leave the guard firing against a size no request reaches. `compactionReactorFor`, `renderMessages`, `modelRequest`, and `ModelConfig.context` all take it.

This is the one policy two places apply, because the reactor runs in the agent and the render runs in the model binding. It rides the same rule the tool surface already does: state it to both. The doc and the comments say so.

### The rest

`BudgetPolicy` replaces `DEFAULT_TOOL_BUDGET` and reaches both `budgetReactorFor` and the spawn package, so a child with no stated budget takes the same ceiling its own wall reads. `SpillPolicy` replaces `TMP_BYTES` and the literal 500-char preview. `SandboxPolicy` replaces `LOG_CAP_BYTES`. `ladderOf` takes the rungs, exposed as `ModelConfig.maxTokensLadder`. `renderSignature` takes its depth.

`AgentPolicy` gathers the four reactor policies at the assembly, so `rlmAgentFor(surface, policy)` and `createRlmAgent({ policy })` set any of them in one call. `agentFor` accepts only `{ infer }`, the one policy the mind applies: a stated field is never a silently ignored one.

### Visibility

Three cuts were silent and now name the cap they cut at. A truncated message and a truncated tool result read `truncated at 10 of 50 chars`. A truncated summary line says where it stopped. Console output past the cap ends with a line saying it was cut, where before it just stopped and a model read a fragment as the whole log.

### Notes

`agentsPackage` trades its four trailing positional optionals for a `SpawnOptions` object; a ninth positional parameter for the budget default would have been worse. `createRlmAgent` is the only caller.

The 1s jitter ceiling in `throttleDelayMs` stays a literal. It is a property of the backoff ladder the consumer already sets through `throttleRetryDelaysMs`, and a separate knob for it reads as noise.

- [x] `bun run gate` passes locally
- [x] Docs updated if behavior changed
- [x] Tests cover the change