### PR TITLE
feat(agent): capability assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import { createBunHost } from "@tardigrade/bun/host"
 import { fileTelemetry } from "@tardigrade/bun/file"
 
 // A capability bundles what the model is shown with how that work settles. Mounting one is
-// adding it to the list; `toolTable([...])` mounts a fixed tool table instead of code mode.
+// adding it to the list; `toolList([...])` mounts a fixed tool table instead of code mode.
 const agent = actorOf([codeMode, reply, budget, compaction])
 
 // createBunHost runs the actor over a durable SQLite log; layersFor wires the model binding.

--- a/README.md
+++ b/README.md
@@ -13,23 +13,14 @@ Prerequisites: bun 1.1 or later, and a model endpoint.
 An agent is reactors over one log.
 
 ```ts
-import { actor } from "@tardigrade/core/actor"
-import { composeKeys } from "@tardigrade/core/event-log"
-import { messageKeys } from "@tardigrade/core/message"
-import { codeReactor, codeKeys } from "@tardigrade/code"
-import { agentKeys, budgetReactor, codeSurface, compactionReactor, inferReactor, replyReactor, toolsReactorFor } from "@tardigrade/agent"
+import { actorOf, budget, codeMode, compaction, reply } from "@tardigrade/agent"
 import { infer } from "@tardigrade/model/model"
 import { createBunHost } from "@tardigrade/bun/host"
 import { fileTelemetry } from "@tardigrade/bun/file"
 
-// surface is the work the model is offered: code mode here, `nativeSurface` for a fixed table.
-const surface = codeSurface()
-
-// Adding a capability is adding a reactor to the list.
-const agent = actor(
-  [inferReactor, budgetReactor, toolsReactorFor(surface), codeReactor, replyReactor, compactionReactor],
-  composeKeys(messageKeys, codeKeys, agentKeys)
-)
+// A capability bundles what the model is shown with how that work settles. Mounting one is
+// adding it to the list; `toolTable([...])` mounts a fixed tool table instead of code mode.
+const agent = actorOf([codeMode, reply, budget, compaction])
 
 // createBunHost runs the actor over a durable SQLite log; layersFor wires the model binding.
 const host = await createBunHost({

--- a/packages/agent/src/capability.test.ts
+++ b/packages/agent/src/capability.test.ts
@@ -4,7 +4,7 @@ import type { Event } from "@tardigrade/core/event"
 import { EventLog, withWatermark } from "@tardigrade/core/event-log"
 import { Router } from "@tardigrade/core/router"
 import { Self } from "@tardigrade/core/actor"
-import { actorOf, budget, codeMode, compaction, renderOf, reply, toolTable } from "./capability"
+import { actorOf, budget, codeMode, compaction, renderOf, reply, toolList } from "./capability"
 import { receive } from "./turn"
 import { Infer, type InferRequest } from "./infer"
 
@@ -36,7 +36,7 @@ const readLog = Effect.flatMap(EventLog, (log) => log.read)
 const run = <A, R>(effect: Effect.Effect<A, never, R>, layers: Layer.Layer<R>) =>
   Effect.runPromise(effect.pipe(Effect.provide(layers)) as Effect.Effect<A>)
 
-const echoTable = toolTable([
+const echoTable = toolList([
   {
     spec: { name: "echo", description: "echoes", inputSchema: { type: "object" } },
     run: (input) => Effect.succeed({ echoed: input })
@@ -98,7 +98,7 @@ describe("actorOf", () => {
   })
 
   test("two capabilities declaring one tool name collide at construction", () => {
-    expect(() => actorOf([echoTable, toolTable([{ spec: { name: "echo", description: "again", inputSchema: {} }, run: () => Effect.succeed({}) }])])).toThrow(
+    expect(() => actorOf([echoTable, toolList([{ spec: { name: "echo", description: "again", inputSchema: {} }, run: () => Effect.succeed({}) }])])).toThrow(
       'tool "echo" declared by capabilities tools and tools'
     )
   })

--- a/packages/agent/src/capability.test.ts
+++ b/packages/agent/src/capability.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test"
+import { Effect, Layer, Ref } from "effect"
+import type { Event } from "@tardigrade/core/event"
+import { EventLog, withWatermark } from "@tardigrade/core/event-log"
+import { Router } from "@tardigrade/core/router"
+import { Self } from "@tardigrade/core/actor"
+import { actorOf, budget, codeMode, compaction, renderOf, reply, toolTable } from "./capability"
+import { receive } from "./turn"
+import { Infer, type InferRequest } from "./infer"
+
+// The capability assembly end to end: the render the model sees is the composed derivation of
+// the mounted capabilities, and a call routes to the capability that declared its tool.
+
+const memoryLog = (initial: ReadonlyArray<Event> = []) =>
+  Layer.effect(
+    EventLog,
+    Effect.gen(function* () {
+      const ref = yield* Ref.make<ReadonlyArray<Event>>(initial)
+      return withWatermark({
+        append: (events: ReadonlyArray<Event>) => Ref.update(ref, (log) => [...log, ...events]),
+        read: Ref.get(ref)
+      })
+    })
+  )
+
+const noRouter = Layer.mergeAll(
+  Layer.succeed(Router, {
+    deliver: () => Effect.void,
+    call: () => Effect.succeed({ error: "no router bound" }),
+    resume: () => Effect.succeed({ error: "no router bound" })
+  }),
+  Layer.succeed(Self, "test-agent")
+)
+
+const readLog = Effect.flatMap(EventLog, (log) => log.read)
+const run = <A, R>(effect: Effect.Effect<A, never, R>, layers: Layer.Layer<R>) =>
+  Effect.runPromise(effect.pipe(Effect.provide(layers)) as Effect.Effect<A>)
+
+const echoTable = toolTable([
+  {
+    spec: { name: "echo", description: "echoes", inputSchema: { type: "object" } },
+    run: (input) => Effect.succeed({ echoed: input })
+  }
+])
+
+describe("actorOf", () => {
+  test("the render is the composed derivation, and the request carries it to the model", async () => {
+    const seen: InferRequest[] = []
+    const mind = Layer.succeed(Infer, {
+      react: (request: InferRequest) => {
+        seen.push(request)
+        const returned = request.trajectory.some((e) => e.type === "ToolReturned")
+        return Effect.succeed(
+          returned
+            ? { kind: "complete" as const, output: "done" }
+            : { kind: "call" as const, callId: "c1", name: "echo", arguments: { hi: 1 } }
+        )
+      }
+    })
+    const agent = actorOf([echoTable, reply, budget, compaction])
+    const events = await run(
+      Effect.gen(function* () {
+        yield* receive(agent, { id: "m1", text: "go" })
+        return yield* readLog
+      }),
+      Layer.mergeAll(memoryLog(), mind, noRouter)
+    )
+    // The model was shown exactly what the capabilities derived.
+    expect(seen[0]!.tools.map((t) => t.name)).toEqual(["echo"])
+    expect(seen[0]!.system).toContain("echo")
+    // The call routed to the table capability and settled.
+    expect(events.find((e) => e.type === "ToolReturned")).toMatchObject({ callId: "c1", result: { echoed: { hi: 1 } } })
+    expect(events.at(-2)?.type).toBe("TurnCompleted")
+  })
+
+  test("a call no capability recognizes answers unknown-tool naming the composed tools", async () => {
+    const mind = Layer.succeed(Infer, {
+      react: (request: InferRequest) => {
+        const returned = request.trajectory.find((e) => e.type === "ToolReturned") as { result?: unknown } | undefined
+        return Effect.succeed(
+          returned === undefined
+            ? { kind: "call" as const, callId: "c9", name: "ghost", arguments: {} }
+            : { kind: "complete" as const, output: JSON.stringify(returned.result) }
+        )
+      }
+    })
+    const agent = actorOf([echoTable, reply])
+    const events = await run(
+      Effect.gen(function* () {
+        yield* receive(agent, { id: "m1", text: "go" })
+        return yield* readLog
+      }),
+      Layer.mergeAll(memoryLog(), mind, noRouter)
+    )
+    expect(events.find((e) => e.type === "ToolReturned")).toMatchObject({
+      result: { error: "unknown tool: ghost. Call one of: echo." }
+    })
+  })
+
+  test("two capabilities declaring one tool name collide at construction", () => {
+    expect(() => actorOf([echoTable, toolTable([{ spec: { name: "echo", description: "again", inputSchema: {} }, run: () => Effect.succeed({}) }])])).toThrow(
+      'tool "echo" declared by capabilities tools and tools'
+    )
+  })
+
+  test("renderOf composes system fragments and tools in mount order", () => {
+    const render = renderOf([codeMode, echoTable], [])
+    expect(render.tools.map((t) => t.name)).toEqual(["execute", "echo"])
+    expect(render.system.indexOf("execute")).toBeLessThan(render.system.indexOf("echo"))
+  })
+})

--- a/packages/agent/src/capability.ts
+++ b/packages/agent/src/capability.ts
@@ -116,10 +116,10 @@ export const codeMode: Capability = {
   serve: cs.serve
 }
 
-// toolTable is a fixed table of named tools, the shape every provider's tool calling takes and
+// toolList is a fixed table of named tools, the shape every provider's tool calling takes and
 // the shape a replicated harness is measured on: each call runs its tool and records the
 // return, no lane of its own.
-export const toolTable = <R = never>(tools: ReadonlyArray<NativeTool<R>>, system = ""): Capability<R> => {
+export const toolList = <R = never>(tools: ReadonlyArray<NativeTool<R>>, system = ""): Capability<R> => {
   const ns = nativeSurface(tools, system)
   return { name: "tools", tools: () => ns.tools, system: ns.system, serve: ns.serve }
 }

--- a/packages/agent/src/capability.ts
+++ b/packages/agent/src/capability.ts
@@ -1,0 +1,132 @@
+import { actor, type Actor, type Reactor, type Self, type Transition } from "@tardigrade/core/actor"
+import { composeKeys } from "@tardigrade/core/event-log"
+import { messageKeys } from "@tardigrade/core/message"
+import type { Event } from "@tardigrade/core/event"
+import type { KeyFragment } from "@tardigrade/core/event-log"
+import { codeKeys } from "@tardigrade/code/events"
+import { codeReactor } from "@tardigrade/code/execute"
+import type { ToolSpec } from "./request"
+import { codeSurface, nativeSurface, type Answer, type NativeTool, type PendingCall } from "./surface"
+import { agentKeys } from "./events"
+import type { Router } from "@tardigrade/core/router"
+import { inferReactorFor, type Infer, type InferPolicy } from "./infer"
+import { toolsReactorFrom } from "./tools"
+import { budgetReactor } from "./budget"
+import { replyReactor } from "./reply"
+import { compactionReactor } from "./compaction"
+import type { AgentR } from "./turn"
+
+// A Capability is one component of an agent: what the model is shown and how that work settles,
+// as one value. `tools` and `system` are the capability's render into the model's context,
+// re-derived from the log each attempt, and `reactors` and `serve` are its handlers. Mounting a
+// capability is adding it to the actorOf list; there is no second place to update.
+//
+// Every field but `name` is optional, because capabilities come in shapes: a policy capability
+// (reply, budget, compaction) has reactors with nothing to show; a tool-table capability has
+// tools and a serve with no lane of its own; code mode has all four.
+export interface Capability<R = never> {
+  // The capability's name, for the collision error and span attributes.
+  readonly name: string
+  // The capability's alphabet fragment. actorOf composes fragments the way composeKeys does,
+  // and a prefix collision is the same construction-time error.
+  readonly keys?: KeyFragment
+  // The reactors that settle this capability's work.
+  readonly reactors?: ReadonlyArray<Reactor<R>>
+  // tools derives what the model is shown, a projection of the log like any other: a constant
+  // capability ignores its argument, a gated one filters by what has happened
+  // (docs/how-to/gate-tools.md). The composed tools are what the infer reactor hands the model
+  // binding per attempt; nothing about tools lives in ModelConfig.
+  readonly tools?: (log: ReadonlyArray<Event>) => ReadonlyArray<ToolSpec>
+  // The system fragment explaining the tools. Fragments join in actorOf order.
+  readonly system?: string
+  // serve returns the transitions one call owes: an empty array while the world still works,
+  // undefined when the call names no tool of this capability (actorOf asks the next capability,
+  // and the reactor answers unknown-tool when every capability declines). The reactor owns the
+  // key and the turn stamp through `answer`.
+  readonly serve?: (
+    call: PendingCall,
+    log: ReadonlyArray<Event>,
+    answer: Answer
+  ) => ReadonlyArray<Transition<never, R>> | undefined
+}
+
+// renderOf is the composed system and tools for one derivation: what the model would be shown
+// over this log. The infer reactor is its one production reader; tests read it directly.
+export const renderOf = <R>(
+  capabilities: ReadonlyArray<Capability<R>>,
+  log: ReadonlyArray<Event>
+): { readonly system: string; readonly tools: ReadonlyArray<ToolSpec> } => ({
+  system: capabilities
+    .map((c) => c.system)
+    .filter((s): s is string => s !== undefined && s !== "")
+    .join("\n"),
+  tools: capabilities.flatMap((c) => c.tools?.(log) ?? [])
+})
+
+// actorOf mounts capabilities into an actor. The infer and call-routing reactors are the
+// runtime of the component model: actorOf injects them, and they are never listed as
+// capabilities, the way a component tree does not list the renderer. The canonical inbound and
+// the agent alphabet are the runtime's own key table; capability fragments compose beside them,
+// and a prefix collision is composeKeys' construction-time error. Two capabilities deriving the
+// same tool name collide at construction too, checked over the empty log (a log-gated duplicate
+// still routes to the first capability that recognizes it).
+// RequirementsOf extracts one capability's R, so a mixed list infers the union of what its
+// members need rather than failing on the first element's R.
+type RequirementsOf<C> = C extends Capability<infer R> ? R : never
+
+export const actorOf = <const Caps extends ReadonlyArray<Capability<never> | Capability<AgentR>>>(
+  caps: Caps,
+  policy: Partial<InferPolicy> = {}
+): Actor<AgentR | RequirementsOf<Caps[number]>> => {
+  const capabilities = caps as ReadonlyArray<Capability<AgentR | RequirementsOf<Caps[number]>>>
+  const named = new Map<string, string>()
+  for (const c of capabilities) {
+    for (const t of c.tools?.([]) ?? []) {
+      const holder = named.get(t.name)
+      if (holder !== undefined) throw new Error(`tool "${t.name}" declared by capabilities ${holder} and ${c.name}`)
+      named.set(t.name, c.name)
+    }
+  }
+  const serve = (call: PendingCall, log: ReadonlyArray<Event>, answer: Answer) => {
+    for (const c of capabilities) {
+      const served = c.serve?.(call, log, answer)
+      if (served !== undefined) return served
+    }
+    return undefined
+  }
+  return actor<AgentR | RequirementsOf<Caps[number]>>(
+    [
+      inferReactorFor(policy, (log) => renderOf(capabilities, log)),
+      toolsReactorFrom(serve, (log) => renderOf(capabilities, log).tools),
+      ...capabilities.flatMap((c) => c.reactors ?? [])
+    ],
+    composeKeys(messageKeys, agentKeys, ...capabilities.flatMap((c) => (c.keys === undefined ? [] : [c.keys])))
+  )
+}
+
+// codeMode is the code-execution capability: one `execute` tool, served by dispatching to the
+// code reactor and answered from its settle. The library default.
+const cs = codeSurface()
+export const codeMode: Capability = {
+  name: "code",
+  keys: codeKeys,
+  reactors: [codeReactor],
+  tools: () => cs.tools,
+  system: cs.system,
+  serve: cs.serve
+}
+
+// toolTable is a fixed table of named tools, the shape every provider's tool calling takes and
+// the shape a replicated harness is measured on: each call runs its tool and records the
+// return, no lane of its own.
+export const toolTable = <R = never>(tools: ReadonlyArray<NativeTool<R>>, system = ""): Capability<R> => {
+  const ns = nativeSurface(tools, system)
+  return { name: "tools", tools: () => ns.tools, system: ns.system, serve: ns.serve }
+}
+
+// The policy capabilities: behavior with nothing to show. Their keys live in the runtime's own
+// agent alphabet, so they carry none. Their R names what each reactor needs, all within the
+// AgentR the runtime already requires.
+export const reply: Capability<Router | Self> = { name: "reply", reactors: [replyReactor] }
+export const budget: Capability = { name: "budget", reactors: [budgetReactor] }
+export const compaction: Capability<Infer> = { name: "compaction", reactors: [compactionReactor] }

--- a/packages/agent/src/compaction.test.ts
+++ b/packages/agent/src/compaction.test.ts
@@ -97,7 +97,7 @@ describe("the compaction pass", () => {
         })
       ),
       Layer.succeed(Infer, {
-        react: (trajectory: ReadonlyArray<Event>) => {
+        react: ({ trajectory }: { trajectory: ReadonlyArray<Event> }) => {
           briefed = String((trajectory[0] as { text?: unknown }).text ?? "")
           return Effect.succeed({ kind: "complete" as const, output: "covenants 1 through 13 extracted" })
         }

--- a/packages/agent/src/compaction.ts
+++ b/packages/agent/src/compaction.ts
@@ -255,8 +255,13 @@ export const compactionReactorFor = (policy: Partial<ContextPolicy> = {}): React
             input.summary === "" ? "" : `Summary so far: ${input.summary}`,
             lines.join("\n")
           ].join("\n\n")
+          // A summarize attempt offers no tools: the only sane action is a completion.
           const action = yield* (yield* Infer).react(
-            [{ type: "MessageReceived", id: `compact-${input.keepFrom}`, text: brief, at }],
+            {
+              trajectory: [{ type: "MessageReceived", id: `compact-${input.keepFrom}`, text: brief, at }],
+              system: "",
+              tools: []
+            },
             `compact-${input.keepFrom}`
           )
           const summary = action.kind === "complete" ? action.output : input.summary

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -23,7 +23,7 @@ const headText = (trajectory: ReadonlyArray<Event>): string => {
 // The scripted mind honors the Infer seam's contract: fresh tool call
 // ids per call (real providers mint tooluse ids), and it reads only the
 // CURRENT turn's slice, so a second turn genuinely re-runs.
-const scripted = async (trajectory: ReadonlyArray<Event>): Promise<Action> => {
+const scripted = async ({ trajectory }: { trajectory: ReadonlyArray<Event> }): Promise<Action> => {
   const brief = headText(trajectory)
   if (brief.startsWith("sum ")) {
     const [a, b] = brief.slice(4).split("+").map(Number)
@@ -111,7 +111,7 @@ describe("createRlmAgent", () => {
     ])
     const mind = createRlmAgent({
       surface,
-      infer: async (trajectory) => {
+      infer: async ({ trajectory }) => {
         const returned = trajectory.find((e) => e.type === "ToolReturned") as { result?: unknown } | undefined
         if (returned !== undefined) return { kind: "complete", output: String(returned.result) }
         return { kind: "call", callId: "n1", name: "read", arguments: { path: "/contract.md" } }
@@ -132,7 +132,7 @@ describe("createRlmAgent", () => {
     ])
     const mind = createRlmAgent({
       surface,
-      infer: async (trajectory) => {
+      infer: async ({ trajectory }) => {
         const returned = trajectory.find((e) => e.type === "ToolReturned") as { result?: { error?: string } } | undefined
         if (returned !== undefined) return { kind: "complete", output: String(returned.result?.error) }
         return { kind: "call", callId: "x1", name: "execute", arguments: { code: "return 1" } }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -39,7 +39,7 @@ export {
 
 // The tool surface: code mode is the default, and an agent measured against a fixed tool table
 // brings its own (surface.ts).
-export { actorOf, renderOf, codeMode, toolTable, reply, budget, compaction, type Capability } from "./capability"
+export { actorOf, renderOf, codeMode, toolList, reply, budget, compaction, type Capability } from "./capability"
 export { codeSurface, nativeSurface, type NativeTool, type ToolSurface } from "./surface"
 
 export interface CreateAgentOptions {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -7,7 +7,7 @@ import { jsSandboxFor, memoryTmp } from "@tardigrade/code/defaults"
 import type { SandboxPolicy } from "@tardigrade/code/sandbox"
 import { createHost, type Host, type LaneEnv } from "@tardigrade/host/host"
 import { rlmAgentFor, type AgentPolicy, type RlmR } from "./turn"
-import { Infer } from "./infer"
+import { Infer, type InferRequest } from "./infer"
 import type { Action } from "./events"
 import { boundaryOf } from "./boundary"
 import { agentsPackage } from "./spawn"
@@ -18,7 +18,7 @@ export { agentFor, rlmAgent, rlmAgentFor, type AgentPolicy, type AgentR, type Rl
 // The parts a caller lists: reactors and key tables. An agent is reactors over one log.
 // Adding a capability is adding a reactor to the list.
 export { agentActorKeys, rlmActorKeys } from "./turn"
-export { inferReactor, inferReactorFor, Infer, DEFAULT_INFER_POLICY, type InferPolicy } from "./infer"
+export { inferReactor, inferReactorFor, Infer, DEFAULT_INFER_POLICY, type InferPolicy, type InferRequest, type Render } from "./infer"
 export { budgetReactor, budgetReactorFor, DEFAULT_BUDGET_POLICY, type BudgetPolicy } from "./budget"
 export { toolsReactor, toolsReactorFor } from "./tools"
 export { replyReactor } from "./reply"
@@ -39,12 +39,14 @@ export {
 
 // The tool surface: code mode is the default, and an agent measured against a fixed tool table
 // brings its own (surface.ts).
+export { actorOf, renderOf, codeMode, toolTable, reply, budget, compaction, type Capability } from "./capability"
 export { codeSurface, nativeSurface, type NativeTool, type ToolSurface } from "./surface"
 
 export interface CreateAgentOptions {
   readonly packages?: ReadonlyArray<Package>
-  // The mind: one inference over the trajectory, one action out.
-  readonly infer: (trajectory: ReadonlyArray<Event>, key?: string) => Promise<Action>
+  // The mind: one inference over the request, one action out. The request carries the render
+  // (system, tools) the assembly derived for the attempt.
+  readonly infer: (request: InferRequest, key?: string) => Promise<Action>
   // The root lane's history: an agent initialises from a persisted log, because the log is the
   // only state there is. The next run derives from everything here, and work the log still owes
   // settles on the first drive (index.test.ts, "an agent initialises from a log").
@@ -77,7 +79,7 @@ const ROOT = "ag.root"
 export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
   const user = options.packages ?? []
   const infer = Layer.succeed(Infer, {
-    react: (trajectory: ReadonlyArray<Event>, key?: string) => Effect.promise(() => options.infer(trajectory, key))
+    react: (request: InferRequest, key?: string) => Effect.promise(() => options.infer(request, key))
   })
   const tmp = memoryTmp()
   const sandbox = jsSandboxFor(options.sandbox ?? {})

--- a/packages/agent/src/infer.ts
+++ b/packages/agent/src/infer.ts
@@ -5,6 +5,7 @@ import { modelCalled, textReturned, turnFailed } from "./events"
 import type { Event } from "@tardigrade/core/event"
 import type { Action } from "./events"
 import { trajectoryOf, turnView } from "@tardigrade/code/turns"
+import { codeSurface } from "./surface"
 
 // The infer reactor: the model loop, and nothing else. A think is owed when the current turn
 // has no unanswered tool call and no terminal; serving marks the attempt, does inference, then
@@ -21,18 +22,27 @@ export interface InferPolicy {
 
 export const DEFAULT_INFER_POLICY: InferPolicy = { giveUpAfter: 3, repairAtMost: 2 }
 
-// Infer is the model seam: one inference over the trajectory, one action out. The platform binds this to
-// a provider. Tests bind it to a stub. `key` is the attempt's identity, the same string the
-// `ModelCalled` mark carries: a binding forwards it as the provider's idempotency key where the
-// provider takes one, so a retried attempt after a crash collapses server side. A binding with
-// no such support ignores it, and the retry stays plain at-least-once.
+// InferRequest is one attempt's whole context: the trajectory, and the render the assembly
+// derived for it (the system text and the tools the model is offered). The render rides the
+// call so the binding holds no opinion about tools; the actor is the render's one owner.
+export interface InferRequest {
+  readonly trajectory: ReadonlyArray<Event>
+  readonly system: string
+  readonly tools: ReadonlyArray<import("./request").ToolSpec>
+}
+
+// Infer is the model seam: one inference over the request, one action out. The platform binds
+// this to a provider. Tests bind it to a stub. `key` is the attempt's identity, the same string
+// the `ModelCalled` mark carries: a binding forwards it as the provider's idempotency key where
+// the provider takes one, so a retried attempt after a crash collapses server side. A binding
+// with no such support ignores it, and the retry stays plain at-least-once.
 //
 // Contract on the action: a call's callId must be fresh per call, never reused across turns
 // (providers mint tool-use ids; a stub must too). A reused id collides with the earlier call's
 // recorded pair and the dispatch dedup absorbs the new work.
 export class Infer extends Context.Service<
   Infer,
-  { readonly react: (trajectory: ReadonlyArray<Event>, key?: string) => Effect.Effect<Action> }
+  { readonly react: (request: InferRequest, key?: string) => Effect.Effect<Action> }
 >()("agent/Infer") {}
 
 // consequenceOf returns the action's recorded answer: the model responds by acting. Every
@@ -71,7 +81,11 @@ const awaitingTool = (slice: ReadonlyArray<Event>): boolean => {
 const terminated = (slice: ReadonlyArray<Event>): boolean =>
   slice.some((e) => e.type === "TurnCompleted" || e.type === "TurnFailed")
 
-export const inferReactorFor = (policy: Partial<InferPolicy> = {}): Reactor<Infer | EventLog> => (log) => {
+// Render derives what the model is shown over this log: the assembly owns it (capability.ts,
+// renderOf), and a surface assembly passes its constant half (turn.ts).
+export type Render = (log: ReadonlyArray<Event>) => { readonly system: string; readonly tools: ReadonlyArray<import("./request").ToolSpec> }
+
+export const inferReactorFor = (policy: Partial<InferPolicy> = {}, render: Render = codeRender): Reactor<Infer | EventLog> => (log) => {
   const giveUpAfter = policy.giveUpAfter ?? DEFAULT_INFER_POLICY.giveUpAfter
   const repairAtMost = policy.repairAtMost ?? DEFAULT_INFER_POLICY.repairAtMost
   const slice = turnView(log)
@@ -116,7 +130,7 @@ export const inferReactorFor = (policy: Partial<InferPolicy> = {}): Reactor<Infe
   return [
     transition({
       key: `mc:${turn}/${marks}`,
-      input: { turn, attempt, ordinal: marks, trajectory: trajectoryOf(log) },
+      input: { turn, attempt, ordinal: marks, trajectory: trajectoryOf(log), render: render(log) },
       act: (input) =>
         Effect.gen(function* () {
           const events = yield* EventLog
@@ -126,7 +140,7 @@ export const inferReactorFor = (policy: Partial<InferPolicy> = {}): Reactor<Infe
           // callId is the provider idempotency key (shared across retries of one logical
           // attempt); ordinal is the occurrence the dedup key reads.
           yield* events.append([modelCalled({ callId: input.attempt, ordinal: input.ordinal, turn: input.turn, at })])
-          const action = yield* (yield* Infer).react(input.trajectory, input.attempt)
+          const action = yield* (yield* Infer).react({ trajectory: input.trajectory, ...input.render }, input.attempt)
           const after = yield* Clock.currentTimeMillis
           return [
             ...(action.kind === "call" && action.text !== undefined && action.text !== ""
@@ -138,5 +152,9 @@ export const inferReactorFor = (policy: Partial<InferPolicy> = {}): Reactor<Infe
     })
   ]
 }
+
+// codeRender is the default render: the code surface's constant half.
+const cs = codeSurface()
+export const codeRender: Render = () => ({ system: cs.system, tools: cs.tools })
 
 export const inferReactor: Reactor<Infer | EventLog> = inferReactorFor()

--- a/packages/agent/src/tools.ts
+++ b/packages/agent/src/tools.ts
@@ -64,7 +64,16 @@ const decisionFor = (
 // derives nothing (the turn is durably paused); the decision's arrival re-derives the answer.
 // Every branch here is surface-independent policy; the surface decides only how a work call
 // becomes events.
-export const toolsReactorFor = <R = never>(surface: ToolSurface<R>): Reactor<R> => (log) => {
+export const toolsReactorFor = <R = never>(surface: ToolSurface<R>): Reactor<R> =>
+  toolsReactorFrom(surface.serve, () => surface.tools)
+
+// toolsReactorFrom is the same policy over a routed serve and a derived tool list: the
+// capability assembly's entry (capability.ts), where the tools are a projection of the log
+// rather than a static table.
+export const toolsReactorFrom = <R = never>(
+  serve: ToolSurface<R>["serve"],
+  toolsFor: (log: ReadonlyArray<Event>) => ReadonlyArray<{ readonly name: string }>
+): Reactor<R> => (log) => {
   const call = pendingCall(log)
   if (call === undefined) return []
   const stamp = call.turn === undefined ? {} : { turn: call.turn }
@@ -122,9 +131,9 @@ export const toolsReactorFor = <R = never>(surface: ToolSurface<R>): Reactor<R> 
       })
     ]
   }
-  const served = surface.serve(call, log, answering)
+  const served = serve(call, log, answering)
   if (served === undefined) {
-    return [answering({ error: `unknown tool: ${call.name}. Call one of: ${surface.tools.map((t) => t.name).join(", ")}.` })]
+    return [answering({ error: `unknown tool: ${call.name}. Call one of: ${toolsFor(log).map((t) => t.name).join(", ")}.` })]
   }
   return served
 }

--- a/packages/agent/src/turn.test.ts
+++ b/packages/agent/src/turn.test.ts
@@ -95,7 +95,7 @@ return { jd_record_id: record.id, hits: found.hits }`
 // The model: write the code once, then complete after reading the return.
 const codeThenComplete = (count: { calls: number }) =>
   Layer.succeed(Infer, {
-    react: (trajectory: ReadonlyArray<Event>) => {
+    react: ({ trajectory }: { trajectory: ReadonlyArray<Event> }) => {
       count.calls += 1
       const returned = trajectory.some((e) => e.type === "ToolReturned")
       return Effect.succeed(
@@ -207,7 +207,7 @@ describe("the agent with execute as the only tool", () => {
     memSpill(),
     memoryLog(),
       Layer.succeed(Infer, {
-        react: (trajectory: ReadonlyArray<Event>) => {
+        react: ({ trajectory }: { trajectory: ReadonlyArray<Event> }) => {
           count.calls += 1
           const returned = trajectory.find((e) => e.type === "ToolReturned")
           return Effect.succeed(
@@ -242,7 +242,7 @@ describe("the agent with execute as the only tool", () => {
       { type: "MessageReceived", id: "m2", text: "second ask", at: 2 }
     ]
     const echoHead = Layer.succeed(Infer, {
-      react: (trajectory: ReadonlyArray<Event>) => {
+      react: ({ trajectory }: { trajectory: ReadonlyArray<Event> }) => {
         let text = ""
         for (const e of trajectory) if (e.type === "MessageReceived") text = String((e as { text?: unknown }).text)
         return Effect.succeed({ kind: "complete" as const, output: `answer to: ${text}` })
@@ -380,7 +380,7 @@ describe("a turn that declares an output schema", () => {
       memoryLog(),
       memSpill(),
       Layer.succeed(Infer, {
-        react: (trajectory: ReadonlyArray<Event>) => {
+        react: ({ trajectory }: { trajectory: ReadonlyArray<Event> }) => {
           // The repair is a real tool return, so the model reads why it was refused.
           const refusal = trajectory.find(
             (e) => e.type === "ToolReturned" && String(((e as { result?: { error?: unknown } }).result ?? {}).error ?? "").includes("output schema")
@@ -469,7 +469,7 @@ describe("the mind on a native surface", () => {
       memoryLog(),
       noRouter,
       Layer.succeed(Infer, {
-        react: (trajectory: ReadonlyArray<Event>) => {
+        react: ({ trajectory }: { trajectory: ReadonlyArray<Event> }) => {
           const returned = trajectory.find((e) => e.type === "ToolReturned") as { result?: unknown } | undefined
           return Effect.succeed(
             returned !== undefined

--- a/packages/agent/src/turn.ts
+++ b/packages/agent/src/turn.ts
@@ -48,7 +48,10 @@ export interface AgentPolicy {
 // The caller chooses the work half. Code mode is rlmAgentFor(codeSurface()), because execute
 // needs the code reactor. The mind applies one policy, the model loop's own ceilings.
 export const agentFor = (surface: ToolSurface<AgentR>, policy: Partial<Pick<AgentPolicy, "infer">> = {}) =>
-  actor<AgentR>([inferReactorFor(policy.infer), toolsReactorFor(surface), replyReactor], agentActorKeys)
+  actor<AgentR>(
+    [inferReactorFor(policy.infer ?? {}, () => ({ system: surface.system, tools: surface.tools })), toolsReactorFor(surface), replyReactor],
+    agentActorKeys
+  )
 
 // rlmAgentFor is the Recursive Language Model default: the mind plus budget, durable code, and
 // compaction. budget precedes tools, so BudgetExhausted is on the log when the dispatch gate
@@ -56,7 +59,7 @@ export const agentFor = (surface: ToolSurface<AgentR>, policy: Partial<Pick<Agen
 export const rlmAgentFor = (surface: ToolSurface<RlmR>, policy: Partial<AgentPolicy> = {}) =>
   actor<RlmR>(
     [
-      inferReactorFor(policy.infer),
+      inferReactorFor(policy.infer ?? {}, () => ({ system: surface.system, tools: surface.tools })),
       budgetReactorFor(policy.budget),
       toolsReactorFor(surface),
       codeReactorFor(policy.code),

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { codeSurface } from "@tardigrade/agent/surface"
+
+// reqOf wraps a trajectory in the render the actor would derive: the code surface half.
+const surfaceRender = codeSurface()
+const reqOf = (trajectory: ReadonlyArray<Event>) => ({ trajectory, system: surfaceRender.system, tools: surfaceRender.tools })
 import { Infer } from "@tardigrade/agent/infer"
 import { actionOf, ladderOf, modelAskOf, modelIdOf, infer, retryAfterMsOf, throttleDelayMs } from "./model"
 import type { Action } from "@tardigrade/agent/events"
+import type { Event } from "@tardigrade/core/event"
 
 // The model binding: the trajectory renders into the provider conversation, the streamed reply
 // decodes into one Action, and the whole loop round-trips through a fake OpenAI-compatible SSE
@@ -104,12 +109,11 @@ describe("infer end to end", () => {
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "test-model",
-      surface: codeSurface(),
       fetch: fetchImpl
     })
     const action = await Effect.runPromise(
       Effect.flatMap(Infer, (model) =>
-        model.react([{ type: "MessageReceived", id: "m1", text: "compute", at: 1 }])
+        model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "compute", at: 1 }]))
       ).pipe(Effect.provide(layer)) as Effect.Effect<unknown>
     )
     expect(action).toMatchObject({ kind: "call", callId: "call_7", name: "execute", arguments: { code: "return 42" }, text: "on it" })
@@ -126,9 +130,9 @@ describe("infer end to end", () => {
         { id: "r2", choices: [{ index: 0, delta: { content: "is 4" } }] },
         { id: "r2", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }
       ])) as unknown as typeof globalThis.fetch
-    const layer = infer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "test-model", surface: codeSurface(), fetch: fetchImpl })
+    const layer = infer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "test-model", fetch: fetchImpl })
     const action = await Effect.runPromise(
-      Effect.flatMap(Infer, (model) => model.react([{ type: "MessageReceived", id: "m1", text: "2+2?", at: 1 }])).pipe(
+      Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "2+2?", at: 1 }]))).pipe(
         Effect.provide(layer)
       ) as Effect.Effect<unknown>
     )
@@ -145,13 +149,13 @@ describe("infer end to end", () => {
         { id: "r3", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }
       ])
     }) as typeof globalThis.fetch
-    const layer = infer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "test-model", surface: codeSurface(), fetch: fetchImpl })
+    const layer = infer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "test-model", fetch: fetchImpl })
     const trajectory = [{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]
     await Effect.runPromise(
-      Effect.flatMap(Infer, (model) => model.react(trajectory, "m1/infer/0")).pipe(Effect.provide(layer)) as Effect.Effect<unknown>
+      Effect.flatMap(Infer, (model) => model.react(reqOf(trajectory), "m1/infer/0")).pipe(Effect.provide(layer)) as Effect.Effect<unknown>
     )
     await Effect.runPromise(
-      Effect.flatMap(Infer, (model) => model.react(trajectory)).pipe(Effect.provide(layer)) as Effect.Effect<unknown>
+      Effect.flatMap(Infer, (model) => model.react(reqOf(trajectory))).pipe(Effect.provide(layer)) as Effect.Effect<unknown>
     )
     expect(seen).toEqual(["m1/infer/0", null])
   })
@@ -168,15 +172,14 @@ describe("infer: cost provenance", () => {
 
   test("a billed cost is provider, an omitted cost is table or unknown", async () => {
     const billed = await Effect.runPromise(
-      Effect.flatMap(Infer, (model) => model.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
+      Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
         Effect.provide(
           infer({
             baseUrl: "https://model.test/v1",
             apiKey: "k",
             model: "test-model",
             provider: "openai",
-            surface: codeSurface(),
-            pricing: table,
+                  pricing: table,
             fetch: (async () => sse([...okText, usageChunk({ prompt_tokens: 10, completion_tokens: 4, cost: 0 })])) as unknown as typeof globalThis.fetch
           })
         )
@@ -196,15 +199,14 @@ describe("infer: cost provenance", () => {
     })
 
     const filled = await Effect.runPromise(
-      Effect.flatMap(Infer, (model) => model.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
+      Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
         Effect.provide(
           infer({
             baseUrl: "https://model.test/v1",
             apiKey: "k",
             model: "test-model",
             provider: "openai",
-            surface: codeSurface(),
-            pricing: table,
+                  pricing: table,
             fetch: (async () => sse([...okText, usageChunk({ prompt_tokens: 10, completion_tokens: 4 })])) as unknown as typeof globalThis.fetch
           })
         )
@@ -220,14 +222,13 @@ describe("infer: cost provenance", () => {
     })
 
     const unknown = await Effect.runPromise(
-      Effect.flatMap(Infer, (model) => model.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
+      Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
         Effect.provide(
           infer({
             baseUrl: "https://model.test/v1",
             apiKey: "k",
             model: "test-model",
-            surface: codeSurface(),
-            fetch: (async () => sse(okText)) as unknown as typeof globalThis.fetch
+                  fetch: (async () => sse(okText)) as unknown as typeof globalThis.fetch
           })
         )
       ) as Effect.Effect<Action>
@@ -258,7 +259,6 @@ describe("infer: throttle-shaped retry", () => {
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "test-model",
-      surface: codeSurface(),
       fetch: fetchImpl,
       sleep: (ms) => {
         slept.push(ms)
@@ -266,7 +266,7 @@ describe("infer: throttle-shaped retry", () => {
       }
     })
     const action = await Effect.runPromise(
-      Effect.flatMap(Infer, (model) => model.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
+      Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
         Effect.provide(layer)
       ) as Effect.Effect<unknown>
     )
@@ -288,7 +288,6 @@ describe("infer: throttle-shaped retry", () => {
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "test-model",
-      surface: codeSurface(),
       fetch: fetchImpl,
       sleep: (ms) => {
         slept.push(ms)
@@ -297,7 +296,7 @@ describe("infer: throttle-shaped retry", () => {
     })
     await expect(
       Effect.runPromise(
-        Effect.flatMap(Infer, (model) => model.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
+        Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
           Effect.provide(layer)
         ) as Effect.Effect<unknown>
       )
@@ -318,7 +317,6 @@ describe("infer: throttle-shaped retry", () => {
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "test-model",
-      surface: codeSurface(),
       fetch: fetchImpl,
       sleep: (ms) => {
         slept.push(ms)
@@ -327,7 +325,7 @@ describe("infer: throttle-shaped retry", () => {
     })
     await expect(
       Effect.runPromise(
-        Effect.flatMap(Infer, (model) => model.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
+        Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
           Effect.provide(layer)
         ) as Effect.Effect<unknown>
       )
@@ -427,9 +425,9 @@ describe("truncation", () => {
       keys.push(request.headers.get("Idempotency-Key"))
       return calls++ === 0 ? cut("half an ans") : whole("the whole answer")
     }) as unknown as typeof fetch
-    const layer = infer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", surface: codeSurface(), fetch: fetchImpl as never })
+    const layer = infer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", fetch: fetchImpl as never })
     const action = await Effect.runPromise(
-      Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }], "t1/infer/0")).pipe(
+      Effect.flatMap(Infer, (i) => i.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]), "t1/infer/0")).pipe(
         Effect.provide(layer)
       ) as Effect.Effect<{ kind: string; output?: string }>
     )
@@ -454,11 +452,10 @@ describe("truncation", () => {
       model: "m",
       baseUrl: "https://x",
       apiKey: "k",
-      surface: codeSurface(),
       fetch: fetchImpl as never
     })
     const action = await Effect.runPromise(
-      Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
+      Effect.flatMap(Infer, (i) => i.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
         Effect.provide(layer)
       ) as Effect.Effect<Action>
     )
@@ -472,9 +469,9 @@ describe("truncation", () => {
 
   test("the top rung still truncating fails the turn loudly, never half an answer", async () => {
     const fetchImpl = (async () => cut("half")) as unknown as typeof fetch
-    const layer = infer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", surface: codeSurface(), fetch: fetchImpl as never })
+    const layer = infer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", fetch: fetchImpl as never })
     const action = await Effect.runPromise(
-      Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
+      Effect.flatMap(Infer, (i) => i.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
         Effect.provide(layer)
       ) as Effect.Effect<{ kind: string; error?: string }>
     )
@@ -484,15 +481,14 @@ describe("truncation", () => {
 
   test("wire-reported provenance beats the configured stamp", async () => {
     const routed = await Effect.runPromise(
-      Effect.flatMap(Infer, (model) => model.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
+      Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
         Effect.provide(
           infer({
             baseUrl: "https://model.test/v1",
             apiKey: "k",
             model: "meta-llama/llama-3.1-70b",
             provider: "openrouter",
-            surface: codeSurface(),
-            fetch: (async () =>
+                  fetch: (async () =>
               sse([
                 { id: "r", provider: "DeepInfra", model: "meta-llama/llama-3.1-70b-instruct", choices: [{ index: 0, delta: { role: "assistant", content: "ok" } }] },
                 { id: "r", provider: "DeepInfra", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
@@ -532,14 +528,13 @@ describe("truncation", () => {
         model: "m",
         baseUrl: "https://x",
         apiKey: "k",
-        surface: codeSurface(),
-        fetch: fetchImpl as never,
+          fetch: fetchImpl as never,
         throttleRetryDelaysMs: [0],
         sleep: () => Promise.resolve()
       })
       await expect(
         Effect.runPromise(
-          Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(
+          Effect.flatMap(Infer, (i) => i.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
             Effect.provide(layer)
           ) as Effect.Effect<unknown>
         )
@@ -571,9 +566,9 @@ describe("declared limits", () => {
         headers: { "content-type": "text/event-stream" }
       })
     }) as unknown as typeof fetch
-    const layer = infer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", surface: codeSurface(), maxOutputTokens: 16_384, fetch: fetchImpl as never })
+    const layer = infer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", maxOutputTokens: 16_384, fetch: fetchImpl as never })
     await Effect.runPromise(
-      Effect.flatMap(Infer, (i) => i.react([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }])).pipe(Effect.provide(layer)) as Effect.Effect<unknown>
+      Effect.flatMap(Infer, (i) => i.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(Effect.provide(layer)) as Effect.Effect<unknown>
     )
     expect(body?.max_tokens).toBe(16_384)
   })

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -4,13 +4,12 @@ import { openaiCompatibleText } from "@tanstack/ai-openai/compatible"
 import * as BedrockRuntime from "@aws-sdk/client-bedrock-runtime"
 import { FetchHttpHandler } from "@smithy/fetch-http-handler"
 import { BedrockConverseTextAdapter, type BEDROCK_CONVERSE_MODELS } from "@tanstack/ai-bedrock"
-import { Infer } from "@tardigrade/agent/infer"
+import { Infer, type InferRequest } from "@tardigrade/agent/infer"
 import type { Action } from "@tardigrade/agent/events"
 import type { Event } from "@tardigrade/core/event"
 import { answerErrors, outputSchemaOf } from "@tardigrade/agent/contract"
 import { modelRequest, type AgentMessage, type ToolSpec } from "@tardigrade/agent/request"
 import type { ContextPolicy } from "@tardigrade/agent/compaction"
-import { codeSurface, type ToolSurface } from "@tardigrade/agent/surface"
 import { sumUsage, usageFrom, type ModelPricing, type Usage } from "@tardigrade/agent/usage"
 
 // The real model binding: one inference per react, streamed through a TanStack adapter and
@@ -177,13 +176,9 @@ export interface ModelConfig {
   readonly baseUrl: string
   readonly apiKey: string
   readonly model: string
-  // The tool surface this binding renders: code mode by default. The actor must be assembled on
-  // the same surface, or the model is offered tools its reactor will not serve
-  // (@tardigrade/agent, surface.ts).
-  readonly surface?: Pick<ToolSurface, "system" | "tools">
-  // What this binding's render truncates, and where. It rides the same rule the surface does:
-  // the agent's compaction reactor must hold the same policy, or its guard fires against a size
-  // the request never reaches (@tardigrade/agent, compaction.ts, ContextPolicy).
+  // What this binding's render truncates, and where: the agent's compaction reactor must hold
+  // the same policy, or its guard fires against a size the request never reaches
+  // (@tardigrade/agent, compaction.ts, ContextPolicy).
   readonly context?: Partial<ContextPolicy>
   readonly provider?: string
   // The model's output ceiling, DECLARED by the operator rather than guessed: no wire this
@@ -498,7 +493,7 @@ export const infer = (config: ModelConfig) => {
     totalMs: config.stream?.totalMs ?? DEFAULT_STREAM_BOUNDS.totalMs
   }
   const throttleDelays = config.throttleRetryDelaysMs ?? DEFAULT_THROTTLE_RETRY_DELAYS_MS
-  const attemptOnce = async (trajectory: ReadonlyArray<Event>, key: string | undefined, maxTokens: number, rung: number, stats: { finish?: string }): Promise<Action> => {
+  const attemptOnce = async (request: InferRequest, key: string | undefined, maxTokens: number, rung: number, stats: { finish?: string }): Promise<Action> => {
     // A changed ceiling is a different request, so it mints a different idempotency key: a
     // provider that dedups would otherwise answer the escalated retry with the cached truncated
      // response, and the ladder would climb nowhere (the removed driver learned this).
@@ -523,9 +518,10 @@ export const infer = (config: ModelConfig) => {
             maxRetries: 0,
             fetch: fetcher
           })
-    // The domain decides the request; the platform maps it to the wire and streams it.
-    const req = modelRequest(trajectory, config.surface ?? codeSurface(), config.context ?? {})
-    const schema = outputSchemaOf(trajectory) // the answer parser needs the turn's declared shape
+    // The actor decides the request, render included; the platform maps it to the wire and
+    // streams it, holding no opinion about tools (@tardigrade/agent, capability.ts).
+    const req = modelRequest(request.trajectory, request, config.context ?? {})
+    const schema = outputSchemaOf(request.trajectory) // the answer parser needs the turn's declared shape
     const stream = adapter.chatStream({
       model: config.model,
       messages: req.messages.map(toMessage) as never,
@@ -563,7 +559,7 @@ export const infer = (config: ModelConfig) => {
     }
   }
   return Layer.succeed(Infer, {
-    react: (trajectory: ReadonlyArray<Event>, key?: string) =>
+    react: (request: InferRequest, key?: string) =>
       Effect.gen(function* () {
         const ladder = ladderOf(config.maxOutputTokens, config.maxTokensLadder)
         const stats: { finish?: string; rung: number; waits: number } = { rung: 0, waits: 0 }
@@ -578,7 +574,7 @@ export const infer = (config: ModelConfig) => {
         for (let attempt = 0; ; attempt++) {
           try {
             stats.rung = rung
-            const action = await attemptOnce(trajectory, key, ladder[rung]!, rung, stats)
+            const action = await attemptOnce(request, key, ladder[rung]!, rung, stats)
             remember(action.usage, true)
             return withSpend(action, spentOf(parts, missed))
           } catch (e) {


### PR DESCRIPTION
The ToolSurface object existed because reactors had no channel to declare what the model is shown, so one side-object carried the declaration to two places that had to agree by convention, and after the defaults change the agreement was two defaults happening to coincide. This gives the declaration a home: a capability bundles what the model is shown with how that work settles, and the render travels with the infer call, so the actor owns it by construction.

- InferRequest: react takes {trajectory, system, tools}; the binding renders what it is handed and ModelConfig loses surface
- Capability: name, keys, reactors, tools (a projection of the log, so log-gated disclosure is native), system, serve
- actorOf mounts capabilities: it injects the infer and call-routing reactors, composes key fragments and tool names with construction-time collision errors, and routes a call to the first capability that recognizes it
- renderOf exposes the composed render for tests
- shipped capabilities: codeMode, toolTable (nativeSurface restated), reply, budget, compaction; requirements infer as the union across a mixed list
- ToolSurface and the surface assemblies remain for now; a follow-up erases them once this shape settles
- designed extension, not in this diff: a capability-scoped provide layer, so one capability (a compaction on a cheaper model) overrides a service for its own acts only
- quickstart: actorOf([codeMode, reply, budget, compaction]), imports drop from eight to four
- new capability tests (render reaches the model, unknown-tool names the composed table, name collision throws, mount-order render); full gate green