### PR TITLE
refactor(agent): rename to agentOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Prerequisites: bun 1.1 or later, and a model endpoint.
 An agent is reactors over one log.
 
 ```ts
-import { actorOf, budget, codeMode, compaction, reply } from "@tardigrade/agent"
+import { agentOf, budget, codeMode, compaction, reply } from "@tardigrade/agent"
 import { infer } from "@tardigrade/model/model"
 import { createBunHost } from "@tardigrade/bun/host"
 import { fileTelemetry } from "@tardigrade/bun/file"
 
 // A capability bundles what the model is shown with how that work settles. Mounting one is
 // adding it to the list; `toolList([...])` mounts a fixed tool table instead of code mode.
-const agent = actorOf([codeMode, reply, budget, compaction])
+const agent = agentOf([codeMode, reply, budget, compaction])
 
 // createBunHost runs the actor over a durable SQLite log; layersFor wires the model binding.
 const host = await createBunHost({
@@ -110,7 +110,7 @@ An actor is a set of reactors over one log, plus the key derivation that decides
 packages/
   core/      contracts: Event, EventLog, KeyFragment, Transition, Reactor, Router
   code/      durable code execution
-  agent/     capabilities, the runtime (`actorOf`), and the RLM default (`createRlmAgent`)
+  agent/     capabilities, the runtime (`agentOf`), and the RLM default (`createRlmAgent`)
   host/      the reference in-memory binding
 platform/
   model/     the Infer binding over TanStack AI

--- a/docs/how-to/policy.md
+++ b/docs/how-to/policy.md
@@ -10,14 +10,14 @@ A type names the values and what each one bounds. A `DEFAULT_` constant states t
 
 ```ts
 // The capability that applies the policy takes it; the bare capability is the same call with none.
-const agent = actorOf([codeMode, reply, budgetFor({ defaultToolBudget: 120 }), compactionFor({ fireTokens: 60_000, keepTokens: 12_000 })])
+const agent = agentOf([codeMode, reply, budgetFor({ defaultToolBudget: 120 }), compactionFor({ fireTokens: 60_000, keepTokens: 12_000 })])
 ```
 
 The third part is visibility. When a policy changes what the model sees, the output says so. A truncated message names the cap it was cut at and the length it was cut from, and cut console output ends with a line saying it was cut. A model that reads a silent cut treats a fragment as the whole value, and the summary or the answer it writes then states a partial fact as complete.
 
 ### Where the values live
 
-The agent applies four policies. Three ride their capabilities: `budget` (the tool-call ceiling a brief that states none takes, `budgetFor`), `context` (the render's truncation caps and compaction's fire and keep lines, `compactionFor`), and `code` (the size at which a result spills to tmp and leaves a pointer, `codeModeFor`). `infer` is the runtime's own give-up and repair ceilings, and `actorOf` takes it beside the list. `createRlmAgent` gathers all four as `AgentPolicy` so one option sets them.
+The agent applies four policies. Three ride their capabilities: `budget` (the tool-call ceiling a brief that states none takes, `budgetFor`), `context` (the render's truncation caps and compaction's fire and keep lines, `compactionFor`), and `code` (the size at which a result spills to tmp and leaves a pointer, `codeModeFor`). `infer` is the runtime's own give-up and repair ceilings, and `agentOf` takes it beside the list. `createRlmAgent` gathers all four as `AgentPolicy` so one option sets them.
 
 The sandbox and the model binding hold the rest. The sandbox bounds captured console output. The model binding bounds the stream (time to first chunk, idle, total), the throttle backoff ladder, and the output-token ladder a truncated answer climbs.
 
@@ -26,5 +26,5 @@ The sandbox and the model binding hold the rest. The sandbox bounds captured con
 `context` is the one policy two places apply: compaction's guard must measure the request the model actually sees, so it counts characters exactly where the render truncates. The reactor runs in the agent; the render runs in the model binding. `compactionFor` states the policy once and contributes it to the render, which rides the infer request to the binding, so the guard and the render hold the same numbers by construction and nothing is stated twice.
 
 ```ts
-const agent = actorOf([codeMode, reply, budget, compactionFor({ messageRenderCap: 40_000, resultRenderCap: 20_000 })])
+const agent = agentOf([codeMode, reply, budget, compactionFor({ messageRenderCap: 40_000, resultRenderCap: 20_000 })])
 ```

--- a/packages/agent/src/budget.test.ts
+++ b/packages/agent/src/budget.test.ts
@@ -3,9 +3,9 @@ import { Effect, Layer } from "effect"
 import type { Event } from "@tardigrade/core/event"
 import { EventLog, withWatermark } from "@tardigrade/core/event-log"
 import { budgetReactor, budgetReactorFor, budgetOf, usedOf, budgetPhase, budgetSpent, canRequestBudget } from "./budget"
-import { actorOf, budget, codeMode, compaction, reply } from "./capability"
+import { agentOf, budget, codeMode, compaction, reply } from "./capability"
 
-const toolsReactor = actorOf([codeMode, reply, budget, compaction]).reactors[1]!
+const toolsReactor = agentOf([codeMode, reply, budget, compaction]).reactors[1]!
 
 // A turn: a `MessageReceived` head carrying `budget`, then `calls` execute tool-calls (each answered
 // except the last), then any extra events appended after.

--- a/packages/agent/src/capability.test.ts
+++ b/packages/agent/src/capability.test.ts
@@ -4,7 +4,7 @@ import type { Event } from "@tardigrade/core/event"
 import { EventLog, withWatermark } from "@tardigrade/core/event-log"
 import { Router } from "@tardigrade/core/router"
 import { Self } from "@tardigrade/core/actor"
-import { actorOf, budget, codeMode, compaction, compactionFor, renderOf, reply, toolList } from "./capability"
+import { agentOf, budget, codeMode, compaction, compactionFor, renderOf, reply, toolList } from "./capability"
 import { receive } from "./turn"
 import { Infer, type InferRequest } from "./infer"
 
@@ -43,7 +43,7 @@ const echoTable = toolList([
   }
 ])
 
-describe("actorOf", () => {
+describe("agentOf", () => {
   test("the render is the composed derivation, and the request carries it to the model", async () => {
     const seen: InferRequest[] = []
     const mind = Layer.succeed(Infer, {
@@ -57,7 +57,7 @@ describe("actorOf", () => {
         )
       }
     })
-    const agent = actorOf([echoTable, reply, budget, compaction])
+    const agent = agentOf([echoTable, reply, budget, compaction])
     const events = await run(
       Effect.gen(function* () {
         yield* receive(agent, { id: "m1", text: "go" })
@@ -84,7 +84,7 @@ describe("actorOf", () => {
         )
       }
     })
-    const agent = actorOf([echoTable, reply])
+    const agent = agentOf([echoTable, reply])
     const events = await run(
       Effect.gen(function* () {
         yield* receive(agent, { id: "m1", text: "go" })
@@ -98,7 +98,7 @@ describe("actorOf", () => {
   })
 
   test("two capabilities declaring one tool name collide at construction", () => {
-    expect(() => actorOf([echoTable, toolList([{ spec: { name: "echo", description: "again", inputSchema: {} }, run: () => Effect.succeed({}) }])])).toThrow(
+    expect(() => agentOf([echoTable, toolList([{ spec: { name: "echo", description: "again", inputSchema: {} }, run: () => Effect.succeed({}) }])])).toThrow(
       'tool "echo" declared by capabilities tools and tools'
     )
   })

--- a/packages/agent/src/capability.ts
+++ b/packages/agent/src/capability.ts
@@ -18,7 +18,7 @@ import type { AgentR } from "./turn"
 // A Capability is one component of an agent: it provides the model its context and services
 // the calls that come back, as one value. `tools`, `system`, and `context` are the capability's
 // render into the model's request, re-derived from the log each attempt; `reactors` and `serve`
-// are its handlers. Mounting a capability is adding it to the actorOf list; there is no second
+// are its handlers. Mounting a capability is adding it to the agentOf list; there is no second
 // place to update.
 //
 // Every field but `name` is optional, because capabilities come in shapes: a policy capability
@@ -27,7 +27,7 @@ import type { AgentR } from "./turn"
 export interface Capability<R = never> {
   // The capability's name, for the collision error and span attributes.
   readonly name: string
-  // The capability's alphabet fragment. actorOf composes fragments the way composeKeys does,
+  // The capability's alphabet fragment. agentOf composes fragments the way composeKeys does,
   // and a prefix collision is the same construction-time error.
   readonly keys?: KeyFragment
   // The reactors that settle this capability's work.
@@ -37,14 +37,14 @@ export interface Capability<R = never> {
   // (docs/how-to/gate-tools.md). The composed tools are what the infer reactor hands the model
   // binding per attempt; nothing about tools lives in ModelConfig.
   readonly tools?: (log: ReadonlyArray<Event>) => ReadonlyArray<ToolSpec>
-  // The system fragment explaining the tools. Fragments join in actorOf order.
+  // The system fragment explaining the tools. Fragments join in agentOf order.
   readonly system?: string
   // What the render truncates and where. The capability that applies a context policy to its
   // reactor states the same one here, so the binding renders against the policy the guard
   // holds and the two cannot drift (compactionFor).
   readonly context?: Partial<ContextPolicy>
   // serve returns the transitions one call owes: an empty array while the world still works,
-  // undefined when the call names no tool of this capability (actorOf asks the next capability,
+  // undefined when the call names no tool of this capability (agentOf asks the next capability,
   // and the reactor answers unknown-tool when every capability declines). The reactor owns the
   // key and the turn stamp through `answer`.
   readonly serve?: Serve<R>
@@ -69,14 +69,14 @@ export const renderOf = <R>(
 // members need rather than failing on the first element's R.
 type RequirementsOf<C> = C extends Capability<infer R> ? R : never
 
-// actorOf mounts capabilities into an actor. The infer and call-routing reactors are the
-// runtime of the component model: actorOf injects them, and they are never listed as
+// agentOf mounts capabilities into an actor. The infer and call-routing reactors are the
+// runtime of the component model: agentOf injects them, and they are never listed as
 // capabilities, the way a component tree does not list the renderer. The canonical inbound and
 // the agent alphabet are the runtime's own key table; capability fragments compose beside them,
 // and a prefix collision is composeKeys' construction-time error. Two capabilities deriving the
 // same tool name collide at construction too, checked over the empty log (a log-gated duplicate
 // still routes to the first capability that recognizes it).
-export const actorOf = <const Caps extends ReadonlyArray<Capability<never> | Capability<AgentR>>>(
+export const agentOf = <const Caps extends ReadonlyArray<Capability<never> | Capability<AgentR>>>(
   caps: Caps,
   policy: Partial<InferPolicy> = {}
 ): Actor<AgentR | RequirementsOf<Caps[number]>> => {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -11,7 +11,7 @@ import { Infer, type InferRequest } from "./infer"
 import type { Action } from "./events"
 import { boundaryOf } from "./boundary"
 import { agentsPackage } from "./spawn"
-import { actorOf, budgetFor, codeModeFor, compactionFor, reply, type Capability } from "./capability"
+import { agentOf, budgetFor, codeModeFor, compactionFor, reply, type Capability } from "./capability"
 
 export { type AgentPolicy, type AgentR, type RlmR, receive } from "./turn"
 
@@ -38,7 +38,7 @@ export {
 
 // The capability assembly: code mode is the default, and an agent measured against a fixed
 // tool list mounts its own (capability.ts).
-export { actorOf, renderOf, codeMode, codeModeFor, toolList, reply, budget, budgetFor, compaction, compactionFor, type Capability, type NativeTool } from "./capability"
+export { agentOf, renderOf, codeMode, codeModeFor, toolList, reply, budget, budgetFor, compaction, compactionFor, type Capability, type NativeTool } from "./capability"
 
 export interface CreateAgentOptions {
   readonly packages?: ReadonlyArray<Package>
@@ -73,7 +73,7 @@ const ROOT = "ag.root"
 // createRlmAgent is the library default: a hosted Recursive Language Model over an in-process
 // host, with spawn and a sandbox (tutorials/rlm-agent.md). It mounts the work capabilities plus
 // reply, budget, and compaction, and adds the host and the agents package. A caller who wants a
-// thinner assembly uses actorOf and their own host.
+// thinner assembly uses agentOf and their own host.
 export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
   const user = options.packages ?? []
   const infer = Layer.succeed(Infer, {
@@ -110,7 +110,7 @@ export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
 
   // Every ag. lane runs the RLM default; anything else is a sink.
   const policy = options.policy ?? {}
-  const assembled = actorOf(
+  const assembled = agentOf(
     [...(options.capabilities ?? [codeModeFor(policy.code ?? {})]), reply, budgetFor(policy.budget ?? {}), compactionFor(policy.context ?? {})],
     policy.infer ?? {}
   )

--- a/packages/agent/src/spawn.ts
+++ b/packages/agent/src/spawn.ts
@@ -44,7 +44,7 @@ import { replyId } from "@tardigrade/core/reply"
 // budget takes the same ceiling the child's own reactor would, and a consumer that moved that
 // ceiling moves both (budget.ts, BudgetPolicy).
 export interface SpawnOptions {
-  readonly actorOf?: () => string | undefined
+  readonly agentOf?: () => string | undefined
   readonly reserve?: (callId: string, want: number) => Promise<number>
   readonly shadowOf?: () => boolean
   // The parent's explicit world label, when its own fire named a shared world instead of taking
@@ -61,7 +61,7 @@ export const agentsPackage = (
   reader: AgentReader,
   options: SpawnOptions = {}
 ): Package => {
-  const actorOf = options.actorOf ?? (() => undefined)
+  const agentOf = options.agentOf ?? (() => undefined)
   const reserve = options.reserve ?? (async (_callId: string, want: number) => want)
   const shadowOf = options.shadowOf ?? (() => false)
   const worldOf = options.worldOf ?? (() => undefined)
@@ -142,7 +142,7 @@ export const agentsPackage = (
           if (budget <= 0) return { error: "the run's budget is exhausted; no budget to spawn this agent" }
           // The child works as the same member the parent does: the actor rides every brief in the
           // family, so a run's whole tree resolves connections identically.
-          const actor = actorOf()
+          const actor = agentOf()
           // The parent's own shadow reading, never the tool args: an agent cannot set or unset it, so
           // a whole run family is shadow by construction from the fire alone. `world` rides along
           // the same way, when the fire named an explicit shared one.

--- a/packages/agent/src/turn.test.ts
+++ b/packages/agent/src/turn.test.ts
@@ -8,11 +8,11 @@ import { Sandbox, type Bindings } from "@tardigrade/code/sandbox"
 import { Router } from "@tardigrade/core/router"
 import { Self } from "@tardigrade/core/actor"
 import { Infer, receive } from "./turn"
-import { actorOf, budget, codeMode, compaction, reply, toolList } from "./capability"
+import { agentOf, budget, codeMode, compaction, reply, toolList } from "./capability"
 
-// The default assembly and its runtime reactors, reconstructed the way actorOf mounts them:
+// The default assembly and its runtime reactors, reconstructed the way agentOf mounts them:
 // reactors[0] is the infer loop, reactors[1] is the call router.
-const rlmAgent = actorOf([codeMode, reply, budget, compaction])
+const rlmAgent = agentOf([codeMode, reply, budget, compaction])
 const inferReactor = rlmAgent.reactors[0]!
 const toolsReactor = rlmAgent.reactors[1]!
 import { Tmp } from "@tardigrade/code/tmp"
@@ -456,7 +456,7 @@ describe("a turn that declares an output schema", () => {
 describe("the mind on a native surface", () => {
   test("a turn completes with no budget, code, or compaction reactors", async () => {
     const reads: string[] = []
-    const mind = actorOf([
+    const mind = agentOf([
       toolList([
         {
           spec: { name: "read", description: "read a file", inputSchema: { type: "object", properties: { path: { type: "string" } } } },

--- a/packages/agent/src/turn.ts
+++ b/packages/agent/src/turn.ts
@@ -18,7 +18,7 @@ export type RlmR = AgentR
 // AgentPolicy is every policy value an assembled agent applies, one field per part that applies
 // one, so a caller sets a single number without listing reactors. Each field is itself partial
 // and fills from its own exported default (infer.ts, budget.ts, compaction.ts,
-// packages/code/src/execute.ts). `infer` is the runtime's policy (actorOf takes it); the rest
+// packages/code/src/execute.ts). `infer` is the runtime's policy (agentOf takes it); the rest
 // ride their capabilities (budgetFor, compactionFor, codeModeFor).
 export interface AgentPolicy {
   readonly infer: Partial<InferPolicy>


### PR DESCRIPTION
actorOf named the assembly by its return type; what it assembles is an agent (it injects the infer runtime and the agent alphabet), and a registry or mailbox actor never goes through it. agentOf names what it builds, keeps the xOf idiom, and avoids the shadow that a bare agent() would put in every quickstart. Mechanical rename across code, tests, and docs; gate green.