### PR TITLE
refactor(bun): path becomes log

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ const agent = agentOf([codeMode, reply, budget, compaction])
 
 // createBunHost runs the actor over a durable SQLite log; layersFor wires the model binding.
 const host = await createBunHost({
-  path: "agents.sqlite",
+  log: "agents.sqlite",
   actorFor: () => agent,
   layersFor: () => infer({ baseUrl: process.env.MODEL_BASE_URL!, apiKey: process.env.MODEL_API_KEY!, model: process.env.MODEL_ID!, provider: "bedrock" }),
   telemetry: fileTelemetry("spans.ndjson")

--- a/docs/how-to/observe.md
+++ b/docs/how-to/observe.md
@@ -12,7 +12,7 @@ import { fileTelemetry } from "@tardigrade/bun/file"
 import { otlpTelemetry } from "@tardigrade/bun/otlp"
 
 const host = await createBunHost({
-  path: "agents.sqlite",
+  log: "agents.sqlite",
   actorFor,
   layersFor,
   telemetry: fileTelemetry("spans.ndjson")

--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -35,7 +35,7 @@ let n = 0
 const freshPath = (): string => join(dir, `host-${n++}.sqlite`)
 
 const options = (path: string): BunHostOptions<never> => ({
-  path,
+  log: path,
   actorFor: (lane) => (lane === "echo" ? echo : undefined),
   keyOf
 })

--- a/platform/bun/src/host.ts
+++ b/platform/bun/src/host.ts
@@ -24,7 +24,7 @@ type LayersFor<R> = [Exclude<R, HostPorts>] extends [never]
   : { readonly layersFor: (lane: string) => LaneEnv<R> }
 
 export type BunHostOptions<R> = {
-  readonly path: string // SQLite file, or ":memory:" for a volatile run
+  readonly log: string // where the log lives: a SQLite file, or ":memory:" for a volatile run
   // The tracer the spans flow to, when the app brings one (an @effect/opentelemetry layer, a
   // test capture). Absent, every span is inert: instrumentation lives in the packages, export
   // is the platform's, and this seam is the whole of it.
@@ -61,7 +61,7 @@ const REFUSED: CallResult = { error: "this host takes no synchronous calls" }
 
 export const createBunHost = async <R = never>(options: BunHostOptions<R>): Promise<BunHost> => {
   const principal = options.principal ?? "bun"
-  const runtime = ManagedRuntime.make(Layer.mergeAll(SqliteClient.layer({ filename: options.path }), options.telemetry ?? Layer.empty))
+  const runtime = ManagedRuntime.make(Layer.mergeAll(SqliteClient.layer({ filename: options.log }), options.telemetry ?? Layer.empty))
   // One client, acquired once: every read and every append shares the connection, so ":memory:"
   // is one database and the per-lane writer stays this process.
   const sql = await runtime.runPromise(SqlClient.SqlClient)


### PR DESCRIPTION
createBunHost's first option named a file-system detail. The thing it locates is the log, the library's one primitive, so the option says so: log: "agents.sqlite" (or ":memory:"). The quickstart's opening line now restates the tagline. Mechanical rename across the host, its tests, and the docs; gate green.