### PR TITLE
docs: visible braces in tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Tardigrade is a durable agent harness built with the log as its core. State at any point is a pure function of the log, and the harness is a set of transitions derived from it.
 
-$$\{\mathrm{transitions}\} = f(\mathrm{log})$$
+$$\lbrace\mathrm{transitions}\rbrace = f(\mathrm{log})$$
 
 ## Quickstart
 


### PR DESCRIPTION
GitHub's markdown layer consumes the backslash escapes before the math renderer runs, so \\{ \\} became invisible grouping and the tagline rendered without its braces. \\lbrace and \\rbrace survive the markdown pass and render the set braces.