### PR TITLE
docs: drop reconciler diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,6 @@ type Reactor = (events: ReadonlyArray<Event>) => ReadonlyArray<Transition>
 
 An actor is a set of reactors over one log, plus the key derivation that decides commitment.
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/reconciler-loop-dark.svg">
-  <img alt="The reconciler loop: the log feeds reactors, reactors derive transitions, unrecorded keys fire, events land keyed record last" src="docs/assets/reconciler-loop-light.svg">
-</picture>
-
 ### Capabilities
 
 A capability is one component of an agent: it provides the model its context and services the calls that come back, as one value. What the model is shown is a projection of the log, like everything else; the handlers are reactors. `agentOf` mounts a list of capabilities into an actor and injects the model loop, so adding a capability is one edit.


### PR DESCRIPTION
The reconciler diagram leaves the README for now. The prose and the tagline carry the loop; the source and the render tool stay in tools/render-diagrams.ts for a return.