### PR TITLE
docs: add readme logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/logo-dark.svg">
+    <img alt="Tardigrade logo: a tardigrade drawn from overlapping circles" src="docs/assets/logo-light.svg" width="170">
+  </picture>
+</p>
+
 # Tardigrade
 
 ### Log is all you need

--- a/docs/assets/logo-dark.svg
+++ b/docs/assets/logo-dark.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1300 1300" width="1300" height="1300">
+<mask id="cuts-dark">
+  <circle cx="1060" cy="694" r="190" fill="#fff"/>
+  <circle cx="1060" cy="694" r="190" fill="none" stroke="#000" stroke-width="48"/>
+  <circle cx="830" cy="639" r="255" fill="#fff"/>
+  <circle cx="830" cy="639" r="255" fill="none" stroke="#000" stroke-width="48"/>
+  <circle cx="565" cy="604" r="300" fill="#fff"/>
+  <circle cx="565" cy="604" r="300" fill="none" stroke="#000" stroke-width="48"/>
+  <circle cx="255" cy="674" r="205" fill="#fff"/>
+  <circle cx="255" cy="674" r="205" fill="none" stroke="#000" stroke-width="48"/>
+  <circle cx="555" cy="954" r="42" fill="#fff"/>
+  <circle cx="850" cy="954" r="42" fill="#fff"/>
+  <circle cx="1125" cy="954" r="42" fill="#fff"/>
+</mask>
+<g>
+<rect width="1300" height="1300" fill="#ffffff" mask="url(#cuts-dark)"/>
+<circle cx="180" cy="704" r="54" fill="none" stroke="#111318" stroke-width="40"/>
+</g>
+</svg>

--- a/docs/assets/logo-light.svg
+++ b/docs/assets/logo-light.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1300 1300" width="1300" height="1300">
+<mask id="cuts-light">
+  <circle cx="1060" cy="694" r="190" fill="#fff"/>
+  <circle cx="1060" cy="694" r="190" fill="none" stroke="#000" stroke-width="38"/>
+  <circle cx="830" cy="639" r="255" fill="#fff"/>
+  <circle cx="830" cy="639" r="255" fill="none" stroke="#000" stroke-width="38"/>
+  <circle cx="565" cy="604" r="300" fill="#fff"/>
+  <circle cx="565" cy="604" r="300" fill="none" stroke="#000" stroke-width="38"/>
+  <circle cx="255" cy="674" r="205" fill="#fff"/>
+  <circle cx="255" cy="674" r="205" fill="none" stroke="#000" stroke-width="38"/>
+  <circle cx="555" cy="954" r="42" fill="#fff"/>
+  <circle cx="850" cy="954" r="42" fill="#fff"/>
+  <circle cx="1125" cy="954" r="42" fill="#fff"/>
+</mask>
+<g>
+<rect width="1300" height="1300" fill="#111318" mask="url(#cuts-light)"/>
+<circle cx="180" cy="704" r="54" fill="none" stroke="#ffffff" stroke-width="32"/>
+</g>
+</svg>


### PR DESCRIPTION
Adds a tardigrade logo above the README title, following the docs/assets light/dark SVG pair convention already used by the diagrams.

- docs/assets/logo-light.svg and logo-dark.svg: the mark is built from circles (head, three humps, feet dots); seams between circles and the outer border are transparent mask cuts, and the mouth is a ring stroked in the inverse of the fill
- the light variant uses thinner cuts than the dark one, since light-on-dark gaps read wider than dark-on-light
- README.md: centered picture element above the title selects the variant by GitHub theme
- bun run gate --only=lint:docs passes; both variants verified on white and dark backgrounds