### PR TITLE
docs: crop logo viewbox

### DIFF
--- a/docs/assets/logo-dark.svg
+++ b/docs/assets/logo-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1300 1300" width="1300" height="1300">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="30 294 1240 712" width="1240" height="712">
 <mask id="cuts-dark">
   <circle cx="1060" cy="694" r="190" fill="#fff"/>
   <circle cx="1060" cy="694" r="190" fill="none" stroke="#000" stroke-width="48"/>

--- a/docs/assets/logo-light.svg
+++ b/docs/assets/logo-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1300 1300" width="1300" height="1300">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="30 294 1240 712" width="1240" height="712">
 <mask id="cuts-light">
   <circle cx="1060" cy="694" r="190" fill="#fff"/>
   <circle cx="1060" cy="694" r="190" fill="none" stroke="#000" stroke-width="38"/>


### PR DESCRIPTION
The README logo files framed the mark in a square 1300x1300 viewBox meant for avatar use, so the transparent padding rendered as a large gap above and below the logo in the README. Crops the viewBox to the mark's bounds so the image box hugs the tardigrade.

- docs/assets/logo-light.svg and logo-dark.svg: viewBox tightened from 0 0 1300 1300 to 30 294 1240 712
- verified on white and dark backgrounds via headless Chrome render