### PR TITLE
docs: logo as vector paths

### DIFF
--- a/docs/assets/logo-dark.svg
+++ b/docs/assets/logo-dark.svg
@@ -1,19 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="30 294 1240 712" width="1240" height="712">
-<mask id="cuts-dark">
-  <circle cx="1060" cy="694" r="190" fill="#fff"/>
-  <circle cx="1060" cy="694" r="190" fill="none" stroke="#000" stroke-width="48"/>
-  <circle cx="830" cy="639" r="255" fill="#fff"/>
-  <circle cx="830" cy="639" r="255" fill="none" stroke="#000" stroke-width="48"/>
-  <circle cx="565" cy="604" r="300" fill="#fff"/>
-  <circle cx="565" cy="604" r="300" fill="none" stroke="#000" stroke-width="48"/>
-  <circle cx="255" cy="674" r="205" fill="#fff"/>
-  <circle cx="255" cy="674" r="205" fill="none" stroke="#000" stroke-width="48"/>
-  <circle cx="555" cy="954" r="42" fill="#fff"/>
-  <circle cx="850" cy="954" r="42" fill="#fff"/>
-  <circle cx="1125" cy="954" r="42" fill="#fff"/>
-</mask>
-<g>
-<rect width="1300" height="1300" fill="#ffffff" mask="url(#cuts-dark)"/>
-<circle cx="180" cy="704" r="54" fill="none" stroke="#111318" stroke-width="40"/>
+<g transform="translate(10 254)" fill="#ffffff">
+  <circle cx="245" cy="420" r="181"/>
+  <path d="M 320.83 203.92 A 276 276 0 1 1 406.32 582.53 A 229 229 0 0 0 320.83 203.92 Z"/>
+  <path d="M 813.07 154.10 A 231 231 0 1 1 753.36 606.18 A 324 324 0 0 0 813.07 154.10 Z"/>
+  <path d="M 1076.91 276.20 A 166 166 0 1 1 999.89 598.26 A 279 279 0 0 0 1076.91 276.20 Z"/>
+  <circle cx="545" cy="700" r="42"/>
+  <circle cx="840" cy="700" r="42"/>
+  <circle cx="1115" cy="700" r="42"/>
+  <circle cx="170" cy="450" r="54" fill="none" stroke="#111318" stroke-width="40"/>
 </g>
 </svg>

--- a/docs/assets/logo-light.svg
+++ b/docs/assets/logo-light.svg
@@ -1,19 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="30 294 1240 712" width="1240" height="712">
-<mask id="cuts-light">
-  <circle cx="1060" cy="694" r="190" fill="#fff"/>
-  <circle cx="1060" cy="694" r="190" fill="none" stroke="#000" stroke-width="38"/>
-  <circle cx="830" cy="639" r="255" fill="#fff"/>
-  <circle cx="830" cy="639" r="255" fill="none" stroke="#000" stroke-width="38"/>
-  <circle cx="565" cy="604" r="300" fill="#fff"/>
-  <circle cx="565" cy="604" r="300" fill="none" stroke="#000" stroke-width="38"/>
-  <circle cx="255" cy="674" r="205" fill="#fff"/>
-  <circle cx="255" cy="674" r="205" fill="none" stroke="#000" stroke-width="38"/>
-  <circle cx="555" cy="954" r="42" fill="#fff"/>
-  <circle cx="850" cy="954" r="42" fill="#fff"/>
-  <circle cx="1125" cy="954" r="42" fill="#fff"/>
-</mask>
-<g>
-<rect width="1300" height="1300" fill="#111318" mask="url(#cuts-light)"/>
-<circle cx="180" cy="704" r="54" fill="none" stroke="#ffffff" stroke-width="32"/>
+<g transform="translate(10 254)" fill="#111318">
+  <circle cx="245" cy="420" r="186"/>
+  <path d="M 313.30 206.67 A 281 281 0 1 1 398.35 583.28 A 224 224 0 0 0 313.30 206.67 Z"/>
+  <path d="M 803.19 149.60 A 236 236 0 1 1 742.66 607.97 A 319 319 0 0 0 803.19 149.60 Z"/>
+  <path d="M 1068.71 270.03 A 171 171 0 1 1 989.79 600.05 A 274 274 0 0 0 1068.71 270.03 Z"/>
+  <circle cx="545" cy="700" r="42"/>
+  <circle cx="840" cy="700" r="42"/>
+  <circle cx="1115" cy="700" r="42"/>
+  <circle cx="170" cy="450" r="54" fill="none" stroke="#ffffff" stroke-width="32"/>
 </g>
 </svg>


### PR DESCRIPTION
The logo SVGs built their shapes with a mask, and browsers rasterize masked content into a bitmap layer, so the logo could render soft or pixelated (for example when zoomed, before a repaint). Replaces the mask with plain vector paths: each hump is its disc shrunk by half the seam width, minus the disc in front of it inflated by the same amount, emitted as a closed two-arc path through the circles' computed intersection points.

- docs/assets/logo-light.svg and logo-dark.svg: mask and full-canvas rect replaced by four fills (one circle, three arc-difference paths), feet dots, and the mouth ring stroke; rendering is unchanged
- verified against the previous version side by side on white and dark backgrounds