### PR TITLE
docs: space above logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <p align="center">
+  <br>
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/assets/logo-dark.svg">
     <img alt="Tardigrade logo: a tardigrade drawn from overlapping circles" src="docs/assets/logo-light.svg" width="170">


### PR DESCRIPTION
The README logo sat close to the top edge of the rendered README card. Adds a line break above the picture element so the logo gets one line-height of breathing room.

- README.md: br before the picture block
- lint:docs passes