### PR TITLE
feat(agent): system as projection

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Organized on the Diátaxis grid: learning, tasks, information, understanding.
 - [tutorials/](tutorials/): guided builds.
   - [rlm-agent.md](tutorials/rlm-agent.md): a Recursive Language Model agent with durable code execution. Ends by killing it mid-recursion.
 - [how-to/](how-to/): task-shaped recipes.
-  - [gate-tools.md](how-to/gate-tools.md): hide, reveal, or revoke tools from the log.
+  - [gate-tools.md](how-to/gate-tools.md): hide, reveal, or revoke tools from the log, and derive the system fragment that names them.
   - [observe.md](how-to/observe.md): wire a tracer, the one-trace contract, the outcome vocabulary.
   - [policy.md](how-to/policy.md): read and set the caps, ceilings, and bounds the framework applies.
 - [reference/](reference/): neutral per-symbol contracts, no analogies.

--- a/docs/how-to/gate-tools.md
+++ b/docs/how-to/gate-tools.md
@@ -41,6 +41,17 @@ const deny = async (call: ToolCalled): Promise<ToolReturned[]> =>
   [{ type: "ToolReturned", callId: call.callId, result: { error: `${call.name} is unavailable` } }]
 ```
 
+### The words that come with the offer
+
+The prompt that names the tools is a projection too. A capability's `system` is a string or a function of the log, so the text that describes a tool is derived where the tool list is derived, and the render is one function of one log.
+
+```ts
+// packagesSystem: the block naming what the model can reach, folded from the same log.
+const catalog = { name: "catalog", system: (events) => `<packages>\n${namesIn(events).join("\n")}\n</packages>` }
+```
+
+A capability that ships a default fragment takes a replacement at the surface that applies it, the way a policy value does (policy.md). `codeModeFor({}, { system })` swaps code mode's `CODE_SYSTEM` for a host's own, and the exported default says what the swap replaced.
+
 ### Why this cannot drift
 
 Offer and enforcement are the same pure function of the same log, read twice. There is no tool registry to fall out of sync with the prompt. The policy is testable by handing `availableTools` event arrays, and auditable after the fact: for any recorded settle, re-derive exactly which tools the model was shown.

--- a/packages/agent/src/capability.test.ts
+++ b/packages/agent/src/capability.test.ts
@@ -4,7 +4,7 @@ import type { Event } from "@tardigrade/core/event"
 import { EventLog, withWatermark } from "@tardigrade/core/event-log"
 import { Router } from "@tardigrade/core/router"
 import { Self } from "@tardigrade/core/actor"
-import { agentOf, budget, codeMode, compaction, compactionFor, renderOf, reply, toolList } from "./capability"
+import { agentOf, budget, CODE_SYSTEM, codeMode, codeModeFor, compaction, compactionFor, renderOf, reply, toolList } from "./capability"
 import { receive } from "./turn"
 import { Infer, type InferRequest } from "./infer"
 
@@ -112,5 +112,34 @@ describe("agentOf", () => {
     const render = renderOf([codeMode, echoTable], [])
     expect(render.tools.map((t) => t.name)).toEqual(["execute", "echo"])
     expect(render.system.indexOf("execute")).toBeLessThan(render.system.indexOf("echo"))
+  })
+
+  test("a system fragment is a projection: it reads the log renderOf was handed", () => {
+    const seen: ReadonlyArray<Event>[] = []
+    const log: ReadonlyArray<Event> = [{ type: "PackageInstalled", name: "github" }, { type: "PackageInstalled", name: "slack" }]
+    const catalog = {
+      name: "catalog",
+      system: (events: ReadonlyArray<Event>) => {
+        seen.push(events)
+        return `packages: ${events.map((e) => String((e as { name?: unknown }).name)).join(", ")}`
+      }
+    }
+    const render = renderOf([catalog, echoTable], log)
+    expect(seen).toEqual([log])
+    expect(render.system).toContain("packages: github, slack")
+    // A constant fragment stays what it says, beside the derived one.
+    expect(render.system).toContain("echo")
+  })
+
+  test("renderOf over one log is deterministic", () => {
+    const log: ReadonlyArray<Event> = [{ type: "PackageInstalled", name: "github" }]
+    const capability = { name: "catalog", system: (events: ReadonlyArray<Event>) => `count: ${events.length}` }
+    expect(renderOf([codeMode, capability], log)).toEqual(renderOf([codeMode, capability], log))
+  })
+
+  test("codeModeFor takes a system fragment, and the bare capability renders the exported default", () => {
+    const overridden = renderOf([codeModeFor({}, { system: (events) => `the packages in scope are:\n${events.length}` })], [{ type: "PackageInstalled" }])
+    expect(overridden.system).toBe("the packages in scope are:\n1")
+    expect(renderOf([codeMode], []).system).toBe(CODE_SYSTEM)
   })
 })

--- a/packages/agent/src/capability.ts
+++ b/packages/agent/src/capability.ts
@@ -37,8 +37,10 @@ export interface Capability<R = never> {
   // (docs/how-to/gate-tools.md). The composed tools are what the infer reactor hands the model
   // binding per attempt; nothing about tools lives in ModelConfig.
   readonly tools?: (log: ReadonlyArray<Event>) => ReadonlyArray<ToolSpec>
-  // The system fragment explaining the tools. Fragments join in agentOf order.
-  readonly system?: string
+  // The system fragment explaining the tools, a projection of the log like `tools`: a constant
+  // string is the constant projection, and a function derives the fragment from what has
+  // happened (docs/how-to/gate-tools.md). Fragments join in agentOf order.
+  readonly system?: string | ((log: ReadonlyArray<Event>) => string)
   // What the render truncates and where. The capability that applies a context policy to its
   // reactor states the same one here, so the binding renders against the policy the guard
   // holds and the two cannot drift (compactionFor).
@@ -58,7 +60,7 @@ export const renderOf = <R>(
   log: ReadonlyArray<Event>
 ): { readonly system: string; readonly tools: ReadonlyArray<ToolSpec>; readonly context: Partial<ContextPolicy> } => ({
   system: capabilities
-    .map((c) => c.system)
+    .map((c) => (typeof c.system === "function" ? c.system(log) : c.system))
     .filter((s): s is string => s !== undefined && s !== "")
     .join("\n"),
   tools: capabilities.flatMap((c) => c.tools?.(log) ?? []),
@@ -120,7 +122,11 @@ const EXECUTE_TOOL: ToolSpec = {
   }
 }
 
-const CODE_SYSTEM = `You act on the world by calling the execute tool with JavaScript; the packages in scope are:\nnone`
+// CODE_SYSTEM is code mode's default system fragment: it names the tool the model acts with and
+// the packages in scope. A host whose packages come from the log renders its own fragment and
+// passes it to codeModeFor, so the default is a value you can read and a value you can replace
+// (docs/how-to/gate-tools.md).
+export const CODE_SYSTEM = `You act on the world by calling the execute tool with JavaScript; the packages in scope are:\nnone`
 
 // settleFor reads one execution's outcome, once the code reactor has recorded it.
 const settleFor = (
@@ -168,13 +174,18 @@ const codeServe: Serve = (call, log, answer) => {
 
 // codeModeFor is the code-execution capability: one `execute` tool, served by dispatching to
 // the code reactor and answered from its settle. The policy is the code lane's own
-// (packages/code/src/execute.ts, CodePolicy).
-export const codeModeFor = (policy: Partial<CodePolicy>): Capability => ({
+// (packages/code/src/execute.ts, CodePolicy). `render.system` replaces CODE_SYSTEM, as a string
+// or as a projection of the log, for a host that names the packages in scope from its own
+// events (capability.test.ts, "codeModeFor takes a system fragment").
+export const codeModeFor = (
+  policy: Partial<CodePolicy>,
+  render: { readonly system?: Capability["system"] } = {}
+): Capability => ({
   name: "code",
   keys: codeKeys,
   reactors: [codeReactorFor(policy)],
   tools: () => [EXECUTE_TOOL],
-  system: CODE_SYSTEM,
+  system: render.system ?? CODE_SYSTEM,
   serve: codeServe
 })
 
@@ -192,7 +203,7 @@ export interface NativeTool<R = never> {
 // toolList is a fixed list of named tools, the shape every provider's tool calling takes and
 // the shape a replicated harness is measured on: each call runs its tool and records the
 // return, no lane of its own.
-export const toolList = <R = never>(tools: ReadonlyArray<NativeTool<R>>, system = ""): Capability<R> => {
+export const toolList = <R = never>(tools: ReadonlyArray<NativeTool<R>>, system: Capability["system"] = ""): Capability<R> => {
   const table = new Map(tools.map((t) => [t.spec.name, t]))
   return {
     name: "tools",

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -38,7 +38,7 @@ export {
 
 // The capability assembly: code mode is the default, and an agent measured against a fixed
 // tool list mounts its own (capability.ts).
-export { agentOf, renderOf, codeMode, codeModeFor, toolList, reply, budget, budgetFor, compaction, compactionFor, type Capability, type NativeTool } from "./capability"
+export { agentOf, renderOf, codeMode, codeModeFor, CODE_SYSTEM, toolList, reply, budget, budgetFor, compaction, compactionFor, type Capability, type NativeTool } from "./capability"
 
 export interface CreateAgentOptions {
   readonly packages?: ReadonlyArray<Package>


### PR DESCRIPTION
A capability's `system` becomes a projection of the log, the same shape `tools` already has, so the whole render the model sees is one pure function of one log. A host whose prompt names things that arrive as events (a package catalog, an approval, a revoked tool) can now derive that text where it derives the tool list, instead of appending it at the wire.

- `Capability.system` widens to `string | ((log: ReadonlyArray<Event>) => string)`; a constant string is the constant projection, so every existing capability is unchanged.
- `renderOf` resolves each fragment against the log it was handed before the existing filter and join.
- `CODE_SYSTEM`, code mode's default fragment, is exported, and `codeModeFor(policy, { system })` takes a replacement at the surface that applies it, per the repo's no-silent-hardcoding rule.
- `toolList`'s `system` parameter widens to the same union.
- `docs/how-to/gate-tools.md` gains the system-fragment analog beside the tool-gating recipe.
- Three tests added: a function fragment receives the exact log `renderOf` was called with, `renderOf` on one log twice is identical, and the `codeModeFor` override renders while the bare `codeMode` still renders the exported default. Full `bun run gate` green.


