### PR TITLE
docs: polish readme intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,17 @@
 
 ### A harness made for self-improvement
 
-Building and running an agent in production is tough. Whenever an agent misbehaves, we often handcraft a new eval case and hope it doesn't happen again. As models get increasingly smart, they will be capable of doing these improvements themselves. To fully use this and create a cycle of self-improvement, we need a harness that can be inspected, forked, and varied. Observability and the ergonomics around it should be native to the harness. Imagine an agent taking any production run that went wrong, forking it, customizing any part of the harness, and replaying thousands of variations before your users hit the next one. We made this possible with tardigrade.
+Building and running an agent in production is tough. Whenever an agent misbehaves, we often handcraft a new eval case and hope it doesn't happen again.
+
+As models get increasingly smart, they will be capable of doing these improvements themselves. To fully use this and create a cycle of self-improvement, we need a harness that can be inspected, forked, and varied. Observability and the ergonomics around it should be native to the harness.
+
+Imagine an agent taking any production run that went wrong, forking it, customizing any part of the harness, and replaying thousands of variations before your users hit the next one. We made this possible with tardigrade.
 
 ### Log is all you need
 
-How can a harness be fully customizable, yet remain reliable in production? We took inspiration from React. Designing a harness is like designing a user interface, except the user is a language model. React solved this for the DOM by declaring the component tree as a function of state: `UI = f(state)` and the set of valid state transitions as `{transitions} = f(state)`. The simplicity of React enabled expressiveness in authoring applications without sacrificing reliability. A harness needs the same shape, but with the log as state.
+How can a harness be fully customizable, yet remain reliable in production? We took inspiration from React. Designing a harness is like designing a user interface, except the user is a language model.
+
+React solved this for the DOM by declaring the component tree as a function of state: `UI = f(state)` and the set of valid state transitions as `{transitions} = f(state)`. The simplicity of React enabled expressiveness in authoring applications without sacrificing reliability. A harness needs the same shape, but with the log as state.
 
 $$\lbrace\mathrm{transitions}\rbrace = f(\mathrm{log})$$
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 ### A harness made for self-improvement
 
-Building and running an agent in production is tough. There are a thousand reasons your agents can misbehave. We often handcraft a new eval case and hope the agent doesn't run into a similar situation in the future. As models get more capable, they will be able to do these improvements themselves. To create a cycle of self-improvement, we need a harness that can be inspected, forked, and varied (meta-harnesses explore this). Observability and the ergonomics around using it should be native to the harness. Imagine an agent taking any production run that went wrong, forking it, customizing any part of the harness, and replaying thousands of variations before your users hit the next one. We made this possible with tardigrade.
+Building and running an agent in production is tough. Whenever an agent misbehaves, we often handcraft a new eval case and hope it doesn't happen again. As models get increasingly smart, they will be capable of doing these improvements themselves. To fully use this and create a cycle of self-improvement, we need a harness that can be inspected, forked, and varied. Observability and the ergonomics around it should be native to the harness. Imagine an agent taking any production run that went wrong, forking it, customizing any part of the harness, and replaying thousands of variations before your users hit the next one. We made this possible with tardigrade.
 
 ### Log is all you need
 
-How can a harness be extremely customizable, yet remain reliable in production? We took inspiration from React. Designing a harness is not very different from designing a user interface, except here the user is a language model. React solved this for the DOM by declaring the component tree as a function of state: `UI = f(state)`. Less known is that the set of valid state transitions is also derived from the same function: `{transitions} = f(state)`. The simplicity of React enabled expressiveness in authoring applications without sacrificing reliability. A harness needs the same shape as React, but with the log as state. A harness can and should be described simply as
+How can a harness be fully customizable, yet remain reliable in production? We took inspiration from React. Designing a harness is like designing a user interface, except the user is a language model. React solved this for the DOM by declaring the component tree as a function of state: `UI = f(state)` and the set of valid state transitions as `{transitions} = f(state)`. The simplicity of React enabled expressiveness in authoring applications without sacrificing reliability. A harness needs the same shape, but with the log as state.
 
 $$\lbrace\mathrm{transitions}\rbrace = f(\mathrm{log})$$
 


### PR DESCRIPTION
Follow-up polish on the readme intro that #86 landed: a grammar pass and a paragraph breakdown so each paragraph carries one idea.

- grammar: "an agent misbehaves", "to fully use" (was "utilise", mixed with the US spellings around it)
- the self-improvement section splits into pain, thesis, and payoff paragraphs; the log section splits the question from the React mechanism
- gate green including lint:docs