### PR TITLE
docs: center masthead tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
   </picture>
 </p>
 
-# Tardigrade
+<h1 align="center">Tardigrade</h1>
 
-A modular and durable agent harness built for self-improvement.
+<p align="center">A modular and durable agent harness built for self-improvement.</p>
 
 ### A harness made for self-improvement
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@
 
 As models get increasingly smart, they will be capable of writing their own harnesses to improve themselves. To enable this, we need a harness that can be inspected, forked, and varied.
 
-How can a harness be fully customizable, yet remain reliable in production? We took inspiration from React. Designing a harness is like designing a user interface, except the user is a language model. React declared the component tree as a function of state: `UI = f(state)` and the set of valid state transitions as `{transitions} = f(state)`.
-
-This simplicity enabled expressiveness in authoring applications without sacrificing reliability. A harness needs the same shape, but with the log as state.
+How can a harness be fully customizable, yet remain reliable in production? We took inspiration from React. Designing a harness is like designing a user interface, except the user is a language model. React declared the component tree as a function of state: `UI = f(state)` and the set of valid state transitions as `{transitions} = f(state)`. This simplicity enabled expressiveness in authoring applications without sacrificing reliability. A harness needs the same shape, but with the log as state.
 
 $$\lbrace\mathrm{transitions}\rbrace = f(\mathrm{log})$$
 


### PR DESCRIPTION
The readme masthead centers as one unit: the logo, an html h1 for the title, and the tagline in a centered paragraph directly under it. Content unchanged; lint:docs green.