### PR TITLE
docs: left-align masthead text

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
   </picture>
 </p>
 
-<h1 align="center">Tardigrade</h1>
+# Tardigrade
 
-<p align="center">A modular and durable agent harness built for self-improvement.</p>
+A modular and durable agent harness built for self-improvement.
 
 ### A harness made for self-improvement
 


### PR DESCRIPTION
The title returns to a markdown h1 and the tagline to a plain left-aligned paragraph; only the logo stays centered. Content unchanged; lint:docs green.