### PR TITLE
feat(bun): durable workspace binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ $$\lbrace\mathrm{transitions}\rbrace = f(\mathrm{log})$$
 Build an RLM agent by combining capabilities.
 
 ```ts
-import { Layer } from "effect"
-import { KeyValueStore } from "effect/unstable/persistence"
 import { agentOf, budget, codeMode, compaction, reply } from "@tardigrade/agent"
 import { infer } from "@tardigrade/model/model"
 import { createBunHost } from "@tardigrade/bun/host"
@@ -34,15 +32,13 @@ import { fileTelemetry } from "@tardigrade/bun/file"
 // Mounting one is adding it to the list; `toolList([...])` mounts a fixed tool list instead.
 const agent = agentOf([codeMode, reply, budget, compaction])
 
-// createBunHost runs the actor over a durable SQLite log; layersFor wires the model binding and
-// the store a large result spills to, which layerMemory holds for the life of the process.
+// createBunHost runs the actor over a durable SQLite log, and gives it a workspace in the same
+// file, so a large result the agent spills is still there after a restart; layersFor wires the
+// model binding.
 const host = await createBunHost({
   log: "agents.sqlite",
   actorFor: () => agent,
-  layersFor: () => Layer.mergeAll(
-    infer({ baseUrl: process.env.MODEL_BASE_URL!, apiKey: process.env.MODEL_API_KEY!, model: process.env.MODEL_ID!, provider: "bedrock" }),
-    KeyValueStore.layerMemory
-  ),
+  layersFor: () => infer({ baseUrl: process.env.MODEL_BASE_URL!, apiKey: process.env.MODEL_API_KEY!, model: process.env.MODEL_ID!, provider: "bedrock" }),
   telemetry: fileTelemetry("spans.ndjson")
 })
 await host.deliver("bun:main", { type: "MessageReceived", id: "m1", text: "What changed in the deploy?", at: Date.now() })

--- a/bun.lock
+++ b/bun.lock
@@ -60,6 +60,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@effect/sql-sqlite-bun": "4.0.0-rc.110",
+        "@tardigrade/code": "workspace:*",
         "@tardigrade/core": "workspace:*",
         "@tardigrade/host": "workspace:*",
         "effect": "4.0.0-rc.110",

--- a/platform/README.md
+++ b/platform/README.md
@@ -11,4 +11,4 @@ in-memory and dependency-free, and it is the executable contract a platform bind
 against.
 
 Nothing lives here yet. `platform/model` (the Infer binding over the AI SDK) is the first
-planned tenant; `platform/bun` binds the log to SQLite through @effect/sql-sqlite-bun; `platform/cloudflare` arrives with the v6 extraction.
+planned tenant; `platform/bun` binds the log to SQLite through @effect/sql-sqlite-bun, and binds the workspace a bounded value spills to (docs/explanations/boundary.md) to a table in that same database, so a run is one file; `platform/cloudflare` arrives with the v6 extraction.

--- a/platform/bun/package.json
+++ b/platform/bun/package.json
@@ -7,6 +7,7 @@
     "./*": "./src/*.ts"
   },
   "dependencies": {
+    "@tardigrade/code": "workspace:*",
     "@tardigrade/core": "workspace:*",
     "@tardigrade/host": "workspace:*",
     "@effect/sql-sqlite-bun": "4.0.0-rc.110",

--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -3,11 +3,14 @@ import { mkdtempSync, readFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { Effect, Layer, Tracer } from "effect"
+import type { KeyValueStore } from "effect/unstable/persistence"
 import type { Event } from "@tardigrade/core/event"
 import { transition, type Actor, type Reactor } from "@tardigrade/core/actor"
+import { hydrate, refs, spill } from "@tardigrade/code/store"
 
 import { createBunHost, type BunHostOptions } from "./host"
 import { fileTelemetry } from "./file"
+import { bunWorkspace } from "./workspace"
 
 // The bun binding against the reference host's contract, plus the two behaviors only physics
 // can show: a reopened database keeps the log, and recover() settles work a death interrupted.
@@ -103,6 +106,97 @@ describe("the bun host", () => {
     ])
     expect((await h.read("echo")).map((e) => String((e as { id?: unknown }).id))).toEqual(["a", "b", "c"])
     await h.close()
+  })
+})
+
+// The workspace the host binds: a value spilled by one process is on disk, so the next process
+// hydrates the same bytes and reads the same manifest.
+
+const REF = "e1.result"
+const VALUE = JSON.stringify({ rows: Array.from({ length: 500 }, (_, i) => ({ i, text: "wideé\n\"quoted\"" })) })
+
+const workspaceKeyOf = (e: Event): string | undefined =>
+  e.type === "Spilled" || e.type === "Loaded" ? `${e.type}:${String((e as { id?: unknown }).id)}` : undefined
+
+// One reactor spills, the other hydrates: the pair runs in two processes over one database file.
+const reactorOver = (
+  type: string,
+  act: (id: string) => Effect.Effect<Event, KeyValueStore.KeyValueStoreError, KeyValueStore.KeyValueStore>
+): Reactor<KeyValueStore.KeyValueStore> =>
+(events) =>
+  events
+    .filter((e) => e.type === "MessageReceived")
+    .map((e) => {
+      const id = String((e as { id?: unknown }).id)
+      return transition({
+        key: `${type}:${id}`,
+        input: id,
+        act: (input: string) => act(input).pipe(Effect.map((event) => [event]), Effect.orDie)
+      })
+    })
+
+const spiller: Actor<KeyValueStore.KeyValueStore> = {
+  keyOf: workspaceKeyOf,
+  reactors: [reactorOver("Spilled", (id) => Effect.as(spill(REF, VALUE), { type: "Spilled", id, at: 1 } as Event))]
+}
+
+const loader: Actor<KeyValueStore.KeyValueStore> = {
+  keyOf: workspaceKeyOf,
+  reactors: [
+    reactorOver("Loaded", (id) =>
+      Effect.map(Effect.all([hydrate(REF), refs()]), ([value, held]) => ({ type: "Loaded", id, value, refs: held, at: 1 } as Event)))
+  ]
+}
+
+describe("the durable workspace", () => {
+  test("a value spilled before a restart hydrates from disk, manifest and all", async () => {
+    const path = freshPath()
+    const first = await createBunHost({
+      log: path,
+      keyOf: workspaceKeyOf,
+      actorFor: (lane) => (lane === "ws" ? spiller : undefined)
+    })
+    await first.seed("ws", [{ type: "MessageReceived", id: "m1", text: "spill", at: 1 } as Event])
+    await first.wake("ws")
+    await first.close()
+
+    const second = await createBunHost({
+      log: path,
+      keyOf: workspaceKeyOf,
+      actorFor: (lane) => (lane === "ws" ? loader : undefined)
+    })
+    await second.seed("ws", [{ type: "MessageReceived", id: "m2", text: "load", at: 2 } as Event])
+    await second.wake("ws")
+    const loaded = (await second.read("ws")).find((e) => e.type === "Loaded") as { value?: unknown; refs?: unknown }
+    expect(loaded.value).toBe(VALUE)
+    expect(loaded.refs).toEqual([REF])
+    await second.close()
+  })
+
+  test("the workspace option replaces the default store", async () => {
+    const path = freshPath()
+    const first = await createBunHost({
+      log: path,
+      keyOf: workspaceKeyOf,
+      workspace: bunWorkspace("elsewhere"),
+      actorFor: (lane) => (lane === "ws" ? spiller : undefined)
+    })
+    await first.seed("ws", [{ type: "MessageReceived", id: "m1", text: "spill", at: 1 } as Event])
+    await first.wake("ws")
+    await first.close()
+
+    // The default table never saw the write: a host on it hydrates nothing.
+    const second = await createBunHost({
+      log: path,
+      keyOf: workspaceKeyOf,
+      actorFor: (lane) => (lane === "ws" ? loader : undefined)
+    })
+    await second.seed("ws", [{ type: "MessageReceived", id: "m2", text: "load", at: 2 } as Event])
+    await second.wake("ws")
+    const loaded = (await second.read("ws")).find((e) => e.type === "Loaded") as { value?: unknown; refs?: unknown }
+    expect(loaded.value).toBeUndefined()
+    expect(loaded.refs).toEqual([])
+    await second.close()
   })
 })
 

--- a/platform/bun/src/host.ts
+++ b/platform/bun/src/host.ts
@@ -1,4 +1,5 @@
 import { Effect, Layer, ManagedRuntime } from "effect"
+import { KeyValueStore } from "effect/unstable/persistence"
 import { SqlClient } from "effect/unstable/sql"
 import { SqliteClient } from "@effect/sql-sqlite-bun"
 import type { Event } from "@tardigrade/core/event"
@@ -6,8 +7,9 @@ import { EventLog } from "@tardigrade/core/event-log"
 import { Router, type CallResult } from "@tardigrade/core/router"
 import { Self, restingActor, settleActor, type Actor } from "@tardigrade/core/actor"
 import { deadlocks, victimOf, type EdgesOf } from "@tardigrade/host/deadlock"
-import type { HostPorts, LaneEnv } from "@tardigrade/host/host"
+import type { HostPorts } from "@tardigrade/host/host"
 import { traceparentOf } from "@tardigrade/core/trace"
+import { bunWorkspace } from "./workspace"
 
 // The bun binding: packages/host's semantics with physics. The log lives in SQLite through
 // @effect/sql-sqlite-bun, so a process death loses nothing and `recover()` re-derives the owed
@@ -17,11 +19,19 @@ import { traceparentOf } from "@tardigrade/core/trace"
 // transaction, dedup by key inside that transaction under a unique index, and the ordered tail
 // read from a watermark. Conformance is behavioral: host.test.ts mirrors the reference host's
 // tests, plus the two only physics can show (a reopen keeps the log; a reopen recovers owed
-// work).
+// work). The same database holds the workspace a bounded value spills to (workspace.ts), so one
+// file is the whole of a run's durable state.
 
-type LayersFor<R> = [Exclude<R, HostPorts>] extends [never]
-  ? { readonly layersFor?: (lane: string) => LaneEnv<R> }
-  : { readonly layersFor: (lane: string) => LaneEnv<R> }
+// BunPorts are the services this binding leaves an actor no work to bind: packages/host's three,
+// plus the workspace store, which on bun is durable and therefore the platform's to give
+// (packages/code/src/store.ts). BunLaneEnv is the rest of an actor's R, the same shape the
+// reference host asks for.
+type BunPorts = HostPorts | KeyValueStore.KeyValueStore
+type BunLaneEnv<R> = Layer.Layer<Exclude<R, BunPorts>, never, BunPorts>
+
+type LayersFor<R> = [Exclude<R, BunPorts>] extends [never]
+  ? { readonly layersFor?: (lane: string) => BunLaneEnv<R> }
+  : { readonly layersFor: (lane: string) => BunLaneEnv<R> }
 
 export type BunHostOptions<R> = {
   readonly log: string // where the log lives: a SQLite file, or ":memory:" for a volatile run
@@ -29,6 +39,10 @@ export type BunHostOptions<R> = {
   // test capture). Absent, every span is inert: instrumentation lives in the packages, export
   // is the platform's, and this seam is the whole of it.
   readonly telemetry?: Layer.Layer<never>
+  // The store spilled values land in. The default is `bunWorkspace()`, durable in the log's own
+  // database; an app that wants another table, a prefixed view, or a volatile run passes its own
+  // layer over the same client (workspace.ts).
+  readonly workspace?: Layer.Layer<KeyValueStore.KeyValueStore, never, SqlClient.SqlClient>
   readonly principal?: string
   readonly actorFor: (lane: string) => Actor<R> | undefined
   readonly call?: Parameters<typeof Router.of>[0]["call"]
@@ -61,10 +75,17 @@ const REFUSED: CallResult = { error: "this host takes no synchronous calls" }
 
 export const createBunHost = async <R = never>(options: BunHostOptions<R>): Promise<BunHost> => {
   const principal = options.principal ?? "bun"
-  const runtime = ManagedRuntime.make(Layer.mergeAll(SqliteClient.layer({ filename: options.log }), options.telemetry ?? Layer.empty))
+  // The workspace is built with the runtime and over the same client, so its table is created once
+  // and every lane spills through the connection the log already holds.
+  const client = SqliteClient.layer({ filename: options.log })
+  const runtime = ManagedRuntime.make(
+    Layer.mergeAll((options.workspace ?? bunWorkspace()).pipe(Layer.provideMerge(client)), options.telemetry ?? Layer.empty)
+  )
   // One client, acquired once: every read and every append shares the connection, so ":memory:"
   // is one database and the per-lane writer stays this process.
   const sql = await runtime.runPromise(SqlClient.SqlClient)
+  // The store, acquired the same way: one instance, one table build, handed to every lane below.
+  const store = await runtime.runPromise(KeyValueStore.KeyValueStore)
   await runtime.runPromise(
     sql`CREATE TABLE IF NOT EXISTS events (
       lane  TEXT    NOT NULL,
@@ -169,11 +190,12 @@ export const createBunHost = async <R = never>(options: BunHostOptions<R>): Prom
         readFrom: (mark: number) => readFromEffect(lane, mark)
       }),
       router,
+      Layer.succeed(KeyValueStore.KeyValueStore, store),
       Layer.succeed(Self, self(lane))
     )
 
   const layersOf = (lane: string): Layer.Layer<R | EventLog> => {
-    const extra = (options.layersFor ?? (() => Layer.empty as unknown as LaneEnv<R>))(lane)
+    const extra = (options.layersFor ?? (() => Layer.empty as unknown as BunLaneEnv<R>))(lane)
     return extra.pipe(Layer.provideMerge(portsOf(lane))) as Layer.Layer<R | EventLog>
   }
 

--- a/platform/bun/src/workspace.ts
+++ b/platform/bun/src/workspace.ts
@@ -1,0 +1,22 @@
+import type { Layer } from "effect"
+import { KeyValueStore } from "effect/unstable/persistence"
+import type { SqlClient } from "effect/unstable/sql"
+
+// The durable workspace on bun: Effect's SQL-backed KeyValueStore over the same SqlClient the log
+// uses, so a spilled value outlives the process that wrote it and replay hydrates a ref from disk
+// (host.test.ts, "a value spilled before a restart hydrates from disk, manifest and all"). The
+// values live in the log's own database file because the event that points at a ref and the value
+// it points at are one artifact: copying, moving, or deleting a run can never take one and leave
+// the other.
+
+// WORKSPACE_TABLE is the table the workspace values and the ref manifest live in. It is a parameter
+// because two isolated workspaces over one database are two tables.
+export const WORKSPACE_TABLE = "workspace"
+
+// bunWorkspace is the workspace layer createBunHost provides by default. It creates its table on
+// build, and it spans the whole database: what one workspace covers is the platform's call
+// (packages/code/src/store.ts), and a consumer that wants a narrower span hands the host its own
+// layer, over another table or over a prefixed view of this one.
+export const bunWorkspace = (
+  table: string = WORKSPACE_TABLE
+): Layer.Layer<KeyValueStore.KeyValueStore, never, SqlClient.SqlClient> => KeyValueStore.layerSql({ table })


### PR DESCRIPTION
The bun host now provides the workspace a bounded value spills to, backed by Effect's SQL KeyValueStore over the SqlClient the log already holds. Spilling became a hard requirement of the code lane when the store landed, and a durable log paired with a volatile store loses the value a surviving event still points at.

- `bunWorkspace(table)` in `platform/bun/src/workspace.ts`: `KeyValueStore.layerSql` over the host's client, with the table name exported as `WORKSPACE_TABLE` and overridable.
- The values live in the log's own database file rather than a sibling file: the event that names a ref and the value it names are one artifact, so a run stays one thing to copy, move, or delete, and the ref can never survive without its value or the other way round. Write contention is not a cost here, because the host is the single writer through one connection and the two tables serialize on it either way.
- `createBunHost` builds the workspace with its runtime and binds it per lane, so the table is created once and an actor no longer has to bring a store. `workspace` in the options takes an alternative layer (another table, a prefixed view, a volatile store for a throwaway run).
- The store leaves the per-lane env an actor must supply, so `layersFor` is now optional for an actor whose only other requirement is the store.
- Tests: a value spilled through one host hydrates byte for byte from a fresh host over the same file, with the `WORKSPACE_REFS` manifest intact, and a host given a `workspace` layer on another table hydrates nothing from the default one.
- Docs: the README quickstart drops its `KeyValueStore.layerMemory` line, and `platform/README.md` states what the bun binding now binds.

The `WorkspaceSql` reference does not exist yet; the binding that lights up the workspace `sql` method on bun follows once the workspace package merges.

Verification: `bun run gate` green (lint, docs lint, typecheck, and every package and platform test suite).
