### PR TITLE
feat(agent): workspace package

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Organized on the Diátaxis grid: learning, tasks, information, understanding.
   - [gate-tools.md](how-to/gate-tools.md): hide, reveal, or revoke tools from the log, and derive the system fragment that names them.
   - [observe.md](how-to/observe.md): wire a tracer, the one-trace contract, the outcome vocabulary.
   - [policy.md](how-to/policy.md): read and set the caps, ceilings, and bounds the framework applies.
+  - [workspace.md](how-to/workspace.md): read a spilled value back by ref, grep across every value, and query where a platform bound SQL.
 - [reference/](reference/): neutral per-symbol contracts, no analogies.
   - [api.md](reference/api.md): Event, Projection, Transition, Reactor, Actor, send, settle, resting.
 - [explanations/](explanations/): the why and the mental model.

--- a/docs/how-to/policy.md
+++ b/docs/how-to/policy.md
@@ -17,7 +17,7 @@ The third part is visibility. When a policy changes what the model sees, the out
 
 ### Where the values live
 
-The agent applies four policies. Three ride their capabilities: `budget` (the tool-call ceiling a brief that states none takes, `budgetFor`), `context` (the render's truncation caps and compaction's fire and keep lines, `compactionFor`), and `code` (the size at which a result spills to the store and leaves a pointer, `codeModeFor`). `infer` is the runtime's own give-up and repair ceilings, and `agentOf` takes it beside the list. `createRlmAgent` gathers all four as `AgentPolicy` so one option sets them.
+The agent applies five policies. Three ride their capabilities: `budget` (the tool-call ceiling a brief that states none takes, `budgetFor`), `context` (the render's truncation caps and compaction's fire and keep lines, `compactionFor`), and `code` (the size at which a result spills to the store and leaves a pointer, `codeModeFor`). `infer` is the runtime's own give-up and repair ceilings, and `agentOf` takes it beside the list. `workspace` bounds what one read or grep of the store can put back into a turn ([workspace.md](workspace.md)). `createRlmAgent` gathers all five as `AgentPolicy` so one option sets them.
 
 The sandbox and the model binding hold the rest. The sandbox bounds captured console output. The model binding bounds the stream (time to first chunk, idle, total), the throttle backoff ladder, and the output-token ladder a truncated answer climbs.
 

--- a/docs/how-to/workspace.md
+++ b/docs/how-to/workspace.md
@@ -1,0 +1,37 @@
+How to read a spilled value back: slice one by ref, search across all of them, and query them where a platform bound SQL.
+
+A result too large for a turn's context spills. The event keeps a pointer with the ref, a preview, and the whole size, and the value itself goes to the store under that ref ([boundary.md](../explanations/boundary.md)). The workspace package is how the model gets the rest of that value back. It is mounted by `createRlmAgent`, so a body calls it like any other package.
+
+### Slice one value
+
+`workspace.read({ ref, offset, length })` answers a slice and the whole value's size. `length` clamps to the read cap, so a body that asks for everything gets a bounded answer and the size it would need to page through. An offset past the end answers with an empty slice and the true size, which is the cue to aim at a smaller offset.
+
+```ts
+const { slice, size } = await workspace.read({ ref: "t1.result", offset: 0, length: 4000 })
+```
+
+### Search across values
+
+`workspace.grep({ pattern, ref })` searches every value the store holds, or one of them when `ref` is given. Each match carries the ref, the offset, and a context window around the hit, so the next `read` starts where the match is. The search sees a value whole however large it grew, which is why a match inside a value far too big for one event is still found.
+
+```ts
+const { matches } = await workspace.grep({ pattern: "invoice_id" })
+const hit = matches[0]
+const { slice } = await workspace.read({ ref: hit.ref, offset: hit.offset, length: 2000 })
+```
+
+### Query, where the platform bound it
+
+`workspace.sql({ query, params })` exists only when the platform bound a SQL surface through `WorkspaceSql`. A platform with a SQL-backed store binds it and the verb appears, with its own docs and annotation; a platform on a plain key/value backend binds nothing and the model sees a workspace with two verbs. The model is never offered a tool that cannot work, so nothing has to explain a tool that always errors.
+
+```ts
+const layer = Layer.succeed(WorkspaceSql, { sql: (query, params) => runOnThePlatform(query, params) })
+```
+
+### The bounds
+
+`WorkspacePolicy` names them: `sliceChars` caps `read`, `contextChars` is the window each match carries, and `maxMatches` is where a match-heavy pattern stops and the answer says it is truncated. `DEFAULT_WORKSPACE_POLICY` states the framework's numbers, and `createRlmAgent` takes an override under `policy.workspace` like every other policy ([policy.md](policy.md)). The method docs the model reads state the numbers in force, so a moved bound moves the words too.
+
+```ts
+const agent = createRlmAgent({ infer, policy: { workspace: { sliceChars: 8_000, maxMatches: 20 } } })
+```

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -142,4 +142,35 @@ describe("createRlmAgent", () => {
     expect(answer.output).toContain("unknown tool: execute")
     expect(answer.output).toContain("read")
   })
+
+  test("the workspace reads back what a spilled result put in the store", async () => {
+    // The mounted workspace and the code reactor's spill path hold one store: a result too large
+    // for the event spills, and the next body finds it by grep and slices it by ref.
+    const mind = createRlmAgent({
+      infer: async ({ trajectory }) => {
+        const start = trajectory.reduce((n, e, i) => (e.type === "MessageReceived" ? i : n), 0)
+        const returns = trajectory.slice(start).filter((e) => e.type === "ToolReturned") as ReadonlyArray<{ result?: { result?: unknown } }>
+        if (returns.length === 0) {
+          return { kind: "call", callId: "w1", name: "execute", arguments: { code: `return "a".repeat(20000) + "NEEDLE";` } }
+        }
+        if (returns.length === 1) {
+          return {
+            kind: "call",
+            callId: "w2",
+            name: "execute",
+            arguments: {
+              code: `const found = await workspace.grep({ pattern: "NEEDLE" });
+                const hit = found.matches[0];
+                const back = await workspace.read({ ref: hit.ref, offset: hit.offset, length: 6 });
+                return hit.ref + ":" + hit.offset + ":" + back.slice + ":" + back.size;`
+            }
+          }
+        }
+        return { kind: "complete", output: String(returns[1]!.result?.result ?? "") }
+      }
+    })
+    // The store holds the result's JSON, so the offset counts the opening quote too.
+    const answer = await mind.run("spill then search")
+    expect(answer.output).toBe("w1.result:20001:NEEDLE:20008")
+  })
 })

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -5,6 +5,7 @@ import { Router } from "@tardigrade/core/router"
 import { Self } from "@tardigrade/core/actor"
 import { Packages, type Package } from "@tardigrade/code/packages"
 import { jsSandboxFor } from "@tardigrade/code/defaults"
+import { workspaceFor } from "@tardigrade/code/workspace"
 import type { SandboxPolicy } from "@tardigrade/code/sandbox"
 import { createHost, type Host, type LaneEnv } from "@tardigrade/host/host"
 import { type AgentPolicy, type RlmR } from "./turn"
@@ -37,6 +38,10 @@ export {
   type ModelPricing
 } from "./usage"
 
+// The workspace the model reads its spilled values back through, and the optional SQL binding a
+// platform lights its third verb up with.
+export { workspacePackage, workspaceFor, WorkspaceSql, DEFAULT_WORKSPACE_POLICY, workspacePolicyOf, type WorkspacePolicy, type SqlRunner } from "@tardigrade/code/workspace"
+
 // The capability assembly: code mode is the default, and an agent measured against a fixed
 // tool list mounts its own (capability.ts).
 export { agentOf, renderOf, codeMode, codeModeFor, CODE_SYSTEM, toolList, reply, budget, budgetFor, compaction, compactionFor, type Capability, type NativeTool } from "./capability"
@@ -54,7 +59,8 @@ export interface CreateAgentOptions {
   // passes [toolList([...])]; reply, budget, and compaction are always mounted.
   readonly capabilities?: ReadonlyArray<Capability<RlmR>>
   // Every policy value the assembled agent applies: the give-up and repair ceilings, the default
-  // tool budget, the context caps, and the spill bound. Absent fields take the exported
+  // tool budget, the context caps, the spill bound, and the workspace's read and grep bounds.
+  // Absent fields take the exported
   // defaults. The context policy reaches the render through the compaction capability, so the
   // binding truncates against the numbers the guard fires on (capability.ts, compactionFor).
   readonly policy?: Partial<AgentPolicy>
@@ -81,8 +87,8 @@ export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
     react: (request: InferRequest, key?: string) => Effect.promise(() => options.infer(request, key))
   })
   // The in-process default spill store: bounded results survive for the life of the process, so
-  // replay within a run hydrates them (packages/code/src/spill.ts). A durable agent provides its
-  // own KeyValueStore layer instead.
+  // replay within a run hydrates them (packages/code/src/store.ts). A durable agent provides its
+  // own KeyValueStore layer instead, and binds WorkspaceSql if it has a SQL surface.
   const spillStore = KeyValueStore.layerMemory
   const sandbox = jsSandboxFor(options.sandbox ?? {})
 
@@ -102,14 +108,19 @@ export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
           // A child with no stated budget takes the same ceiling this agent's own wall reads.
           { budget: options.policy?.budget ?? {} }
         )
-        const all = [...user, spawn]
+        // The workspace reads the same store the spill path writes, and its sql verb appears only
+        // where the platform bound one (packages/code/src/workspace.ts, W5).
+        const workspace = yield* workspaceFor(options.policy?.workspace ?? {})
+        const all = [...user, spawn, workspace]
         return Packages.of({
           resolve: (name) => all.find((p) => p.name === name),
           list: () => Effect.succeed(all.map((p) => ({ name: p.name, description: p.description })))
         })
       })
     )
-    return Layer.mergeAll(packages, sandbox, spillStore, infer)
+    // The workspace package is built from the store, so the store feeds the packages layer and is
+    // exported from the same build: the package and the code reactor's spill path hold one store.
+    return Layer.mergeAll(Layer.provideMerge(packages, spillStore), sandbox, infer)
   }
 
   // Every ag. lane runs the RLM default; anything else is a sink.

--- a/packages/agent/src/turn.ts
+++ b/packages/agent/src/turn.ts
@@ -8,6 +8,7 @@ import type { Infer, InferPolicy } from "./infer"
 import type { BudgetPolicy } from "./budget"
 import type { ContextPolicy } from "./compaction"
 import type { CodePolicy } from "@tardigrade/code/execute"
+import type { WorkspacePolicy } from "@tardigrade/code/workspace"
 
 export { Infer } from "./infer"
 
@@ -21,13 +22,15 @@ export type RlmR = AgentR
 // AgentPolicy is every policy value an assembled agent applies, one field per part that applies
 // one, so a caller sets a single number without listing reactors. Each field is itself partial
 // and fills from its own exported default (infer.ts, budget.ts, compaction.ts,
-// packages/code/src/execute.ts). `infer` is the runtime's policy (agentOf takes it); the rest
-// ride their capabilities (budgetFor, compactionFor, codeModeFor).
+// packages/code/src/execute.ts). `infer` is the runtime's policy (agentOf takes it); `workspace`
+// bounds the workspace package's own read and grep answers (packages/code/src/workspace.ts); the
+// rest ride their capabilities (budgetFor, compactionFor, codeModeFor).
 export interface AgentPolicy {
   readonly infer: Partial<InferPolicy>
   readonly budget: Partial<BudgetPolicy>
   readonly context: Partial<ContextPolicy>
   readonly code: Partial<CodePolicy>
+  readonly workspace: Partial<WorkspacePolicy>
 }
 
 // receive sends the inbound to the given actor. The message id is the dedup key, so delivery can

--- a/packages/code/src/workspace.test.ts
+++ b/packages/code/src/workspace.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { KeyValueStore } from "effect/unstable/persistence"
+import { spill } from "./store"
+import { DEFAULT_WORKSPACE_POLICY, workspacePackage, type SqlRunner } from "./workspace"
+
+// The model's view of the store: a bounded slice of one value, a search across all of them, and a
+// sql verb only where a platform bound one.
+
+const call = async (pkg: ReturnType<typeof workspacePackage>, method: string, args: unknown) =>
+  Effect.runPromise(pkg.methods[method]!(args, { callId: "c1" }) as Effect.Effect<Record<string, unknown>>)
+
+// A store built straight from the memory layer, seeded through the spill path so the manifest is
+// the one grep reads.
+const seeded = (values: Readonly<Record<string, string>>, store?: KeyValueStore.KeyValueStore) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      for (const [ref, json] of Object.entries(values)) yield* spill(ref, json)
+      return yield* KeyValueStore.KeyValueStore
+    }).pipe(
+      store === undefined
+        ? Effect.provide(KeyValueStore.layerMemory)
+        : Effect.provideService(KeyValueStore.KeyValueStore, store)
+    ) as Effect.Effect<KeyValueStore.KeyValueStore>
+  )
+
+// A second backend with no shared code with the memory layer: a Map behind makeStringOnly. W6's
+// other half, a SQL-backed store, belongs to the bun platform and is tested there.
+const mapStore = (): KeyValueStore.KeyValueStore => {
+  const held = new Map<string, string>()
+  return KeyValueStore.makeStringOnly({
+    get: (key) => Effect.succeed(held.get(key)),
+    set: (key, value) => Effect.sync(() => void held.set(key, value)),
+    remove: (key) => Effect.sync(() => void held.delete(key)),
+    clear: Effect.sync(() => held.clear()),
+    size: Effect.sync(() => held.size)
+  })
+}
+
+describe("workspace.read", () => {
+  test("a slice never exceeds the cap, whatever length the model asks for", async () => {
+    const whole = "x".repeat(DEFAULT_WORKSPACE_POLICY.sliceChars * 2)
+    const store = await seeded({ "e1.result": whole })
+    const answer = await call(workspacePackage(store), "read", { ref: "e1.result", length: 10_000_000 })
+    expect((answer.slice as string).length).toBe(DEFAULT_WORKSPACE_POLICY.sliceChars)
+    expect(answer.size).toBe(whole.length)
+  })
+
+  test("the cap is the consumer's to move", async () => {
+    const store = await seeded({ "e1.result": "abcdefghij" })
+    const answer = await call(workspacePackage(store, { policy: { sliceChars: 4 } }), "read", { ref: "e1.result" })
+    expect(answer.slice).toBe("abcd")
+  })
+
+  test("an offset past the end answers with an empty slice and the true size", async () => {
+    const store = await seeded({ "e1.result": "0123456789" })
+    const answer = await call(workspacePackage(store), "read", { ref: "e1.result", offset: 99 })
+    expect(answer.slice).toBe("")
+    expect(answer.size).toBe(10)
+  })
+
+  test("a ref the store never held is an error the model can act on", async () => {
+    const store = await seeded({})
+    const answer = await call(workspacePackage(store), "read", { ref: "nothing.here" })
+    expect(String(answer.error)).toContain("nothing.here")
+  })
+})
+
+describe("workspace.grep", () => {
+  test("a match inside a value far larger than one event carries its ref, offset, and context", async () => {
+    const needle = "SECRET-PIN-4417"
+    const whole = `${"a".repeat(200_000)}${needle}${"b".repeat(200_000)}`
+    const store = await seeded({ "e1.noise": "nothing to see", "e2.result": whole })
+    const answer = await call(workspacePackage(store), "grep", { pattern: needle })
+    const matches = answer.matches as ReadonlyArray<{ ref: string; offset: number; context: string }>
+    expect(matches).toHaveLength(1)
+    expect(matches[0]!.ref).toBe("e2.result")
+    expect(matches[0]!.offset).toBe(200_000)
+    expect(matches[0]!.context).toContain(needle)
+    expect(matches[0]!.context.length).toBe(needle.length + DEFAULT_WORKSPACE_POLICY.contextChars * 2)
+    // The offset locates the match for a read, and the read lands on it.
+    const slice = await call(workspacePackage(store), "read", { ref: "e2.result", offset: matches[0]!.offset, length: needle.length })
+    expect(slice.slice).toBe(needle)
+  })
+
+  test("a ref narrows the search to one value", async () => {
+    const store = await seeded({ a: "find me", b: "find me too" })
+    const answer = await call(workspacePackage(store), "grep", { pattern: "find me", ref: "b" })
+    expect((answer.matches as ReadonlyArray<{ ref: string }>).map((m) => m.ref)).toEqual(["b"])
+  })
+
+  test("a match-heavy pattern stops at the bound and says so", async () => {
+    const store = await seeded({ a: "hit ".repeat(50) })
+    const answer = await call(workspacePackage(store, { policy: { maxMatches: 3, contextChars: 0 } }), "grep", { pattern: "hit" })
+    expect(answer.matches).toHaveLength(3)
+    expect(answer.truncated).toBe(true)
+  })
+})
+
+describe("the sql verb", () => {
+  const runner: SqlRunner = { sql: (query, params) => Effect.succeed({ rows: [{ query, params: params.length }] }) }
+
+  test("an unbound workspace has no sql: no method, no doc, no annotation", async () => {
+    const pkg = workspacePackage(await seeded({}))
+    expect(Object.keys(pkg.methods).sort()).toEqual(["grep", "read"])
+    expect(pkg.docs?.sql).toBeUndefined()
+    expect(pkg.annotations?.sql).toBeUndefined()
+    expect(pkg.description).not.toContain("sql")
+  })
+
+  test("a bound workspace lists sql and calls the runner", async () => {
+    const pkg = workspacePackage(await seeded({}), { sql: runner })
+    expect(Object.keys(pkg.methods).sort()).toEqual(["grep", "read", "sql"])
+    expect(pkg.docs?.sql).toBeDefined()
+    const answer = await call(pkg, "sql", { query: "select 1", params: [7] })
+    expect(answer.rows).toEqual([{ query: "select 1", params: 1 }])
+  })
+})
+
+describe("backend independence", () => {
+  test("two unrelated stores answer read and grep identically for the same values", async () => {
+    const values = {
+      "e1.result": JSON.stringify({ rows: Array.from({ length: 200 }, (_, i) => ({ i, note: "wideé" })) }),
+      "e2.result": `${"pad".repeat(20_000)}NEEDLE${"pad".repeat(20_000)}`
+    }
+    const memory = workspacePackage(await seeded(values))
+    const other = workspacePackage(await seeded(values, mapStore()))
+    for (const args of [{ ref: "e1.result" }, { ref: "e2.result", offset: 59_990, length: 20 }]) {
+      expect(await call(other, "read", args)).toEqual(await call(memory, "read", args))
+    }
+    for (const args of [{ pattern: "NEEDLE" }, { pattern: '"note":"wideé"' }]) {
+      expect(await call(other, "grep", args)).toEqual(await call(memory, "grep", args))
+    }
+  })
+})

--- a/packages/code/src/workspace.ts
+++ b/packages/code/src/workspace.ts
@@ -1,0 +1,182 @@
+import { Context, Effect } from "effect"
+import { KeyValueStore } from "effect/unstable/persistence"
+import type { Package } from "./packages"
+import { hydrate, refs } from "./store"
+
+// The workspace package: the model's own view of the store its spilled values live in (store.ts).
+// `read` and `grep` are derived from the store alone, so every backend the platform can bind
+// answers them, and they see a value whole however large it grew. `sql` is the power tool for
+// structure and agent-created tables, and it exists only where a platform bound a SQL surface
+// (WorkspaceSql), so the model is never offered a tool that cannot work (workspace.test.ts, W5).
+
+// SqlRunner is the optional SQL surface a platform binds. The answer shape is the model's: `rows`
+// when the query returned some, `truncated` when the platform's own row or byte bound cut them, and
+// `error` instead of a failure, because a bad query is the model's information to act on.
+export interface SqlRunner {
+  readonly sql: (
+    query: string,
+    params: ReadonlyArray<unknown>
+  ) => Effect.Effect<{
+    readonly rows?: ReadonlyArray<Record<string, unknown>>
+    readonly truncated?: boolean
+    readonly error?: string
+  }>
+}
+
+// WorkspaceSql is the binding platforms declare their SQL surface through. Its default is absent,
+// so an agent on a plain key/value backend gets a workspace with two verbs and no promise of a
+// third.
+export const WorkspaceSql: Context.Reference<SqlRunner | undefined> = Context.Reference("code/WorkspaceSql", {
+  defaultValue: (): SqlRunner | undefined => undefined
+})
+
+// WorkspacePolicy bounds what one call can put in a turn's context. `sliceChars` caps `read`, and a
+// larger `length` argument clamps to it. `contextChars` is the window `grep` returns on each side of
+// a match, and `maxMatches` is where a match-heavy pattern stops and reports itself truncated.
+export interface WorkspacePolicy {
+  readonly sliceChars: number
+  readonly contextChars: number
+  readonly maxMatches: number
+}
+
+export const DEFAULT_WORKSPACE_POLICY: WorkspacePolicy = { sliceChars: 32_768, contextChars: 200, maxMatches: 50 }
+
+export const workspacePolicyOf = (policy: Partial<WorkspacePolicy> = {}): WorkspacePolicy => ({
+  sliceChars: policy.sliceChars ?? DEFAULT_WORKSPACE_POLICY.sliceChars,
+  contextChars: policy.contextChars ?? DEFAULT_WORKSPACE_POLICY.contextChars,
+  maxMatches: policy.maxMatches ?? DEFAULT_WORKSPACE_POLICY.maxMatches
+})
+
+export interface WorkspaceOptions {
+  readonly sql?: SqlRunner
+  readonly policy?: Partial<WorkspacePolicy>
+}
+
+// workspacePackage builds the package over one store. The store is a value here rather than a
+// requirement of the methods, because a package method's environment is fixed by the Package type;
+// the lane that holds the store binding builds the package from it (workspaceFor).
+export const workspacePackage = (store: KeyValueStore.KeyValueStore, options: WorkspaceOptions = {}): Package => {
+  const policy = workspacePolicyOf(options.policy)
+  const runner = options.sql
+  const of = <A>(effect: Effect.Effect<A, KeyValueStore.KeyValueStoreError, KeyValueStore.KeyValueStore>) =>
+    effect.pipe(Effect.provideService(KeyValueStore.KeyValueStore, store))
+  const sqlDoc = {
+    description:
+      "Run SQL against the workspace. Spilled values live under their refs; use read/grep for those, and CREATE whatever tables you need for structure. A value above the platform's row bound is not readable through sql; read and grep never miss it.",
+    input: {
+      type: "object",
+      properties: { query: { type: "string" }, params: { type: "array" } },
+      required: ["query"]
+    },
+    output: {
+      type: "object",
+      properties: { rows: { type: "array" }, truncated: { type: "boolean" }, error: { type: "string" } }
+    }
+  }
+  return {
+    name: "workspace",
+    description:
+      runner === undefined
+        ? "The agent's workspace: every value a result spilled, whole. workspace.read slices one value by ref, workspace.grep searches across them."
+        : "The agent's workspace: every value a result spilled, plus any tables you create. workspace.sql for queries and your own tables; workspace.read / workspace.grep to slice and search spilled values of any size.",
+    annotations: {
+      ...(runner === undefined
+        ? {}
+        : { sql: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false } }),
+      read: { readOnlyHint: true, openWorldHint: false },
+      grep: { readOnlyHint: true, openWorldHint: false }
+    },
+    docs: {
+      ...(runner === undefined ? {} : { sql: sqlDoc }),
+      read: {
+        description: `A bounded slice of one spilled value by ref, any size. offset/length in characters; length caps at ${policy.sliceChars}. \`size\` is the whole value's length, so an offset past the end answers with an empty slice and the size to aim at.`,
+        input: {
+          type: "object",
+          properties: { ref: { type: "string" }, offset: { type: "number" }, length: { type: "number" } },
+          required: ["ref"]
+        },
+        output: {
+          type: "object",
+          properties: { slice: { type: "string" }, size: { type: "number" }, error: { type: "string" } }
+        }
+      },
+      grep: {
+        description: `Substring search across every spilled value (or one ref), any size. Each match: ref, offset, and ${policy.contextChars} characters of context on each side. Use read with the offset to see more. At ${policy.maxMatches} matches the answer says truncated.`,
+        input: {
+          type: "object",
+          properties: { pattern: { type: "string" }, ref: { type: "string" } },
+          required: ["pattern"]
+        },
+        output: {
+          type: "object",
+          properties: { matches: { type: "array" }, truncated: { type: "boolean" }, error: { type: "string" } }
+        }
+      }
+    },
+    methods: {
+      ...(runner === undefined
+        ? {}
+        : {
+            sql: (args: unknown) =>
+              Effect.gen(function* () {
+                const a = args as { query?: string; params?: ReadonlyArray<unknown> } | undefined
+                if (!a?.query) return { error: "workspace.sql needs { query }" }
+                return yield* runner.sql(a.query, a.params ?? [])
+              })
+          }),
+      // The slice never exceeds the policy's cap however large a `length` the model asks for: the
+      // turn's context is what the cap protects (workspace.test.ts, W3).
+      read: (args: unknown) =>
+        Effect.gen(function* () {
+          const a = args as { ref?: string; offset?: number; length?: number } | undefined
+          if (!a?.ref) return { error: "workspace.read needs { ref }" }
+          const whole = yield* of(hydrate(a.ref)).pipe(Effect.orElseSucceed(() => undefined))
+          if (whole === undefined) return { error: `no value under ref '${a.ref}'` }
+          const from = Math.max(0, Math.floor(a.offset ?? 0))
+          const take = Math.min(Math.max(0, Math.floor(a.length ?? policy.sliceChars)), policy.sliceChars)
+          return { slice: whole.slice(from, from + take), size: whole.length }
+        }),
+      // Every value the manifest names is searched whole, so a match inside a value far too large
+      // for one event is still found and located (workspace.test.ts, W4).
+      grep: (args: unknown) =>
+        Effect.gen(function* () {
+          const a = args as { pattern?: string; ref?: string } | undefined
+          const pattern = a?.pattern ?? ""
+          if (pattern === "") return { error: "workspace.grep needs { pattern }" }
+          const one = a?.ref === undefined || a.ref === "" ? undefined : a.ref
+          const held = one === undefined ? yield* of(refs()).pipe(Effect.orElseSucceed(() => [] as ReadonlyArray<string>)) : [one]
+          const matches: Array<{ ref: string; offset: number; context: string }> = []
+          let truncated = false
+          for (const ref of held) {
+            const whole = yield* of(hydrate(ref)).pipe(Effect.orElseSucceed(() => undefined))
+            if (whole === undefined) continue
+            let at = whole.indexOf(pattern)
+            while (at !== -1) {
+              if (matches.length >= policy.maxMatches) {
+                truncated = true
+                break
+              }
+              const from = Math.max(0, at - policy.contextChars)
+              matches.push({ ref, offset: at, context: whole.slice(from, at + pattern.length + policy.contextChars) })
+              // The next search starts past this match's context window, so overlapping hits report
+              // once and a repeated pattern cannot fill the answer with the same text.
+              at = whole.indexOf(pattern, at + pattern.length + policy.contextChars)
+            }
+            if (truncated) break
+          }
+          return { matches, ...(truncated ? { truncated } : {}) }
+        })
+    }
+  }
+}
+
+// workspaceFor builds the package from the lane's own bindings: the store it spills to, and the SQL
+// surface if the platform declared one. A lane with no SQL binding gets the two-verb workspace.
+export const workspaceFor = (
+  policy: Partial<WorkspacePolicy> = {}
+): Effect.Effect<Package, never, KeyValueStore.KeyValueStore> =>
+  Effect.gen(function* () {
+    const store = yield* KeyValueStore.KeyValueStore
+    const sql = yield* WorkspaceSql
+    return workspacePackage(store, { ...(sql === undefined ? {} : { sql }), policy })
+  })


### PR DESCRIPTION
The model can spill a result to the store but has no way to read one back, so every consumer rebuilds the same three verbs over its own storage. `workspacePackage` derives them from the store alone: `read` slices one value by ref, `grep` searches every value the manifest names, and `sql` appears only where a platform bound a SQL surface, so the model is never offered a tool that cannot work.

- `packages/code/src/workspace.ts` holds the package, beside `store.ts` whose `hydrate` and `refs` it reads. It needs the `Package` type from `packages/code/src/packages.ts` and nothing from `packages/agent`, so homing it in `code` keeps the imports one-directional; `packages/agent` re-exports it for callers who import the agent surface.
- `read` clamps `length` to `sliceChars` and answers the whole value's size, so an offset past the end returns an empty slice and the number to aim at.
- `grep` scans each value whole and returns ref, offset, and a context window per match, stopping at `maxMatches` with `truncated: true`. The next search starts past the previous match's window, so overlapping hits report once.
- `WorkspaceSql` is a `Context.Reference<SqlRunner | undefined>` defaulting to absent. A platform binds `sql: (query, params) => Effect<{ rows?; truncated?; error? }>`, and the package then carries the `sql` method, its doc, and its annotation; unbound, all three are absent and the description says two verbs.
- `WorkspacePolicy` exports `sliceChars` (32768), `contextChars` (200), and `maxMatches` (50) as `DEFAULT_WORKSPACE_POLICY`, overridable where the package is built. The method docs state the numbers in force, so a moved bound moves the model-facing words with it. `AgentPolicy` gains a `workspace` field and `createRlmAgent` passes it through.
- `createRlmAgent` builds the package from the lane's store with `workspaceFor` and mounts it beside the agents package. The store layer feeds the packages layer through `provideMerge`, so the package and the code reactor's spill path hold one store.
- Docs: a how-to on reading a spilled value back, linked from the docs index, plus the policy page's count of what an agent applies.
- Tests: W3 (cap honored, override honored, offset past end), W4 (a match inside a 400KB value, found with ref, offset, and bounded context, and readable at that offset), W5 (sql absent unbound, present and called when bound), W6 (the memory layer and an unrelated Map-backed store answer read and grep identically), plus an agent-level test that a spilled result is found by grep and sliced by ref through `createRlmAgent`. W6's SQL-backed half belongs to the bun platform, where the SQL store layer lands, so it is tested there rather than dragging platform deps into the core tests. Full `bun run gate` green.
