### PR TITLE
feat(bun): workspace sql binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ import { fileTelemetry } from "@tardigrade/bun/file"
 const agent = agentOf([codeMode, reply, budget, compaction])
 
 // createBunHost runs the actor over a durable SQLite log, and gives it a workspace in the same
-// file, so a large result the agent spills is still there after a restart; layersFor wires the
-// model binding.
+// file, so a large result the agent spills is still there after a restart; the workspace's sql
+// verb runs on `agents.workspace.sqlite`, out of the log's reach; layersFor wires the model
+// binding.
 const host = await createBunHost({
   log: "agents.sqlite",
   actorFor: () => agent,

--- a/platform/README.md
+++ b/platform/README.md
@@ -11,4 +11,4 @@ in-memory and dependency-free, and it is the executable contract a platform bind
 against.
 
 Nothing lives here yet. `platform/model` (the Infer binding over the AI SDK) is the first
-planned tenant; `platform/bun` binds the log to SQLite through @effect/sql-sqlite-bun, and binds the workspace a bounded value spills to (docs/explanations/boundary.md) to a table in that same database, so a run is one file; `platform/cloudflare` arrives with the v6 extraction.
+planned tenant; `platform/bun` binds the log to SQLite through @effect/sql-sqlite-bun, binds the workspace a bounded value spills to (docs/explanations/boundary.md) to a table in that same database, so an event and the value it points at are one file, and binds the workspace's sql verb to a second database beside it, where the model's own tables are durable and the log is out of a wrong statement's reach (docs/how-to/workspace.md); `platform/cloudflare` arrives with the v6 extraction.

--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -8,9 +8,11 @@ import type { Event } from "@tardigrade/core/event"
 import { transition, type Actor, type Reactor } from "@tardigrade/core/actor"
 import { hydrate, refs, spill } from "@tardigrade/code/store"
 
-import { createBunHost, type BunHostOptions } from "./host"
+import { workspaceFor } from "@tardigrade/code/workspace"
+
+import { createBunHost, type BunHost, type BunHostOptions } from "./host"
 import { fileTelemetry } from "./file"
-import { bunWorkspace } from "./workspace"
+import { bunWorkspace, bunWorkspaceSql } from "./workspace"
 
 // The bun binding against the reference host's contract, plus the two behaviors only physics
 // can show: a reopened database keeps the log, and recover() settles work a death interrupted.
@@ -260,5 +262,161 @@ describe("telemetry seam", () => {
     expect(fired?.StatusCode).toBe("Ok")
     expect(fired?.Duration).toBeGreaterThan(0)
     expect(fired?.Links[0]?.TraceId).toBe(delivered?.TraceId)
+  })
+})
+
+// The SQL surface behind workspace.sql: the model's own database, bound by the host and reached
+// through the workspace package exactly as an agent's lane reaches it.
+
+const askKeyOf = (e: Event): string | undefined =>
+  e.type === "Answered" ? `Answered:${String((e as { id?: unknown }).id)}` : undefined
+
+type Answer = { rows?: ReadonlyArray<Record<string, unknown>>; truncated?: boolean; error?: string }
+
+// One reactor runs the given statements through the lane's workspace package and records what came
+// back, so a test reads the answers a model would read.
+const asker = (queries: ReadonlyArray<string>): Actor<KeyValueStore.KeyValueStore> => ({
+  keyOf: askKeyOf,
+  reactors: [
+    (events) =>
+      events
+        .filter((e) => e.type === "MessageReceived")
+        .map((e) => {
+          const id = String((e as { id?: unknown }).id)
+          return transition({
+            key: `Answered:${id}`,
+            input: id,
+            act: (input: string) =>
+              Effect.gen(function* () {
+                const pkg = yield* workspaceFor()
+                const answers: Array<unknown> = []
+                for (const query of queries) {
+                  const method = pkg.methods["sql"]
+                  if (method === undefined) break
+                  answers.push(yield* method({ query, params: [] }, { callId: input }))
+                }
+                return [
+                  {
+                    type: "Answered",
+                    id: input,
+                    methods: Object.keys(pkg.methods).sort(),
+                    doc: pkg.docs?.["sql"] !== undefined,
+                    answers,
+                    at: 1
+                  } as Event
+                ]
+              }).pipe(Effect.orDie)
+          })
+        })
+  ]
+})
+
+const asked = async (
+  host: BunHost,
+  id: string
+): Promise<{ methods: ReadonlyArray<string>; doc: boolean; answers: ReadonlyArray<Answer> }> => {
+  await host.seed("ws", [{ type: "MessageReceived", id, text: "ask", at: 1 } as Event])
+  await host.wake("ws")
+  const found = (await host.read("ws")).find((e) => e.type === "Answered" && String((e as { id?: unknown }).id) === id)
+  return found as unknown as { methods: ReadonlyArray<string>; doc: boolean; answers: ReadonlyArray<Answer> }
+}
+
+describe("the workspace sql surface", () => {
+  test("the sql verb is bound, and the tables it creates outlive the process", async () => {
+    const path = freshPath()
+    const first = await createBunHost({
+      log: path,
+      keyOf: askKeyOf,
+      actorFor: (lane) =>
+        lane === "ws" ? asker(["CREATE TABLE notes (n TEXT)", "INSERT INTO notes VALUES ('kept')"]) : undefined
+    })
+    const wrote = await asked(first, "m1")
+    expect(wrote.methods).toEqual(["grep", "read", "sql"])
+    expect(wrote.doc).toBe(true)
+    await first.close()
+
+    const second = await createBunHost({
+      log: path,
+      keyOf: askKeyOf,
+      actorFor: (lane) => (lane === "ws" ? asker(["SELECT n FROM notes"]) : undefined)
+    })
+    expect((await asked(second, "m2")).answers[0]?.rows).toEqual([{ n: "kept" }])
+    await second.close()
+  })
+
+  test("the default surface does not reach the log", async () => {
+    const h = await createBunHost({
+      log: freshPath(),
+      keyOf: askKeyOf,
+      actorFor: (lane) => (lane === "ws" ? asker(["SELECT COUNT(*) AS n FROM events"]) : undefined)
+    })
+    expect((await asked(h, "m1")).answers[0]?.error).toContain("events")
+    await h.close()
+  })
+
+  test("a broken query answers an error the model can read", async () => {
+    const h = await createBunHost({
+      log: freshPath(),
+      keyOf: askKeyOf,
+      actorFor: (lane) => (lane === "ws" ? asker(["SELECT * FROM nowhere"]) : undefined)
+    })
+    const answer = (await asked(h, "m1")).answers[0]
+    expect(answer?.error).toContain("nowhere")
+    expect(answer?.rows).toBeUndefined()
+    await h.close()
+  })
+
+  test("an answer stops at the row cap and says truncated", async () => {
+    const h = await createBunHost({
+      log: freshPath(),
+      keyOf: askKeyOf,
+      workspaceSql: bunWorkspaceSql({ rows: 2 }),
+      actorFor: (lane) =>
+        lane === "ws"
+          ? asker([
+              "CREATE TABLE wide (n INTEGER)",
+              "INSERT INTO wide VALUES (1), (2), (3), (4), (5)",
+              "SELECT n FROM wide ORDER BY n"
+            ])
+          : undefined
+    })
+    const answer = (await asked(h, "m1")).answers[2]
+    expect(answer?.rows).toEqual([{ n: 1 }, { n: 2 }])
+    expect(answer?.truncated).toBe(true)
+    await h.close()
+  })
+
+  test("the byte bound cuts a row set the row bound would pass", async () => {
+    const h = await createBunHost({
+      log: freshPath(),
+      keyOf: askKeyOf,
+      workspaceSql: bunWorkspaceSql({ bytes: 40 }),
+      actorFor: (lane) =>
+        lane === "ws"
+          ? asker([
+              "CREATE TABLE wide (n TEXT)",
+              `INSERT INTO wide VALUES ('${"x".repeat(60)}'), ('short')`,
+              "SELECT n FROM wide"
+            ])
+          : undefined
+    })
+    const answer = (await asked(h, "m1")).answers[2]
+    expect(answer?.rows).toEqual([])
+    expect(answer?.truncated).toBe(true)
+    await h.close()
+  })
+
+  test("sql withheld: the package offers two verbs and no third", async () => {
+    const h = await createBunHost({
+      log: freshPath(),
+      keyOf: askKeyOf,
+      workspaceSql: false,
+      actorFor: (lane) => (lane === "ws" ? asker(["SELECT 1"]) : undefined)
+    })
+    const answered = await asked(h, "m1")
+    expect(answered.methods).toEqual(["grep", "read"])
+    expect(answered.doc).toBe(false)
+    expect(answered.answers).toEqual([])
+    await h.close()
   })
 })

--- a/platform/bun/src/host.ts
+++ b/platform/bun/src/host.ts
@@ -9,7 +9,7 @@ import { Self, restingActor, settleActor, type Actor } from "@tardigrade/core/ac
 import { deadlocks, victimOf, type EdgesOf } from "@tardigrade/host/deadlock"
 import type { HostPorts } from "@tardigrade/host/host"
 import { traceparentOf } from "@tardigrade/core/trace"
-import { bunWorkspace } from "./workspace"
+import { bunWorkspace, bunWorkspaceSql, workspaceSqlFile } from "./workspace"
 
 // The bun binding: packages/host's semantics with physics. The log lives in SQLite through
 // @effect/sql-sqlite-bun, so a process death loses nothing and `recover()` re-derives the owed
@@ -19,8 +19,9 @@ import { bunWorkspace } from "./workspace"
 // transaction, dedup by key inside that transaction under a unique index, and the ordered tail
 // read from a watermark. Conformance is behavioral: host.test.ts mirrors the reference host's
 // tests, plus the two only physics can show (a reopen keeps the log; a reopen recovers owed
-// work). The same database holds the workspace a bounded value spills to (workspace.ts), so one
-// file is the whole of a run's durable state.
+// work). The same database holds the workspace a bounded value spills to; the tables the model
+// creates through workspace.sql live in a second file beside it, out of the log's reach
+// (workspace.ts).
 
 // BunPorts are the services this binding leaves an actor no work to bind: packages/host's three,
 // plus the workspace store, which on bun is durable and therefore the platform's to give
@@ -43,6 +44,12 @@ export type BunHostOptions<R> = {
   // database; an app that wants another table, a prefixed view, or a volatile run passes its own
   // layer over the same client (workspace.ts).
   readonly workspace?: Layer.Layer<KeyValueStore.KeyValueStore, never, SqlClient.SqlClient>
+  // The SQL surface the workspace's sql verb runs on. The default is `bunWorkspaceSql()` over a
+  // database beside the log, so the model's own tables are durable and the log is out of its reach
+  // (workspace.ts). `false` withholds the surface and the workspace package drops the method, which
+  // is the honest answer for an agent that should never run SQL; any other layer replaces it, and
+  // one built over the host's own client hands the model the log's database too.
+  readonly workspaceSql?: false | Layer.Layer<never, never, SqlClient.SqlClient>
   readonly principal?: string
   readonly actorFor: (lane: string) => Actor<R> | undefined
   readonly call?: Parameters<typeof Router.of>[0]["call"]
@@ -78,8 +85,21 @@ export const createBunHost = async <R = never>(options: BunHostOptions<R>): Prom
   // The workspace is built with the runtime and over the same client, so its table is created once
   // and every lane spills through the connection the log already holds.
   const client = SqliteClient.layer({ filename: options.log })
+  // The SQL surface holds its own client on its own file, so a statement the model wrote reaches
+  // its tables and nothing else (workspace.ts). Both clients are built with the runtime and closed
+  // with it.
+  const workspaceSql =
+    options.workspaceSql === false
+      ? Layer.empty
+      : options.workspaceSql === undefined
+        ? bunWorkspaceSql().pipe(Layer.provide(SqliteClient.layer({ filename: workspaceSqlFile(options.log) })))
+        : options.workspaceSql.pipe(Layer.provide(client))
   const runtime = ManagedRuntime.make(
-    Layer.mergeAll((options.workspace ?? bunWorkspace()).pipe(Layer.provideMerge(client)), options.telemetry ?? Layer.empty)
+    Layer.mergeAll(
+      (options.workspace ?? bunWorkspace()).pipe(Layer.provideMerge(client)),
+      workspaceSql,
+      options.telemetry ?? Layer.empty
+    )
   )
   // One client, acquired once: every read and every append shares the connection, so ":memory:"
   // is one database and the per-lane writer stays this process.

--- a/platform/bun/src/workspace.ts
+++ b/platform/bun/src/workspace.ts
@@ -1,6 +1,7 @@
-import type { Layer } from "effect"
+import { Effect, Layer } from "effect"
 import { KeyValueStore } from "effect/unstable/persistence"
-import type { SqlClient } from "effect/unstable/sql"
+import { SqlClient } from "effect/unstable/sql"
+import { WorkspaceSql, type SqlRunner } from "@tardigrade/code/workspace"
 
 // The durable workspace on bun: Effect's SQL-backed KeyValueStore over the same SqlClient the log
 // uses, so a spilled value outlives the process that wrote it and replay hydrates a ref from disk
@@ -20,3 +21,82 @@ export const WORKSPACE_TABLE = "workspace"
 export const bunWorkspace = (
   table: string = WORKSPACE_TABLE
 ): Layer.Layer<KeyValueStore.KeyValueStore, never, SqlClient.SqlClient> => KeyValueStore.layerSql({ table })
+
+// The SQL surface behind workspace.sql: the model's own database, where it creates the tables a
+// long run needs structure for (packages/code/src/workspace.ts). It is a database of its own,
+// beside the log rather than inside it, because the log is append-only and this process is its one
+// writer: a `DROP TABLE events` from a model that mistook its scratch space for its history would
+// take the run's whole source of truth with it. Spilled values stay reachable through read and
+// grep, which see a value whole whatever its size, and a consumer who wants the model querying the
+// log's own database passes `workspaceSql: bunWorkspaceSql()` and accepts that reach (host.ts).
+
+// BunWorkspaceSqlPolicy bounds one answer, so a query over a wide table cannot flood the turn's
+// context: `rows` caps the row count and `bytes` caps their JSON, whichever comes first, and the
+// answer says `truncated` when either cut it.
+export interface BunWorkspaceSqlPolicy {
+  readonly rows: number
+  readonly bytes: number
+}
+
+export const DEFAULT_BUN_WORKSPACE_SQL_POLICY: BunWorkspaceSqlPolicy = { rows: 200, bytes: 32_768 }
+
+export const bunWorkspaceSqlPolicyOf = (policy: Partial<BunWorkspaceSqlPolicy> = {}): BunWorkspaceSqlPolicy => ({
+  rows: policy.rows ?? DEFAULT_BUN_WORKSPACE_SQL_POLICY.rows,
+  bytes: policy.bytes ?? DEFAULT_BUN_WORKSPACE_SQL_POLICY.bytes
+})
+
+// workspaceSqlFile is where the default surface's database lives: a sibling of the log, named after
+// it, so the two files of one run travel together. A volatile log gets a volatile surface.
+export const workspaceSqlFile = (log: string): string => {
+  if (log === "" || log === ":memory:") return ":memory:"
+  const dot = log.lastIndexOf(".")
+  return dot > log.lastIndexOf("/") ? `${log.slice(0, dot)}.workspace${log.slice(dot)}` : `${log}.workspace`
+}
+
+// messageOf walks the cause chain, because the wrapper says only that a statement failed and the
+// sentence the model needs ("no such table: notes") is the reason underneath it.
+const messageOf = (error: unknown): string => {
+  const said: Array<string> = []
+  let at: unknown = error
+  for (let depth = 0; at !== undefined && at !== null && depth < 4; depth += 1) {
+    const message = (at as { message?: unknown }).message
+    if (typeof message === "string" && message !== "" && !said.includes(message)) said.push(message)
+    at = (at as { cause?: unknown }).cause
+  }
+  return said.length === 0 ? String(error) : said.join(": ")
+}
+
+const boundedBy = (policy: BunWorkspaceSqlPolicy, rows: ReadonlyArray<Record<string, unknown>>) => {
+  const kept: Array<Record<string, unknown>> = []
+  let bytes = 0
+  for (const row of rows) {
+    bytes += JSON.stringify(row)?.length ?? 0
+    if (kept.length >= policy.rows || bytes > policy.bytes) return { rows: kept, truncated: true }
+    kept.push(row)
+  }
+  return { rows: kept }
+}
+
+// bunWorkspaceSql binds the workspace's sql verb to the ambient SqlClient. A query that fails comes
+// back as `{ error }` rather than as a failure, because a rejected statement is the model's next
+// piece of information and it is the one who has to fix the SQL (packages/code/src/workspace.ts;
+// host.test.ts, "a broken query answers an error the model can read").
+export const bunWorkspaceSql = (
+  policy: Partial<BunWorkspaceSqlPolicy> = {}
+): Layer.Layer<never, never, SqlClient.SqlClient> => {
+  const bounds = bunWorkspaceSqlPolicyOf(policy)
+  return Layer.effect(
+    WorkspaceSql,
+    Effect.map(
+      SqlClient.SqlClient,
+      (sql): SqlRunner => ({
+        sql: (query, params) =>
+          sql.unsafe<Record<string, unknown>>(query, params).pipe(
+            Effect.map((rows) => boundedBy(bounds, rows)),
+            Effect.catch((error) => Effect.succeed({ error: messageOf(error) })),
+            Effect.catchDefect((defect) => Effect.succeed({ error: messageOf(defect) }))
+          )
+      })
+    )
+  )
+}


### PR DESCRIPTION
Binds `WorkspaceSql` on bun, so an agent on `createBunHost` gets the workspace's `sql` verb alongside `read` and `grep`. The surface runs on a database of its own, `agents.workspace.sqlite` beside `agents.sqlite`, because the log is append-only with the host as its one writer: a statement the model wrote must not be able to drop, rewrite, or lock the run's own history. Spilled values stay on the `read` and `grep` side, which see a value whole whatever its size, which is what the method docs already tell the model to use for them.

- `bunWorkspaceSql` builds the runner over the ambient `SqlClient`: it runs the query with its params, bounds the answer, and turns a failed statement into `{ error }` instead of a failure, since a rejected query is the model's own information to act on.
- The error string walks the cause chain, so the model reads "no such table: notes" rather than the wrapper's "Failed to execute statement".
- `BunWorkspaceSqlPolicy` is the bound, exported with `DEFAULT_BUN_WORKSPACE_SQL_POLICY` (200 rows, 32768 bytes of JSON, whichever comes first) and overridable through `bunWorkspaceSql({ rows, bytes })`; the answer says `truncated` when either cut it.
- `workspaceSqlFile` derives the surface's file from the log path, so the two files of one run travel under one name; a `:memory:` log gets a `:memory:` surface.
- `createBunHost` takes `workspaceSql`: absent is the default surface, `false` withholds it and the package drops the method entirely, and any other layer replaces it and is handed the host's own client, which is how a consumer opts into the model querying the log's database.
- Tests cover the verb being bound and its tables surviving a restart, the default surface failing to reach the `events` table, a broken query answering an error, the row bound and the byte bound each marking `truncated`, and the withheld case leaving a two-verb package with no `sql` doc.
- Docs: the platform and root READMEs state the second file; the workspace how-to paragraph was dropped in rebase, since the docs curation on main removed the how-to directory. Full `bun run gate` green after rebase.

