### PR TITLE
feat(code): sql runner doc

### DIFF
--- a/packages/code/src/workspace.test.ts
+++ b/packages/code/src/workspace.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { KeyValueStore } from "effect/unstable/persistence"
 import { spill } from "./store"
-import { DEFAULT_WORKSPACE_POLICY, workspacePackage, type SqlRunner } from "./workspace"
+import { DEFAULT_WORKSPACE_POLICY, WORKSPACE_SQL_DESCRIPTION, workspacePackage, type SqlRunner } from "./workspace"
 
 // The model's view of the store: a bounded slice of one value, a search across all of them, and a
 // sql verb only where a platform bound one.
@@ -114,6 +114,17 @@ describe("the sql verb", () => {
     expect(pkg.docs?.sql).toBeDefined()
     const answer = await call(pkg, "sql", { query: "select 1", params: [7] })
     expect(answer.rows).toEqual([{ query: "select 1", params: 1 }])
+  })
+
+  test("a runner with no doc describes sql in the generic text alone", async () => {
+    const pkg = workspacePackage(await seeded({}), { sql: runner })
+    expect(pkg.docs?.sql?.description).toBe(WORKSPACE_SQL_DESCRIPTION)
+  })
+
+  test("a runner's doc is spliced onto the generic text, so the model reads the bound schema", async () => {
+    const doc = "notes(id, body) is already here."
+    const pkg = workspacePackage(await seeded({}), { sql: { ...runner, doc } })
+    expect(pkg.docs?.sql?.description).toBe(`${WORKSPACE_SQL_DESCRIPTION} ${doc}`)
   })
 })
 

--- a/packages/code/src/workspace.ts
+++ b/packages/code/src/workspace.ts
@@ -21,6 +21,11 @@ export interface SqlRunner {
     readonly truncated?: boolean
     readonly error?: string
   }>
+  // doc is what the platform knows about the surface it bound and the generic text cannot say: the
+  // tables that are already there, their columns, the dialect. The sql description is the generic
+  // text, then a single space, then this sentence; an absent doc leaves the generic text alone
+  // (workspace.test.ts, "the sql verb").
+  readonly doc?: string
 }
 
 // WorkspaceSql is the binding platforms declare their SQL surface through. Its default is absent,
@@ -47,6 +52,11 @@ export const workspacePolicyOf = (policy: Partial<WorkspacePolicy> = {}): Worksp
   maxMatches: policy.maxMatches ?? DEFAULT_WORKSPACE_POLICY.maxMatches
 })
 
+// WORKSPACE_SQL_DESCRIPTION is the part of the sql doc that holds wherever the verb exists. What is
+// true of one platform's surface arrives from the runner's own `doc` and is spliced onto the end.
+export const WORKSPACE_SQL_DESCRIPTION =
+  "Run SQL against the workspace. Spilled values live under their refs; use read/grep for those, and CREATE whatever tables you need for structure. A value above the platform's row bound is not readable through sql; read and grep never miss it."
+
 export interface WorkspaceOptions {
   readonly sql?: SqlRunner
   readonly policy?: Partial<WorkspacePolicy>
@@ -62,7 +72,9 @@ export const workspacePackage = (store: KeyValueStore.KeyValueStore, options: Wo
     effect.pipe(Effect.provideService(KeyValueStore.KeyValueStore, store))
   const sqlDoc = {
     description:
-      "Run SQL against the workspace. Spilled values live under their refs; use read/grep for those, and CREATE whatever tables you need for structure. A value above the platform's row bound is not readable through sql; read and grep never miss it.",
+      runner?.doc === undefined || runner.doc === ""
+        ? WORKSPACE_SQL_DESCRIPTION
+        : `${WORKSPACE_SQL_DESCRIPTION} ${runner.doc}`,
     input: {
       type: "object",
       properties: { query: { type: "string" }, params: { type: "array" } },

--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -8,11 +8,17 @@ import type { Event } from "@tardigrade/core/event"
 import { transition, type Actor, type Reactor } from "@tardigrade/core/actor"
 import { hydrate, refs, spill } from "@tardigrade/code/store"
 
-import { workspaceFor } from "@tardigrade/code/workspace"
+import { workspaceFor, WORKSPACE_SQL_DESCRIPTION } from "@tardigrade/code/workspace"
 
 import { createBunHost, type BunHost, type BunHostOptions } from "./host"
 import { fileTelemetry } from "./file"
-import { bunWorkspace, bunWorkspaceSql } from "./workspace"
+import {
+  bunWorkspace,
+  bunWorkspaceLogSqlDoc,
+  bunWorkspaceSql,
+  DEFAULT_BUN_WORKSPACE_SQL_DOC,
+  WORKSPACE_TABLE
+} from "./workspace"
 
 // The bun binding against the reference host's contract, plus the two behaviors only physics
 // can show: a reopened database keeps the log, and recover() settles work a death interrupted.
@@ -301,6 +307,7 @@ const asker = (queries: ReadonlyArray<string>): Actor<KeyValueStore.KeyValueStor
                     id: input,
                     methods: Object.keys(pkg.methods).sort(),
                     doc: pkg.docs?.["sql"] !== undefined,
+                    sqlDoc: pkg.docs?.["sql"]?.description ?? "",
                     answers,
                     at: 1
                   } as Event
@@ -314,11 +321,16 @@ const asker = (queries: ReadonlyArray<string>): Actor<KeyValueStore.KeyValueStor
 const asked = async (
   host: BunHost,
   id: string
-): Promise<{ methods: ReadonlyArray<string>; doc: boolean; answers: ReadonlyArray<Answer> }> => {
+): Promise<{ methods: ReadonlyArray<string>; doc: boolean; sqlDoc: string; answers: ReadonlyArray<Answer> }> => {
   await host.seed("ws", [{ type: "MessageReceived", id, text: "ask", at: 1 } as Event])
   await host.wake("ws")
   const found = (await host.read("ws")).find((e) => e.type === "Answered" && String((e as { id?: unknown }).id) === id)
-  return found as unknown as { methods: ReadonlyArray<string>; doc: boolean; answers: ReadonlyArray<Answer> }
+  return found as unknown as {
+    methods: ReadonlyArray<string>
+    doc: boolean
+    sqlDoc: string
+    answers: ReadonlyArray<Answer>
+  }
 }
 
 describe("the workspace sql surface", () => {
@@ -351,6 +363,28 @@ describe("the workspace sql surface", () => {
       actorFor: (lane) => (lane === "ws" ? asker(["SELECT COUNT(*) AS n FROM events"]) : undefined)
     })
     expect((await asked(h, "m1")).answers[0]?.error).toContain("events")
+    await h.close()
+  })
+
+  test("the sql doc says what the bound surface is, generic text first", async () => {
+    const h = await createBunHost({
+      log: freshPath(),
+      keyOf: askKeyOf,
+      actorFor: (lane) => (lane === "ws" ? asker([]) : undefined)
+    })
+    expect((await asked(h, "m1")).sqlDoc).toBe(`${WORKSPACE_SQL_DESCRIPTION} ${DEFAULT_BUN_WORKSPACE_SQL_DOC}`)
+    await h.close()
+  })
+
+  test("a surface over the log's own client names the table the spilled values are in", async () => {
+    const h = await createBunHost({
+      log: freshPath(),
+      keyOf: askKeyOf,
+      workspaceSql: bunWorkspaceSql({ doc: bunWorkspaceLogSqlDoc() }),
+      actorFor: (lane) => (lane === "ws" ? asker([]) : undefined)
+    })
+    expect((await asked(h, "m1")).sqlDoc).toBe(`${WORKSPACE_SQL_DESCRIPTION} ${bunWorkspaceLogSqlDoc()}`)
+    expect(bunWorkspaceLogSqlDoc()).toContain(`${WORKSPACE_TABLE}(id, value, value_type)`)
     await h.close()
   })
 

--- a/platform/bun/src/host.ts
+++ b/platform/bun/src/host.ts
@@ -48,7 +48,8 @@ export type BunHostOptions<R> = {
   // database beside the log, so the model's own tables are durable and the log is out of its reach
   // (workspace.ts). `false` withholds the surface and the workspace package drops the method, which
   // is the honest answer for an agent that should never run SQL; any other layer replaces it, and
-  // one built over the host's own client hands the model the log's database too.
+  // one built over the host's own client hands the model the log's database too, which is what
+  // `bunWorkspaceSql({ doc: bunWorkspaceLogSqlDoc() })` tells the model it is holding.
   readonly workspaceSql?: false | Layer.Layer<never, never, SqlClient.SqlClient>
   readonly principal?: string
   readonly actorFor: (lane: string) => Actor<R> | undefined

--- a/platform/bun/src/workspace.ts
+++ b/platform/bun/src/workspace.ts
@@ -45,6 +45,20 @@ export const bunWorkspaceSqlPolicyOf = (policy: Partial<BunWorkspaceSqlPolicy> =
   bytes: policy.bytes ?? DEFAULT_BUN_WORKSPACE_SQL_POLICY.bytes
 })
 
+// DEFAULT_BUN_WORKSPACE_SQL_DOC is what the model is told about the surface `bunWorkspaceSql()`
+// binds under the default host wiring: its own SQLite file, which starts empty. A consumer who
+// points the surface at another database passes the `doc` that is true of it, and one who points it
+// at the host's own client has `bunWorkspaceLogSqlDoc` for the tables that are already there.
+export const DEFAULT_BUN_WORKSPACE_SQL_DOC =
+  "The surface is SQLite, and the database is yours: it starts empty, holds the tables you CREATE, and lasts as long as the run's log does. Spilled values are held outside it, so read and grep are how you reach those."
+
+// bunWorkspaceLogSqlDoc names the workspace store's own table, for a surface built over the host's
+// client, where the log's database is the one the model queries. `id` is the ref a truncation
+// pointed at and `value` is its JSON, so a row here is a spilled value; read and grep still see one
+// whole whatever its size, which SQL over this table does not promise.
+export const bunWorkspaceLogSqlDoc = (table: string = WORKSPACE_TABLE): string =>
+  `This database is the run's own. ${table}(id, value, value_type) is the workspace store: id is a value's ref and value is its JSON. Use read and grep to see a spilled value whole, and SQL here for shape across them.`
+
 // workspaceSqlFile is where the default surface's database lives: a sibling of the log, named after
 // it, so the two files of one run travel together. A volatile log gets a volatile surface.
 export const workspaceSqlFile = (log: string): string => {
@@ -82,14 +96,15 @@ const boundedBy = (policy: BunWorkspaceSqlPolicy, rows: ReadonlyArray<Record<str
 // piece of information and it is the one who has to fix the SQL (packages/code/src/workspace.ts;
 // host.test.ts, "a broken query answers an error the model can read").
 export const bunWorkspaceSql = (
-  policy: Partial<BunWorkspaceSqlPolicy> = {}
+  options: Partial<BunWorkspaceSqlPolicy> & { readonly doc?: string } = {}
 ): Layer.Layer<never, never, SqlClient.SqlClient> => {
-  const bounds = bunWorkspaceSqlPolicyOf(policy)
+  const bounds = bunWorkspaceSqlPolicyOf(options)
   return Layer.effect(
     WorkspaceSql,
     Effect.map(
       SqlClient.SqlClient,
       (sql): SqlRunner => ({
+        doc: options.doc ?? DEFAULT_BUN_WORKSPACE_SQL_DOC,
         sql: (query, params) =>
           sql.unsafe<Record<string, unknown>>(query, params).pipe(
             Effect.map((rows) => boundedBy(bounds, rows)),


### PR DESCRIPTION
The sql method's description is the only documentation the model has of the workspace's SQL surface, and the generic text cannot state which tables are already there or what their columns are, because those are facts about the database a platform bound. `SqlRunner` now carries an optional `doc`, so the platform that knows the schema can say it.

- `SqlRunner.doc` is the platform's sentence about its surface; `workspacePackage` renders the sql description as the generic text, one space, then that sentence, and an absent doc leaves the generic text alone
- the generic half is exported as `WORKSPACE_SQL_DESCRIPTION`, so a consumer and a test can name the part that holds everywhere
- `bunWorkspaceSql` takes a `doc` option and defaults to `DEFAULT_BUN_WORKSPACE_SQL_DOC`, which describes the surface as the default host wiring builds it: a SQLite database of its own, starting empty, with the spilled values outside it
- `bunWorkspaceLogSqlDoc(table)` is the doc for a surface built over the host's own client, where the workspace store's table is in reach; it names `workspace(id, value, value_type)`, the shape `KeyValueStore.layerSql` creates
- tests: bound-with-doc splices, bound-without-doc renders the generic text exactly, unbound still has no sql method, doc, or annotation; on bun, the default surface's doc and the log-database doc both reach the package. Full `bun run gate` green.
