### PR TITLE
docs: honest quickstart claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,8 @@ import { infer } from "@tardigrade/model/model"
 import { createBunHost } from "@tardigrade/bun/host"
 import { fileTelemetry } from "@tardigrade/bun/file"
 
-// A capability provides the model its context and services the calls that come back.
 const agent = agentOf([codeMode, reply, budget, compaction])
 
-// A durable SQLite log, with a spill store in the same file: a large result
-// survives a restart. layersFor wires the model binding.
 const host = await createBunHost({
   log: "agents.sqlite",
   actorFor: () => agent,

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $$\lbrace\mathrm{transitions}\rbrace = f(\mathrm{log})$$
 
 ## Quickstart
 
-Build a durable code-mode agent by combining capabilities.
+Build a durable codemode agent by combining capabilities.
 
 ```ts
 import { agentOf, budget, codeMode, compaction, reply } from "@tardigrade/agent"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $$\lbrace\mathrm{transitions}\rbrace = f(\mathrm{log})$$
 
 ## Quickstart
 
-Build an RLM agent by combining capabilities.
+Build a durable code-mode agent by combining capabilities.
 
 ```ts
 import { agentOf, budget, codeMode, compaction, reply } from "@tardigrade/agent"
@@ -29,13 +29,10 @@ import { createBunHost } from "@tardigrade/bun/host"
 import { fileTelemetry } from "@tardigrade/bun/file"
 
 // A capability provides the model its context and services the calls that come back.
-// Mounting one is adding it to the list; `toolList([...])` mounts a fixed tool list instead.
 const agent = agentOf([codeMode, reply, budget, compaction])
 
-// createBunHost runs the actor over a durable SQLite log, and gives it a workspace in the same
-// file, so a large result the agent spills is still there after a restart; the workspace's sql
-// verb runs on `agents.workspace.sqlite`, out of the log's reach; layersFor wires the model
-// binding.
+// A durable SQLite log, with a spill store in the same file: a large result
+// survives a restart. layersFor wires the model binding.
 const host = await createBunHost({
   log: "agents.sqlite",
   actorFor: () => agent,


### PR DESCRIPTION
The quickstart assembly mounts no agents package and no workspace package, so the page stops calling it an RLM and stops advertising the workspace sql verb. What stays claimed is what the snippet delivers: a durable code-mode agent whose spilled results survive a restart. Comments shortened to one idea each. Gate green including lint:docs.