### PR TITLE
feat: unify npm package

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,8 +1,3 @@
 {
-  "packages/core": "0.0.1",
-  "packages/code": "0.0.1",
-  "packages/host": "0.0.1",
-  "packages/agent": "0.0.1",
-  "platform/bun": "0.0.1",
-  "platform/model": "0.0.1"
+  "packages/agent": "0.0.1"
 }

--- a/README.md
+++ b/README.md
@@ -23,16 +23,16 @@ $$\lbrace\mathrm{transitions}\rbrace = f(\mathrm{log})$$
 Prerequisites: Bun 1.3 or later and a model endpoint.
 
 ```bash
-bun add @clavia/tardigrade @clavia/tardigrade-model @clavia/tardigrade-bun
+bun add @clavia/tardigrade
 ```
 
 Build a durable codemode agent by combining capabilities.
 
 ```ts
 import { agentOf, budget, codeMode, compaction, reply } from "@clavia/tardigrade"
-import { infer } from "@clavia/tardigrade-model/model"
-import { createBunHost } from "@clavia/tardigrade-bun/host"
-import { fileTelemetry } from "@clavia/tardigrade-bun/file"
+import { infer } from "@clavia/tardigrade/model"
+import { createBunHost } from "@clavia/tardigrade/bun/host"
+import { fileTelemetry } from "@clavia/tardigrade/bun/file"
 
 const agent = agentOf([codeMode, reply, budget, compaction])
 

--- a/bun.lock
+++ b/bun.lock
@@ -73,9 +73,9 @@
         "@clavia/tardigrade": "workspace:*",
         "@clavia/tardigrade-core": "workspace:*",
         "@smithy/fetch-http-handler": "^5.6.3",
-        "@tanstack/ai": "0.44.0",
-        "@tanstack/ai-bedrock": "0.2.1",
-        "@tanstack/ai-openai": "0.19.0",
+        "@tanstack/ai": "0.46.0",
+        "@tanstack/ai-bedrock": "0.2.3",
+        "@tanstack/ai-openai": "0.20.0",
         "effect": "4.0.0-rc.110",
       },
     },
@@ -301,19 +301,19 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@tanstack/ai": ["@tanstack/ai@0.44.0", "", { "dependencies": { "@ag-ui/core": "0.1.1-canary.beta.0", "@standard-schema/spec": "^1.1.0", "@tanstack/ai-event-client": "^0.8.0", "@tanstack/ai-utils": "^0.4.0", "partial-json": "^0.1.7" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-tSHFNYg+x+SQeUUjIOqNmM0Y41+3Fw08LDE3A0vvN4+5O5EG/0SCLl6neCEsPuLPPKCHIJQIItWAfqQeQXR5qA=="],
+    "@tanstack/ai": ["@tanstack/ai@0.46.0", "", { "dependencies": { "@ag-ui/core": "0.1.1-canary.beta.0", "@standard-schema/spec": "^1.1.0", "@tanstack/ai-event-client": "^0.9.0", "@tanstack/ai-utils": "^0.4.0", "partial-json": "^0.1.7" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-c0L9MssuCEdVTxNlWQ8R39v1sTqvahDA3OsFfUSWIFwtE39fc3SKY5osOElkPs5/UpwsCvhVmMOHDFA2PrdtzQ=="],
 
-    "@tanstack/ai-bedrock": ["@tanstack/ai-bedrock@0.2.1", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-sdk/client-bedrock-runtime": "^3.1057.0", "@aws-sdk/credential-providers": "^3.1057.0", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "@tanstack/openai-base": "^0.9.12", "openai": "^6.41.0" }, "peerDependencies": { "@tanstack/ai": "^0.44.0", "zod": "^4.0.0" } }, "sha512-dPFnFKplr9xy/li9nEko+NELNc4qhuc+bhfukHqddWPzO3HDSHkDMSibfPV1L4gZfB0IzR8LbM/dXteisR39NA=="],
+    "@tanstack/ai-bedrock": ["@tanstack/ai-bedrock@0.2.3", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-sdk/client-bedrock-runtime": "^3.1057.0", "@aws-sdk/credential-providers": "^3.1057.0", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "@tanstack/openai-base": "^0.9.15", "openai": "^6.41.0" }, "peerDependencies": { "@tanstack/ai": "^0.46.0", "zod": "^4.0.0" } }, "sha512-Uhzd3YGWbhfLqyZyFdQ47V4rAP8gAsjpNtew4giL2McCspdi01FE4WbXcELngr+LZxI0UlGQAgzyx5UyMVIMhA=="],
 
-    "@tanstack/ai-event-client": ["@tanstack/ai-event-client@0.8.0", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1" } }, "sha512-UzhGQERwGU0yymziuGiHXNnKRZeR2JaGoPXeNzKuHwQtUmvMu1H8g0C9wpkpksj+pmTQPhdEBUOMlU6NhLDVpA=="],
+    "@tanstack/ai-event-client": ["@tanstack/ai-event-client@0.9.0", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1" } }, "sha512-R4jd8Gt6ZGFezteh9nH3E2Zii5b2x6Pv6Y3Gk3MoU8f9vMxCLckm3rohkC6JqYY1zESiS9ZG0mxrkJAZc+p+GA=="],
 
-    "@tanstack/ai-openai": ["@tanstack/ai-openai@0.19.0", "", { "dependencies": { "@tanstack/ai-utils": "^0.4.0", "@tanstack/openai-base": "^0.9.11", "openai": "^6.41.0" }, "peerDependencies": { "@tanstack/ai": "^0.44.0", "zod": "^4.0.0" } }, "sha512-qBPX45oDUdFjphVui9+qN62zxXZU6VgGI/MDxS5n0xhCz1X/RqLbwUmdefLSiyoHAh1gdw4lmpCdURYD/uMObQ=="],
+    "@tanstack/ai-openai": ["@tanstack/ai-openai@0.20.0", "", { "dependencies": { "@tanstack/ai-utils": "^0.4.0", "@tanstack/openai-base": "^0.9.15", "openai": "^6.41.0" }, "peerDependencies": { "@tanstack/ai": "^0.46.0", "zod": "^4.0.0" } }, "sha512-bJaIDFpWHWJOU8Fk2ksHen1h5RWNgAHShrX33dsqaNNh84bCM9X9EqNME+FBtH6kV0q1povWw/nepklmuGp0AQ=="],
 
     "@tanstack/ai-utils": ["@tanstack/ai-utils@0.4.0", "", {}, "sha512-xqvAgPJkIuGk1m+jZKyb7vBTQIaBmUD9EVzlPkDWWMp80n69uwL0TnBZCVk+OwL9goTQiFy648dnBfLsiJgl6A=="],
 
     "@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.4.4", "", { "bin": { "intent": "./bin/intent.js" } }, "sha512-6T5Yop/793YI+H+5J8Hsyj4kCih9sl4t3ElLgKioW5hk3ocn+ZdSJ94tT7vL7uabxSugWYBZlOTMPzEw2puvQw=="],
 
-    "@tanstack/openai-base": ["@tanstack/openai-base@0.9.12", "", { "dependencies": { "@tanstack/ai-utils": "^0.4.0", "openai": "^6.41.0" }, "peerDependencies": { "@tanstack/ai": "^0.44.0" } }, "sha512-UZwt+3O2WYQ4rWHc95EfIPFFIlWsZQncNZlyw05tpuogwWoR+9xtPot+uPbx6tGr/XX+/vPwQn0jVljBD1zppQ=="],
+    "@tanstack/openai-base": ["@tanstack/openai-base@0.9.15", "", { "dependencies": { "@tanstack/ai-utils": "^0.4.0", "openai": "^6.41.0" }, "peerDependencies": { "@tanstack/ai": "^0.46.0" } }, "sha512-JMwgnmvxC+c4CJJ6/6Ww6w6Gfn2Htf7KlWh4nALbvviv2nB3ZONRbsnMEHs5BsPY561d5Sa03CHt6SNUJxpy6w=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 

--- a/docs/how-to/publish.md
+++ b/docs/how-to/publish.md
@@ -4,7 +4,7 @@ How to publish RC and stable releases to npm.
 
 ## Packages
 
-The published names are `@clavia/tardigrade` (the agent), `@clavia/tardigrade-core`, `@clavia/tardigrade-code`, `@clavia/tardigrade-host`, `@clavia/tardigrade-bun`, and `@clavia/tardigrade-model`. They ship TypeScript source and run on Bun 1.3 or later. All six share one version. The initial version is `0.0.1`.
+The published package is `@clavia/tardigrade`. It ships the agent and the `core`, `code`, `host`, `bun`, and `model` subpaths as TypeScript source. It runs on Bun 1.3 or later. The initial version is `0.0.1`.
 
 ## First version of a package
 
@@ -15,9 +15,9 @@ npm login
 bun run tools/publish.ts
 ```
 
-The command packs with Bun. Bun rewrites each `workspace:*` dependency to the tarball version. npm publishes the packages under the `latest` tag. Use `--tag <tag>` to select another npm tag.
+The command assembles the private workspaces into one tarball. It rewrites internal imports to package subpaths and combines external dependencies. npm publishes the package under the `latest` tag. Use `--tag <tag>` to select another npm tag. Use `--output <dir>` with `--dry-run` to keep a tarball for inspection.
 
-On each new package at npmjs.com: Settings, Trusted publishing, GitHub Actions. Organization `clavia-labs`, repository `tardigrade`, workflow filename `publish.yml`, environment `npm`, allowed action `npm publish`. Create a GitHub environment named `npm` on `clavia-labs/tardigrade` (Settings, Environments). Required reviewers are optional.
+On the package at npmjs.com: Settings, Trusted publishing, GitHub Actions. Organization `clavia-labs`, repository `tardigrade`, workflow filename `publish.yml`, environment `npm`, allowed action `npm publish`. Create a GitHub environment named `npm` on `clavia-labs/tardigrade` (Settings, Environments). Required reviewers are optional.
 
 In the repository: Settings, Actions, General, allow GitHub Actions to create and approve pull requests.
 
@@ -29,6 +29,6 @@ In the repository: Settings, Actions, General, allow GitHub Actions to create an
 
 After a stable release, merge `main` into `next`. This merge gives the integration branch the stable manifest and changelog.
 
-Conventional commit titles on merged PRs (`feat`, `fix`, `perf`, and a `BREAKING CHANGE` footer) determine the next version. Release Please bumps all packages together. It writes each package `CHANGELOG.md` and updates `.release-please-manifest.json`. `docs`, `chore`, `ci`, and `test` titles do not bump a version.
+Conventional commit titles on merged PRs (`feat`, `fix`, `perf`, and a `BREAKING CHANGE` footer) determine the next version. Release Please updates `@clavia/tardigrade`, its changelog, and `.release-please-manifest.json`. `docs`, `chore`, `ci`, and `test` titles do not bump a version.
 
 The `publish.yml` workflow runs on pushes to `next` and `main`. Merging a release PR tags `v<version>` and publishes through GitHub OIDC. A dry run is `bun run pack` or a manual workflow run with `dry-run`. A repeated run skips versions that exist on the registry.

--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@clavia/tardigrade-code",
   "version": "0.0.1",
+  "private": true,
   "license": "MIT",
   "author": "Clavia, Inc.",
   "description": "Durable code execution over the tardigrade log.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@clavia/tardigrade-core",
   "version": "0.0.1",
+  "private": true,
   "license": "MIT",
   "author": "Clavia, Inc.",
   "description": "Event, log, actor, and reactor contracts for tardigrade.",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@clavia/tardigrade-host",
   "version": "0.0.1",
+  "private": true,
   "license": "MIT",
   "author": "Clavia, Inc.",
   "description": "In-memory host binding for tardigrade.",

--- a/platform/bun/package.json
+++ b/platform/bun/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@clavia/tardigrade-bun",
   "version": "0.0.1",
+  "private": true,
   "license": "MIT",
   "author": "Clavia, Inc.",
   "description": "Durable SQLite host binding for tardigrade on Bun.",

--- a/platform/model/package.json
+++ b/platform/model/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@clavia/tardigrade-model",
   "version": "0.0.1",
+  "private": true,
   "license": "MIT",
   "author": "Clavia, Inc.",
   "description": "Infer binding for tardigrade over TanStack AI.",
@@ -32,9 +33,9 @@
     "@clavia/tardigrade": "workspace:*",
     "@aws-sdk/client-bedrock-runtime": "^3.1079.0",
     "@smithy/fetch-http-handler": "^5.6.3",
-    "@tanstack/ai": "0.44.0",
-    "@tanstack/ai-bedrock": "0.2.1",
-    "@tanstack/ai-openai": "0.19.0",
+    "@tanstack/ai": "0.46.0",
+    "@tanstack/ai-bedrock": "0.2.3",
+    "@tanstack/ai-openai": "0.20.0",
     "effect": "4.0.0-rc.110"
   },
   "scripts": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,41 +8,8 @@
   "bump-minor-pre-major": true,
   "group-pull-request-title-pattern": "chore: release ${version}",
   "packages": {
-    "packages/core": {
-      "component": "tardigrade-core"
-    },
-    "packages/code": {
-      "component": "tardigrade-code"
-    },
-    "packages/host": {
-      "component": "tardigrade-host"
-    },
     "packages/agent": {
       "component": "tardigrade"
-    },
-    "platform/bun": {
-      "component": "tardigrade-bun"
-    },
-    "platform/model": {
-      "component": "tardigrade-model"
     }
-  },
-  "plugins": [
-    {
-      "type": "node-workspace",
-      "merge": false
-    },
-    {
-      "type": "linked-versions",
-      "groupName": "tardigrade",
-      "components": [
-        "tardigrade-core",
-        "tardigrade-code",
-        "tardigrade-host",
-        "tardigrade",
-        "tardigrade-bun",
-        "tardigrade-model"
-      ]
-    }
-  ]
+  }
 }

--- a/release-please-config.next.json
+++ b/release-please-config.next.json
@@ -9,41 +9,8 @@
   "bump-minor-pre-major": true,
   "group-pull-request-title-pattern": "chore: release ${version}",
   "packages": {
-    "packages/core": {
-      "component": "tardigrade-core"
-    },
-    "packages/code": {
-      "component": "tardigrade-code"
-    },
-    "packages/host": {
-      "component": "tardigrade-host"
-    },
     "packages/agent": {
       "component": "tardigrade"
-    },
-    "platform/bun": {
-      "component": "tardigrade-bun"
-    },
-    "platform/model": {
-      "component": "tardigrade-model"
     }
-  },
-  "plugins": [
-    {
-      "type": "node-workspace",
-      "merge": false
-    },
-    {
-      "type": "linked-versions",
-      "groupName": "tardigrade",
-      "components": [
-        "tardigrade-core",
-        "tardigrade-code",
-        "tardigrade-host",
-        "tardigrade",
-        "tardigrade-bun",
-        "tardigrade-model"
-      ]
-    }
-  ]
+  }
 }

--- a/tools/publish.ts
+++ b/tools/publish.ts
@@ -1,11 +1,13 @@
-import { copyFile, mkdtemp, rm, unlink } from "node:fs/promises"
+import { cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { isAbsolute, join } from "node:path"
+import { isAbsolute, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 type PkgJson = {
   readonly name: string
   readonly version: string
+  readonly dependencies?: Readonly<Record<string, string>>
+  readonly [key: string]: unknown
 }
 
 const root = fileURLToPath(new URL("../", import.meta.url))
@@ -21,15 +23,13 @@ const option = (name: string) => {
   return value
 }
 
-// Dependency order: a tarball's workspace:* deps rewrite to this version, and
-// the registry must already hold those names before a consumer can install.
-const dirs = [
-  "packages/core",
-  "packages/code",
-  "packages/host",
-  "packages/agent",
-  "platform/bun",
-  "platform/model"
+const sources = [
+  { dir: "packages/agent", namespace: "agent" },
+  { dir: "packages/core", namespace: "core" },
+  { dir: "packages/code", namespace: "code" },
+  { dir: "packages/host", namespace: "host" },
+  { dir: "platform/bun", namespace: "bun" },
+  { dir: "platform/model", namespace: "model" }
 ] as const
 
 const npmMin = { maj: 11, min: 5, patch: 1 } as const
@@ -41,7 +41,7 @@ const readPkg = async (dir: string): Promise<PkgJson> => {
   if (typeof raw.name !== "string" || typeof raw.version !== "string") {
     throw new Error(`${dir}/package.json is missing name or version`)
   }
-  return { name: raw.name, version: raw.version }
+  return raw as PkgJson
 }
 
 const output = async (cmd: string[], cwd: string) => {
@@ -52,47 +52,69 @@ const output = async (cmd: string[], cwd: string) => {
 }
 
 const run = async (cmd: string[], cwd: string) => {
-  const proc = Bun.spawn(cmd, { cwd, stdout: "inherit", stderr: "inherit" })
+  const proc = Bun.spawn(cmd, { cwd, stdin: "inherit", stdout: "inherit", stderr: "inherit" })
   const code = await proc.exited
   if (code !== 0) throw new Error(`${cmd.join(" ")} exited ${code}`)
 }
 
-const parseNpm = (v: string) => {
-  const [maj, min, patch] = v.trim().split(".").map((n) => Number(n))
-  if (maj === undefined || min === undefined || patch === undefined || [maj, min, patch].some((n) => !Number.isFinite(n))) {
-    throw new Error(`unreadable npm version: ${v}`)
+const parseNpm = (version: string) => {
+  const [maj, min, patch] = version.trim().split(".").map((part) => Number(part))
+  if (maj === undefined || min === undefined || patch === undefined || [maj, min, patch].some((part) => !Number.isFinite(part))) {
+    throw new Error(`unreadable npm version: ${version}`)
   }
   return { maj, min, patch }
 }
 
-const npmAtLeast = (v: string, min: typeof npmMin) => {
-  const n = parseNpm(v)
-  if (n.maj !== min.maj) return n.maj > min.maj
-  if (n.min !== min.min) return n.min > min.min
-  return n.patch >= min.patch
+const npmAtLeast = (version: string, min: typeof npmMin) => {
+  const found = parseNpm(version)
+  if (found.maj !== min.maj) return found.maj > min.maj
+  if (found.min !== min.min) return found.min > min.min
+  return found.patch >= min.patch
 }
 
 const published = async (name: string, version: string) => {
   const url = `https://registry.npmjs.org/${encodeURIComponent(name)}/${version}`
-  const res = await fetch(url, { headers: { accept: "application/json" } })
-  if (res.status === 404) return false
-  if (!res.ok) throw new Error(`registry ${url} -> ${res.status}`)
+  const response = await fetch(url, { headers: { accept: "application/json" } })
+  if (response.status === 404) return false
+  if (!response.ok) throw new Error(`registry ${url} -> ${response.status}`)
   return true
 }
 
-const withCopied = async (from: string, to: string, body: () => Promise<void>) => {
-  await copyFile(from, to)
-  try {
-    await body()
-  } finally {
-    await unlink(to)
+const dependencyUnion = (packages: ReadonlyArray<PkgJson>) => {
+  const workspaceNames = new Set(packages.map((pkg) => pkg.name))
+  const dependencies = new Map<string, string>()
+  for (const pkg of packages) {
+    for (const [name, version] of Object.entries(pkg.dependencies ?? {})) {
+      if (workspaceNames.has(name)) continue
+      const previous = dependencies.get(name)
+      if (previous !== undefined && previous !== version) {
+        throw new Error(`dependency ${name} has versions ${previous} and ${version}`)
+      }
+      dependencies.set(name, version)
+    }
+  }
+  return Object.fromEntries([...dependencies].sort(([left], [right]) => left.localeCompare(right)))
+}
+
+const rewriteSources = async (dir: string, rewrites: ReadonlyMap<string, string>): Promise<void> => {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      await rewriteSources(path, rewrites)
+      continue
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".ts")) continue
+    let source = await readFile(path, "utf8")
+    for (const [from, to] of rewrites) {
+      source = source.replaceAll(`${from}/`, `${to}/`).replaceAll(`"${from}"`, `"${to}"`).replaceAll(`'${from}'`, `'${to}'`)
+    }
+    await writeFile(path, source)
   }
 }
 
-const pkgs = await Promise.all(dirs.map(async (dir) => ({ dir, ...(await readPkg(dir)) })))
-const versions = new Set(pkgs.map((p) => p.version))
-if (versions.size !== 1) throw new Error(`publish versions must match: ${pkgs.map((p) => `${p.name}@${p.version}`).join(", ")}`)
-const version = pkgs[0]!.version
+const packages = await Promise.all(sources.map(async (source) => ({ ...source, pkg: await readPkg(source.dir) })))
+const publicSource = packages.find((source) => source.namespace === "agent")!
+const version = publicSource.pkg.version
 const prerelease = version.includes("-")
 const distTag = option("--tag") ?? (prerelease ? DEFAULT_PRERELEASE_NPM_TAG : DEFAULT_STABLE_NPM_TAG)
 if (prerelease && distTag === DEFAULT_STABLE_NPM_TAG) {
@@ -111,32 +133,75 @@ if (process.env.GITHUB_ACTIONS === "true" && !dryRun) {
   }
 }
 
-const dest = await mkdtemp(join(tmpdir(), "tardigrade-pack-"))
-const license = join(root, "LICENSE")
-const readme = join(root, "README.md")
+if (!dryRun && (await published(publicSource.pkg.name, version))) {
+  console.log(`skip ${publicSource.pkg.name}@${version} (already on the registry)`)
+  process.exit(0)
+}
+
+const requestedOutput = option("--output")
+const destination = requestedOutput === undefined ? await mkdtemp(join(tmpdir(), "tardigrade-pack-")) : resolve(root, requestedOutput)
+const temporary = requestedOutput === undefined
+const stage = join(destination, "package")
 
 try {
-  for (const pkg of pkgs) {
-    const dir = join(root, pkg.dir)
-    if (await published(pkg.name, pkg.version)) {
-      console.log(`skip ${pkg.name}@${pkg.version} (already on the registry)`)
-      continue
-    }
-    const pack = async () => {
-      const filename = await output(["bun", "pm", "pack", "--destination", dest, "--quiet", "--ignore-scripts"], dir)
-      const tarball = isAbsolute(filename) ? filename : join(dest, filename)
-      const publish = ["npm", "publish", tarball, "--access", "public", "--tag", distTag, ...(dryRun ? ["--dry-run"] : [])]
-      console.log(`${dryRun ? "dry-run" : "publish"} ${pkg.name}@${pkg.version} with npm tag ${distTag}`)
-      await run(publish, root)
-    }
-    await withCopied(license, join(dir, "LICENSE"), async () => {
-      if (pkg.name === "@clavia/tardigrade") {
-        await withCopied(readme, join(dir, "README.md"), pack)
-        return
-      }
-      await pack()
+  await mkdir(stage, { recursive: true })
+  await Promise.all([
+    cp(join(root, "LICENSE"), join(stage, "LICENSE")),
+    cp(join(root, "README.md"), join(stage, "README.md")),
+    ...packages.map(async (source) => {
+      await cp(join(root, source.dir, "src"), join(stage, "src", source.namespace), {
+        recursive: true,
+        filter: (path) => !path.endsWith(".test.ts")
+      })
     })
+  ])
+
+  const rewrites = new Map(
+    packages
+      .filter((source) => source.namespace !== "agent")
+      .map((source) => [source.pkg.name, `${publicSource.pkg.name}/${source.namespace}`] as const)
+  )
+  await rewriteSources(join(stage, "src"), rewrites)
+
+  const repository = publicSource.pkg.repository
+  const publishManifest = {
+    name: publicSource.pkg.name,
+    version,
+    license: publicSource.pkg.license,
+    author: publicSource.pkg.author,
+    description: publicSource.pkg.description,
+    homepage: publicSource.pkg.homepage,
+    repository:
+      typeof repository === "object" && repository !== null && "type" in repository && "url" in repository
+        ? { type: repository.type, url: repository.url }
+        : repository,
+    bugs: publicSource.pkg.bugs,
+    publishConfig: publicSource.pkg.publishConfig,
+    files: ["src"],
+    engines: publicSource.pkg.engines,
+    type: "module",
+    exports: {
+      ".": "./src/agent/index.ts",
+      "./package.json": "./package.json",
+      "./core/*": "./src/core/*.ts",
+      "./code": "./src/code/index.ts",
+      "./code/*": "./src/code/*.ts",
+      "./host/*": "./src/host/*.ts",
+      "./bun/*": "./src/bun/*.ts",
+      "./model": "./src/model/model.ts",
+      "./model/*": "./src/model/*.ts",
+      "./*": "./src/agent/*.ts"
+    },
+    dependencies: dependencyUnion(packages.map((source) => source.pkg))
   }
+  await writeFile(join(stage, "package.json"), `${JSON.stringify(publishManifest, null, 2)}\n`)
+
+  const filename = await output(["bun", "pm", "pack", "--destination", destination, "--quiet", "--ignore-scripts"], stage)
+  const tarball = isAbsolute(filename) ? filename : join(destination, filename)
+  const publish = ["npm", "publish", tarball, "--access", "public", "--tag", distTag, ...(dryRun ? ["--dry-run"] : [])]
+  console.log(`${dryRun ? "dry-run" : "publish"} ${publicSource.pkg.name}@${version} with npm tag ${distTag}`)
+  await run(publish, root)
+  if (requestedOutput !== undefined) console.log(`tarball ${tarball}`)
 } finally {
-  await rm(dest, { recursive: true, force: true })
+  if (temporary) await rm(destination, { recursive: true, force: true })
 }


### PR DESCRIPTION
## What and why

Publish one `@clavia/tardigrade` package with stable subpaths so consumers install a single dependency. Keep the internal workspaces private, assemble them into one tarball, and simplify Release Please to one version and changelog.

- [x] `bun run gate` passes locally
- [x] Docs updated if behavior changed
- [ ] Tests cover the change
