### PR TITLE
chore: set release baseline

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "1e6eafa64d223d712d6bbe92e855282f85464caf",
   "release-type": "node",
   "versioning": "prerelease",
   "prerelease": false,

--- a/release-please-config.next.json
+++ b/release-please-config.next.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "1e6eafa64d223d712d6bbe92e855282f85464caf",
   "release-type": "node",
   "versioning": "prerelease",
   "prerelease-type": "rc",


### PR DESCRIPTION
## What and why

Set the unified package merge as Release Please's bootstrap point so the existing `0.0.1` version remains the initial baseline. This prevents repository history from generating an incorrect `0.1.0-rc` first release.

- [x] `bun run gate` passes locally
- [x] Docs updated if behavior changed
- [ ] Tests cover the change
