### PR TITLE
fix: handle published dry runs

### DIFF
--- a/docs/how-to/publish.md
+++ b/docs/how-to/publish.md
@@ -31,4 +31,4 @@ After a stable release, merge `main` into `next`. This merge gives the integrati
 
 Conventional commit titles on merged PRs (`feat`, `fix`, `perf`, and a `BREAKING CHANGE` footer) determine the next version. Release Please updates `@clavia/tardigrade`, its changelog, and `.release-please-manifest.json`. `docs`, `chore`, `ci`, and `test` titles do not bump a version.
 
-The `publish.yml` workflow runs on pushes to `next` and `main`. Merging a release PR tags `v<version>` and publishes through GitHub OIDC. A dry run is `bun run pack` or a manual workflow run with `dry-run`. A repeated run skips versions that exist on the registry.
+The `publish.yml` workflow runs on pushes to `next` and `main`. Merging a release PR tags `v<version>` and publishes through GitHub OIDC. A dry run is `bun run pack` or a manual workflow run with `dry-run`. A dry run always builds the tarball. It skips npm validation when the version already exists because npm rejects a dry-run publication over an existing version. A repeated live run skips versions that exist on the registry.

--- a/tools/publish.ts
+++ b/tools/publish.ts
@@ -133,7 +133,8 @@ if (process.env.GITHUB_ACTIONS === "true" && !dryRun) {
   }
 }
 
-if (!dryRun && (await published(publicSource.pkg.name, version))) {
+const alreadyPublished = await published(publicSource.pkg.name, version)
+if (!dryRun && alreadyPublished) {
   console.log(`skip ${publicSource.pkg.name}@${version} (already on the registry)`)
   process.exit(0)
 }
@@ -200,7 +201,11 @@ try {
   const tarball = isAbsolute(filename) ? filename : join(destination, filename)
   const publish = ["npm", "publish", tarball, "--access", "public", "--tag", distTag, ...(dryRun ? ["--dry-run"] : [])]
   console.log(`${dryRun ? "dry-run" : "publish"} ${publicSource.pkg.name}@${version} with npm tag ${distTag}`)
-  await run(publish, root)
+  if (dryRun && alreadyPublished) {
+    console.log(`skip npm dry-run validation (version already on the registry)`)
+  } else {
+    await run(publish, root)
+  }
   if (requestedOutput !== undefined) console.log(`tarball ${tarball}`)
 } finally {
   if (temporary) await rm(destination, { recursive: true, force: true })


### PR DESCRIPTION
## What and why

Keep package dry runs useful after a version reaches npm. The script still assembles the tarball, then skips npm's upload validation because npm rejects dry-run publication over an existing version.

- [x] `bun run gate` passes locally
- [x] Docs updated if behavior changed
- [ ] Tests cover the change
