### PR TITLE
feat(agent): harden inference recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: canary
       # --frozen-lockfile: a PR that changes deps without committing bun.lock fails here instead of
       # silently resolving something different from what everyone else installed.
       - run: bun install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: canary
       - run: bun install --frozen-lockfile
       - run: bun run gate
       - uses: actions/setup-node@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-[bun](https://bun.sh) 1.3 or newer. It is the runtime, the package manager, and the test runner, so it is the only tool you need to install.
+Install the [supported Bun runtime](docs/explanations/runtime-and-recovery.md#runtime). Bun is the runtime, package manager, and test runner, so it is the only tool you need to install.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Build durable agents by composing small, inspectable capabilities.
 
 ## Quickstart
 
-Use Bun 1.3 or later and an OpenAI-compatible or Bedrock model endpoint.
+Use a [supported Bun runtime](docs/explanations/runtime-and-recovery.md#runtime) and an OpenAI-compatible or Bedrock model endpoint.
 
 ```bash
 bun add @clavia/tardigrade
@@ -152,6 +152,7 @@ Effects have at-least-once execution. Each keyed result is recorded once. Provid
 ## Learn more
 
 - [Quickstart](docs/quickstart.md): build the event loop and its agent capabilities from first principles.
+- [Runtime and turn recovery](docs/explanations/runtime-and-recovery.md): understand runtime requirements, retry scopes, and failed-turn recovery.
 - [Why Tardigrade](docs/explanations/why.md): learn what the log-as-state model makes possible.
 
 ## Contributing

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "tardigrade",
@@ -73,6 +74,7 @@
         "@clavia/tardigrade": "workspace:*",
         "@clavia/tardigrade-core": "workspace:*",
         "@smithy/fetch-http-handler": "^5.6.3",
+        "@smithy/node-http-handler": "^4.11.2",
         "@tanstack/ai": "0.46.0",
         "@tanstack/ai-bedrock": "0.2.3",
         "@tanstack/ai-openai": "0.20.0",

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,5 @@
 # tardigrade docs
 
 - [quickstart.md](quickstart.md): all the core concepts you need to get started.
+- [explanations/runtime-and-recovery.md](explanations/runtime-and-recovery.md): runtime requirements, retry scopes, and failed-turn recovery.
 - [explanations/why.md](explanations/why.md): why tardigrade exists. {transitions} = f(log), and what the log-as-state shape enables.

--- a/docs/explanations/runtime-and-recovery.md
+++ b/docs/explanations/runtime-and-recovery.md
@@ -1,0 +1,42 @@
+# Runtime and turn recovery
+
+Tardigrade uses a turn as its unit of durable work. A turn starts with one inbound message and ends with `TurnCompleted` or `TurnFailed`. One turn can contain many inference attempts and tool calls. A campaign is an application term for a group of turns. The framework does not create campaign records.
+
+## Runtime
+
+Tardigrade requires Bun 1.4.0 or later. CI uses the Bun canary channel until Bun 1.4 has a stable release. `MINIMUM_BUN_VERSION` exposes this requirement, and the public runtime entry points reject older Bun releases.
+
+Bun 1.3 can end a fetch after about five idle minutes even when the request declares a longer deadline. This [Bun defect](https://github.com/oven-sh/bun/issues/16682) can terminate a valid long inference. The [runtime repair](https://github.com/oven-sh/bun/pull/33647) lets the explicit request deadline control the call. `ModelConfig.stream` remains the operator's source for first-chunk, idle, and total stream limits.
+
+## Automatic retries
+
+The model binding retries throttle-shaped failures inside one inference operation. These failures include rate limits, server failures, connection resets, and stream timeouts. `DEFAULT_THROTTLE_RETRY_DELAYS_MS` is `[2000, 8000, 30000]`, so the default permits three retries after the first request. `ModelConfig.throttleRetryDelaysMs` accepts another list, including an empty list. A valid `Retry-After` value takes priority when it fits the configured ceiling.
+
+Retry exhaustion returns a failed model action. The agent records it as `TurnFailed`, with the failure cause, attempt count, logical attempt key, and effective retry policy. Missing provider usage remains unknown. The framework does not invent token or cost data.
+
+`InferPolicy.giveUpAfter` covers a different failure. It bounds repeated process deaths that leave `ModelCalled` without a consequence. Its default is three, and `policy.infer.giveUpAfter` can replace it.
+
+## Operator resume
+
+`TurnFailed` is the failure terminal for one execution epoch. `TurnResumed` records an operator command that opens the next epoch. It is not another terminal state. The original failure remains in the append-only log, while current-state projections select the latest epoch.
+
+```ts
+const first = await agent.run("Review the contract")
+
+if (first.error !== undefined) {
+  const retried = await agent.resume(first.turn)
+  console.log(retried)
+}
+```
+
+An assembly that owns its host can use the same operation directly.
+
+```ts
+await resumeTurn(host, "ag.root", turn)
+```
+
+Resume accepts only a turn whose active epoch ended in `TurnFailed`. It preserves committed tool calls and results, removes the superseded failure from the next model request, and resets the epoch retry counters. The operation returns the new boundary to the operator. It does not redeliver the turn's original reply. A failed inference keeps its logical idempotency key. A model-declared failure advances to a new inference key because the prior model response completed.
+
+Provider behavior limits the delivery guarantee. The OpenAI-compatible binding sends the logical key as `Idempotency-Key`. Bedrock Converse has no equivalent request field, so a replay remains at least once. A timed-out Bedrock request can finish after the client loses the response, and its exact replay can incur another charge.
+
+Automatic retries stop at `TurnFailed`. Resume is an explicit operator choice because it can spend money and repeat a provider-side effect.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "tardigrade",
   "version": "0.0.2-rc",
   "type": "module",
+  "engines": {
+    "bun": ">=1.4.0"
+  },
   "workspaces": [
     "packages/*",
     "platform/*"

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -1,9 +1,0 @@
-# Changelog
-
-## [0.0.2-rc](https://github.com/clavia-labs/tardigrade/compare/v0.0.1...v0.0.2-rc) (2026-08-19)
-
-
-### Bug Fixes
-
-* handle published dry runs ([#104](https://github.com/clavia-labs/tardigrade/issues/104)) ([b5e684c](https://github.com/clavia-labs/tardigrade/commit/b5e684c1d8992330b845573af8c716fb03f347d1))
-* track unified release scope ([#105](https://github.com/clavia-labs/tardigrade/issues/105)) ([0d5360c](https://github.com/clavia-labs/tardigrade/commit/0d5360ccb69345133cad75ae4786bb60f4dcdbf8))

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@clavia/tardigrade",
   "version": "0.0.1",
-  "private": true,
   "license": "MIT",
   "author": "Clavia, Inc.",
   "description": "A durable agent harness. State is a pure function of the log.",
@@ -22,7 +21,7 @@
     "!src/**/*.test.ts"
   ],
   "engines": {
-    "bun": ">=1.3.0"
+    "bun": ">=1.4.0"
   },
   "type": "module",
   "exports": {

--- a/packages/agent/src/boundary.test.ts
+++ b/packages/agent/src/boundary.test.ts
@@ -52,4 +52,16 @@ describe("boundaryOf", () => {
     ]
     expect(boundaryOf(log, "m1")).toEqual({ kind: "requesting", callId: "rb2", reason: "second", amount: 3 })
   })
+
+  test("a resume request clears the failed boundary until the next terminal", () => {
+    const resumed = [
+      ...base,
+      { type: "TurnFailed", error: "timeout", turn: "m1", at: 1 } as Event,
+      { type: "TurnResumed", turn: "m1", failedEpoch: 0, epoch: 1, at: 2 } as Event
+    ]
+    expect(boundaryOf(resumed, "m1")).toBeUndefined()
+    expect(
+      boundaryOf([...resumed, { type: "TurnCompleted", output: "done", turn: "m1", epoch: 1, at: 3 } as Event], "m1")
+    ).toEqual({ kind: "completed", output: "done" })
+  })
 })

--- a/packages/agent/src/boundary.ts
+++ b/packages/agent/src/boundary.ts
@@ -1,4 +1,5 @@
 import type { Event } from "@clavia/tardigrade-core/event"
+import { turnTerminalOf } from "@clavia/tardigrade-code/turns"
 
 // Boundary is where a settle left a turn: a terminal, or a park on a budget ask. The
 // platform's call and resume read it to answer the spawning code. Pure over the log, so a
@@ -13,9 +14,7 @@ export type Boundary =
 // over a park: a resumed turn that finished reads completed even though it once asked. A park
 // is the last BudgetRequested no grant or denial has answered.
 export const boundaryOf = (log: ReadonlyArray<Event>, turn: string): Boundary | undefined => {
-  const terminal = log.find(
-    (e) => (e.type === "TurnCompleted" || e.type === "TurnFailed") && String((e as { turn?: unknown }).turn) === turn
-  )
+  const terminal = turnTerminalOf(log, turn)
   if (terminal !== undefined) {
     return terminal.type === "TurnCompleted"
       ? { kind: "completed", output: String((terminal as { output?: unknown }).output) }

--- a/packages/agent/src/events.ts
+++ b/packages/agent/src/events.ts
@@ -49,6 +49,7 @@ export const ModelCalled = Schema.Struct({
   // The occurrence: distinct per physical attempt, the dedup key's scope. callId stays the
   // provider idempotency key, shared across retries of one logical attempt.
   ordinal: Schema.optional(Schema.Number),
+  epoch: Schema.optional(Schema.Number),
   turn: Schema.optional(Schema.String),
   at: Schema.Number
 })
@@ -66,15 +67,32 @@ export const TurnCompleted = Schema.Struct({
   type: Schema.Literal("TurnCompleted"),
   output: Schema.String,
   usage: Schema.optional(Schema.Unknown),
+  epoch: Schema.optional(Schema.Number),
   at: Schema.Number
 })
 
-// TurnFailed is the failure terminal: the turn died and recovery gave up.
+// TurnFailed is the failure terminal for one execution epoch.
 export const TurnFailed = Schema.Struct({
   type: Schema.Literal("TurnFailed"),
   error: Schema.String,
   // Present only on the fail a live attempt answered; the give-up terminal carries none.
   usage: Schema.optional(Schema.Unknown),
+  epoch: Schema.optional(Schema.Number),
+  cause: Schema.optional(
+    Schema.Literals(["model", "inference_error", "inference_attempts_exhausted", "schema_repairs_exhausted"])
+  ),
+  attempts: Schema.optional(Schema.Number),
+  attemptKey: Schema.optional(Schema.String),
+  policy: Schema.optional(Schema.Unknown),
+  at: Schema.Number
+})
+
+// TurnResumed records the operator request that starts the next execution epoch.
+export const TurnResumed = Schema.Struct({
+  type: Schema.Literal("TurnResumed"),
+  turn: Schema.String,
+  failedEpoch: Schema.Number,
+  epoch: Schema.Number,
   at: Schema.Number
 })
 
@@ -137,6 +155,7 @@ export const AgentEvent = Schema.Union([
   ToolReturned,
   TurnCompleted,
   TurnFailed,
+  TurnResumed,
   ReplyDelivered,
   BudgetExhausted,
   BudgetRequested,
@@ -150,14 +169,25 @@ export type AgentEvent = typeof AgentEvent.Type
 export type Action =
   | { readonly kind: "call"; readonly callId: string; readonly name: string; readonly arguments: unknown; readonly text?: string; readonly usage?: Usage }
   | { readonly kind: "complete"; readonly output: string; readonly usage?: Usage }
-  | { readonly kind: "fail"; readonly error: string; readonly usage?: Usage }
+  | {
+      readonly kind: "fail"
+      readonly error: string
+      readonly usage?: Usage
+      readonly failure?: {
+        readonly cause: "inference_error" | "inference_attempts_exhausted"
+        readonly attempts: number
+        readonly policy?: unknown
+      }
+    }
 
 // agentKeys is the agent lane's dedup fragment, owned beside its alphabet. tr names the tool call's recorded
 // pair; bg/bd name the budget request a decision answers (a grant is SUMMED into the ceiling,
 // src/budget.ts, so a redelivered decision landing twice would double it). A decision that
 // carries no callId predates the stamp and lands unkeyed; the fold tolerates it.
+const epochSuffix = (epoch: unknown): string => epoch === undefined || Number(epoch) === 0 ? "" : `/${String(epoch)}`
+
 export const agentKeys: KeyFragment = {
-  prefixes: ["tr:", "bg:", "bd:", "rd:", "tn:", "mc:", "bw:", "br:", "cc:"],
+  prefixes: ["tr:", "bg:", "bd:", "rd:", "tn:", "rs:", "mc:", "bw:", "br:", "cc:"],
   keyOf: (e) => {
     const v = e as Record<string, unknown>
     switch (e.type) {
@@ -168,12 +198,14 @@ export const agentKeys: KeyFragment = {
       case "BudgetDenied":
         return v.callId === undefined ? undefined : `bd:${String(v.callId)}`
       case "ReplyDelivered":
-        // One reply per turn.
+        // One reply per logical turn. A resumed boundary returns to its operator.
         return `rd:${String(v.turn)}`
       case "TurnCompleted":
       case "TurnFailed":
-        // One terminal per turn, whichever kind: a duplicate of either absorbs.
-        return `tn:${String(v.turn)}`
+        // One terminal per turn epoch, whichever kind: a duplicate of either absorbs.
+        return `tn:${String(v.turn)}${epochSuffix(v.epoch)}`
+      case "TurnResumed":
+        return `rs:${String(v.turn)}/${String(v.epoch)}`
       case "ModelCalled":
         // Occurrence-keyed marks: the ordinal is distinct per physical attempt, so the
         // repetition that evidences died attempts is preserved. A mark predating the ordinal
@@ -198,6 +230,7 @@ export const agentKeys: KeyFragment = {
 // packages/code/src/events.ts's; the gate is on the way in, never a new representation).
 
 type Stamp = { readonly turn?: string; readonly at: number }
+type EpochStamp = Stamp & { readonly epoch?: number }
 
 export const toolCalled = (
   fields: { readonly callId: string; readonly name: string; readonly arguments?: unknown } & Stamp
@@ -207,17 +240,28 @@ export const toolReturned = (fields: { readonly callId: string; readonly result:
   ({ type: "ToolReturned", ...fields }) as Event
 
 export const modelCalled = (
-  fields: { readonly callId: string; readonly ordinal?: number } & Stamp
+  fields: { readonly callId: string; readonly ordinal?: number } & EpochStamp
 ): Event => ({ type: "ModelCalled", ...fields }) as Event
 
 export const textReturned = (fields: { readonly text: string } & Stamp): Event =>
   ({ type: "TextReturned", ...fields }) as Event
 
-export const turnCompleted = (fields: { readonly output: string } & Stamp): Event =>
+export const turnCompleted = (fields: { readonly output: string } & EpochStamp): Event =>
   ({ type: "TurnCompleted", ...fields }) as Event
 
-export const turnFailed = (fields: { readonly error: string } & Stamp): Event =>
+export const turnFailed = (
+  fields: {
+    readonly error: string
+    readonly cause?: "model" | "inference_error" | "inference_attempts_exhausted" | "schema_repairs_exhausted"
+    readonly attempts?: number
+    readonly attemptKey?: string
+    readonly policy?: unknown
+  } & EpochStamp
+): Event =>
   ({ type: "TurnFailed", ...fields }) as Event
+
+export const turnResumed = (fields: { readonly turn: string; readonly failedEpoch: number; readonly epoch: number; readonly at: number }): Event =>
+  ({ type: "TurnResumed", ...fields }) as Event
 
 export const replyDelivered = (fields: { readonly turn: string; readonly to?: string; readonly at: number }): Event =>
   ({ type: "ReplyDelivered", ...fields }) as Event

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -126,6 +126,86 @@ describe("createRlmAgent", () => {
     expect(log.filter((e) => e.type === "ToolReturned")).toHaveLength(1)
   })
 
+  test("a failed turn resumes from its last committed inference", async () => {
+    const reads: string[] = []
+    const keys: string[] = []
+    const failureInRequest: boolean[] = []
+    let postToolCalls = 0
+    const mind = createRlmAgent({
+      capabilities: [
+        toolList([
+          {
+            spec: { name: "read", description: "read a file", inputSchema: { type: "object", properties: {} } },
+            run: () => {
+              reads.push("contract")
+              return Effect.succeed("contents")
+            }
+          }
+        ])
+      ],
+      infer: async ({ trajectory }, key) => {
+        keys.push(String(key))
+        failureInRequest.push(trajectory.some((event) => event.type === "TurnFailed"))
+        const returned = trajectory.find((event) => event.type === "ToolReturned")
+        if (returned === undefined) return { kind: "call", callId: "read-1", name: "read", arguments: {} }
+        postToolCalls += 1
+        if (postToolCalls === 1) throw new Error("provider connection ended")
+        return { kind: "complete", output: String((returned as { result?: unknown }).result) }
+      }
+    })
+
+    const failed = await mind.run("read the contract")
+    expect(failed).toMatchObject({ turn: "run-0", error: "provider connection ended" })
+
+    const completed = await mind.resume(failed.turn)
+    expect(completed).toEqual({ turn: "run-0", output: "contents" })
+    expect(reads).toEqual(["contract"])
+    expect(keys).toEqual(["run-0/infer/0", "run-0/infer/1", "run-0/infer/1"])
+    expect(failureInRequest).toEqual([false, false, false])
+
+    const log = mind.host.read(ROOT_LANE)
+    expect(log.filter((event) => event.type === "TurnFailed")).toEqual([
+      expect.objectContaining({
+        turn: "run-0",
+        error: "provider connection ended",
+        cause: "inference_error",
+        attempts: 1,
+        attemptKey: "run-0/infer/1"
+      })
+    ])
+    expect(log.filter((event) => event.type === "TurnResumed")).toEqual([
+      expect.objectContaining({ turn: "run-0", failedEpoch: 0, epoch: 1 })
+    ])
+    expect(log.filter((event) => event.type === "TurnCompleted")).toEqual([
+      expect.objectContaining({ turn: "run-0", epoch: 1, output: "contents" })
+    ])
+    expect(log.filter((event) => event.type === "ReplyDelivered")).toHaveLength(1)
+  })
+
+  test("only a failed active epoch can resume", async () => {
+    const mind = createRlmAgent({ infer: async () => ({ kind: "complete", output: "done" }) })
+    const completed = await mind.run("finish")
+
+    await expect(mind.resume(completed.turn)).rejects.toThrow("active epoch is not failed")
+    await expect(mind.resume("missing")).rejects.toThrow("active epoch is not failed")
+  })
+
+  test("a model-declared failure advances the inference key on resume", async () => {
+    const keys: string[] = []
+    const mind = createRlmAgent({
+      infer: async (_request, key) => {
+        keys.push(String(key))
+        return keys.length === 1
+          ? { kind: "fail", error: "the task is invalid" }
+          : { kind: "complete", output: "reconsidered" }
+      }
+    })
+
+    const failed = await mind.run("try")
+    expect(await mind.resume(failed.turn)).toMatchObject({ output: "reconsidered" })
+    expect(keys).toEqual(["run-0/infer/0", "run-0/infer/1"])
+  })
+
   test("a call outside the surface comes back as an unknown tool, never a dead turn", async () => {
     const capabilities = [toolList([
       { spec: { name: "read", description: "read", inputSchema: {} }, run: () => Effect.succeed("ok") }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,6 +1,7 @@
 import { Effect, Layer } from "effect"
 import { KeyValueStore } from "effect/unstable/persistence"
 import type { Event } from "@clavia/tardigrade-core/event"
+import { assertSupportedBun } from "@clavia/tardigrade-core/runtime"
 import { Router } from "@clavia/tardigrade-core/router"
 import { Self } from "@clavia/tardigrade-core/actor"
 import { Packages, type Package } from "@clavia/tardigrade-code/packages"
@@ -12,6 +13,7 @@ import { type AgentPolicy, type RlmR } from "./turn"
 import { Infer, type InferRequest } from "./infer"
 import type { Action } from "./events"
 import { boundaryOf } from "./boundary"
+import { resumeTurn } from "./resume"
 import { agentsPackage } from "./spawn"
 import { agentOf, budgetFor, codeModeFor, compactionFor, reply, type Capability } from "./capability"
 
@@ -25,6 +27,7 @@ export { toolsReactorFrom, type Answer, type PendingCall, type Serve } from "./t
 export { replyReactor } from "./reply"
 export { compactionReactorFor, DEFAULT_CONTEXT_POLICY, type ContextPolicy } from "./compaction"
 export { agentKeys } from "./events"
+export { resumeTurn, type ResumeTurnOptions, type TurnDriver } from "./resume"
 export {
   usageIn,
   usageOf,
@@ -70,8 +73,15 @@ export interface CreateAgentOptions {
   readonly sandbox?: Partial<SandboxPolicy>
 }
 
+export interface TurnResult {
+  readonly turn: string
+  readonly output?: string
+  readonly error?: string
+}
+
 export interface RlmAgent {
-  readonly run: (brief: string) => Promise<{ readonly output?: string; readonly error?: string }>
+  readonly run: (brief: string) => Promise<TurnResult>
+  readonly resume: (turn: string) => Promise<TurnResult>
   readonly host: Host
 }
 
@@ -82,6 +92,7 @@ const ROOT = "ag.root"
 // reply, budget, and compaction, and adds the host and the agents package. A caller who wants a
 // thinner assembly uses agentOf and their own host.
 export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
+  assertSupportedBun()
   const user = options.packages ?? []
   const infer = Layer.succeed(Infer, {
     react: (request: InferRequest, key?: string) => Effect.promise(() => options.infer(request, key))
@@ -140,16 +151,25 @@ export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
   // Run ids continue past the seeded history, so a resumed agent's new run never wears an id
   // the log already dedups.
   let n = options.log?.length ?? 0
-  const run = async (brief: string): Promise<{ readonly output?: string; readonly error?: string }> => {
+  const resultOf = (turn: string): TurnResult => {
+    const boundary = boundaryOf(host.read(ROOT), turn)
+    if (boundary === undefined) return { turn, error: "the root never settled" }
+    if (boundary.kind === "completed") return { turn, output: boundary.output }
+    if (boundary.kind === "failed") return { turn, error: boundary.error }
+    return { turn, error: "the root parked on a budget ask with nobody to answer" }
+  }
+
+  const run = async (brief: string): Promise<TurnResult> => {
     const id = `run-${n++}`
     host.deliver(host.self(ROOT), { type: "MessageReceived", id, text: brief, at: n } as Event)
     await host.drive()
-    const boundary = boundaryOf(host.read(ROOT), id)
-    if (boundary === undefined) return { error: "the root never settled" }
-    if (boundary.kind === "completed") return { output: boundary.output }
-    if (boundary.kind === "failed") return { error: boundary.error }
-    return { error: "the root parked on a budget ask with nobody to answer" }
+    return resultOf(id)
   }
 
-  return { run, host }
+  const resume = async (turn: string): Promise<TurnResult> => {
+    await resumeTurn(host, ROOT, turn)
+    return resultOf(turn)
+  }
+
+  return { run, resume, host }
 }

--- a/packages/agent/src/infer.ts
+++ b/packages/agent/src/infer.ts
@@ -1,10 +1,10 @@
-import { Clock, Context, Effect } from "effect"
+import { Cause, Clock, Context, Effect } from "effect"
 import { EventLog } from "@clavia/tardigrade-core/event-log"
 import { transition, type Reactor } from "@clavia/tardigrade-core/actor"
 import { modelCalled, textReturned, turnFailed } from "./events"
 import type { Event } from "@clavia/tardigrade-core/event"
 import type { Action } from "./events"
-import { trajectoryOf, turnView } from "@clavia/tardigrade-code/turns"
+import { trajectoryOf, turnEpochOf, turnView } from "@clavia/tardigrade-code/turns"
 import type { ContextPolicy } from "./compaction"
 
 // The infer reactor: the model loop, and nothing else. A think is owed when the current turn
@@ -13,8 +13,8 @@ import type { ContextPolicy } from "./compaction"
 // is unanswered the turn owes nothing here: the tools and code reactors carry it. The pieces
 // compose over one log through event names alone.
 //
-// InferPolicy is the give-up and repair ceilings. The defaults match the old constants; a
-// caller who wants a longer crash loop or more schema repairs lists inferReactorFor.
+// InferPolicy is the process-crash and schema-repair ceilings. A caller who wants more recovery
+// attempts or schema repairs passes an override to inferReactorFor.
 export interface InferPolicy {
   readonly giveUpAfter: number
   readonly repairAtMost: number
@@ -34,6 +34,9 @@ export interface InferRequest {
   readonly context?: Partial<ContextPolicy>
 }
 
+const epochStamp = (epoch: number): { readonly epoch?: number } =>
+  epoch === 0 ? {} : { epoch }
+
 // Infer is the model seam: one inference over the request, one action out. The platform binds
 // this to a provider. Tests bind it to a stub. `key` is the attempt's identity, the same string
 // the `ModelCalled` mark carries: a binding forwards it as the provider's idempotency key where
@@ -52,22 +55,43 @@ export class Infer extends Context.Service<
 // consequence carries the turn it serves and the attempt's spend: `usage` is always stamped,
 // and an attempt whose binding reported nothing stamps an empty object, so usageIn reads the
 // spend as unknown rather than absent (usage.test.ts, "unknown is sticky").
-const consequenceOf = (action: Action, turn: string, at: number): Event => {
+const consequenceOf = (action: Action, turn: string, epoch: number, attempt: string, at: number): Event => {
   const usage = action.usage ?? {}
   return action.kind === "call"
     ? { type: "ToolCalled", callId: action.callId, name: action.name, arguments: action.arguments, usage, turn, at }
     : action.kind === "complete"
-      ? { type: "TurnCompleted", output: action.output, usage, turn, at }
-      : { type: "TurnFailed", error: action.error, usage, turn, at }
+      ? { type: "TurnCompleted", output: action.output, usage, turn, ...epochStamp(epoch), at }
+      : {
+          type: "TurnFailed",
+          error: action.error,
+          usage,
+          turn,
+          ...epochStamp(epoch),
+          cause: action.failure?.cause ?? "model",
+          ...(action.failure === undefined
+            ? {}
+            : {
+                attempts: action.failure.attempts,
+                attemptKey: attempt,
+                ...(action.failure.policy === undefined ? {} : { policy: action.failure.policy })
+              }),
+          at
+        }
+}
+
+const failureMessage = (cause: Cause.Cause<never>): string => {
+  const error = Cause.squash(cause)
+  return error instanceof Error ? error.message : String(error)
 }
 
 // diedAttempts counts the `ModelCalled` marks at the end of the turn's slice, with nothing after
 // them. Any committed event after a mark is progress and resets the count. Counting inside the
 // slice keeps a queued message on the log from masking a crash loop.
-const diedAttempts = (turn: ReadonlyArray<Event>): number => {
+const diedAttempts = (turn: ReadonlyArray<Event>, epoch: number): number => {
   let n = 0
   for (let i = turn.length - 1; i >= 0; i--) {
-    if (turn[i]!.type === "ModelCalled") n += 1
+    const event = turn[i]!
+    if (event.type === "ModelCalled" && Number((event as { epoch?: unknown }).epoch ?? 0) === epoch) n += 1
     else break
   }
   return n
@@ -84,6 +108,9 @@ const awaitingTool = (slice: ReadonlyArray<Event>): boolean => {
 const terminated = (slice: ReadonlyArray<Event>): boolean =>
   slice.some((e) => e.type === "TurnCompleted" || e.type === "TurnFailed")
 
+const terminalKey = (turn: string, epoch: number): string =>
+  epoch === 0 ? `tn:${turn}` : `tn:${turn}/${epoch}`
+
 // Render derives what the model is shown over this log: the assembly owns it (capability.ts,
 // renderOf).
 export type Render = (log: ReadonlyArray<Event>) => {
@@ -99,45 +126,89 @@ export const inferReactorFor = (policy: Partial<InferPolicy>, render: Render): R
   if (slice.length === 0 || awaitingTool(slice) || terminated(slice)) return []
   const head = slice[0] as { id?: unknown }
   const turn = String(head.id)
+  const epoch = turnEpochOf(log, turn)
+  const died = diedAttempts(slice, epoch)
+  const marks = slice.filter((e) => e.type === "ModelCalled").length
+  const modelFailures = log.filter(
+    (event) =>
+      event.type === "TurnFailed" &&
+      String((event as { turn?: unknown }).turn) === turn &&
+      String((event as { cause?: unknown }).cause) === "model"
+  ).length
+  const logicalAttempt = slice.filter((e) => e.type === "ToolCalled").length + modelFailures
+  const attempt = `${turn}/infer/${logicalAttempt}`
+  const effectivePolicy = { giveUpAfter, repairAtMost }
   // The give-up and repair bounds are derivations, so each derives its own terminal
-  // transition: one terminal per turn (tn:<turn>), and a duplicate of either kind absorbs.
-  if (diedAttempts(slice) >= giveUpAfter) {
+  // transition: one terminal per turn epoch, and a duplicate of either kind absorbs.
+  if (died >= giveUpAfter) {
     return [
       transition({
-        key: `tn:${turn}`,
-        input: { turn, error: `the model attempt died ${giveUpAfter} times in a row` },
+        key: terminalKey(turn, epoch),
+        input: { turn, epoch, attempt, attempts: died, policy: effectivePolicy, error: `the model attempt died ${giveUpAfter} times in a row` },
         act: (input) =>
           Effect.gen(function* () {
             const at = yield* Clock.currentTimeMillis
-            return [turnFailed({ error: input.error, turn: input.turn, at })]
+            return [
+              turnFailed({
+                error: input.error,
+                cause: "inference_attempts_exhausted",
+                attempts: input.attempts,
+                attemptKey: input.attempt,
+                policy: input.policy,
+                turn: input.turn,
+                ...epochStamp(input.epoch),
+                at
+              })
+            ]
           })
       })
     ]
   }
-  const rejections = slice.filter((e) => e.type === "ToolCalled" && String((e as { name?: unknown }).name) === "answer").length
+  const epochStart = slice.findLastIndex(
+    (event) => event.type === "TurnResumed" && Number((event as { epoch?: unknown }).epoch) === epoch
+  )
+  const epochEvents = epochStart === -1 ? slice : slice.slice(epochStart + 1)
+  const rejections = epochEvents.filter(
+    (event) => event.type === "ToolCalled" && String((event as { name?: unknown }).name) === "answer"
+  ).length
   if (rejections > repairAtMost) {
     return [
       transition({
-        key: `tn:${turn}`,
-        input: { turn, error: `the model's answer did not satisfy the declared schema after ${repairAtMost} corrections` },
+        key: terminalKey(turn, epoch),
+        input: {
+          turn,
+          epoch,
+          attempt,
+          attempts: rejections,
+          policy: effectivePolicy,
+          error: `the model's answer did not satisfy the declared schema after ${repairAtMost} corrections`
+        },
         act: (input) =>
           Effect.gen(function* () {
             const at = yield* Clock.currentTimeMillis
-            return [turnFailed({ error: input.error, turn: input.turn, at })]
+            return [
+              turnFailed({
+                error: input.error,
+                cause: "schema_repairs_exhausted",
+                attempts: input.attempts,
+                attemptKey: input.attempt,
+                policy: input.policy,
+                turn: input.turn,
+                ...epochStamp(input.epoch),
+                at
+              })
+            ]
           })
       })
     ]
   }
-  const marks = slice.filter((e) => e.type === "ModelCalled").length
   // The attempt's identity, the same string its ModelCalled mark carries. A died attempt leaves
-  // its mark, so the retry subtracts the trailing died marks: retries of one logical attempt
-  // share one provider idempotency key, while the marks stay one per run (their repetition is
-  // the give-up evidence; the mark's ordinal keys it, so evidence is preserved, not absorbed).
-  const attempt = `${turn}/infer/${marks - diedAttempts(slice)}`
+  // its mark. The completed tool calls count logical attempts, so an operator resume keeps the
+  // failed inference's provider idempotency key. The mark ordinal remains unique per physical run.
   return [
     transition({
       key: `mc:${turn}/${marks}`,
-      input: { turn, attempt, ordinal: marks, trajectory: trajectoryOf(log), render: render(log) },
+      input: { turn, epoch, attempt, ordinal: marks, trajectory: trajectoryOf(log), render: render(log), policy: effectivePolicy },
       act: (input) =>
         Effect.gen(function* () {
           const events = yield* EventLog
@@ -146,14 +217,28 @@ export const inferReactorFor = (policy: Partial<InferPolicy>, render: Render): R
           // died attempt leaves its mark, the next derivation counts it, the bound holds.
           // callId is the provider idempotency key (shared across retries of one logical
           // attempt); ordinal is the occurrence the dedup key reads.
-          yield* events.append([modelCalled({ callId: input.attempt, ordinal: input.ordinal, turn: input.turn, at })])
-          const action = yield* (yield* Infer).react({ trajectory: input.trajectory, ...input.render }, input.attempt)
+          yield* events.append([
+            modelCalled({ callId: input.attempt, ordinal: input.ordinal, turn: input.turn, ...epochStamp(input.epoch), at })
+          ])
+          const action = yield* (yield* Infer)
+            .react({ trajectory: input.trajectory, ...input.render }, input.attempt)
+            .pipe(
+              Effect.catchCause((cause) =>
+                Cause.hasInterruptsOnly(cause)
+                  ? Effect.failCause(cause)
+                  : Effect.succeed<Action>({
+                      kind: "fail",
+                      error: failureMessage(cause),
+                      failure: { cause: "inference_error", attempts: 1 }
+                    })
+              )
+            )
           const after = yield* Clock.currentTimeMillis
           return [
             ...(action.kind === "call" && action.text !== undefined && action.text !== ""
               ? [textReturned({ text: action.text, turn: input.turn, at: after })]
               : []),
-            consequenceOf(action, input.turn, after)
+            consequenceOf(action, input.turn, input.epoch, input.attempt, after)
           ]
         })
     })

--- a/packages/agent/src/reply.ts
+++ b/packages/agent/src/reply.ts
@@ -4,7 +4,7 @@ import { Self, transition, type Reactor } from "@clavia/tardigrade-core/actor"
 import { replyDelivered } from "./events"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { replyEvent } from "@clavia/tardigrade-core/reply"
-import { replyView } from "@clavia/tardigrade-code/turns"
+import { turnTerminalOf, replyView } from "@clavia/tardigrade-code/turns"
 
 // The reply reactor: report the turn's terminal home. When the inbound named a `replyTo`, the
 // terminal goes back to that actor as a plain `MessageReceived`, and the caller folds it as a
@@ -21,14 +21,15 @@ const owedTurn = (
 ): { readonly id: string; readonly replyTo?: string; readonly text: string; readonly outcome: "completed" | "failed" } => {
   const view = replyView(log)
   const inbound = view[0] as { id?: unknown; replyTo?: unknown } | undefined
-  const terminal = view.find((e) => e.type === "TurnCompleted" || e.type === "TurnFailed") as
+  const id = String(inbound?.id)
+  const terminal = turnTerminalOf(log, id) as
     | { output?: unknown; error?: unknown }
     | undefined
   if (inbound === undefined || terminal === undefined) {
     throw new Error("replying with no finished turn: the derivation and the serve disagree")
   }
   return {
-    id: String(inbound.id),
+    id,
     ...(inbound.replyTo === undefined ? {} : { replyTo: String(inbound.replyTo) }),
     text: terminal.error === undefined ? String(terminal.output) : `error: ${String(terminal.error)}`,
     // The outcome rides as a typed field, so a reader never sniffs the text for failure.

--- a/packages/agent/src/resume.ts
+++ b/packages/agent/src/resume.ts
@@ -1,0 +1,39 @@
+import type { Event } from "@clavia/tardigrade-core/event"
+import { turnEpochOf } from "@clavia/tardigrade-code/turns"
+import { boundaryOf, type Boundary } from "./boundary"
+import { turnResumed } from "./events"
+
+type Awaitable<T> = T | Promise<T>
+
+// TurnDriver is the common control surface of the memory host and the durable Bun host.
+export interface TurnDriver {
+  readonly read: (lane: string) => Awaitable<ReadonlyArray<Event>>
+  readonly deliver: (address: string, event: Event) => Awaitable<void>
+  readonly drive: () => Promise<void>
+  readonly self: (lane: string) => string
+}
+
+export interface ResumeTurnOptions {
+  readonly at?: number
+}
+
+// resumeTurn starts a new execution epoch from a failed turn's committed history.
+export const resumeTurn = async (
+  host: TurnDriver,
+  lane: string,
+  turn: string,
+  options: ResumeTurnOptions = {}
+): Promise<Boundary | undefined> => {
+  const before = await host.read(lane)
+  const boundary = boundaryOf(before, turn)
+  if (boundary?.kind !== "failed") {
+    throw new Error(`turn "${turn}" cannot resume because its active epoch is not failed`)
+  }
+  const failedEpoch = turnEpochOf(before, turn)
+  await host.deliver(
+    host.self(lane),
+    turnResumed({ turn, failedEpoch, epoch: failedEpoch + 1, at: options.at ?? Date.now() })
+  )
+  await host.drive()
+  return boundaryOf(await host.read(lane), turn)
+}

--- a/packages/agent/src/turn.test.ts
+++ b/packages/agent/src/turn.test.ts
@@ -349,6 +349,41 @@ describe("the agent with execute as the only tool", () => {
       usage: spent
     })
   })
+
+  test("provider retry exhaustion records a resumable failure with its policy", async () => {
+    const retry = { throttleRetryDelaysMs: [100], stream: { firstChunkMs: 1, idleMs: 2, totalMs: 3 } }
+    const layers = Layer.mergeAll(
+      KeyValueStore.layerMemory,
+      memoryLog(),
+      Layer.succeed(Infer, {
+        react: () =>
+          Effect.succeed({
+            kind: "fail" as const,
+            error: "model inference retries exhausted after 2 attempts: timeout",
+            failure: { cause: "inference_attempts_exhausted" as const, attempts: 2, policy: retry }
+          })
+      }),
+      registry([]),
+      jsSandbox,
+      noRouter
+    )
+    const events = await run(
+      Effect.gen(function* () {
+        yield* receive(rlmAgent, { id: "m1", text: "hi" })
+        return yield* readLog
+      }),
+      layers
+    )
+
+    expect(events.find((event) => event.type === "TurnFailed")).toMatchObject({
+      turn: "m1",
+      cause: "inference_attempts_exhausted",
+      attempts: 2,
+      attemptKey: "m1/infer/0",
+      policy: retry,
+      usage: {}
+    })
+  })
 })
 
 // The scout schema from a research task, and the two answers a model gives: the double-encoded

--- a/packages/code/package.json
+++ b/packages/code/package.json
@@ -22,7 +22,7 @@
     "!src/**/*.test.ts"
   ],
   "engines": {
-    "bun": ">=1.3.0"
+    "bun": ">=1.4.0"
   },
   "type": "module",
   "exports": {

--- a/packages/code/src/turns.test.ts
+++ b/packages/code/src/turns.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { Event } from "@clavia/tardigrade-core/event"
-import { turnHead } from "./turns"
+import { replyView, trajectoryOf, turnEpochOf, turnHead, turnTerminalOf, turnView } from "./turns"
 
 // `heads()` (private to this module) is what `turnHead`/`turnView` fold over: every
 // `MessageReceived`, except a reply a package call was still parked on when it landed. That
@@ -45,5 +45,42 @@ describe("turnHead: a reply claimed by a still-open package call", () => {
     ]
     const head = turnHead(log)
     expect(head).toMatchObject({ id: "run-c1.reply" })
+  })
+})
+
+describe("a resumed turn", () => {
+  const failed: ReadonlyArray<Event> = [
+    { type: "MessageReceived", id: "m1", text: "read", at: 1 },
+    { type: "ModelCalled", callId: "m1/infer/0", ordinal: 0, turn: "m1", at: 2 },
+    { type: "ToolCalled", callId: "c1", name: "read", arguments: {}, turn: "m1", at: 3 },
+    { type: "ToolReturned", callId: "c1", result: "contents", turn: "m1", at: 4 },
+    { type: "ModelCalled", callId: "m1/infer/1", ordinal: 1, turn: "m1", at: 5 },
+    { type: "TurnFailed", error: "timeout", turn: "m1", at: 6 },
+    { type: "ReplyDelivered", turn: "m1", at: 7 }
+  ]
+
+  test("the retry request opens the next epoch over the committed history", () => {
+    const log: ReadonlyArray<Event> = [
+      ...failed,
+      { type: "TurnResumed", turn: "m1", failedEpoch: 0, epoch: 1, at: 8 }
+    ]
+
+    expect(turnEpochOf(log, "m1")).toBe(1)
+    expect(turnHead(log)).toMatchObject({ id: "m1" })
+    expect(turnTerminalOf(log, "m1")).toBeUndefined()
+    expect(turnView(log).filter((event) => event.type === "ToolReturned")).toHaveLength(1)
+    expect(trajectoryOf(log).some((event) => event.type === "TurnFailed")).toBe(false)
+  })
+
+  test("the new epoch owns its terminal without redelivering the turn", () => {
+    const completed: ReadonlyArray<Event> = [
+      ...failed,
+      { type: "TurnResumed", turn: "m1", failedEpoch: 0, epoch: 1, at: 8 },
+      { type: "TurnCompleted", output: "done", turn: "m1", epoch: 1, at: 9 }
+    ]
+
+    expect(turnHead(completed)).toBeUndefined()
+    expect(turnTerminalOf(completed, "m1")).toMatchObject({ type: "TurnCompleted", output: "done" })
+    expect(replyView(completed)).toEqual([])
   })
 })

--- a/packages/code/src/turns.ts
+++ b/packages/code/src/turns.ts
@@ -16,8 +16,31 @@ export const turnOf = (e: Event): string | undefined => {
 const stamped = (log: ReadonlyArray<Event>, id: string): ReadonlyArray<Event> =>
   log.filter((e) => turnOf(e) === id)
 
-const hasStamped = (log: ReadonlyArray<Event>, id: string, types: ReadonlyArray<string>): boolean =>
-  log.some((e) => types.includes(e.type) && turnOf(e) === id)
+// eventEpochOf returns the execution epoch stamped on an event. Historical events belong to epoch zero.
+export const eventEpochOf = (event: Event): number => {
+  const epoch = (event as { epoch?: unknown }).epoch
+  return typeof epoch === "number" && Number.isSafeInteger(epoch) && epoch >= 0 ? epoch : 0
+}
+
+// turnEpochOf returns the latest execution epoch that an operator started for one turn.
+export const turnEpochOf = (log: ReadonlyArray<Event>, turn: string): number =>
+  log.reduce((epoch, event) => {
+    if (event.type !== "TurnResumed" || turnOf(event) !== turn) return epoch
+    return Math.max(epoch, eventEpochOf(event))
+  }, 0)
+
+const isTerminal = (event: Event): boolean => event.type === "TurnCompleted" || event.type === "TurnFailed"
+
+// turnTerminalOf returns the terminal in the active execution epoch.
+export const turnTerminalOf = (log: ReadonlyArray<Event>, turn: string): Event | undefined => {
+  const epoch = turnEpochOf(log, turn)
+  return log.find((event) => isTerminal(event) && turnOf(event) === turn && eventEpochOf(event) === epoch)
+}
+
+const activeStamped = (log: ReadonlyArray<Event>, turn: string): ReadonlyArray<Event> => {
+  const epoch = turnEpochOf(log, turn)
+  return stamped(log, turn).filter((event) => !isTerminal(event) || eventEpochOf(event) === epoch)
+}
 
 // claimedByPark: a reply an open package call was awaiting when it landed belongs to that call,
 // never to a fresh turn of its own; the awaiting body harvests it, and nothing else may react
@@ -45,21 +68,25 @@ const heads = (log: ReadonlyArray<Event>): ReadonlyArray<Event> =>
 
 // turnHead returns the current turn's head: the earliest message with no stamped terminal.
 export const turnHead = (log: ReadonlyArray<Event>): Event | undefined =>
-  heads(log).find((h) => !hasStamped(log, idOf(h), ["TurnCompleted", "TurnFailed"]))
+  heads(log).find((head) => turnTerminalOf(log, idOf(head)) === undefined)
 
 // turnView returns the current turn's slice: its head plus its stamped events, in log order.
 export const turnView = (log: ReadonlyArray<Event>): ReadonlyArray<Event> => {
   const head = turnHead(log)
-  return head === undefined ? [] : [head, ...stamped(log, idOf(head))]
+  return head === undefined ? [] : [head, ...activeStamped(log, idOf(head))]
 }
 
 // replyView returns the turn owed a reply: terminal stamped, reply not.
 export const replyView = (log: ReadonlyArray<Event>): ReadonlyArray<Event> => {
   const head = heads(log).find(
-    (h) =>
-      hasStamped(log, idOf(h), ["TurnCompleted", "TurnFailed"]) && !hasStamped(log, idOf(h), ["ReplyDelivered"])
+    (candidate) => {
+      const turn = idOf(candidate)
+      const terminal = turnTerminalOf(log, turn)
+      if (terminal === undefined) return false
+      return !log.some((event) => event.type === "ReplyDelivered" && turnOf(event) === turn)
+    }
   )
-  return head === undefined ? [] : [head, ...stamped(log, idOf(head))]
+  return head === undefined ? [] : [head, ...activeStamped(log, idOf(head))]
 }
 
 // trajectoryOf is the model's projection: turns in service order, each head just before its
@@ -73,6 +100,7 @@ export const trajectoryOf = (log: ReadonlyArray<Event>): ReadonlyArray<Event> =>
   for (const e of log) {
     if (e.type === "MessageReceived") continue
     const turn = turnOf(e)
+    if (turn !== undefined && isTerminal(e) && eventEpochOf(e) !== turnEpochOf(log, turn)) continue
     if (turn !== undefined && !emitted.has(turn)) {
       const head = byId.get(turn)
       if (head !== undefined) out.push(head)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
     "!src/**/*.test.ts"
   ],
   "engines": {
-    "bun": ">=1.3.0"
+    "bun": ">=1.4.0"
   },
   "type": "module",
   "exports": {

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+import { MINIMUM_BUN_VERSION, assertSupportedBun, supportsBunVersion } from "./runtime"
+
+describe("Bun compatibility", () => {
+  test("the supported range starts at Bun 1.4", () => {
+    expect(MINIMUM_BUN_VERSION).toBe("1.4.0")
+    expect(supportsBunVersion("1.3.14")).toBe(false)
+    expect(supportsBunVersion("1.4.0-canary.1")).toBe(true)
+    expect(supportsBunVersion("1.4.1")).toBe(true)
+    expect(supportsBunVersion("unknown")).toBe(false)
+  })
+
+  test("the runtime check names the installed and required versions", () => {
+    expect(() => assertSupportedBun("1.3.1")).toThrow("Tardigrade requires Bun 1.4.0 or later. Found Bun 1.3.1.")
+    expect(() => assertSupportedBun("1.4.0")).not.toThrow()
+  })
+})

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1,0 +1,30 @@
+export const MINIMUM_BUN_VERSION = "1.4.0"
+
+const partsOf = (version: string): readonly [number, number, number] | undefined => {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version)
+  if (match === null) return undefined
+  return [Number(match[1]), Number(match[2]), Number(match[3])]
+}
+
+// supportsBunVersion reports whether a Bun version includes the required transport behavior.
+export const supportsBunVersion = (version: string): boolean => {
+  const actual = partsOf(version)
+  const minimum = partsOf(MINIMUM_BUN_VERSION)!
+  if (actual === undefined) return false
+  for (let i = 0; i < minimum.length; i++) {
+    if (actual[i]! > minimum[i]!) return true
+    if (actual[i]! < minimum[i]!) return false
+  }
+  return true
+}
+
+const detectedBunVersion = (): string | undefined => {
+  const version = (globalThis as { Bun?: { version?: unknown } }).Bun?.version
+  return typeof version === "string" ? version : undefined
+}
+
+// assertSupportedBun rejects Bun releases with the five-minute fetch idle deadline.
+export const assertSupportedBun = (version: string | undefined = detectedBunVersion()): void => {
+  if (version === undefined || supportsBunVersion(version)) return
+  throw new Error(`Tardigrade requires Bun ${MINIMUM_BUN_VERSION} or later. Found Bun ${version}. Upgrade Bun before starting Tardigrade.`)
+}

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -22,7 +22,7 @@
     "!src/**/*.test.ts"
   ],
   "engines": {
-    "bun": ">=1.3.0"
+    "bun": ">=1.4.0"
   },
   "type": "module",
   "exports": {

--- a/platform/bun/package.json
+++ b/platform/bun/package.json
@@ -22,7 +22,7 @@
     "!src/**/*.test.ts"
   ],
   "engines": {
-    "bun": ">=1.3.0"
+    "bun": ">=1.4.0"
   },
   "type": "module",
   "exports": {

--- a/platform/bun/src/host.ts
+++ b/platform/bun/src/host.ts
@@ -4,6 +4,7 @@ import { SqlClient } from "effect/unstable/sql"
 import { SqliteClient } from "@effect/sql-sqlite-bun"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { EventLog } from "@clavia/tardigrade-core/event-log"
+import { assertSupportedBun } from "@clavia/tardigrade-core/runtime"
 import { Router, type CallResult } from "@clavia/tardigrade-core/router"
 import { Self, restingActor, settleActor, type Actor } from "@clavia/tardigrade-core/actor"
 import { deadlocks, victimOf, type EdgesOf } from "@clavia/tardigrade-host/deadlock"
@@ -82,6 +83,7 @@ const laneOf = (address: string): string => {
 const REFUSED: CallResult = { error: "this host takes no synchronous calls" }
 
 export const createBunHost = async <R = never>(options: BunHostOptions<R>): Promise<BunHost> => {
+  assertSupportedBun()
   const principal = options.principal ?? "bun"
   // The workspace is built with the runtime and over the same client, so its table is created once
   // and every lane spills through the connection the log already holds.

--- a/platform/bun/src/runtime.test.ts
+++ b/platform/bun/src/runtime.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+
+test("a numeric fetch deadline extends Bun's socket idle deadline", async () => {
+  const server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch: async () => {
+      await Bun.sleep(10_000)
+      return new Response("ok")
+    }
+  })
+
+  try {
+    const script = `const response = await fetch(${JSON.stringify(server.url.toString())}, { timeout: 20000 }); process.stdout.write(await response.text())`
+    const child = Bun.spawn([process.execPath, "-e", script], {
+      env: { ...process.env, BUN_CONFIG_HTTP_IDLE_TIMEOUT: "1" },
+      stdout: "pipe",
+      stderr: "pipe"
+    })
+    const [exit, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text()
+    ])
+
+    expect({ exit, stdout, stderr }).toEqual({ exit: 0, stdout: "ok", stderr: "" })
+  } finally {
+    server.stop(true)
+  }
+}, 15_000)

--- a/platform/model/package.json
+++ b/platform/model/package.json
@@ -22,7 +22,7 @@
     "!src/**/*.test.ts"
   ],
   "engines": {
-    "bun": ">=1.3.0"
+    "bun": ">=1.4.0"
   },
   "type": "module",
   "exports": {
@@ -33,6 +33,7 @@
     "@clavia/tardigrade": "workspace:*",
     "@aws-sdk/client-bedrock-runtime": "^3.1079.0",
     "@smithy/fetch-http-handler": "^5.6.3",
+    "@smithy/node-http-handler": "^4.11.2",
     "@tanstack/ai": "0.46.0",
     "@tanstack/ai-bedrock": "0.2.3",
     "@tanstack/ai-openai": "0.20.0",

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -179,7 +179,7 @@ describe("infer: cost provenance", () => {
             apiKey: "k",
             model: "test-model",
             provider: "openai",
-                  pricing: table,
+            pricing: table,
             fetch: (async () => sse([...okText, usageChunk({ prompt_tokens: 10, completion_tokens: 4, cost: 0 })])) as unknown as typeof globalThis.fetch
           })
         )
@@ -206,7 +206,7 @@ describe("infer: cost provenance", () => {
             apiKey: "k",
             model: "test-model",
             provider: "openai",
-                  pricing: table,
+            pricing: table,
             fetch: (async () => sse([...okText, usageChunk({ prompt_tokens: 10, completion_tokens: 4 })])) as unknown as typeof globalThis.fetch
           })
         )
@@ -228,7 +228,7 @@ describe("infer: cost provenance", () => {
             baseUrl: "https://model.test/v1",
             apiKey: "k",
             model: "test-model",
-                  fetch: (async () => sse(okText)) as unknown as typeof globalThis.fetch
+            fetch: (async () => sse(okText)) as unknown as typeof globalThis.fetch
           })
         )
       ) as Effect.Effect<Action>
@@ -237,10 +237,9 @@ describe("infer: cost provenance", () => {
   })
 })
 
-// A throttle-shaped failure (429, 5xx, a stream timeout) retries inside the one act, so the
-// give-up fold in src/agent/infer.ts only ever counts a died attempt when the retries themselves
-// are exhausted. `sleep` is the test seam that swaps the real backoff wait for an instant one, so
-// these run in milliseconds instead of tens of seconds.
+// A throttle-shaped failure (429, 5xx, a stream timeout) retries inside the one act. Exhaustion
+// returns a failed action that the agent records as a resumable terminal. `sleep` is the test seam
+// that swaps the real backoff wait for an instant one, so these run in milliseconds.
 describe("infer: throttle-shaped retry", () => {
   const okStream = () =>
     sse([
@@ -277,7 +276,7 @@ describe("infer: throttle-shaped retry", () => {
     expect(slept[0]).toBeLessThan(2_000)
   })
 
-  test("retries exhaust after the bounded set (three), and the fourth failure still surfaces", async () => {
+  test("retries exhaust after the bounded set and report the effective policy", async () => {
     let calls = 0
     const fetchImpl = (async () => {
       calls += 1
@@ -294,13 +293,23 @@ describe("infer: throttle-shaped retry", () => {
         return Promise.resolve()
       }
     })
-    await expect(
-      Effect.runPromise(
-        Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
-          Effect.provide(layer)
-        ) as Effect.Effect<unknown>
-      )
-    ).rejects.toBeTruthy()
+    const action = await Effect.runPromise(
+      Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
+        Effect.provide(layer)
+      ) as Effect.Effect<Action>
+    )
+    expect(action).toMatchObject({
+      kind: "fail",
+      error: expect.stringContaining("retries exhausted after 4 attempts"),
+      failure: {
+        cause: "inference_attempts_exhausted",
+        attempts: 4,
+        policy: {
+          throttleRetryDelaysMs: [2_000, 8_000, 30_000],
+          stream: { firstChunkMs: 90_000, idleMs: 90_000, totalMs: 300_000 }
+        }
+      }
+    })
     // Four tries total: the first, plus one retry per configured backoff base.
     expect(calls).toBe(4)
     expect(slept).toHaveLength(3)
@@ -323,15 +332,44 @@ describe("infer: throttle-shaped retry", () => {
         return Promise.resolve()
       }
     })
-    await expect(
-      Effect.runPromise(
-        Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
-          Effect.provide(layer)
-        ) as Effect.Effect<unknown>
-      )
-    ).rejects.toBeTruthy()
+    const action = await Effect.runPromise(
+      Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
+        Effect.provide(layer)
+      ) as Effect.Effect<Action>
+    )
+    expect(action).toMatchObject({
+      kind: "fail",
+      error: expect.stringContaining("failed after 1 attempt"),
+      failure: { cause: "inference_error", attempts: 1 }
+    })
     expect(calls).toBe(1)
     expect(slept).toHaveLength(0)
+  })
+
+  test("Bun's timed-out wording enters the bounded retry policy", async () => {
+    let calls = 0
+    const layer = infer({
+      baseUrl: "https://model.test/v1",
+      apiKey: "k",
+      model: "test-model",
+      fetch: (() => {
+        calls += 1
+        return Promise.reject(new Error("AbortError: The operation timed out"))
+      }) as unknown as typeof globalThis.fetch,
+      throttleRetryDelaysMs: [0],
+      sleep: () => Promise.resolve()
+    })
+
+    const action = await Effect.runPromise(
+      Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
+        Effect.provide(layer)
+      ) as Effect.Effect<Action>
+    )
+    expect(action).toMatchObject({
+      kind: "fail",
+      failure: { cause: "inference_attempts_exhausted", attempts: 2 }
+    })
+    expect(calls).toBe(2)
   })
 })
 
@@ -374,7 +412,7 @@ describe("retry-after", () => {
     expect(retryAfterMsOf({}, NOW)).toBeUndefined()
   })
 
-  test("a stated wait within the ceiling is honored; past it, the attempt dies", () => {
+  test("a stated wait within the ceiling is honored; past it, retries stop", () => {
     const stated = throttleDelayMs({ headers: { "retry-after": "7" } }, 0, NOW)
     expect(stated).toBeGreaterThanOrEqual(7_000)
     expect(stated).toBeLessThan(8_000)
@@ -488,7 +526,7 @@ describe("truncation", () => {
             apiKey: "k",
             model: "meta-llama/llama-3.1-70b",
             provider: "openrouter",
-                  fetch: (async () =>
+            fetch: (async () =>
               sse([
                 { id: "r", provider: "DeepInfra", model: "meta-llama/llama-3.1-70b-instruct", choices: [{ index: 0, delta: { role: "assistant", content: "ok" } }] },
                 { id: "r", provider: "DeepInfra", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
@@ -528,17 +566,19 @@ describe("truncation", () => {
         model: "m",
         baseUrl: "https://x",
         apiKey: "k",
-          fetch: fetchImpl as never,
+        fetch: fetchImpl as never,
         throttleRetryDelaysMs: [0],
         sleep: () => Promise.resolve()
       })
-      await expect(
-        Effect.runPromise(
-          Effect.flatMap(Infer, (i) => i.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
-            Effect.provide(layer)
-          ) as Effect.Effect<unknown>
-        )
-      ).rejects.toBeTruthy()
+      const action = await Effect.runPromise(
+        Effect.flatMap(Infer, (i) => i.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
+          Effect.provide(layer)
+        ) as Effect.Effect<Action>
+      )
+      expect(action).toMatchObject({
+        kind: "fail",
+        failure: { cause: "inference_attempts_exhausted", attempts: 2 }
+      })
       await Promise.resolve()
       expect(leaked).toEqual([])
     } finally {
@@ -556,20 +596,31 @@ describe("declared limits", () => {
     expect(ladderOf(16_384)).toEqual([16_384])
   })
 
-  test("the compatible leg states its ceiling on the wire", async () => {
+  test("the compatible leg states its ceiling and request timeout on the wire", async () => {
     let body: { max_tokens?: number } | undefined
+    let timeout: unknown
     const fetchImpl = (async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
       const request = input instanceof Request ? input : new Request(String(input), init)
       body = JSON.parse(await request.text()) as { max_tokens?: number }
+      timeout = (init as (RequestInit & { timeout?: number }) | undefined)?.timeout
       return new Response('data: {"choices":[{"delta":{"content":"ok"},"index":0}]}\n\ndata: {"choices":[{"delta":{},"finish_reason":"stop","index":0}]}\n\ndata: [DONE]\n\n', {
         status: 200,
         headers: { "content-type": "text/event-stream" }
       })
     }) as unknown as typeof fetch
-    const layer = infer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", maxOutputTokens: 16_384, fetch: fetchImpl as never })
+    const layer = infer({
+      provider: "openai",
+      model: "m",
+      baseUrl: "https://x",
+      apiKey: "k",
+      maxOutputTokens: 16_384,
+      stream: { totalMs: 600_000 },
+      fetch: fetchImpl as never
+    })
     await Effect.runPromise(
       Effect.flatMap(Infer, (i) => i.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(Effect.provide(layer)) as Effect.Effect<unknown>
     )
     expect(body?.max_tokens).toBe(16_384)
+    expect(timeout).toBe(600_000)
   })
 })

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -7,15 +7,16 @@ import { BedrockConverseTextAdapter, type BEDROCK_CONVERSE_MODELS } from "@tanst
 import { Infer, type InferRequest } from "@clavia/tardigrade/infer"
 import type { Action } from "@clavia/tardigrade/events"
 import type { Event } from "@clavia/tardigrade-core/event"
+import { assertSupportedBun } from "@clavia/tardigrade-core/runtime"
 import { answerErrors, outputSchemaOf } from "@clavia/tardigrade/contract"
 import { modelRequest, type AgentMessage, type ToolSpec } from "@clavia/tardigrade/request"
 import { sumUsage, usageFrom, type ModelPricing, type Usage } from "@clavia/tardigrade/usage"
 
 // The real model binding: one inference per react, streamed through a TanStack adapter and
 // decoded by their StreamProcessor. The reactors never learn this layer exists. Resilience is
-// layered: the stream bounds below catch a hung provider inside the call, the platform's 30s
-// liveness alarm catches a hung binding, and the marks-and-give-up fold bounds the retries. A
-// thrown attempt here is an attempt that died, and the next settle retries it.
+// layered: the stream bounds below catch a hung provider inside the call, and the retry ladder
+// bounds transient provider failures. Exhaustion returns a failed action with its policy and
+// attempt count, so the turn records one resumable `TurnFailed` terminal.
 
 export interface ModelEnv {
   readonly MODEL_BASE_URL?: string // OpenAI-compat endpoint, or the gateway's bedrock-runtime URL
@@ -55,7 +56,7 @@ export const modelAskOf = (trajectory: ReadonlyArray<Event>): string | undefined
 }
 
 // StreamBounds is time to first chunk, idle between chunks, and the whole stream. Each timeout
-// throws; the attempt dies and the marks count it (v5's stream-idle lesson).
+// enters the bounded provider retry policy (model.test.ts, "throttle-shaped retry").
 export interface StreamBounds {
   readonly firstChunkMs: number
   readonly idleMs: number
@@ -124,7 +125,7 @@ const toTool = (t: ToolSpec): Tool => ({
 })
 
 // The decode: the processed stream becomes one Action. A tool call acts; plain text completes;
-// nothing at all is a failed attempt (thrown, so the marks count it and the settle retries).
+// an empty response enters the provider failure path.
 export const actionOf = (result: ProcessorResult, schema?: unknown): Action => {
   const calls = result.toolCalls ?? []
   const text = (result.content ?? "").trim()
@@ -198,17 +199,10 @@ export interface ModelConfig {
   readonly sleep?: (ms: number) => Promise<void> // test seam: swap the backoff wait for an instant one
 }
 
-// Throttle-shaped failures die fast under fan-out: many agents firing at once trip the gateway's
-// rate limit, and three back-to-back attempts with no wait between them exhaust
-// infer's give-up ceiling (`inferReactorFor`) before the throttle even clears. `inferMachine`'s
-// attempt/give-up fold has no notion of time: settleActor (src/core/actor.ts) re-serves owed
-// work on the very next event, and a delayed re-serve would need the lane to rest until an
-// alarm keyed off the attempt count wakes it — a real change to the reactor
-// framework's vocabulary, not a local one. The seam that IS local and honest: retry the
-// throttle-shaped failure inside this one act, before it ever becomes a died mark, so the
-// attempt counter only counts failures that were not a gateway saying "slow down". Retries stay
-// bounded (the configured delay list's length) so a genuinely wedged provider still
-// dies and gives up in time.
+// Throttle-shaped failures need delayed retries because fan-out can trip a gateway's rate limit.
+// The reactor has no timer vocabulary, so the model binding owns these waits inside one act.
+// The configured delay list bounds the retries. Exhaustion returns a failed action with the
+// effective policy, which lets the turn record a resumable terminal.
 //
 // The openai SDK client `chatStream` runs on (`@tanstack/openai-base`) throws its `APIError`
 // subclasses with a numeric `.status`: 429 is the gateway's rate limit, 5xx is its own upstream
@@ -221,7 +215,7 @@ const isThrottleShaped = (e: unknown): boolean => {
   const status = typeof err.status === "number" ? err.status : typeof err.statusCode === "number" ? err.statusCode : undefined
   if (status === 429 || (status !== undefined && status >= 500)) return true
   const message = String(err.message ?? e)
-  return /\b429\b|rate.?limit|too many requests|\b5\d\d\b|timeout|idle beyond bound|exceeded its total bound|no first chunk within bound|ECONNRESET|ETIMEDOUT|EAI_AGAIN/i.test(
+  return /\b429\b|rate.?limit|too many requests|\b5\d\d\b|timeout|timed?\s*out|idle beyond bound|exceeded its total bound|no first chunk within bound|ECONNRESET|ETIMEDOUT|EAI_AGAIN/i.test(
     message
   )
 }
@@ -259,8 +253,7 @@ export const retryAfterMsOf = (e: unknown, now: number): number | undefined => {
 // throttleDelayMs decides one in-flight wait: the provider's stated Retry-After when it fits
 // the ladder's own ceiling (plus up to a second of jitter, so a herd released together does not
 // re-trip the limit), the jittered ladder otherwise, and undefined for a stated wait past the
-// ceiling: holding a turn open longer than the ladder ever would is worse than dying, and a
-// died attempt's mark lets the platform alarm re-drive after the queue clears.
+// ceiling. A stated wait past the ceiling ends the bounded retry set.
 export const throttleDelayMs = (
   e: unknown,
   attempt: number,
@@ -310,14 +303,44 @@ const isTruncated = (e: unknown): e is TruncatedError =>
 // authorization header is stripped; `cf-aig-authorization` carries our token, the gateway holds
 // the AWS credential), and the dynamic SDK import is resolved statically because wrangler's
 // esbuild cannot follow the adapter's indirection on workerd.
-const bedrockAdapter = (config: ModelConfig, maxTokens: number) => {
-  const handler = new (class extends FetchHttpHandler {
-    override async handle(request: Parameters<FetchHttpHandler["handle"]>[0], handlerOptions?: Parameters<FetchHttpHandler["handle"]>[1]) {
-      request.headers = Object.fromEntries(Object.entries(request.headers).filter(([k]) => k.toLowerCase() !== "authorization"))
+type SmithyHandler = Pick<FetchHttpHandler, "handle" | "destroy">
+
+// bedrockHandler selects a transport that can enforce the configured stream bounds. Bun's
+// fetch transport cannot carry a numeric deadline through Smithy's Request object, while
+// workerd cannot use the Node transport.
+const bedrockHandler = (config: ModelConfig, bounds: StreamBounds): SmithyHandler => {
+  const transport: Promise<SmithyHandler> =
+    (globalThis as { Bun?: unknown }).Bun === undefined
+      ? Promise.resolve(new FetchHttpHandler({ requestTimeout: bounds.totalMs }))
+      : (() => {
+          const moduleName = "@smithy/node-http-handler"
+          return (import(/* @vite-ignore */ moduleName) as Promise<typeof import("@smithy/node-http-handler")>).then(
+            ({ NodeHttpHandler: Handler }) =>
+              new Handler({
+                connectionTimeout: bounds.firstChunkMs,
+                socketTimeout: bounds.idleMs,
+                requestTimeout: bounds.totalMs,
+                throwOnRequestTimeout: true
+              })
+          )
+        })()
+
+  return {
+    handle: async (request, handlerOptions) => {
+      request.headers = Object.fromEntries(
+        Object.entries(request.headers).filter(([key]) => key.toLowerCase() !== "authorization")
+      )
       request.headers["cf-aig-authorization"] = `Bearer ${config.apiKey}`
-      return super.handle(request, handlerOptions)
+      return (await transport).handle(request, handlerOptions)
+    },
+    destroy: () => {
+      void transport.then((handler) => handler.destroy()).catch(() => undefined)
     }
-  })()
+  }
+}
+
+const bedrockAdapter = (config: ModelConfig, maxTokens: number, bounds: StreamBounds) => {
+  const handler = bedrockHandler(config, bounds)
   const region = config.baseUrl.split("/").filter((s) => s !== "").at(-1) ?? "us-east-1"
   return new (class extends BedrockConverseTextAdapter<(typeof BEDROCK_CONVERSE_MODELS)[number]> {
     protected override importBedrockRuntime(): Promise<typeof BedrockRuntime> {
@@ -430,11 +453,13 @@ const captureWire = async (reader: BodyReader): Promise<Wire | undefined> => {
 const withCapture = (
   base: FetchImpl | undefined,
   key: string | undefined,
+  timeoutMs: number,
   sink: { promise: Promise<Wire | undefined>; reader?: BodyReader }
 ): FetchImpl => {
   const inner = withKey(base, key) ?? ((input, init) => globalThis.fetch(input, init))
   return async (input, init) => {
-    const res = await inner(input, init)
+    const timed = { ...init, timeout: timeoutMs } as NonNullable<Parameters<FetchImpl>[1]>
+    const res = await inner(input, timed)
     if (res.body === null) return res
     const [live, copy] = res.body.tee()
     const reader = copy.getReader()
@@ -481,6 +506,7 @@ const spentOf = (parts: ReadonlyArray<Usage>, missed: boolean): Usage | undefine
 }
 
 export const infer = (config: ModelConfig) => {
+  assertSupportedBun()
   const sleep = config.sleep ?? realSleep
   const bounds: StreamBounds = {
     firstChunkMs: config.stream?.firstChunkMs ?? DEFAULT_STREAM_BOUNDS.firstChunkMs,
@@ -488,21 +514,21 @@ export const infer = (config: ModelConfig) => {
     totalMs: config.stream?.totalMs ?? DEFAULT_STREAM_BOUNDS.totalMs
   }
   const throttleDelays = config.throttleRetryDelaysMs ?? DEFAULT_THROTTLE_RETRY_DELAYS_MS
+  const failurePolicy = { throttleRetryDelaysMs: throttleDelays, stream: bounds }
   const attemptOnce = async (request: InferRequest, key: string | undefined, maxTokens: number, rung: number, stats: { finish?: string }): Promise<Action> => {
     // A changed ceiling is a different request, so it mints a different idempotency key: a
     // provider that dedups would otherwise answer the escalated retry with the cached truncated
-     // response, and the ladder would climb nowhere (the removed driver learned this).
-     // Rung zero keeps the bare key, so crash-retries of the same request still
-    // collapse.
+    // response, and the ladder would climb nowhere (the removed driver learned this). Rung zero
+    // keeps the bare key, so crash-retries of the same request still collapse.
     const keyForRung = key === undefined ? undefined : rung === 0 ? key : `${key}/mt${maxTokens}`
     const sink: { promise: Promise<Wire | undefined>; reader?: BodyReader } = {
       promise: Promise.resolve(undefined)
     }
     const held: { tokens?: { readonly promptTokens: number; readonly completionTokens: number; readonly cost?: number } } = {}
-    const fetcher = withCapture(config.fetch, keyForRung, sink)
+    const fetcher = withCapture(config.fetch, keyForRung, bounds.totalMs, sink)
     const adapter =
       config.provider === "bedrock"
-        ? bedrockAdapter(config, maxTokens)
+        ? bedrockAdapter(config, maxTokens, bounds)
         : openaiCompatibleText(config.model, {
             name: "tardigrade",
             baseURL: config.baseUrl,
@@ -557,7 +583,11 @@ export const infer = (config: ModelConfig) => {
     react: (request: InferRequest, key?: string) =>
       Effect.gen(function* () {
         const ladder = ladderOf(config.maxOutputTokens, config.maxTokensLadder)
-        const stats: { finish?: string; rung: number; waits: number } = { rung: 0, waits: 0 }
+        const stats: { finish?: string; rung: number; waits: number; attempts: number } = {
+          rung: 0,
+          waits: 0,
+          attempts: 0
+        }
         const action = yield* Effect.promise<Action>(async () => {
         let rung = 0
         const parts: Usage[] = []
@@ -569,6 +599,7 @@ export const infer = (config: ModelConfig) => {
         for (let attempt = 0; ; attempt++) {
           try {
             stats.rung = rung
+            stats.attempts += 1
             const action = await attemptOnce(request, key, ladder[rung]!, rung, stats)
             remember(action.usage, true)
             return withSpend(action, spentOf(parts, missed))
@@ -590,9 +621,33 @@ export const infer = (config: ModelConfig) => {
                 spentOf(parts, missed)
               )
             }
-            if (!isThrottleShaped(e)) throw e
+            if (!isThrottleShaped(e)) {
+              const message = e instanceof Error ? e.message : String(e)
+              return withSpend(
+                {
+                  kind: "fail",
+                  error: `model inference failed after ${stats.attempts} attempt${stats.attempts === 1 ? "" : "s"}: ${message}`,
+                  failure: { cause: "inference_error", attempts: stats.attempts, policy: failurePolicy }
+                },
+                spentOf(parts, missed)
+              )
+            }
             const delay = throttleDelayMs(e, attempt, Date.now(), throttleDelays)
-            if (delay === undefined) throw e
+            if (delay === undefined) {
+              const message = e instanceof Error ? e.message : String(e)
+              return withSpend(
+                {
+                  kind: "fail",
+                  error: `model inference retries exhausted after ${stats.attempts} attempt${stats.attempts === 1 ? "" : "s"}: ${message}`,
+                  failure: {
+                    cause: "inference_attempts_exhausted",
+                    attempts: stats.attempts,
+                    policy: failurePolicy
+                  }
+                },
+                spentOf(parts, missed)
+              )
+            }
             stats.waits += 1
             await sleep(delay)
           }
@@ -603,6 +658,7 @@ export const infer = (config: ModelConfig) => {
         yield* Effect.annotateCurrentSpan("gen_ai.response.finish_reasons", [stats.finish ?? "unknown"])
         yield* Effect.annotateCurrentSpan("retry.rung", stats.rung)
         yield* Effect.annotateCurrentSpan("retry.throttle_waits", stats.waits)
+        yield* Effect.annotateCurrentSpan("retry.attempts", stats.attempts)
         if (action.usage !== undefined) {
           // The usage stamp may carry wire-reported provenance; the span follows the same rule.
           if (action.usage.provider !== undefined) {


### PR DESCRIPTION
## Summary

This change makes long provider calls and failed turns recoverable. It requires Bun 1.4 for the repaired socket deadline behavior, carries the configured model deadline into each transport, and retries transient failures with a visible configurable policy.

A failed inference now records its cause, attempt count, logical attempt key, and effective policy on `TurnFailed`. An operator can resume that same turn in a new execution epoch. The existing failure remains in the log, committed tool results remain reusable, and the new model request excludes the superseded terminal.

The change also restores the publishable agent manifest and removes the generated agent changelog.

## Recovery behavior

- The default provider policy retries after 2, 8, and 30 seconds. Callers can replace the list or disable retries.
- OpenAI-compatible calls send the configured deadline and logical idempotency key.
- Bedrock uses a Bun-safe transport with configured connection, socket, and request bounds.
- `TurnResumed` records the operator command that opens the next epoch. `TurnFailed` remains the failure terminal.
- Resume does not repeat committed tool effects or redeliver the original reply.

## Verification

- `bun run gate`
- `bun run pack`
