### PR TITLE
docs: fix statecharts link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A durable and modular agent harness built for self-improvement.
 ### A harness made for self-improvement
 As models get increasingly smart, they will be capable of writing their own harnesses to improve themselves ([Meta-Harness](https://arxiv.org/abs/2603.28052)). A harness that is too rigid and complex is a hindrance to this. We need something more composable, and easy to author.
 
-We took inspiration from React. React derives the component tree as a function of state (`UI = f(state)`). Similarly, Tardigrade defines the harness as a set of state transitions derived from the event log, an idea with roots in [Harel's statecharts](https://www.wisdom.weizmann.ac.il/~harel/papers/Statecharts.pdf).
+We took inspiration from React. React derives the component tree as a function of state (`UI = f(state)`). Similarly, Tardigrade defines the harness as a set of state transitions derived from the event log, an idea with roots in [Harel's statecharts](https://www.sciencedirect.com/science/article/pii/0167642387900359).
 
 $$\lbrace\mathrm{transitions}\rbrace = f(\mathrm{log})$$
 


### PR DESCRIPTION
The readme's statecharts citation pointed at a PDF on Harel's university site that now redirects to his profile page. Point it at the publisher's article page instead (Science of Computer Programming, 1987), which resolves and identifies the paper.

- swap the Harel citation URL to the ScienceDirect article page
- bun run gate --only=lint:docs is green