### PR TITLE
feat(code): type package requirements

### DIFF
--- a/packages/code/src/execute.test.ts
+++ b/packages/code/src/execute.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import { Effect, Layer, Ref } from "effect"
+import { Context, Effect, Layer, Ref } from "effect"
 import { KeyValueStore } from "effect/unstable/persistence"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { composeKeys, EventLog, withWatermark } from "@clavia/tardigrade-core/event-log"
 import { settleActor } from "@clavia/tardigrade-core/actor"
 import { messageKeys } from "@clavia/tardigrade-core/message"
-import { Packages, type Package } from "./packages"
+import { Packages, type Package, type PackagesService } from "./packages"
 import { Sandbox, type Bindings } from "./sandbox"
 import { codeReactor, codeReactorFor } from "./execute"
 import { codeKeys } from "./events"
@@ -238,5 +238,67 @@ describe("the spill bound", () => {
     const whole = (await drive(codeReactor)).find((e) => e.type === "CodeSettled") as { tmp?: string; result?: unknown }
     expect(whole.tmp).toBeUndefined()
     expect(whole.result).toBe("q".repeat(60))
+  })
+})
+
+describe("a package's requirements ride its type", () => {
+  // A package that reaches for a service names it in its type, and the reactor that runs the
+  // package declares the same requirement, so the environment that drives the lane must provide
+  // it. The funnel is what makes this true at run time: every method runs under the attempt's own
+  // context (execute.ts, executeRecorded).
+  class Ticker extends Context.Service<Ticker, string>()("code/test/Ticker") {}
+
+  const tickerPackage: Package<Ticker> = {
+    name: "ticker",
+    description: "answers with the value the environment bound",
+    annotations: { now: { readOnlyHint: true, openWorldHint: false } },
+    methods: {
+      now: () =>
+        Effect.gen(function* () {
+          return { tick: yield* Ticker }
+        })
+    }
+  }
+
+  const tickerRegistry: PackagesService<Ticker> = {
+    resolve: (name: string) => (name === "ticker" ? tickerPackage : undefined),
+    list: () => Effect.succeed([{ name: "ticker", description: tickerPackage.description }])
+  }
+
+  test("a package method reads its service through the funnel", async () => {
+    const log: Event[] = [
+      { type: "MessageReceived", id: "t1", text: "go", at: 1 },
+      { type: "CodeDispatched", execId: "e1", code: "return await ticker.now({})", turn: "t1", at: 2 }
+    ]
+    const events = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* settleActor({ reactors: [codeReactorFor<Ticker>()], keyOf: composeKeys(messageKeys, codeKeys) })
+        return yield* Effect.flatMap(EventLog, (l) => l.read)
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            memoryLog(log),
+            Layer.succeed(Packages, tickerRegistry),
+            jsSandbox,
+            KeyValueStore.layerMemory,
+            Layer.succeed(Ticker, "bound")
+          )
+        )
+      ) as Effect.Effect<ReadonlyArray<Event>>
+    )
+    const settle = events.find((e) => e.type === "CodeSettled") as { result?: { tick?: string }; error?: string }
+    expect(settle.error).toBeUndefined()
+    // The value the environment bound, carried into the method's own effect by the attempt's
+    // context: the requirement is real work, not a phantom type parameter.
+    expect(settle.result?.tick).toBe("bound")
+  })
+
+  test("a registry the powerless reactor can run refuses a package that names a service", () => {
+    // codeReactorFor at its default R promises an environment of KeyValueStore alone, so the
+    // registry it runs is a PackagesService<never>. A package whose method reaches for Ticker has
+    // nowhere to read it from there, and the type says so before anything runs.
+    // @ts-expect-error a Package<Ticker> is not a Package<never>
+    const powerless: PackagesService<never> = tickerRegistry
+    expect(powerless.resolve("ticker")?.name).toBe("ticker")
   })
 })

--- a/packages/code/src/execute.ts
+++ b/packages/code/src/execute.ts
@@ -4,7 +4,7 @@ import { EventLog } from "@clavia/tardigrade-core/event-log"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { transition, type Reactor } from "@clavia/tardigrade-core/actor"
 import { workOwed } from "./projections"
-import { annotationsOf, Packages } from "./packages"
+import { annotationsOf, Packages, type PackagesService } from "./packages"
 import { checkInput, renderSignature } from "./contract"
 import { Sandbox, type Bindings } from "./sandbox"
 import { turnHead, turnOf } from "./turns"
@@ -32,13 +32,13 @@ type CallOutcome = { readonly parked: true } | { readonly parked: false; readonl
 // (callId, src/grammar/grammar.ts); a committed answer replays, an uncommitted call runs live
 // and records its pair before the body continues. A parked call records no pair: the next
 // attempt asks again.
-const executeRecorded = (
+const executeRecorded = <R = never>(
   execId: string,
   code: string,
   spill: SpillPolicy,
   turn?: string,
   dispatchedAt?: number
-): Effect.Effect<ReadonlyArray<Event>, never, EventLog | KeyValueStore.KeyValueStore> =>
+): Effect.Effect<ReadonlyArray<Event>, never, EventLog | KeyValueStore.KeyValueStore | R> =>
   Effect.gen(function* () {
     const stamp = turn === undefined ? {} : { turn }
     const log = yield* EventLog
@@ -46,12 +46,17 @@ const executeRecorded = (
     // The shadow reading rides the turn's own brief, folded once here: it never changes
     // mid-turn, and every package call below reads the same value.
     const shadow = (turnHead(events) as { shadow?: unknown } | undefined)?.shadow === true
-    const packages = yield* Packages
+    // The registry reference is R-erased (packages.ts, Packages). This attempt runs its packages
+    // under `R`, the requirement the reactor declared and the caller provided, so the funnel
+    // reads the registry back at that type.
+    const packages = (yield* Packages) as PackagesService<R>
     const sandbox = yield* Sandbox
     // The proxy runs each call as its own promise, so it carries the attempt's context. The spill
     // store is in it: a call's own hydrate and spill run under the same store the attempt was
-    // provided.
-    const context = yield* Effect.context<KeyValueStore.KeyValueStore>()
+    // provided. So is `R`: a method that reaches for a service reaches into this same context,
+    // which is why the requirement rides the reactor's type (execute.test.ts, "a package method
+    // reads its service through the funnel").
+    const context = yield* Effect.context<KeyValueStore.KeyValueStore | R>()
     let n = 0
     // Park bookkeeping. inFlight counts proxy calls from synchronous invoke to committed pair
     // or park; parkGate completes when every open call settled or parked and at least one
@@ -284,7 +289,13 @@ export interface CodePolicy {
 // a blocked head (open BlockedOn calls, no awaited reply home) derives nothing, so the lane
 // rests honestly and a landing reply re-derives it. An attempt that parks mid-act returns
 // BlockedOn evidence instead of the settle; the reconciler reads that as blocked, never wedged.
-export const codeReactorFor = (policy: Partial<CodePolicy> = {}): Reactor<KeyValueStore.KeyValueStore> => (events) => {
+//
+// `R` is what this lane's packages need beyond the spill store: a reactor over a registry of
+// `Package<R>` declares the same R, so the environment that runs it must provide it
+// (packages.ts, Package). The default is the powerless one.
+export const codeReactorFor = <R = never>(
+  policy: Partial<CodePolicy> = {}
+): Reactor<KeyValueStore.KeyValueStore | R> => (events) => {
   const spill = spillPolicyOf(policy.spill)
   const owed = workOwed(events)
   if (owed === undefined) return []
@@ -296,7 +307,7 @@ export const codeReactorFor = (policy: Partial<CodePolicy> = {}): Reactor<KeyVal
   return [
     transition<
       { execId: string; code: string; turn: string | undefined; at: number | undefined },
-      KeyValueStore.KeyValueStore
+      KeyValueStore.KeyValueStore | R
     >({
       key: `cs:${owed.execId}`,
       input: {
@@ -305,7 +316,7 @@ export const codeReactorFor = (policy: Partial<CodePolicy> = {}): Reactor<KeyVal
         turn: turnOf(dispatch),
         at: typeof d.at === "number" ? d.at : undefined
       },
-      act: (input) => executeRecorded(input.execId, input.code, spill, input.turn, input.at)
+      act: (input) => executeRecorded<R>(input.execId, input.code, spill, input.turn, input.at)
     })
   ]
 }

--- a/packages/code/src/packages.ts
+++ b/packages/code/src/packages.ts
@@ -83,8 +83,10 @@ export const ANNOTATION_DEFAULTS: Required<MethodAnnotations> = {
   openWorldHint: true
 }
 
-// annotationsOf resolves one method's annotations over the dangerous defaults.
-export const annotationsOf = (pkg: Package, method: string): Required<MethodAnnotations> => ({
+// annotationsOf resolves one method's annotations over the dangerous defaults. It reads the name
+// table only, so a package's requirements are irrelevant to it: `unknown` is the shape every
+// `Package<R>` widens to.
+export const annotationsOf = (pkg: Package<unknown>, method: string): Required<MethodAnnotations> => ({
   ...ANNOTATION_DEFAULTS,
   ...pkg.annotations?.[method]
 })
@@ -104,7 +106,12 @@ export const annotationsOf = (pkg: Package, method: string): Required<MethodAnno
 // Inbound delivery, where a provider's webhooks or polls become `MessageReceived`, is
 // deliberately outside Package: it belongs to the host boundary and gets its own concept once a
 // consumer exists.
-export interface Package {
+//
+// `R` is what a package's methods need from the environment, the dual of `Capability<R>` on the
+// model face. A package that reaches for a service names it in its type, and the reactor that
+// runs the package must declare the same requirement (execute.ts, codeReactorFor); a package
+// that reaches for nothing is `Package<never>` and runs anywhere.
+export interface Package<R = never> {
   readonly name: string
   readonly description: string
   // Method docs, two levels: describe({name}) lists names and one-liners; describe({name,
@@ -119,7 +126,7 @@ export interface Package {
   // `tasks.result`) fail it when a reply has not landed yet, and every other method's `never`
   // error is a subtype of it, so nothing else changes shape.
   readonly methods: Readonly<
-    Record<string, (args: unknown, ctx: { readonly callId: string }) => Effect.Effect<unknown, Park>>
+    Record<string, (args: unknown, ctx: { readonly callId: string }) => Effect.Effect<unknown, Park, R>>
   >
 }
 
@@ -127,11 +134,18 @@ export interface Package {
 // must never send messages is bound to a registry that holds no sending package, and the code
 // cannot name what the registry does not hold. The default registry holds nothing, so the
 // unwired case is the powerless one.
-export interface PackagesService {
-  readonly resolve: (name: string) => Package | undefined
+export interface PackagesService<R = never> {
+  readonly resolve: (name: string) => Package<R> | undefined
   readonly list: () => Effect.Effect<ReadonlyArray<{ readonly name: string; readonly description: string }>>
 }
 
-export const Packages: Context.Reference<PackagesService> = Context.Reference("code/Packages", {
-  defaultValue: (): PackagesService => ({ resolve: () => undefined, list: () => Effect.succeed([]) })
+// The reference stands at `unknown`, the widest registry: a Context.Reference carries one type,
+// and `Package<R>` widens to `Package<unknown>` for every R, so a registry of service-needing
+// packages mounts here without a cast. What the packages need is checked at the two ends that
+// can see it: the package value states its own R, and the reactor that runs the registry
+// declares the environment it will run them in (execute.ts, codeReactorFor; the funnel restores
+// the reactor's R over the erased reference). A registry typed at `never` refuses a package that
+// names a service (execute.test.ts, "a package's requirements ride its type").
+export const Packages: Context.Reference<PackagesService<unknown>> = Context.Reference("code/Packages", {
+  defaultValue: (): PackagesService<unknown> => ({ resolve: () => undefined, list: () => Effect.succeed([]) })
 })

--- a/packages/code/src/workspace.test.ts
+++ b/packages/code/src/workspace.test.ts
@@ -7,8 +7,19 @@ import { DEFAULT_WORKSPACE_POLICY, WORKSPACE_SQL_DESCRIPTION, workspacePackage, 
 // The model's view of the store: a bounded slice of one value, a search across all of them, and a
 // sql verb only where a platform bound one.
 
-const call = async (pkg: ReturnType<typeof workspacePackage>, method: string, args: unknown) =>
-  Effect.runPromise(pkg.methods[method]!(args, { callId: "c1" }) as Effect.Effect<Record<string, unknown>>)
+// A method states the store in its type rather than closing over one, so a call binds the store
+// the way the code funnel does: by providing it to the method's own effect (packages.ts, Package).
+const call = async (
+  pkg: ReturnType<typeof workspacePackage>,
+  method: string,
+  args: unknown,
+  store: KeyValueStore.KeyValueStore
+) =>
+  Effect.runPromise(
+    pkg.methods[method]!(args, { callId: "c1" }).pipe(
+      Effect.provideService(KeyValueStore.KeyValueStore, store)
+    ) as Effect.Effect<Record<string, unknown>>
+  )
 
 // A store built straight from the memory layer, seeded through the spill path so the manifest is
 // the one grep reads.
@@ -41,27 +52,27 @@ describe("workspace.read", () => {
   test("a slice never exceeds the cap, whatever length the model asks for", async () => {
     const whole = "x".repeat(DEFAULT_WORKSPACE_POLICY.sliceChars * 2)
     const store = await seeded({ "e1.result": whole })
-    const answer = await call(workspacePackage(store), "read", { ref: "e1.result", length: 10_000_000 })
+    const answer = await call(workspacePackage(), "read", { ref: "e1.result", length: 10_000_000 }, store)
     expect((answer.slice as string).length).toBe(DEFAULT_WORKSPACE_POLICY.sliceChars)
     expect(answer.size).toBe(whole.length)
   })
 
   test("the cap is the consumer's to move", async () => {
     const store = await seeded({ "e1.result": "abcdefghij" })
-    const answer = await call(workspacePackage(store, { policy: { sliceChars: 4 } }), "read", { ref: "e1.result" })
+    const answer = await call(workspacePackage({ policy: { sliceChars: 4 } }), "read", { ref: "e1.result" }, store)
     expect(answer.slice).toBe("abcd")
   })
 
   test("an offset past the end answers with an empty slice and the true size", async () => {
     const store = await seeded({ "e1.result": "0123456789" })
-    const answer = await call(workspacePackage(store), "read", { ref: "e1.result", offset: 99 })
+    const answer = await call(workspacePackage(), "read", { ref: "e1.result", offset: 99 }, store)
     expect(answer.slice).toBe("")
     expect(answer.size).toBe(10)
   })
 
   test("a ref the store never held is an error the model can act on", async () => {
     const store = await seeded({})
-    const answer = await call(workspacePackage(store), "read", { ref: "nothing.here" })
+    const answer = await call(workspacePackage(), "read", { ref: "nothing.here" }, store)
     expect(String(answer.error)).toContain("nothing.here")
   })
 })
@@ -71,7 +82,7 @@ describe("workspace.grep", () => {
     const needle = "SECRET-PIN-4417"
     const whole = `${"a".repeat(200_000)}${needle}${"b".repeat(200_000)}`
     const store = await seeded({ "e1.noise": "nothing to see", "e2.result": whole })
-    const answer = await call(workspacePackage(store), "grep", { pattern: needle })
+    const answer = await call(workspacePackage(), "grep", { pattern: needle }, store)
     const matches = answer.matches as ReadonlyArray<{ ref: string; offset: number; context: string }>
     expect(matches).toHaveLength(1)
     expect(matches[0]!.ref).toBe("e2.result")
@@ -79,19 +90,19 @@ describe("workspace.grep", () => {
     expect(matches[0]!.context).toContain(needle)
     expect(matches[0]!.context.length).toBe(needle.length + DEFAULT_WORKSPACE_POLICY.contextChars * 2)
     // The offset locates the match for a read, and the read lands on it.
-    const slice = await call(workspacePackage(store), "read", { ref: "e2.result", offset: matches[0]!.offset, length: needle.length })
+    const slice = await call(workspacePackage(), "read", { ref: "e2.result", offset: matches[0]!.offset, length: needle.length }, store)
     expect(slice.slice).toBe(needle)
   })
 
   test("a ref narrows the search to one value", async () => {
     const store = await seeded({ a: "find me", b: "find me too" })
-    const answer = await call(workspacePackage(store), "grep", { pattern: "find me", ref: "b" })
+    const answer = await call(workspacePackage(), "grep", { pattern: "find me", ref: "b" }, store)
     expect((answer.matches as ReadonlyArray<{ ref: string }>).map((m) => m.ref)).toEqual(["b"])
   })
 
   test("a match-heavy pattern stops at the bound and says so", async () => {
     const store = await seeded({ a: "hit ".repeat(50) })
-    const answer = await call(workspacePackage(store, { policy: { maxMatches: 3, contextChars: 0 } }), "grep", { pattern: "hit" })
+    const answer = await call(workspacePackage({ policy: { maxMatches: 3, contextChars: 0 } }), "grep", { pattern: "hit" }, store)
     expect(answer.matches).toHaveLength(3)
     expect(answer.truncated).toBe(true)
   })
@@ -101,7 +112,7 @@ describe("the sql verb", () => {
   const runner: SqlRunner = { sql: (query, params) => Effect.succeed({ rows: [{ query, params: params.length }] }) }
 
   test("an unbound workspace has no sql: no method, no doc, no annotation", async () => {
-    const pkg = workspacePackage(await seeded({}))
+    const pkg = workspacePackage()
     expect(Object.keys(pkg.methods).sort()).toEqual(["grep", "read"])
     expect(pkg.docs?.sql).toBeUndefined()
     expect(pkg.annotations?.sql).toBeUndefined()
@@ -109,21 +120,21 @@ describe("the sql verb", () => {
   })
 
   test("a bound workspace lists sql and calls the runner", async () => {
-    const pkg = workspacePackage(await seeded({}), { sql: runner })
+    const pkg = workspacePackage({ sql: runner })
     expect(Object.keys(pkg.methods).sort()).toEqual(["grep", "read", "sql"])
     expect(pkg.docs?.sql).toBeDefined()
-    const answer = await call(pkg, "sql", { query: "select 1", params: [7] })
+    const answer = await call(pkg, "sql", { query: "select 1", params: [7] }, await seeded({}))
     expect(answer.rows).toEqual([{ query: "select 1", params: 1 }])
   })
 
   test("a runner with no doc describes sql in the generic text alone", async () => {
-    const pkg = workspacePackage(await seeded({}), { sql: runner })
+    const pkg = workspacePackage({ sql: runner })
     expect(pkg.docs?.sql?.description).toBe(WORKSPACE_SQL_DESCRIPTION)
   })
 
   test("a runner's doc is spliced onto the generic text, so the model reads the bound schema", async () => {
     const doc = "notes(id, body) is already here."
-    const pkg = workspacePackage(await seeded({}), { sql: { ...runner, doc } })
+    const pkg = workspacePackage({ sql: { ...runner, doc } })
     expect(pkg.docs?.sql?.description).toBe(`${WORKSPACE_SQL_DESCRIPTION} ${doc}`)
   })
 })
@@ -134,13 +145,14 @@ describe("backend independence", () => {
       "e1.result": JSON.stringify({ rows: Array.from({ length: 200 }, (_, i) => ({ i, note: "wideé" })) }),
       "e2.result": `${"pad".repeat(20_000)}NEEDLE${"pad".repeat(20_000)}`
     }
-    const memory = workspacePackage(await seeded(values))
-    const other = workspacePackage(await seeded(values, mapStore()))
+    const pkg = workspacePackage()
+    const memory = await seeded(values)
+    const other = await seeded(values, mapStore())
     for (const args of [{ ref: "e1.result" }, { ref: "e2.result", offset: 59_990, length: 20 }]) {
-      expect(await call(other, "read", args)).toEqual(await call(memory, "read", args))
+      expect(await call(pkg, "read", args, other)).toEqual(await call(pkg, "read", args, memory))
     }
     for (const args of [{ pattern: "NEEDLE" }, { pattern: '"note":"wideé"' }]) {
-      expect(await call(other, "grep", args)).toEqual(await call(memory, "grep", args))
+      expect(await call(pkg, "grep", args, other)).toEqual(await call(pkg, "grep", args, memory))
     }
   })
 })

--- a/packages/code/src/workspace.ts
+++ b/packages/code/src/workspace.ts
@@ -62,14 +62,13 @@ export interface WorkspaceOptions {
   readonly policy?: Partial<WorkspacePolicy>
 }
 
-// workspacePackage builds the package over one store. The store is a value here rather than a
-// requirement of the methods, because a package method's environment is fixed by the Package type;
-// the lane that holds the store binding builds the package from it (workspaceFor).
-export const workspacePackage = (store: KeyValueStore.KeyValueStore, options: WorkspaceOptions = {}): Package => {
+// workspacePackage builds the package. The store is a requirement of its methods, stated in the
+// type as `Package<KeyValueStore.KeyValueStore>`: the code funnel runs every method under the
+// attempt's own context, and the spill store is always in it, so this package mounts on the code
+// reactor at any R (packages/code/src/execute.ts, executeRecorded).
+export const workspacePackage = (options: WorkspaceOptions = {}): Package<KeyValueStore.KeyValueStore> => {
   const policy = workspacePolicyOf(options.policy)
   const runner = options.sql
-  const of = <A>(effect: Effect.Effect<A, KeyValueStore.KeyValueStoreError, KeyValueStore.KeyValueStore>) =>
-    effect.pipe(Effect.provideService(KeyValueStore.KeyValueStore, store))
   const sqlDoc = {
     description:
       runner?.doc === undefined || runner.doc === ""
@@ -142,7 +141,7 @@ export const workspacePackage = (store: KeyValueStore.KeyValueStore, options: Wo
         Effect.gen(function* () {
           const a = args as { ref?: string; offset?: number; length?: number } | undefined
           if (!a?.ref) return { error: "workspace.read needs { ref }" }
-          const whole = yield* of(hydrate(a.ref)).pipe(Effect.orElseSucceed(() => undefined))
+          const whole = yield* hydrate(a.ref).pipe(Effect.orElseSucceed(() => undefined))
           if (whole === undefined) return { error: `no value under ref '${a.ref}'` }
           const from = Math.max(0, Math.floor(a.offset ?? 0))
           const take = Math.min(Math.max(0, Math.floor(a.length ?? policy.sliceChars)), policy.sliceChars)
@@ -156,11 +155,11 @@ export const workspacePackage = (store: KeyValueStore.KeyValueStore, options: Wo
           const pattern = a?.pattern ?? ""
           if (pattern === "") return { error: "workspace.grep needs { pattern }" }
           const one = a?.ref === undefined || a.ref === "" ? undefined : a.ref
-          const held = one === undefined ? yield* of(refs()).pipe(Effect.orElseSucceed(() => [] as ReadonlyArray<string>)) : [one]
+          const held = one === undefined ? yield* refs().pipe(Effect.orElseSucceed(() => [] as ReadonlyArray<string>)) : [one]
           const matches: Array<{ ref: string; offset: number; context: string }> = []
           let truncated = false
           for (const ref of held) {
-            const whole = yield* of(hydrate(ref)).pipe(Effect.orElseSucceed(() => undefined))
+            const whole = yield* hydrate(ref).pipe(Effect.orElseSucceed(() => undefined))
             if (whole === undefined) continue
             let at = whole.indexOf(pattern)
             while (at !== -1) {
@@ -182,13 +181,14 @@ export const workspacePackage = (store: KeyValueStore.KeyValueStore, options: Wo
   }
 }
 
-// workspaceFor builds the package from the lane's own bindings: the store it spills to, and the SQL
-// surface if the platform declared one. A lane with no SQL binding gets the two-verb workspace.
+// workspaceFor builds the package from the lane's own bindings: the SQL surface, if the platform
+// declared one. A lane with no SQL binding gets the two-verb workspace. Which verbs exist is a
+// construction-time reading of the bindings, so the build is an effect; what the verbs need at
+// call time stays in the package's own type, and the funnel supplies it.
 export const workspaceFor = (
   policy: Partial<WorkspacePolicy> = {}
-): Effect.Effect<Package, never, KeyValueStore.KeyValueStore> =>
+): Effect.Effect<Package<KeyValueStore.KeyValueStore>> =>
   Effect.gen(function* () {
-    const store = yield* KeyValueStore.KeyValueStore
     const sql = yield* WorkspaceSql
-    return workspacePackage(store, { ...(sql === undefined ? {} : { sql }), policy })
+    return workspacePackage({ ...(sql === undefined ? {} : { sql }), policy })
   })


### PR DESCRIPTION
A package's service needs were erased at construction: methods were Effect<unknown, Park> with no R, so a package that reaches for Router or a store could only be built by a closure at the one place holding those services. Carry the needs in the type instead, the way Capability<R> already does on the model face.

- Package<R = never>: methods are Effect<unknown, Park, R>; header comment states the duality and where R is checked
- executeRecorded and codeReactorFor take R and capture it in the funnel's context, so methods run under the attempt's own environment; runtime behavior unchanged
- the Packages reference widens to PackagesService<unknown> (a Context.Reference carries one type); the package value and the reactor are the two typed ends
- workspacePackage becomes a plain Package<KeyValueStore> value, store reached by requirement instead of closure; workspaceFor stays as the bindings reader, consumers unchanged
- new fixture: a Package<Ticker> runs through the funnel with the service bound, and a @ts-expect-error proves a requiring package is refused by a powerless registry
- bun run gate fully green