### PR TITLE
feat(code): packages flow as values

### DIFF
--- a/packages/agent/src/capability.test.ts
+++ b/packages/agent/src/capability.test.ts
@@ -5,6 +5,7 @@ import type { Event } from "@clavia/tardigrade-core/event"
 import { EventLog, withWatermark } from "@clavia/tardigrade-core/event-log"
 import { Router } from "@clavia/tardigrade-core/router"
 import { Self } from "@clavia/tardigrade-core/actor"
+import type { Package } from "@clavia/tardigrade-code/packages"
 import { agentOf, budget, CODE_SYSTEM, codeMode, codeModeFor, compaction, compactionFor, renderOf, reply, toolList } from "./capability"
 import { receive, type AgentR } from "./turn"
 import { Infer, type InferRequest } from "./infer"
@@ -142,5 +143,20 @@ describe("agentOf", () => {
     const overridden = renderOf([codeModeFor({}, { system: (events) => `the packages in scope are:\n${events.length}` })], [{ type: "PackageInstalled" }])
     expect(overridden.system).toBe("the packages in scope are:\n1")
     expect(renderOf([codeMode], []).system).toBe(CODE_SYSTEM)
+  })
+
+  test("a mounted package names itself in the system fragment", () => {
+    // The model is told what the code can name, from the same values the code reactor mounts:
+    // one line per package, `name: description` (capability.ts, codeSystemFor).
+    const notes: Package = {
+      name: "notes",
+      description: "the team's notes",
+      methods: { put: () => Effect.succeed(null) }
+    }
+    const { system } = renderOf([codeModeFor({}, {}, [notes])], [])
+    expect(system).toContain("notes: the team's notes")
+    expect(system).not.toContain("none")
+    // An explicit fragment still wins over the derivation.
+    expect(renderOf([codeModeFor({}, { system: "my own scope" }, [notes])], []).system).toBe("my own scope")
   })
 })

--- a/packages/agent/src/capability.ts
+++ b/packages/agent/src/capability.ts
@@ -6,6 +6,7 @@ import { messageKeys } from "@clavia/tardigrade-core/message"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { codeDispatched, codeKeys } from "@clavia/tardigrade-code/events"
 import { codeReactorFor, type CodePolicy } from "@clavia/tardigrade-code/execute"
+import type { Package, PackageRequirements } from "@clavia/tardigrade-code/packages"
 import type { Router } from "@clavia/tardigrade-core/router"
 import type { ToolSpec } from "./request"
 import { agentKeys, toolReturned } from "./events"
@@ -123,10 +124,17 @@ const EXECUTE_TOOL: ToolSpec = {
   }
 }
 
-// CODE_SYSTEM is code mode's default system fragment: it names the tool the model acts with and
-// the packages in scope. A host whose packages come from the log renders its own fragment and
-// passes it to codeModeFor, so the default is a value you can read and a value you can replace.
-export const CODE_SYSTEM = `You act on the world by calling the execute tool with JavaScript; the packages in scope are:\nnone`
+// CODE_SYSTEM is code mode's system fragment with nothing in scope: it names the tool the model
+// acts with and says the scope is empty. codeSystemFor renders the same sentence over the
+// packages an assembly passed, so what the model reads is derived from the same values the code
+// reactor mounts (capability.test.ts, "a mounted package names itself in the system fragment").
+const CODE_SYSTEM_LEAD = "You act on the world by calling the execute tool with JavaScript; the packages in scope are:"
+export const CODE_SYSTEM = `${CODE_SYSTEM_LEAD}\nnone`
+
+// codeSystemFor names each package on its own line, `name: description`. An empty list reads
+// "none", which is CODE_SYSTEM.
+export const codeSystemFor = (packages: ReadonlyArray<Package<unknown>>): string =>
+  `${CODE_SYSTEM_LEAD}\n${packages.length === 0 ? "none" : packages.map((p) => `${p.name}: ${p.description}`).join("\n")}`
 
 // settleFor reads one execution's outcome, once the code reactor has recorded it.
 const settleFor = (
@@ -174,22 +182,29 @@ const codeServe: Serve = (call, log, answer) => {
 
 // codeModeFor is the code-execution capability: one `execute` tool, served by dispatching to
 // the code reactor and answered from its settle. The policy is the code lane's own
-// (packages/code/src/execute.ts, CodePolicy). `render.system` replaces CODE_SYSTEM, as a string
-// or as a projection of the log, for a host that names the packages in scope from its own
-// events (capability.test.ts, "codeModeFor takes a system fragment").
-export const codeModeFor = (
+// (packages/code/src/execute.ts, CodePolicy). `packages` are the values the code may name; the
+// capability's R is the spill store plus what those packages need, and the model's fragment is
+// derived from the same values, so what the code can call and what the model is told cannot
+// drift. `render.system` replaces that derivation, as a string or as a projection of the log,
+// for a host that names its scope from its own events (capability.test.ts, "codeModeFor takes a
+// system fragment").
+export const codeModeFor = <
+  const P extends ReadonlyArray<Package<never>> | ReadonlyArray<Package<unknown>> = readonly []
+>(
   policy: Partial<CodePolicy>,
-  render: { readonly system?: Capability["system"] } = {}
-): Capability<KeyValueStore.KeyValueStore> => ({
+  render: { readonly system?: Capability["system"] } = {},
+  packages: P = [] as unknown as P
+): Capability<KeyValueStore.KeyValueStore | PackageRequirements<P[number]>> => ({
   name: "code",
   keys: codeKeys,
-  reactors: [codeReactorFor(policy)],
+  reactors: [codeReactorFor(policy, packages)],
   tools: () => [EXECUTE_TOOL],
-  system: render.system ?? CODE_SYSTEM,
+  system: render.system ?? codeSystemFor(packages as ReadonlyArray<Package<unknown>>),
   serve: codeServe
 })
 
-// codeMode is that capability on defaults: the library default work surface.
+// codeMode is that capability on defaults, with nothing in scope: the library default work
+// surface.
 export const codeMode: Capability<KeyValueStore.KeyValueStore> = codeModeFor({})
 
 // A NativeTool is one named tool the model calls directly: its wire shape, and the effect that

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,12 +1,12 @@
-import { Effect, Layer } from "effect"
+import { Context, Effect, Layer } from "effect"
 import { KeyValueStore } from "effect/unstable/persistence"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { assertSupportedBun } from "@clavia/tardigrade-core/runtime"
-import { Router } from "@clavia/tardigrade-core/router"
-import { Self } from "@clavia/tardigrade-core/actor"
-import { Packages, type Package } from "@clavia/tardigrade-code/packages"
+import type { Router } from "@clavia/tardigrade-core/router"
+import type { Actor } from "@clavia/tardigrade-core/actor"
+import type { Package } from "@clavia/tardigrade-code/packages"
 import { jsSandboxFor } from "@clavia/tardigrade-code/defaults"
-import { workspaceFor } from "@clavia/tardigrade-code/workspace"
+import { workspacePackage } from "@clavia/tardigrade-code/workspace"
 import type { SandboxPolicy } from "@clavia/tardigrade-code/sandbox"
 import { createHost, type Host, type LaneEnv } from "@clavia/tardigrade-host/host"
 import { type AgentPolicy, type RlmR } from "./turn"
@@ -47,7 +47,7 @@ export { workspacePackage, workspaceFor, WorkspaceSql, DEFAULT_WORKSPACE_POLICY,
 
 // The capability assembly: code mode is the default, and an agent measured against a fixed
 // tool list mounts its own (capability.ts).
-export { agentOf, renderOf, codeMode, codeModeFor, CODE_SYSTEM, toolList, reply, budget, budgetFor, compaction, compactionFor, type Capability, type NativeTool } from "./capability"
+export { agentOf, renderOf, codeMode, codeModeFor, CODE_SYSTEM, codeSystemFor, toolList, reply, budget, budgetFor, compaction, compactionFor, type Capability, type NativeTool } from "./capability"
 
 export interface CreateAgentOptions {
   readonly packages?: ReadonlyArray<Package>
@@ -103,46 +103,58 @@ export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
   const spillStore = KeyValueStore.layerMemory
   const sandbox = jsSandboxFor(options.sandbox ?? {})
 
-  // Packages is built from the host's Router and Self. place and the
-  // facet reader still close over the host: they name other lanes.
-  const layersFor = (_lane: string): LaneEnv<RlmR> => {
-    const packages = Layer.effect(
-      Packages,
-      Effect.gen(function* () {
-        const router = yield* Router
-        const self = yield* Self
-        const spawn = agentsPackage(
-          router,
-          self,
-          (callId) => host.self(`ag.${callId}`),
-          { events: (facet: string) => Promise.resolve(host.read(facet)) },
-          // A child with no stated budget takes the same ceiling this agent's own wall reads.
-          { budget: options.policy?.budget ?? {} }
-        )
-        // The workspace reads the same store the spill path writes, and its sql verb appears only
-        // where the platform bound one (packages/code/src/workspace.ts, W5).
-        const workspace = yield* workspaceFor(options.policy?.workspace ?? {})
-        const all = [...user, spawn, workspace]
-        return Packages.of({
-          resolve: (name) => all.find((p) => p.name === name),
-          list: () => Effect.succeed(all.map((p) => ({ name: p.name, description: p.description })))
-        })
-      })
-    )
-    // The workspace package is built from the store, so the store feeds the packages layer and is
-    // exported from the same build: the package and the code reactor's spill path hold one store.
-    return Layer.mergeAll(Layer.provideMerge(packages, spillStore), sandbox, infer)
+  const layersFor = (_lane: string): LaneEnv<RlmR> => Layer.mergeAll(spillStore, sandbox, infer)
+
+  const policy = options.policy ?? {}
+  // This host takes no synchronous calls, so an escalatable spawn's ask and agents.continue
+  // refuse here. One value is both the host's own doors and the doors the spawn package's router
+  // offers, so the two cannot disagree (packages/agent/src/spawn.ts, agentsPackage).
+  const refused = () => Effect.succeed({ error: "this host takes no synchronous calls" })
+  // The router as a value: a delivery goes through this host, exactly as the router layer the
+  // host binds delivers (packages/host/src/host.ts, createHost).
+  const router: Context.Service.Shape<typeof Router> = {
+    deliver: (address: string, event: Event) => Effect.sync(() => host.deliver(address, event)),
+    call: refused,
+    resume: refused
   }
 
-  // Every ag. lane runs the RLM default; anything else is a sink.
-  const policy = options.policy ?? {}
-  const assembled = agentOf(
-    [...(options.capabilities ?? [codeModeFor(policy.code ?? {})]), reply, budgetFor(policy.budget ?? {}), compactionFor(policy.context ?? {})],
-    policy.infer ?? {}
-  )
+  // Every ag. lane runs the RLM default; anything else is a sink. A lane's actor is built on its
+  // first visit, because the spawn package closes over this lane's own address and the host that
+  // routes for it: both are values by then, so the packages reach code mode as values and the
+  // assembly's requirements are what those values state (capability.ts, codeModeFor).
+  const actors = new Map<string, Actor<RlmR>>()
+  const actorFor = (lane: string): Actor<RlmR> | undefined => {
+    if (!lane.startsWith("ag.")) return undefined
+    const built = actors.get(lane)
+    if (built !== undefined) return built
+    const spawn = agentsPackage(
+      router,
+      host.self(lane),
+      (callId) => host.self(`ag.${callId}`),
+      { events: (facet: string) => Promise.resolve(host.read(facet)) },
+      // A child with no stated budget takes the same ceiling this agent's own wall reads.
+      { budget: policy.budget ?? {} }
+    )
+    // The workspace reads the same store the spill path writes. This host binds no SQL surface,
+    // so it is the two-verb workspace (packages/code/src/workspace.ts, workspacePackage).
+    const workspace = workspacePackage({ policy: policy.workspace ?? {} })
+    const assembled = agentOf(
+      [
+        ...(options.capabilities ?? [codeModeFor(policy.code ?? {}, {}, [...user, spawn, workspace])]),
+        reply,
+        budgetFor(policy.budget ?? {}),
+        compactionFor(policy.context ?? {})
+      ],
+      policy.infer ?? {}
+    )
+    actors.set(lane, assembled)
+    return assembled
+  }
   const host: Host = createHost<RlmR>({
     principal: "mem",
-    actorFor: (lane) => (lane.startsWith("ag.") ? assembled : undefined),
+    actorFor,
+    call: refused,
+    resume: refused,
     layersFor
   })
 

--- a/packages/agent/src/turn.test.ts
+++ b/packages/agent/src/turn.test.ts
@@ -4,16 +4,20 @@ import { KeyValueStore } from "effect/unstable/persistence"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { EventLog, withWatermark } from "@clavia/tardigrade-core/event-log"
 import { settleActor } from "@clavia/tardigrade-core/actor"
-import { Packages, type Package } from "@clavia/tardigrade-code/packages"
+import type { Package } from "@clavia/tardigrade-code/packages"
 import { Sandbox, type Bindings } from "@clavia/tardigrade-code/sandbox"
 import { Router } from "@clavia/tardigrade-core/router"
 import { Self } from "@clavia/tardigrade-core/actor"
 import { Infer, receive } from "./turn"
-import { agentOf, budget, codeMode, compaction, reply, toolList } from "./capability"
+import { agentOf, budget, codeModeFor, compaction, reply, toolList } from "./capability"
 
-// The default assembly and its runtime reactors, reconstructed the way agentOf mounts them:
-// reactors[0] is the infer loop, reactors[1] is the call router.
-const rlmAgent = agentOf([codeMode, reply, budget, compaction])
+// The default assembly over a stated scope, and its runtime reactors, reconstructed the way
+// agentOf mounts them: reactors[0] is the infer loop, reactors[1] is the call router. The
+// packages are values the assembly passes, so a test that needs one names it here
+// (capability.ts, codeModeFor).
+const agentWith = (packages: ReadonlyArray<Package>) =>
+  agentOf([codeModeFor({}, {}, packages), reply, budget, compaction])
+const rlmAgent = agentWith([])
 const inferReactor = rlmAgent.reactors[0]!
 const toolsReactor = rlmAgent.reactors[1]!
 // The agent end to end: the model writes code, the code calls packages, every call is recorded,
@@ -48,12 +52,6 @@ const jsSandbox = Layer.succeed(Sandbox, {
       }
     })
 })
-
-const registry = (packages: ReadonlyArray<Package>) =>
-  Layer.succeed(Packages, {
-    resolve: (name: string) => packages.find((p) => p.name === name),
-    list: () => Effect.succeed(packages.map((p) => ({ name: p.name, description: p.description })))
-  })
 
 const zoho = (spies: { insert: number; search: number }): Package => ({
   name: "zohorecruit",
@@ -106,12 +104,13 @@ describe("the agent with execute as the only tool", () => {
   test("the model's code runs with every package call recorded", async () => {
     const count = { calls: 0 }
     const spies = { insert: 0, search: 0 }
+    const agent = agentWith([zoho(spies)])
     const layers = Layer.mergeAll(
     KeyValueStore.layerMemory,
-    memoryLog(), codeThenComplete(count), registry([zoho(spies)]), jsSandbox, noRouter)
+    memoryLog(), codeThenComplete(count), jsSandbox, noRouter)
     const events = await run(
       Effect.gen(function* () {
-        yield* receive(rlmAgent, { id: "m1", text: "add the JD and search candidates" })
+        yield* receive(agent, { id: "m1", text: "add the JD and search candidates" })
         return yield* readLog
       }),
       layers
@@ -184,10 +183,10 @@ describe("the agent with execute as the only tool", () => {
     ]
     const count = { calls: 0 }
     const spies = { insert: 0, search: 0 }
-    const layers = Layer.mergeAll(KeyValueStore.layerMemory, memoryLog(crashed), codeThenComplete(count), registry([zoho(spies)]), jsSandbox, noRouter)
+    const layers = Layer.mergeAll(KeyValueStore.layerMemory, memoryLog(crashed), codeThenComplete(count), jsSandbox, noRouter)
     const events = await run(
       Effect.gen(function* () {
-        yield* settleActor(rlmAgent)
+        yield* settleActor(agentWith([zoho(spies)]))
         return yield* readLog
       }),
       layers
@@ -213,7 +212,6 @@ describe("the agent with execute as the only tool", () => {
           )
         }
       }),
-      registry([]),
       jsSandbox,
       noRouter
     )
@@ -246,7 +244,7 @@ describe("the agent with execute as the only tool", () => {
     })
     const layers = Layer.mergeAll(
     KeyValueStore.layerMemory,
-    memoryLog(queued), echoHead, registry([]), jsSandbox, noRouter)
+    memoryLog(queued), echoHead, jsSandbox, noRouter)
     const events = await run(
       Effect.gen(function* () {
         yield* settleActor(rlmAgent)
@@ -273,7 +271,7 @@ describe("the agent with execute as the only tool", () => {
       { type: "ModelCalled", callId: "m1/infer/2", turn: "m1", at: 4 }
     ]
     const count = { calls: 0 }
-    const layers = Layer.mergeAll(KeyValueStore.layerMemory, memoryLog(crashed), codeThenComplete(count), registry([]), jsSandbox, noRouter)
+    const layers = Layer.mergeAll(KeyValueStore.layerMemory, memoryLog(crashed), codeThenComplete(count), jsSandbox, noRouter)
     const events = await run(
       Effect.gen(function* () {
         yield* settleActor(rlmAgent)
@@ -296,7 +294,6 @@ describe("the agent with execute as the only tool", () => {
           return Effect.succeed({ kind: "complete" as const, output: "ok" })
         }
       }),
-      registry([]),
       jsSandbox,
       noRouter
     )
@@ -327,7 +324,6 @@ describe("the agent with execute as the only tool", () => {
       Layer.succeed(Infer, {
         react: () => Effect.succeed({ kind: "complete" as const, output: "ok", usage: spent })
       }),
-      registry([]),
       jsSandbox,
       noRouter
     )
@@ -363,7 +359,6 @@ describe("the agent with execute as the only tool", () => {
             failure: { cause: "inference_attempts_exhausted" as const, attempts: 2, policy: retry }
           })
       }),
-      registry([]),
       jsSandbox,
       noRouter
     )
@@ -425,7 +420,6 @@ describe("a turn that declares an output schema", () => {
           )
         }
       }),
-      registry([]),
       jsSandbox,
       noRouter
     )
@@ -462,7 +456,6 @@ describe("a turn that declares an output schema", () => {
           })
         }
       }),
-      registry([]),
       jsSandbox,
       noRouter
     )

--- a/packages/code/src/contract.test.ts
+++ b/packages/code/src/contract.test.ts
@@ -6,14 +6,14 @@ import { composeKeys, EventLog, withWatermark } from "@clavia/tardigrade-core/ev
 import { settleActor } from "@clavia/tardigrade-core/actor"
 import { messageKeys } from "@clavia/tardigrade-core/message"
 import { checkInput, renderSignature } from "./contract"
-import { Packages, type Package } from "./packages"
+import type { Package } from "./packages"
 import { Sandbox, type Bindings } from "./sandbox"
-import { codeReactor } from "./execute"
+import { codeReactorFor } from "./execute"
 import { codeKeys } from "./events"
 
 // The method contract: `renderSignature` folds a declared input schema into one calling line,
 // and the funnel checks the args against the same schema before the method runs. The last block
-// drives the real `codeReactor`, so the refusal is proven at the one door every call crosses.
+// drives the real code reactor, so the refusal is proven at the one door every call crosses.
 
 const putSchema = {
   type: "object",
@@ -166,18 +166,14 @@ const settled = async (code: string): Promise<ReadonlyArray<Event>> => {
   ]
   return Effect.runPromise(
     Effect.gen(function* () {
-      yield* settleActor({ reactors: [codeReactor], keyOf: composeKeys(messageKeys, codeKeys) })
+      yield* settleActor({ reactors: [codeReactorFor({}, [notesLike])], keyOf: composeKeys(messageKeys, codeKeys) })
       return yield* Effect.flatMap(EventLog, (l) => l.read)
     }).pipe(
       Effect.provide(
         Layer.mergeAll(
           memoryLog(log),
           KeyValueStore.layerMemory,
-          jsSandbox,
-          Layer.succeed(Packages, {
-            resolve: (name: string) => (name === "notes" ? notesLike : undefined),
-            list: () => Effect.succeed([{ name: "notes", description: notesLike.description }])
-          })
+          jsSandbox
         )
       )
     ) as Effect.Effect<ReadonlyArray<Event>>

--- a/packages/code/src/defaults.test.ts
+++ b/packages/code/src/defaults.test.ts
@@ -9,7 +9,6 @@ import { DEFAULT_SANDBOX_POLICY, Sandbox } from "./sandbox"
 import { jsSandbox, jsSandboxFor } from "./defaults"
 import { codeReactor } from "./execute"
 import { codeKeys } from "./events"
-import { Packages } from "./packages"
 
 // Console capture: a body's prints come back on the result's `logs`, capped, and ride the
 // settle so the model reads them beside the result (TODO.md item 8: a print-to-inspect habit
@@ -123,11 +122,6 @@ const memoryLog = (initial: ReadonlyArray<Event>) =>
     })
   )
 
-const packagesLayer = Layer.succeed(Packages, {
-  resolve: () => undefined,
-  list: () => Effect.succeed([])
-})
-
 describe("logs ride the settle", () => {
   test("CodeSettled carries the body's prints", async () => {
     const log: Event[] = [
@@ -138,7 +132,7 @@ describe("logs ride the settle", () => {
       Effect.gen(function* () {
         yield* settleActor({ reactors: [codeReactor], keyOf: composeKeys(messageKeys, codeKeys) })
         return yield* Effect.flatMap(EventLog, (l) => l.read)
-      }).pipe(Effect.provide(Layer.mergeAll(memoryLog(log), packagesLayer, jsSandbox, KeyValueStore.layerMemory))) as Effect.Effect<
+      }).pipe(Effect.provide(Layer.mergeAll(memoryLog(log), jsSandbox, KeyValueStore.layerMemory))) as Effect.Effect<
         ReadonlyArray<Event>
       >
     )

--- a/packages/code/src/execute.test.ts
+++ b/packages/code/src/execute.test.ts
@@ -3,9 +3,9 @@ import { Context, Effect, Layer, Ref } from "effect"
 import { KeyValueStore } from "effect/unstable/persistence"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { composeKeys, EventLog, withWatermark } from "@clavia/tardigrade-core/event-log"
-import { settleActor } from "@clavia/tardigrade-core/actor"
+import { settleActor, type Reactor } from "@clavia/tardigrade-core/actor"
 import { messageKeys } from "@clavia/tardigrade-core/message"
-import { Packages, type Package, type PackagesService } from "./packages"
+import type { Package } from "./packages"
 import { Sandbox, type Bindings } from "./sandbox"
 import { codeReactor, codeReactorFor } from "./execute"
 import { codeKeys } from "./events"
@@ -62,11 +62,6 @@ const worldPackage: Package = {
   }
 }
 
-const packagesLayer = Layer.succeed(Packages, {
-  resolve: (name: string) => (name === "world" ? worldPackage : undefined),
-  list: () => Effect.succeed([{ name: "world", description: worldPackage.description }])
-})
-
 const code = `
   const a = await world.read({})
   const b = await world.ownedWrite({})
@@ -79,9 +74,9 @@ const settled = async (head: Event): Promise<ReadonlyArray<Event>> => {
   const log: Event[] = [head, { type: "CodeDispatched", execId: "e1", code, turn: "t1", at: 2 }]
   return Effect.runPromise(
     Effect.gen(function* () {
-      yield* settleActor({ reactors: [codeReactor], keyOf: composeKeys(messageKeys, codeKeys) })
+      yield* settleActor({ reactors: [codeReactorFor({}, [worldPackage])], keyOf: composeKeys(messageKeys, codeKeys) })
       return yield* Effect.flatMap(EventLog, (l) => l.read)
-    }).pipe(Effect.provide(Layer.mergeAll(memoryLog(log), packagesLayer, jsSandbox, KeyValueStore.layerMemory))) as Effect.Effect<ReadonlyArray<Event>>
+    }).pipe(Effect.provide(Layer.mergeAll(memoryLog(log), jsSandbox, KeyValueStore.layerMemory))) as Effect.Effect<ReadonlyArray<Event>>
   )
 }
 
@@ -105,10 +100,6 @@ describe("transience never reaches the body", () => {
           })
       }
     }
-    const flakyLayer = Layer.succeed(Packages, {
-      resolve: (name: string) => (name === "flaky" ? flakyPackage : undefined),
-      list: () => Effect.succeed([{ name: "flaky", description: flakyPackage.description }])
-    })
     // The body's catch is the trap: if transience rejects, the fallback becomes data.
     const code = `
       const a = await flaky.read({}).catch(() => ({ fell: "back" }))
@@ -120,9 +111,9 @@ describe("transience never reaches the body", () => {
     ]
     const events = await Effect.runPromise(
       Effect.gen(function* () {
-        yield* settleActor({ reactors: [codeReactor], keyOf: composeKeys(messageKeys, codeKeys) })
+        yield* settleActor({ reactors: [codeReactorFor({}, [flakyPackage])], keyOf: composeKeys(messageKeys, codeKeys) })
         return yield* Effect.flatMap(EventLog, (l) => l.read)
-      }).pipe(Effect.provide(Layer.mergeAll(memoryLog(log), flakyLayer, jsSandbox, KeyValueStore.layerMemory))) as Effect.Effect<ReadonlyArray<Event>>
+      }).pipe(Effect.provide(Layer.mergeAll(memoryLog(log), jsSandbox, KeyValueStore.layerMemory))) as Effect.Effect<ReadonlyArray<Event>>
     )
     const settle = events.find((e) => e.type === "CodeSettled") as { result?: { a: unknown } } | undefined
     expect(settle).toBeDefined()
@@ -154,9 +145,9 @@ describe("the replay guard", () => {
     ]
     const events = await Effect.runPromise(
       Effect.gen(function* () {
-        yield* settleActor({ reactors: [codeReactor], keyOf: composeKeys(messageKeys, codeKeys) })
+        yield* settleActor({ reactors: [codeReactorFor({}, [worldPackage])], keyOf: composeKeys(messageKeys, codeKeys) })
         return yield* Effect.flatMap(EventLog, (l) => l.read)
-      }).pipe(Effect.provide(Layer.mergeAll(memoryLog(log), packagesLayer, jsSandbox, KeyValueStore.layerMemory))) as Effect.Effect<ReadonlyArray<Event>>
+      }).pipe(Effect.provide(Layer.mergeAll(memoryLog(log), jsSandbox, KeyValueStore.layerMemory))) as Effect.Effect<ReadonlyArray<Event>>
     )
     const settle = events.find((e) => e.type === "CodeSettled") as { error?: string }
     expect(settle.error).toContain("nondeterministic body")
@@ -177,9 +168,9 @@ describe("the replay guard", () => {
     ]
     const events = await Effect.runPromise(
       Effect.gen(function* () {
-        yield* settleActor({ reactors: [codeReactor], keyOf: composeKeys(messageKeys, codeKeys) })
+        yield* settleActor({ reactors: [codeReactorFor({}, [worldPackage])], keyOf: composeKeys(messageKeys, codeKeys) })
         return yield* Effect.flatMap(EventLog, (l) => l.read)
-      }).pipe(Effect.provide(Layer.mergeAll(memoryLog(log), packagesLayer, jsSandbox, KeyValueStore.layerMemory))) as Effect.Effect<ReadonlyArray<Event>>
+      }).pipe(Effect.provide(Layer.mergeAll(memoryLog(log), jsSandbox, KeyValueStore.layerMemory))) as Effect.Effect<ReadonlyArray<Event>>
     )
     const settle = events.find((e) => e.type === "CodeSettled") as { error?: string }
     expect(settle.error).toContain("nondeterministic body")
@@ -225,11 +216,11 @@ describe("the spill bound", () => {
         Effect.gen(function* () {
           yield* settleActor({ reactors: [reactor], keyOf: composeKeys(messageKeys, codeKeys) })
           return yield* Effect.flatMap(EventLog, (l) => l.read)
-        }).pipe(Effect.provide(Layer.mergeAll(memoryLog(log), packagesLayer, jsSandbox, KeyValueStore.layerMemory))) as Effect.Effect<
+        }).pipe(Effect.provide(Layer.mergeAll(memoryLog(log), jsSandbox, KeyValueStore.layerMemory))) as Effect.Effect<
           ReadonlyArray<Event>
         >
       )
-    const spilled = (await drive(codeReactorFor({ spill: { spillBytes: 10, previewChars: 4 } }))).find(
+    const spilled = (await drive(codeReactorFor({ spill: { spillBytes: 10, previewChars: 4 } }, []))).find(
       (e) => e.type === "CodeSettled"
     ) as { tmp?: string; size?: number; preview?: string; result?: unknown }
     expect(spilled.tmp).toBe("e1.result")
@@ -260,11 +251,6 @@ describe("a package's requirements ride its type", () => {
     }
   }
 
-  const tickerRegistry: PackagesService<Ticker> = {
-    resolve: (name: string) => (name === "ticker" ? tickerPackage : undefined),
-    list: () => Effect.succeed([{ name: "ticker", description: tickerPackage.description }])
-  }
-
   test("a package method reads its service through the funnel", async () => {
     const log: Event[] = [
       { type: "MessageReceived", id: "t1", text: "go", at: 1 },
@@ -272,13 +258,12 @@ describe("a package's requirements ride its type", () => {
     ]
     const events = await Effect.runPromise(
       Effect.gen(function* () {
-        yield* settleActor({ reactors: [codeReactorFor<Ticker>()], keyOf: composeKeys(messageKeys, codeKeys) })
+        yield* settleActor({ reactors: [codeReactorFor({}, [tickerPackage])], keyOf: composeKeys(messageKeys, codeKeys) })
         return yield* Effect.flatMap(EventLog, (l) => l.read)
       }).pipe(
         Effect.provide(
           Layer.mergeAll(
             memoryLog(log),
-            Layer.succeed(Packages, tickerRegistry),
             jsSandbox,
             KeyValueStore.layerMemory,
             Layer.succeed(Ticker, "bound")
@@ -293,12 +278,21 @@ describe("a package's requirements ride its type", () => {
     expect(settle.result?.tick).toBe("bound")
   })
 
-  test("a registry the powerless reactor can run refuses a package that names a service", () => {
-    // codeReactorFor at its default R promises an environment of KeyValueStore alone, so the
-    // registry it runs is a PackagesService<never>. A package whose method reaches for Ticker has
-    // nowhere to read it from there, and the type says so before anything runs.
-    // @ts-expect-error a Package<Ticker> is not a Package<never>
-    const powerless: PackagesService<never> = tickerRegistry
-    expect(powerless.resolve("ticker")?.name).toBe("ticker")
+  test("the reactor a service-needing package builds cannot stand where the service is missing", () => {
+    // The packages are values, so the reactor's environment is derived from them: mounting the
+    // ticker package makes a Reactor<KeyValueStore | Ticker>, and the powerless environment has
+    // nowhere to read Ticker from. The type says so before anything runs.
+    const powered: Reactor<KeyValueStore.KeyValueStore | Ticker> = codeReactorFor({}, [tickerPackage])
+    // @ts-expect-error a Reactor<KeyValueStore | Ticker> is not a Reactor<KeyValueStore>
+    const powerless: Reactor<KeyValueStore.KeyValueStore> = powered
+    expect(powerless([])).toEqual([])
+  })
+
+  test("two packages under one name fail at construction", () => {
+    // One name, one object in the body's scope: a second package under it would decide which
+    // methods the code reaches by list order (execute.ts, codeReactorFor).
+    expect(() => codeReactorFor({}, [tickerPackage, { ...tickerPackage, description: "another" }])).toThrow(
+      'package "ticker" declared twice'
+    )
   })
 })

--- a/packages/code/src/execute.ts
+++ b/packages/code/src/execute.ts
@@ -4,7 +4,7 @@ import { EventLog } from "@clavia/tardigrade-core/event-log"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { transition, type Reactor } from "@clavia/tardigrade-core/actor"
 import { workOwed } from "./projections"
-import { annotationsOf, Packages, type PackagesService } from "./packages"
+import { annotationsOf, type Package, type PackageRequirements } from "./packages"
 import { checkInput, renderSignature } from "./contract"
 import { Sandbox, type Bindings } from "./sandbox"
 import { turnHead, turnOf } from "./turns"
@@ -36,6 +36,7 @@ const executeRecorded = <R = never>(
   execId: string,
   code: string,
   spill: SpillPolicy,
+  packages: ReadonlyArray<Package<R>>,
   turn?: string,
   dispatchedAt?: number
 ): Effect.Effect<ReadonlyArray<Event>, never, EventLog | KeyValueStore.KeyValueStore | R> =>
@@ -46,10 +47,6 @@ const executeRecorded = <R = never>(
     // The shadow reading rides the turn's own brief, folded once here: it never changes
     // mid-turn, and every package call below reads the same value.
     const shadow = (turnHead(events) as { shadow?: unknown } | undefined)?.shadow === true
-    // The registry reference is R-erased (packages.ts, Packages). This attempt runs its packages
-    // under `R`, the requirement the reactor declared and the caller provided, so the funnel
-    // reads the registry back at that type.
-    const packages = (yield* Packages) as PackagesService<R>
     const sandbox = yield* Sandbox
     // The proxy runs each call as its own promise, so it carries the attempt's context. The spill
     // store is in it: a call's own hydrate and spill run under the same store the attempt was
@@ -70,9 +67,7 @@ const executeRecorded = <R = never>(
     const blocked: Array<{ readonly callId: string; readonly awaiting?: string }> = []
     const parkGate = yield* Deferred.make<void>()
     const bindings: Record<string, Record<string, (args: unknown) => Promise<unknown>>> = {}
-    for (const card of yield* packages.list()) {
-      const pkg = packages.resolve(card.name)
-      if (pkg === undefined) continue
+    for (const pkg of packages) {
       const methods: Record<string, (args: unknown) => Promise<unknown>> = {}
       for (const [method, fn] of Object.entries(pkg.methods)) {
         methods[method] = (args: unknown) => {
@@ -290,36 +285,51 @@ export interface CodePolicy {
 // rests honestly and a landing reply re-derives it. An attempt that parks mid-act returns
 // BlockedOn evidence instead of the settle; the reconciler reads that as blocked, never wedged.
 //
-// `R` is what this lane's packages need beyond the spill store: a reactor over a registry of
-// `Package<R>` declares the same R, so the environment that runs it must provide it
-// (packages.ts, Package). The default is the powerless one.
-export const codeReactorFor = <R = never>(
-  policy: Partial<CodePolicy> = {}
-): Reactor<KeyValueStore.KeyValueStore | R> => (events) => {
+// The packages arrive as values, and what they need arrives with them: the reactor's environment
+// is the spill store plus the union of the packages' own requirements, so a lane assembled with a
+// service-needing package cannot be run where that service is missing (execute.test.ts, "a
+// package's requirements ride its type"). Which packages are passed is the capability scope: the
+// code can only name these, and the empty array is the powerless lane (packages.ts, Package).
+// Two packages under one name would make `pkg.name` ambiguous in the body's scope, so a duplicate
+// is a construction-time error, the same reading agentOf takes of two capabilities claiming one
+// tool name (packages/agent/src/capability.ts, agentOf).
+export const codeReactorFor = <const P extends ReadonlyArray<Package<never>> | ReadonlyArray<Package<unknown>>>(
+  policy: Partial<CodePolicy>,
+  packages: P
+): Reactor<KeyValueStore.KeyValueStore | PackageRequirements<P[number]>> => {
+  const named = new Set<string>()
+  for (const pkg of packages as ReadonlyArray<Package<unknown>>) {
+    if (named.has(pkg.name)) throw new Error(`package "${pkg.name}" declared twice`)
+    named.add(pkg.name)
+  }
+  type R = PackageRequirements<P[number]>
+  const mounted = packages as unknown as ReadonlyArray<Package<R>>
   const spill = spillPolicyOf(policy.spill)
-  const owed = workOwed(events)
-  if (owed === undefined) return []
-  const dispatch = events.find(
-    (e) => e.type === "CodeDispatched" && (e as { execId?: unknown }).execId === owed.execId
-  )
-  if (dispatch === undefined) return []
-  const d = dispatch as { code?: unknown; at?: unknown }
-  return [
-    transition<
-      { execId: string; code: string; turn: string | undefined; at: number | undefined },
-      KeyValueStore.KeyValueStore | R
-    >({
-      key: `cs:${owed.execId}`,
-      input: {
-        execId: owed.execId,
-        code: String(d.code ?? ""),
-        turn: turnOf(dispatch),
-        at: typeof d.at === "number" ? d.at : undefined
-      },
-      act: (input) => executeRecorded<R>(input.execId, input.code, spill, input.turn, input.at)
-    })
-  ]
+  return (events) => {
+    const owed = workOwed(events)
+    if (owed === undefined) return []
+    const dispatch = events.find(
+      (e) => e.type === "CodeDispatched" && (e as { execId?: unknown }).execId === owed.execId
+    )
+    if (dispatch === undefined) return []
+    const d = dispatch as { code?: unknown; at?: unknown }
+    return [
+      transition<
+        { execId: string; code: string; turn: string | undefined; at: number | undefined },
+        KeyValueStore.KeyValueStore | R
+      >({
+        key: `cs:${owed.execId}`,
+        input: {
+          execId: owed.execId,
+          code: String(d.code ?? ""),
+          turn: turnOf(dispatch),
+          at: typeof d.at === "number" ? d.at : undefined
+        },
+        act: (input) => executeRecorded<R>(input.execId, input.code, spill, mounted, input.turn, input.at)
+      })
+    ]
+  }
 }
 
-// codeReactor is that reactor on the default spill bound.
-export const codeReactor: Reactor<KeyValueStore.KeyValueStore> = codeReactorFor()
+// codeReactor is that reactor on the default spill bound, with no packages: the powerless lane.
+export const codeReactor: Reactor<KeyValueStore.KeyValueStore> = codeReactorFor({}, [])

--- a/packages/code/src/packages.ts
+++ b/packages/code/src/packages.ts
@@ -1,4 +1,4 @@
-import { Context, Effect } from "effect"
+import type { Effect } from "effect"
 import type { Park } from "./errors"
 
 // DoorRequest is a request through a connection's door: method, a RELATIVE path (the door
@@ -107,10 +107,14 @@ export const annotationsOf = (pkg: Package<unknown>, method: string): Required<M
 // deliberately outside Package: it belongs to the host boundary and gets its own concept once a
 // consumer exists.
 //
+// Which packages an assembly passes is capability scoping: a task that must never send messages
+// is given no sending package, and the code cannot name what the assembly did not pass. The
+// powerless default is the empty array (execute.ts, codeReactor).
+//
 // `R` is what a package's methods need from the environment, the dual of `Capability<R>` on the
 // model face. A package that reaches for a service names it in its type, and the reactor that
-// runs the package must declare the same requirement (execute.ts, codeReactorFor); a package
-// that reaches for nothing is `Package<never>` and runs anywhere.
+// runs the package declares the union of what its packages need (execute.ts, codeReactorFor); a
+// package that reaches for nothing is `Package<never>` and runs anywhere.
 export interface Package<R = never> {
   readonly name: string
   readonly description: string
@@ -130,22 +134,9 @@ export interface Package<R = never> {
   >
 }
 
-// Packages is the registry seam. Which packages exist here is capability scoping: a task that
-// must never send messages is bound to a registry that holds no sending package, and the code
-// cannot name what the registry does not hold. The default registry holds nothing, so the
-// unwired case is the powerless one.
-export interface PackagesService<R = never> {
-  readonly resolve: (name: string) => Package<R> | undefined
-  readonly list: () => Effect.Effect<ReadonlyArray<{ readonly name: string; readonly description: string }>>
-}
-
-// The reference stands at `unknown`, the widest registry: a Context.Reference carries one type,
-// and `Package<R>` widens to `Package<unknown>` for every R, so a registry of service-needing
-// packages mounts here without a cast. What the packages need is checked at the two ends that
-// can see it: the package value states its own R, and the reactor that runs the registry
-// declares the environment it will run them in (execute.ts, codeReactorFor; the funnel restores
-// the reactor's R over the erased reference). A registry typed at `never` refuses a package that
-// names a service (execute.test.ts, "a package's requirements ride its type").
-export const Packages: Context.Reference<PackagesService<unknown>> = Context.Reference("code/Packages", {
-  defaultValue: (): PackagesService<unknown> => ({ resolve: () => undefined, list: () => Effect.succeed([]) })
-})
+// PackageRequirements extracts one package's R, so a mixed list infers the union of what its
+// members need rather than collapsing on the first element's R. It is the package-face twin of
+// RequirementsOf (packages/agent/src/capability.ts), and what makes the environment a code
+// reactor demands a function of the packages it was passed (execute.test.ts, "a package's
+// requirements ride its type").
+export type PackageRequirements<T> = T extends Package<infer R> ? R : never


### PR DESCRIPTION
Packages reached the code funnel through the Packages Context.Reference. A tag's type is fixed once globally, so a mixed registry rode through at PackagesService<unknown> and the funnel cast back down: a requirements mismatch compiled and then parked at run time. Pass packages as values instead, so the R union is inferred from what will actually run and a missing service fails during compile in the host.

- codeReactorFor(policy, packages) infers Reactor<KeyValueStore | union of the packages' R> via PackageRequirements; duplicate package names throw at construction, mirroring agentOf's tool collision
- delete the Packages reference and PackagesService; the powerless default is the empty array, and scoping reads: the code cannot name what the assembly did not pass
- codeModeFor(policy, render, packages) mounts the reactor and derives the system fragment from the package values (codeSystemFor); an explicit render.system still wins, CODE_SYSTEM stays as the empty-scope fragment
- createRlmAgent assembles per lane inside actorFor (memoized), so the spawn and workspace packages pass as values; layersFor shrinks to store, sandbox, and model
- fixtures migrate to the values API; new tests for the collision error and the derived fragment
- bun run gate fully green