### PR TITLE
test(core): driver rest debt

### DIFF
--- a/packages/core/tla/Driver.cfg
+++ b/packages/core/tla/Driver.cfg
@@ -3,5 +3,6 @@ SPECIFICATION Spec
 CONSTANTS
   Lanes = {l1, l2}
   MaxCrashes = 1
+  Poisoned = {}
 INVARIANT TypeOK
 INVARIANT Accounting

--- a/packages/core/tla/Driver.tla
+++ b/packages/core/tla/Driver.tla
@@ -18,6 +18,13 @@
    SERVICE: every owed lane is eventually served, whatever the other
      lanes do: crashes bounded, arrivals adversarial, passes recurring.
 
+   REST (unpaid): a lane whose visits always crash eventually settles
+     as failed and goes quiet. No action discharges it today: the
+     give-up guard died with the room machine, so a deterministic
+     crasher retries on the watchdog forever. DriverPoisoned.cfg is
+     the ledger entry: EventuallyServed over a poisoned lane, expected
+     to FAIL until a GiveUp action pays the debt.
+
    THE MODEL. Lanes' owed work is a boolean derivation (the abstraction
    of Reactor.tla's WorkOwed). Arrive raises it and arms the alarm (the
    deliver contract: every append arms). Fire consumes the alarm and
@@ -36,7 +43,14 @@
 
 EXTENDS Naturals, FiniteSets, TLC
 
-CONSTANTS Lanes, MaxCrashes
+(* Poisoned lanes model the deterministic crasher: a visit that can
+   never serve (the Uniconnect run facet, 2026-08-18). Their crashes
+   are free: the MaxCrashes budget bounds only transient failures, so
+   the budget cannot smuggle convergence past a lane that never
+   converges. *)
+CONSTANTS Lanes, MaxCrashes, Poisoned
+
+ASSUME Poisoned \subseteq Lanes
 
 VARIABLES owed, armed, inPass, queue, answers, crashes
 
@@ -80,6 +94,7 @@ Fire ==
 VisitOk(l) ==
   /\ inPass
   /\ l \in queue
+  /\ l \notin Poisoned
   /\ owed' = [owed EXCEPT ![l] = FALSE]
   /\ answers' = [answers EXCEPT ![l] = FALSE]
   /\ queue' = queue \ {l}
@@ -91,10 +106,10 @@ VisitOk(l) ==
 VisitCrash(l) ==
   /\ inPass
   /\ l \in queue
-  /\ crashes < MaxCrashes
+  /\ (l \in Poisoned \/ crashes < MaxCrashes)
   /\ answers' = [answers EXCEPT ![l] = FALSE]
   /\ queue' = queue \ {l}
-  /\ crashes' = crashes + 1
+  /\ crashes' = IF l \in Poisoned THEN crashes ELSE crashes + 1
   /\ UNCHANGED <<owed, armed, inPass>>
 
 (* The contract re-arm: live derivations folded in, mid-pass arms kept. *)
@@ -130,6 +145,11 @@ LiveSpec ==
   /\ WF_vars(Fire)
   /\ WF_vars(ReArm)
   /\ \A l \in Lanes: SF_vars(VisitOk(l))
+  (* Every queued lane is eventually visited: a visit completes, by
+     serve or by crash. This is the fail-fast assumption. A visit
+     that HANGS holds the pass open past this module's model; the
+     runtime's alarm time limit owns that door, unmodeled here. *)
+  /\ \A l \in Lanes: WF_vars(VisitOk(l) \/ VisitCrash(l))
 
 -----------------------------------------------------------------------
 (* The debts. *)
@@ -137,7 +157,17 @@ LiveSpec ==
 (* ACCOUNTING: owed work always has a wake coming. *)
 Accounting == (\E l \in Lanes: owed[l]) => (armed \/ inPass)
 
-(* SERVICE (under LiveSpec): every owed lane is eventually served. *)
+(* SERVICE (under LiveSpec, Poisoned empty): every owed lane is
+   eventually served. Over a nonempty Poisoned this same formula is
+   the REST debt, and DriverPoisoned.cfg expects TLC to refute it:
+   the counterexample is the eternal watchdog retry. *)
 EventuallyServed == \A l \in Lanes: [](owed[l] => <>(~owed[l]))
+
+(* ISOLATION (under LiveSpec): every healthy lane is eventually
+   served, whatever the poisoned lanes do. The implementation half is
+   the per-visit catch in HostSupervisor.alarm: before it, one
+   poisoned facet failed the whole pass and starved every lane (the
+   2026-08-18 Uniconnect wedge). *)
+HealthyServed == \A l \in (Lanes \ Poisoned): [](owed[l] => <>(~owed[l]))
 
 =======================================================================

--- a/packages/core/tla/DriverDrop.cfg
+++ b/packages/core/tla/DriverDrop.cfg
@@ -4,4 +4,5 @@ SPECIFICATION DropSpec
 CONSTANTS
   Lanes = {l1, l2}
   MaxCrashes = 1
+  Poisoned = {}
 INVARIANT Accounting

--- a/packages/core/tla/DriverIsolate.cfg
+++ b/packages/core/tla/DriverIsolate.cfg
@@ -1,0 +1,11 @@
+\* ISOLATION: every healthy lane is eventually served with a poisoned
+\* lane in the pass. Expected to PASS: the per-visit catch in
+\* HostSupervisor.alarm is the implementation half.
+SPECIFICATION LiveSpec
+CONSTANTS
+  Lanes = {l1, l2}
+  MaxCrashes = 1
+  Poisoned = {l2}
+INVARIANT TypeOK
+INVARIANT Accounting
+PROPERTY HealthyServed

--- a/packages/core/tla/DriverLive.cfg
+++ b/packages/core/tla/DriverLive.cfg
@@ -3,4 +3,5 @@ SPECIFICATION LiveSpec
 CONSTANTS
   Lanes = {l1, l2}
   MaxCrashes = 1
+  Poisoned = {}
 PROPERTY EventuallyServed

--- a/packages/core/tla/DriverPoisoned.cfg
+++ b/packages/core/tla/DriverPoisoned.cfg
@@ -1,0 +1,9 @@
+\* REST: a lane whose visits always crash eventually rests. Expected
+\* to FAIL: no GiveUp action exists, so the poisoned lane's owed work
+\* is never discharged. The trace is the eternal watchdog retry.
+SPECIFICATION LiveSpec
+CONSTANTS
+  Lanes = {l1, l2}
+  MaxCrashes = 1
+  Poisoned = {l2}
+PROPERTY EventuallyServed


### PR DESCRIPTION
Driver.tla models crashing visits with a bounded budget (MaxCrashes), so its SERVICE theorem proves convergence only for transient failures. A deterministic crasher (the Uniconnect run facet, 2026-08-18) sits outside that premise: the real system retries it on the watchdog forever, and no property in the suite states that a lane whose visits always crash eventually settles as failed. This change puts that debt on the ledger as an expected-fail config, red until a GiveUp action pays it.

- add the Poisoned constant to Driver.tla: lanes whose visits can never serve; their crashes are exempt from the MaxCrashes budget, so the budget cannot smuggle convergence past a lane that never converges
- add the fail-fast fairness conjunct to LiveSpec (every queued lane is eventually visited, by serve or by crash); a hanging visit is outside this module and stays with the runtime's alarm time limit
- DriverPoisoned.cfg: EventuallyServed over a poisoned lane, expected to FAIL; TLC's counterexample lasso is Fire, serve the healthy lane, crash the poisoned lane, ReArm, forever
- DriverIsolate.cfg: HealthyServed, expected to PASS; the spec half of the per-visit catch in HostSupervisor.alarm (flamecast-v6 #115)
- TLC run on all five Driver configs: Driver, DriverLive, DriverIsolate green; DriverDrop and DriverPoisoned red as expected