### PR TITLE
feat(core): facets observe service

### DIFF
--- a/packages/agent/src/capability.test.ts
+++ b/packages/agent/src/capability.test.ts
@@ -4,6 +4,7 @@ import { KeyValueStore } from "effect/unstable/persistence"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { EventLog, withWatermark } from "@clavia/tardigrade-core/event-log"
 import { Router } from "@clavia/tardigrade-core/router"
+import { Facets } from "@clavia/tardigrade-core/facets"
 import { Self } from "@clavia/tardigrade-core/actor"
 import type { Package } from "@clavia/tardigrade-code/packages"
 import { agentOf, budget, CODE_SYSTEM, codeMode, codeModeFor, compaction, compactionFor, renderOf, reply, toolList } from "./capability"
@@ -26,6 +27,7 @@ const memoryLog = (initial: ReadonlyArray<Event> = []) =>
   )
 
 const noRouter = Layer.mergeAll(
+  Layer.succeed(Facets, { read: () => Effect.succeed([]) }),
   Layer.succeed(Router, {
     deliver: () => Effect.void,
     call: () => Effect.succeed({ error: "no router bound" }),

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,8 +1,7 @@
-import { Context, Effect, Layer } from "effect"
+import { Effect, Layer } from "effect"
 import { KeyValueStore } from "effect/unstable/persistence"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { assertSupportedBun } from "@clavia/tardigrade-core/runtime"
-import type { Router } from "@clavia/tardigrade-core/router"
 import type { Actor } from "@clavia/tardigrade-core/actor"
 import type { Package } from "@clavia/tardigrade-code/packages"
 import { jsSandboxFor } from "@clavia/tardigrade-code/defaults"
@@ -107,49 +106,30 @@ export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
 
   const policy = options.policy ?? {}
   // This host takes no synchronous calls, so an escalatable spawn's ask and agents.continue
-  // refuse here. One value is both the host's own doors and the doors the spawn package's router
-  // offers, so the two cannot disagree (packages/agent/src/spawn.ts, agentsPackage).
+  // refuse here. The spawn package reaches the same Router the host binds per lane, so its
+  // doors and the host's cannot disagree (packages/host/src/host.ts, createHost).
   const refused = () => Effect.succeed({ error: "this host takes no synchronous calls" })
-  // The router as a value: a delivery goes through this host, exactly as the router layer the
-  // host binds delivers (packages/host/src/host.ts, createHost).
-  const router: Context.Service.Shape<typeof Router> = {
-    deliver: (address: string, event: Event) => Effect.sync(() => host.deliver(address, event)),
-    call: refused,
-    resume: refused
-  }
 
-  // Every ag. lane runs the RLM default; anything else is a sink. A lane's actor is built on its
-  // first visit, because the spawn package closes over this lane's own address and the host that
-  // routes for it: both are values by then, so the packages reach code mode as values and the
-  // assembly's requirements are what those values state (capability.ts, codeModeFor).
-  const actors = new Map<string, Actor<RlmR>>()
-  const actorFor = (lane: string): Actor<RlmR> | undefined => {
-    if (!lane.startsWith("ag.")) return undefined
-    const built = actors.get(lane)
-    if (built !== undefined) return built
-    const spawn = agentsPackage(
-      router,
-      host.self(lane),
-      (callId) => host.self(`ag.${callId}`),
-      { events: (facet: string) => Promise.resolve(host.read(facet)) },
-      // A child with no stated budget takes the same ceiling this agent's own wall reads.
-      { budget: policy.budget ?? {} }
-    )
-    // The workspace reads the same store the spill path writes. This host binds no SQL surface,
-    // so it is the two-verb workspace (packages/code/src/workspace.ts, workspacePackage).
-    const workspace = workspacePackage({ policy: policy.workspace ?? {} })
-    const assembled = agentOf(
-      [
-        ...(options.capabilities ?? [codeModeFor(policy.code ?? {}, {}, [...user, spawn, workspace])]),
-        reply,
-        budgetFor(policy.budget ?? {}),
-        compactionFor(policy.context ?? {})
-      ],
-      policy.infer ?? {}
-    )
-    actors.set(lane, assembled)
-    return assembled
-  }
+  // The spawn package is a value with no lane in it: Router, Self, and Facets serve its methods
+  // from the environment the host binds per lane (spawn.ts, agentsPackage). A child with no
+  // stated budget takes the same ceiling this agent's own wall reads.
+  const spawn = agentsPackage({ budget: policy.budget ?? {} })
+  // The workspace reads the same store the spill path writes. This host binds no SQL surface,
+  // so it is the two-verb workspace (packages/code/src/workspace.ts, workspacePackage).
+  const workspace = workspacePackage({ policy: policy.workspace ?? {} })
+  // Every ag. lane runs the RLM default; anything else is a sink. Nothing in the assembly names
+  // a lane, so one actor serves them all: the lane arrives as Self, and the packages are values
+  // the whole host shares (capability.ts, codeModeFor).
+  const assembled = agentOf(
+    [
+      ...(options.capabilities ?? [codeModeFor(policy.code ?? {}, {}, [...user, spawn, workspace])]),
+      reply,
+      budgetFor(policy.budget ?? {}),
+      compactionFor(policy.context ?? {})
+    ],
+    policy.infer ?? {}
+  )
+  const actorFor = (lane: string): Actor<RlmR> | undefined => (lane.startsWith("ag.") ? assembled : undefined)
   const host: Host = createHost<RlmR>({
     principal: "mem",
     actorFor,

--- a/packages/agent/src/spawn.test.ts
+++ b/packages/agent/src/spawn.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+import type { Event } from "@clavia/tardigrade-core/event"
+import { Router } from "@clavia/tardigrade-core/router"
+import { Self } from "@clavia/tardigrade-core/actor"
+import { Facets } from "@clavia/tardigrade-core/facets"
+import { createHost } from "@clavia/tardigrade-host/host"
+import { replyId } from "@clavia/tardigrade-core/reply"
+import { Park } from "@clavia/tardigrade-code/errors"
+import { agentsPackage } from "./spawn"
+
+// The package is a value: its three privileges arrive as services, so a test binds them the way
+// a host does and the same value runs anywhere.
+
+const REFUSED = Effect.succeed({ error: "no synchronous calls" })
+
+const env = (
+  lane: string,
+  sent: Array<{ readonly address: string; readonly event: Event }>,
+  lanes: Readonly<Record<string, ReadonlyArray<Event>>> = {}
+) =>
+  Layer.mergeAll(
+    Layer.succeed(Router, {
+      deliver: (address: string, event: Event) => Effect.sync(() => void sent.push({ address, event })),
+      call: () => REFUSED,
+      resume: () => REFUSED
+    }),
+    Layer.succeed(Self, lane),
+    Layer.succeed(Facets, { read: (name: string) => Effect.succeed(lanes[name] ?? []) })
+  )
+
+describe("agentsPackage", () => {
+  test("the default placement is the host's own sibling address", async () => {
+    const host = createHost({ actorFor: () => undefined, principal: "mem" })
+    const sent: Array<{ readonly address: string; readonly event: Event }> = []
+    const pkg = agentsPackage()
+    await Effect.runPromise(
+      pkg.methods.run!({ text: "scout", background: true }, { callId: "c1" }).pipe(Effect.provide(env(host.self("ag.root"), sent)))
+    )
+    // Parity with the closure the in-process host used to pass: same principal, `ag.<callId>`
+    // for the lane.
+    expect(sent[0]?.address).toBe(host.self("ag.c1"))
+  })
+
+  test("a stated place overrides the default", async () => {
+    const sent: Array<{ readonly address: string; readonly event: Event }> = []
+    const pkg = agentsPackage({ place: (callId, self) => `far:${self}/${callId}` })
+    await Effect.runPromise(
+      pkg.methods.run!({ text: "scout", background: true }, { callId: "c2" }).pipe(Effect.provide(env("mem:ag.root", sent)))
+    )
+    expect(sent[0]?.address).toBe("far:mem:ag.root/c2")
+  })
+
+  test("the callId is the child's identity and the brief's id", async () => {
+    const sent: Array<{ readonly address: string; readonly event: Event }> = []
+    const pkg = agentsPackage()
+    const answer = await Effect.runPromise(
+      pkg.methods.run!({ text: "scout", background: true }, { callId: "c3" }).pipe(Effect.provide(env("mem:ag.root", sent)))
+    )
+    expect(answer).toEqual({ dispatched: true, callId: "c3" })
+    const brief = sent[0]!.event as { id?: unknown; replyTo?: unknown }
+    expect(brief.id).toBe("c3")
+    expect(brief.replyTo).toBe("mem:ag.root")
+  })
+
+  test("a reply already on the lane answers without parking", async () => {
+    const sent: Array<{ readonly address: string; readonly event: Event }> = []
+    const pkg = agentsPackage()
+    const lanes = {
+      "ag.root": [{ type: "MessageReceived", id: replyId("c4"), outcome: "completed", text: "4", at: 1 }]
+    } as Readonly<Record<string, ReadonlyArray<Event>>>
+    const answer = await Effect.runPromise(
+      pkg.methods.run!({ text: "sum 2+2" }, { callId: "c4" }).pipe(Effect.provide(env("mem:ag.root", sent, lanes)))
+    )
+    expect(answer).toEqual({ output: "4" })
+    // The observe privilege answered, so nothing was re-delivered.
+    expect(sent.length).toBe(0)
+  })
+
+  test("a foreground run with no reply yet parks on the reply row", async () => {
+    const sent: Array<{ readonly address: string; readonly event: Event }> = []
+    const pkg = agentsPackage()
+    const parked = await Effect.runPromise(
+      pkg.methods.run!({ text: "sum 2+2" }, { callId: "c5" }).pipe(Effect.provide(env("mem:ag.root", sent)), Effect.flip)
+    )
+    expect(parked).toBeInstanceOf(Park)
+    expect((parked as Park).awaiting).toBe(replyId("c5"))
+    expect(sent[0]?.address).toBe("mem:ag.c5")
+  })
+
+  test("result reads the lane through Facets", async () => {
+    const sent: Array<{ readonly address: string; readonly event: Event }> = []
+    const pkg = agentsPackage()
+    const lanes = {
+      "ag.root": [{ type: "MessageReceived", id: replyId("c6"), outcome: "failed", text: "error: nope", at: 1 }]
+    } as Readonly<Record<string, ReadonlyArray<Event>>>
+    const answer = await Effect.runPromise(
+      pkg.methods.result!({ id: "c6" }, { callId: "c7" }).pipe(Effect.provide(env("mem:ag.root", sent, lanes)))
+    )
+    expect(answer).toEqual({ error: "nope" })
+  })
+})

--- a/packages/agent/src/spawn.ts
+++ b/packages/agent/src/spawn.ts
@@ -1,10 +1,11 @@
-import { Clock, Context, Effect } from "effect"
+import { Clock, Effect } from "effect"
 import { Router } from "@clavia/tardigrade-core/router"
+import { Self } from "@clavia/tardigrade-core/actor"
+import { Facets } from "@clavia/tardigrade-core/facets"
 import type { Package } from "@clavia/tardigrade-code/packages"
-import type { Event } from "@clavia/tardigrade-core/event"
 import { budgetPolicyOf, type BudgetPolicy } from "./budget"
 import { Park } from "@clavia/tardigrade-code/errors"
-import { readAddress } from "@clavia/tardigrade-core/router"
+import { address as addressOf, readAddress } from "@clavia/tardigrade-core/router"
 import { replyId } from "@clavia/tardigrade-core/reply"
 
 // The agents package: ad-hoc agents, reachable from code like any other package. One verb with a
@@ -20,9 +21,15 @@ import { replyId } from "@clavia/tardigrade-core/reply"
 // committed run and re-delivers a crashed dispatch. The call id is the child's identity AND the
 // message id, so a replayed dispatch reaches the same child and is absorbed as a duplicate.
 //
-// `place` is the placement policy: the call's id in, the child's address out. The caller never
-// learns where the child lives; the platform's default colocates children as sibling facets of
-// the parent's host, and a remote child is one different returned string.
+// The package is a value any consumer mounts: its host privileges are services, not constructor
+// arguments. `Router` delivers and calls, `Self` names the calling lane, and `Facets` reads that
+// lane's committed replies (`@clavia/tardigrade-core/facets`), so `Package<Router | Self | Facets>`
+// states what a host must bind for these methods to run.
+//
+// `place` is the placement policy: the call's id and the parent's own address in, the child's
+// address out. The caller never learns where the child lives; the default colocates children as
+// sibling facets of the parent's principal, `ag.<callId>` beside the parent's own lane, and a
+// remote child is one different returned string.
 //
 // A plain foreground run parks, the same mechanism `tasks.fire` (`src/packages/tasks.ts`) uses:
 // deliver the brief with `replyTo` this lane, then await the reply row on this lane, host-side
@@ -54,13 +61,16 @@ export interface SpawnOptions {
   readonly budget?: Partial<BudgetPolicy>
 }
 
+// sibling is the default placement: the child is a facet of the parent's own principal, named
+// `ag.<callId>`. It parses the parent's address with core's one parser, so a placement can never
+// disagree with the router about what an address is (spawn.test.ts, "the default placement is
+// the host's own sibling address").
+const sibling = (callId: string, self: string): string => addressOf(readAddress(self).home, `ag.${callId}`)
+
 export const agentsPackage = (
-  router: Context.Service.Shape<typeof Router>,
-  self: string,
-  place: (callId: string) => string,
-  reader: AgentReader,
-  options: SpawnOptions = {}
-): Package => {
+  options: SpawnOptions & { readonly place?: (callId: string, self: string) => string } = {}
+): Package<Router | Self | Facets> => {
+  const place = options.place ?? sibling
   const agentOf = options.agentOf ?? (() => undefined)
   const reserve = options.reserve ?? (async (_callId: string, want: number) => want)
   const shadowOf = options.shadowOf ?? (() => false)
@@ -116,6 +126,10 @@ export const agentsPackage = (
     methods: {
       run: (args, ctx) =>
         Effect.gen(function* () {
+          // The three cross-lane privileges, read where the work happens: deliver, identity,
+          // observe. A host that binds them serves this method; nothing here closes over one.
+          const router = yield* Router
+          const self = yield* Self
           const a = args as
             | { text?: unknown; background?: unknown; output?: unknown; outputSchema?: unknown; model?: unknown; budget?: unknown; escalatable?: unknown }
             | undefined
@@ -148,7 +162,7 @@ export const agentsPackage = (
           // the same way, when the fire named an explicit shared one.
           const shadow = shadowOf()
           const world = worldOf()
-          const address = place(ctx.callId)
+          const address = place(ctx.callId, self)
           if (a?.background === true) {
             // A background run has no synchronous parent to decide an escalation, so it never asks:
             // the brief carries no `escalatable`, and the reply comes home as an inbound, awaited
@@ -190,7 +204,7 @@ export const agentsPackage = (
           // (a replayed attempt) answers at once, with no re-delivery; otherwise the brief goes
           // out with `replyTo` this lane, exactly the background delivery above, and the host
           // parks this call until the reply lands.
-          const already = yield* awaitedReply(reader, self, ctx.callId)
+          const already = yield* awaitedReply(self, ctx.callId)
           if (already !== undefined) return shape(answerOf(already), address, ctx.callId, output !== undefined)
           const at = yield* Clock.currentTimeMillis
           yield* router.deliver(address, {
@@ -214,10 +228,11 @@ export const agentsPackage = (
       // run answered.
       result: (args, ctx) =>
         Effect.gen(function* () {
+          const self = yield* Self
           const a = args as { id?: unknown; output?: unknown } | undefined
           const id = String(a?.id ?? "")
           if (id === "") return { error: "agents.result needs { id }" }
-          const reply = yield* awaitedReply(reader, self, id)
+          const reply = yield* awaitedReply(self, id)
           if (reply !== undefined) return shape(answerOf(reply), "", id, a?.output !== undefined)
           return yield* Effect.fail(new Park({ callId: ctx.callId, awaiting: replyId(id) }))
         }),
@@ -227,6 +242,7 @@ export const agentsPackage = (
       // boundary, another request or its final answer, in the same shape `run` returns.
       continue: (args, ctx) =>
         Effect.gen(function* () {
+          const router = yield* Router
           const a = args as { handle?: unknown; grant?: unknown } | undefined
           const handle = a?.handle as { address?: unknown; turn?: unknown; structured?: unknown } | undefined
           const address = String(handle?.address ?? "")
@@ -242,27 +258,21 @@ export const agentsPackage = (
   }
 }
 
-// AgentReader reads one facet's committed events. `run` (awaiting) and `result` use it to check
-// whether a spawned child's reply has already landed, before ever parking: the same shape
-// `tasks.ts` (`TaskReader`) reads its own lane with.
-export interface AgentReader {
-  readonly events: (facet: string) => Promise<ReadonlyArray<Event>>
-}
-
 // SpawnTerminal is a spawned child's terminal, once its reply has landed on the calling lane.
 interface SpawnTerminal {
   readonly outcome: "completed" | "failed"
   readonly text: string
 }
 
-// awaitedReply returns the reply row for one spawn, if it has landed on the calling lane. `id`
-// is `replyEvent`'s own convention (`src/core/reply.ts`): `<id>.reply` (`replyId`,
-// `src/grammar/grammar.ts`), so a redelivered brief dedups at the sender and a redelivered reply
-// dedups at the receiver.
-const awaitedReply = (reader: AgentReader, self: string, id: string): Effect.Effect<SpawnTerminal | undefined> =>
-  Effect.promise(async () => {
-    const facet = readAddress(self).facet
-    const events = await reader.events(facet)
+// awaitedReply returns the reply row for one spawn, if it has landed on the calling lane. The
+// read is the observe privilege (`Facets`), over this lane's own facet: `run` (awaiting) and
+// `result` ask it whether a spawned child's reply is already home before ever parking. `id` is
+// `replyEvent`'s own convention (`packages/core/src/reply.ts`): `<id>.reply` (`replyId`), so a
+// redelivered brief dedups at the sender and a redelivered reply dedups at the receiver.
+const awaitedReply = (self: string, id: string): Effect.Effect<SpawnTerminal | undefined, never, Facets> =>
+  Effect.gen(function* () {
+    const logs = yield* Facets
+    const events = yield* logs.read(readAddress(self).facet)
     const reply = events.find(
       (e) => e.type === "MessageReceived" && (e as { id?: unknown }).id === replyId(id)
     ) as { outcome?: unknown; text?: unknown } | undefined

--- a/packages/agent/src/turn.test.ts
+++ b/packages/agent/src/turn.test.ts
@@ -7,6 +7,7 @@ import { settleActor } from "@clavia/tardigrade-core/actor"
 import type { Package } from "@clavia/tardigrade-code/packages"
 import { Sandbox, type Bindings } from "@clavia/tardigrade-code/sandbox"
 import { Router } from "@clavia/tardigrade-core/router"
+import { Facets } from "@clavia/tardigrade-core/facets"
 import { Self } from "@clavia/tardigrade-core/actor"
 import { Infer, receive } from "./turn"
 import { agentOf, budget, codeModeFor, compaction, reply, toolList } from "./capability"
@@ -70,6 +71,7 @@ const zoho = (spies: { insert: number; search: number }): Package => ({
 
 // No other actors exist in these tests: delivery is a no-op and a sync call answers with an error.
 const noRouter = Layer.mergeAll(
+  Layer.succeed(Facets, { read: () => Effect.succeed([]) }),
   Layer.succeed(Router, {
     deliver: () => Effect.void,
     call: () => Effect.succeed({ error: "no router bound" }),

--- a/packages/agent/src/turn.ts
+++ b/packages/agent/src/turn.ts
@@ -4,6 +4,7 @@ import { EventLog } from "@clavia/tardigrade-core/event-log"
 import { send, type Actor } from "@clavia/tardigrade-core/actor"
 import type { Router } from "@clavia/tardigrade-core/router"
 import type { Self } from "@clavia/tardigrade-core/actor"
+import type { Facets } from "@clavia/tardigrade-core/facets"
 import type { Infer, InferPolicy } from "./infer"
 import type { BudgetPolicy } from "./budget"
 import type { ContextPolicy } from "./compaction"
@@ -12,11 +13,12 @@ import type { WorkspacePolicy } from "@clavia/tardigrade-code/workspace"
 
 export { Infer } from "./infer"
 
-// AgentR is the runtime's needs: Infer for the model, EventLog for settle, Router and Self for
-// reply, and KeyValueStore for the spill store code mode writes bounded results to
+// AgentR is the runtime's needs: Infer for the model, EventLog for settle, Router, Self, and
+// Facets for reply and spawn (the deliver, identity, and observe privileges; core/facets.ts), and
+// KeyValueStore for the spill store code mode writes bounded results to
 // (packages/code/src/spill.ts). Capabilities add their own on top (capability.ts,
 // RequirementsOf).
-export type AgentR = Infer | EventLog | Router | Self | KeyValueStore.KeyValueStore
+export type AgentR = Infer | EventLog | Router | Self | Facets | KeyValueStore.KeyValueStore
 export type RlmR = AgentR
 
 // AgentPolicy is every policy value an assembled agent applies, one field per part that applies

--- a/packages/core/src/facets.test.ts
+++ b/packages/core/src/facets.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+import type { Event } from "./event"
+import { Facets } from "./facets"
+
+// The observe privilege: a name in, that lane's committed events out. A binding that cannot
+// reach the named lane answers in the same shape, so a reader never learns where a log lives.
+
+const lanes: Readonly<Record<string, ReadonlyArray<Event>>> = {
+  "ag.child": [{ type: "MessageReceived", id: "m1", text: "hello", at: 1 }]
+}
+
+const shared = Layer.succeed(Facets, { read: (name: string) => Effect.succeed(lanes[name] ?? []) })
+
+describe("Facets", () => {
+  test("Facets reads a sibling lane by name", async () => {
+    const read = Effect.gen(function* () {
+      const logs = yield* Facets
+      return yield* logs.read("ag.child")
+    })
+    const events = await Effect.runPromise(read.pipe(Effect.provide(shared)))
+    expect(events.map((e) => e.type)).toEqual(["MessageReceived"])
+    expect((events[0] as { text?: unknown }).text).toBe("hello")
+  })
+
+  test("an unknown lane reads empty, never absent", async () => {
+    const read = Effect.gen(function* () {
+      const logs = yield* Facets
+      return yield* logs.read("ag.nobody")
+    })
+    expect(await Effect.runPromise(read.pipe(Effect.provide(shared)))).toEqual([])
+  })
+
+  test("a remote binding refuses in the same shape", async () => {
+    const remote = Layer.succeed(Facets, { read: () => Effect.succeed([] as ReadonlyArray<Event>) })
+    const read = Effect.gen(function* () {
+      const logs = yield* Facets
+      return yield* logs.read("ag.child")
+    })
+    expect(await Effect.runPromise(read.pipe(Effect.provide(remote)))).toEqual([])
+  })
+})

--- a/packages/core/src/facets.ts
+++ b/packages/core/src/facets.ts
@@ -1,0 +1,19 @@
+import { Context, Effect } from "effect"
+import type { Event } from "./event"
+
+// Facets is the observe privilege: it reads a sibling actor's committed log by name, the way
+// Router reaches one and Self names this one. A facet is another lane's log seen from outside.
+// A lane owns its own log through EventLog; the two privileges stay separate, so a reader
+// cannot append.
+//
+// It exists only where logs share a store, a placement-2 privilege: a host whose lanes are
+// remote provides a Facets that proxies the read or refuses it, and the caller sees the same
+// shape either way. Beside Router (deliver) and Self (identity) it completes the cross-lane
+// vocabulary, so a package that watches a sibling names a service instead of closing over a
+// host (facets.test.ts, "Facets reads a sibling lane by name").
+export class Facets extends Context.Service<
+  Facets,
+  {
+    readonly read: (name: string) => Effect.Effect<ReadonlyArray<Event>>
+  }
+>()("tardigrade/Facets") {}

--- a/packages/host/src/host.test.ts
+++ b/packages/host/src/host.test.ts
@@ -3,6 +3,7 @@ import { Effect } from "effect"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { Router } from "@clavia/tardigrade-core/router"
 import { transition, type Reactor } from "@clavia/tardigrade-core/actor"
+import { Facets } from "@clavia/tardigrade-core/facets"
 import { createHost } from "./host"
 
 // The host against toy reactors, package-pure: no app vocabulary.
@@ -105,5 +106,33 @@ describe("the router membrane", () => {
     )
     host.deliver("mem:lane", { type: "Keyed", id: "k1", at: 1 } as never)
     expect(host.read("lane").length).toBe(1)
+  })
+})
+
+describe("the observe privilege", () => {
+  // All lanes share one store here, so the host binds Facets beside Router and Self: a lane reads
+  // a sibling's committed events by name (packages/core/src/logs.ts, Facets).
+  test("a lane reads a seeded sibling lane through Facets", async () => {
+    const watcher: Reactor<Facets> = (events) =>
+      events.some((e) => e.type === "Saw")
+        ? []
+        : [
+            transition({
+              key: "saw:one",
+              input: null,
+              act: () =>
+                Effect.gen(function* () {
+                  const logs = yield* Facets
+                  const seen = yield* logs.read("other")
+                  return [{ type: "Saw", n: seen.length, at: 1 } as Event]
+                })
+            })
+          ]
+    const host = createHost<Facets>({
+      actorFor: (lane) => (lane === "watch" ? { reactors: [watcher], keyOf: (e) => (e.type === "Saw" ? "saw:one" : undefined) } : undefined)
+    })
+    host.seed("other", [{ type: "MessageReceived", id: "m1", text: "hi", at: 1 } as Event])
+    await host.wake("watch")
+    expect(host.read("watch")).toEqual([{ type: "Saw", n: 1, at: 1 }])
   })
 })

--- a/packages/host/src/host.ts
+++ b/packages/host/src/host.ts
@@ -3,6 +3,7 @@ import type { Event } from "@clavia/tardigrade-core/event"
 import { EventLog, withWatermark } from "@clavia/tardigrade-core/event-log"
 import { Router, type CallResult } from "@clavia/tardigrade-core/router"
 import { Self, restingActor, settleActor, type Actor } from "@clavia/tardigrade-core/actor"
+import { Facets } from "@clavia/tardigrade-core/facets"
 import { deadlocks, victimOf, type EdgesOf } from "./deadlock"
 
 // A host runs the emergent graph: many lanes, one router, one driver.
@@ -12,9 +13,9 @@ import { deadlocks, victimOf, type EdgesOf } from "./deadlock"
 // conformance contract is packages/core/tla (Driver, Delivery).
 
 // HostPorts are the services every host binds per lane: the log, the
-// router, and this lane's address. layersFor may require them and must
-// not provide them.
-export type HostPorts = EventLog | Router | Self
+// router, this lane's address, and the read over its siblings' logs.
+// layersFor may require them and must not provide them.
+export type HostPorts = EventLog | Router | Self | Facets
 
 // LaneEnv is the rest of an actor's R: what the host does not bind.
 // Construction may require HostPorts; Layer.provideMerge discharges them.
@@ -144,6 +145,8 @@ export const createHost = <R = never>(options: HostOptions<R>): Host => {
     resume: options.resume ?? (() => Effect.succeed(REFUSED))
   })
 
+  const logs = Layer.succeed(Facets, { read: (name: string) => Effect.sync(() => read(name)) })
+
   const self = (lane: string): string => `${principal}:${lane}`
 
   const portsOf = (lane: string) =>
@@ -156,7 +159,11 @@ export const createHost = <R = never>(options: HostOptions<R>): Host => {
         })
       ),
       router,
-      Layer.succeed(Self, self(lane))
+      Layer.succeed(Self, self(lane)),
+      // All lanes share one store here, so the observe privilege is the host's own read
+      // (packages/core/src/logs.ts, Facets). A lane's own log still arrives as EventLog: this
+      // one reads a sibling and cannot append.
+      logs
     )
 
   // Exclude is not distributive over a generic R, so the merge is named

--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -6,6 +6,7 @@ import { Effect, Layer, Tracer } from "effect"
 import type { KeyValueStore } from "effect/unstable/persistence"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { transition, type Actor, type Reactor } from "@clavia/tardigrade-core/actor"
+import { Facets } from "@clavia/tardigrade-core/facets"
 import { hydrate, refs, spill } from "@clavia/tardigrade-code/store"
 
 import { workspaceFor, WORKSPACE_SQL_DESCRIPTION } from "@clavia/tardigrade-code/workspace"
@@ -451,6 +452,37 @@ describe("the workspace sql surface", () => {
     expect(answered.methods).toEqual(["grep", "read"])
     expect(answered.doc).toBe(false)
     expect(answered.answers).toEqual([])
+    await h.close()
+  })
+})
+
+describe("the observe privilege", () => {
+  // Every lane's log lives in this one database, so the binding gives a lane the durable read
+  // over its siblings (packages/core/src/logs.ts, Facets).
+  test("a lane reads a seeded sibling lane through Facets", async () => {
+    const watcher: Reactor<Facets> = (events) =>
+      events.some((e) => e.type === "Saw")
+        ? []
+        : [
+            transition({
+              key: "saw:one",
+              input: null,
+              act: () =>
+                Effect.gen(function* () {
+                  const logs = yield* Facets
+                  const seen = yield* logs.read("other")
+                  return [{ type: "Saw", n: seen.length, at: 1 } as Event]
+                })
+            })
+          ]
+    const h = await createBunHost<Facets>({
+      log: freshPath(),
+      actorFor: (lane) =>
+        lane === "watch" ? { reactors: [watcher], keyOf: (e) => (e.type === "Saw" ? "saw:one" : undefined) } : undefined
+    })
+    await h.seed("other", [{ type: "MessageReceived", id: "m1", text: "hi", at: 1 } as Event])
+    await h.wake("watch")
+    expect((await h.read("watch")).map((e) => [e.type, (e as { n?: unknown }).n])).toEqual([["Saw", 1]])
     await h.close()
   })
 })

--- a/platform/bun/src/host.ts
+++ b/platform/bun/src/host.ts
@@ -7,6 +7,7 @@ import { EventLog } from "@clavia/tardigrade-core/event-log"
 import { assertSupportedBun } from "@clavia/tardigrade-core/runtime"
 import { Router, type CallResult } from "@clavia/tardigrade-core/router"
 import { Self, restingActor, settleActor, type Actor } from "@clavia/tardigrade-core/actor"
+import { Facets } from "@clavia/tardigrade-core/facets"
 import { deadlocks, victimOf, type EdgesOf } from "@clavia/tardigrade-host/deadlock"
 import type { HostPorts } from "@clavia/tardigrade-host/host"
 import { traceparentOf } from "@clavia/tardigrade-core/trace"
@@ -24,7 +25,7 @@ import { bunWorkspace, bunWorkspaceSql, workspaceSqlFile } from "./workspace"
 // creates through workspace.sql live in a second file beside it, out of the log's reach
 // (workspace.ts).
 
-// BunPorts are the services this binding leaves an actor no work to bind: packages/host's three,
+// BunPorts are the services this binding leaves an actor no work to bind: packages/host's four,
 // plus the workspace store, which on bun is durable and therefore the platform's to give
 // (packages/code/src/store.ts). BunLaneEnv is the rest of an actor's R, the same shape the
 // reference host asks for.
@@ -214,7 +215,11 @@ export const createBunHost = async <R = never>(options: BunHostOptions<R>): Prom
       }),
       router,
       Layer.succeed(KeyValueStore.KeyValueStore, store),
-      Layer.succeed(Self, self(lane))
+      Layer.succeed(Self, self(lane)),
+      // Every lane's log lives in this one durable store, so the observe privilege is the same
+      // read the host serves itself (packages/core/src/logs.ts, Facets). A binding whose lanes
+      // are remote proxies or refuses instead.
+      Layer.succeed(Facets, { read: (name: string) => readEffect(name) })
     )
 
   const layersOf = (lane: string): Layer.Layer<R | EventLog> => {


### PR DESCRIPTION
The agents/spawn package could only be built by createRlmAgent, because it took the host's router, address, and facet reader as constructor closures. Name those privileges as services instead, so the package is a value any assembly can mount and its needs ride its type.

A facet is another lane's log seen from outside. The new core Facets service is the observe privilege (read a sibling's log by name), completing the cross-lane vocabulary beside Router (deliver) and Self (identity). It exists only where logs share a store; a remote host proxies or refuses. Named Facets rather than Logs so it cannot be confused with EventLog, the own-log service.

- core: Facets service in facets.ts, contract and tests
- agentsPackage(options?) returns Package<Router | Self | Facets>; place stays an overridable policy whose default derives the sibling address from Self via core's readAddress, with a parity test against host.self
- both hosts bind Facets per lane from their own read
- AgentR gains Facets; the test envs bind an empty one
- createRlmAgent shrinks: no hand-built router value, no host closures, one shared actor again
- bun run gate fully green