### PR TITLE
docs: ban rhetorical uniqueness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ No silent hardcoding. When the framework applies a policy value, such as a cap, 
 - Go stdlib register: start with the identifier's name; one declarative sentence is the contract; further sentences only for constraints.
 - State what the code cannot: the contract, the constraint, the why. Never narrate mechanics or edit history.
 - Cite the spec or test that proves any property claimed (e.g. "tla/Reconcile.tla, NoVoid"). A citation can dangle visibly; a freehand assertion rots invisibly.
+- No rhetorical uniqueness: avoid "the one X", "the canonical X", "never a second concept" as phrasing. When exactly-one is a real invariant, state what enforces it ("duplicate names throw at construction"); when it is not, describe the thing plainly.
 
 ## Style
 


### PR DESCRIPTION
Comments in this repo often assert exactly-one by phrasing (the one shape, the canonical inbound, never a second concept). The phrase claims an invariant without naming what holds it. Add a comment rule: when exactly-one is real, state the enforcement; when it is not, describe plainly.

- add a no-rhetorical-uniqueness bullet to the Comments section of AGENTS.md