### PR TITLE
refactor(agent)!: drop rlm assembly

### DIFF
--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+import { KeyValueStore } from "effect/unstable/persistence"
 import type { Event } from "@clavia/tardigrade-core/event"
+import type { Actor } from "@clavia/tardigrade-core/actor"
+import { jsSandboxFor } from "@clavia/tardigrade-code/defaults"
+import { workspacePackage } from "@clavia/tardigrade-code/workspace"
+import { createHost, type Host, type LaneEnv } from "@clavia/tardigrade-host/host"
 import type { Action } from "./events"
-import { Effect } from "effect"
-import { createRlmAgent } from "./index"
-import { toolList } from "./capability"
+import { Infer, type InferRequest } from "./infer"
+import { boundaryOf } from "./boundary"
+import { resumeTurn } from "./resume"
+import { agentsPackage } from "./spawn"
+import { agentOf, budgetFor, codeModeFor, compactionFor, reply, toolList, type Capability } from "./capability"
+import type { RlmR } from "./turn"
 
 const ROOT_LANE = "ag.root"
 
@@ -11,6 +20,60 @@ const ROOT_LANE = "ag.root"
 // The root's code spawns two children; the host births their lanes,
 // routes briefs and replies, parks and wakes the root, and ask returns
 // when the root settles. No app imports anywhere.
+
+type Mind = (request: InferRequest, key?: string) => Promise<Action>
+
+type Settled = { readonly turn: string; readonly output?: string; readonly error?: string }
+
+// work is the default work surface these tests assemble against: code mode with the spawn and
+// workspace packages in scope. The packages are values, so the same list mounts on any host.
+const work = () => codeModeFor({}, {}, [agentsPackage({ budget: {} }), workspacePackage({ policy: {} })])
+
+// hosted binds one assembled actor to an in-process host and drives the root lane. It is the
+// test's own driver: deliver a brief, drive to quiescence, read the boundary the settle left.
+// A caller with its own host does the same three things (host.ts, Host).
+const hosted = (assembled: Actor<RlmR>, mind: Mind, log: ReadonlyArray<Event> = []) => {
+  const layersFor = (_lane: string): LaneEnv<RlmR> =>
+    Layer.mergeAll(
+      KeyValueStore.layerMemory,
+      jsSandboxFor({}),
+      Layer.succeed(Infer, { react: (request: InferRequest, key?: string) => Effect.promise(() => mind(request, key)) })
+    )
+  const host: Host = createHost<RlmR>({
+    principal: "mem",
+    actorFor: (lane: string) => (lane.startsWith("ag.") ? assembled : undefined),
+    layersFor
+  })
+  if (log.length > 0) host.seed(ROOT_LANE, log)
+
+  // Run ids continue past a seeded history, so a resumed agent's new run never wears an id the
+  // log already dedups.
+  let n = log.length
+  const settled = (turn: string): Settled => {
+    const boundary = boundaryOf(host.read(ROOT_LANE), turn)
+    if (boundary === undefined) return { turn, error: "the root never settled" }
+    if (boundary.kind === "completed") return { turn, output: boundary.output }
+    if (boundary.kind === "failed") return { turn, error: boundary.error }
+    return { turn, error: "the root parked on a budget ask with nobody to answer" }
+  }
+  const run = async (brief: string): Promise<Settled> => {
+    const id = `run-${n++}`
+    host.deliver(host.self(ROOT_LANE), { type: "MessageReceived", id, text: brief, at: n } as Event)
+    await host.drive()
+    return settled(id)
+  }
+  const resume = async (turn: string): Promise<Settled> => {
+    await resumeTurn(host, ROOT_LANE, turn)
+    return settled(turn)
+  }
+  return { run, resume, host }
+}
+
+// rlm is the default assembly: the work surface plus reply, budget, and compaction, over an
+// in-process host. The three policy capabilities are always mounted, so a test that swaps the
+// work surface still runs the same turn loop, budget wall, and answer contract.
+const rlm = (mind: Mind, capabilities: ReadonlyArray<Capability<RlmR>> = [work()], log: ReadonlyArray<Event> = []) =>
+  hosted(agentOf([...capabilities, reply, budgetFor({}), compactionFor({})], {}), mind, log)
 
 const headText = (trajectory: ReadonlyArray<Event>): string => {
   for (let i = trajectory.length - 1; i >= 0; i--) {
@@ -49,12 +112,12 @@ const scripted = async ({ trajectory }: { trajectory: ReadonlyArray<Event> }): P
   }
 }
 
-describe("createRlmAgent", () => {
+describe("an assembled agent", () => {
   test("one run fans out to two children and settles with their answers", async () => {
-    const mind = createRlmAgent({ infer: scripted })
-    const reply = await mind.run("fan out and add")
-    expect(reply.error).toBeUndefined()
-    expect(reply.output).toBe('"4,6"')
+    const mind = rlm(scripted)
+    const answer = await mind.run("fan out and add")
+    expect(answer.error).toBeUndefined()
+    expect(answer.output).toBe('"4,6"')
     // The graph existed: two child lanes, each with a served turn.
     const children = ["ag.t1.0", "ag.t1.1"].map((lane) => mind.host.read(lane))
     for (const log of children) {
@@ -66,13 +129,13 @@ describe("createRlmAgent", () => {
   })
 
   test("an agent initialises from a log: history carries, new runs continue past it", async () => {
-    // Run one agent to a settled state, carry its log into a fresh one: the resumed agent
-    // reads the same history, and a new run serves without colliding with a recorded id.
-    const first = createRlmAgent({ infer: scripted })
+    // Run one agent to a settled state, carry its log into a fresh one: the seeded agent reads
+    // the same history, and a new run serves without colliding with a recorded id.
+    const first = rlm(scripted)
     await first.run("sum 1+2")
     const carried = first.host.read(ROOT_LANE)
 
-    const resumed = createRlmAgent({ infer: scripted, log: carried })
+    const resumed = rlm(scripted, [work()], carried)
     expect(resumed.host.read(ROOT_LANE)).toEqual(carried)
     const again = await resumed.run("sum 3+4")
     expect(again.output).toBe("7")
@@ -82,7 +145,7 @@ describe("createRlmAgent", () => {
   })
 
   test("a second run reuses the root lane as a genuinely fresh turn", async () => {
-    const mind = createRlmAgent({ infer: scripted })
+    const mind = rlm(scripted)
     await mind.run("fan out and add")
     const again = await mind.run("fan out and add")
     expect(again.output).toBe('"4,6"')
@@ -109,14 +172,11 @@ describe("createRlmAgent", () => {
         }
       }
     ])]
-    const mind = createRlmAgent({
-      capabilities,
-      infer: async ({ trajectory }) => {
-        const returned = trajectory.find((e) => e.type === "ToolReturned") as { result?: unknown } | undefined
-        if (returned !== undefined) return { kind: "complete", output: String(returned.result) }
-        return { kind: "call", callId: "n1", name: "read", arguments: { path: "/contract.md" } }
-      }
-    })
+    const mind = rlm(async ({ trajectory }) => {
+      const returned = trajectory.find((e) => e.type === "ToolReturned") as { result?: unknown } | undefined
+      if (returned !== undefined) return { kind: "complete", output: String(returned.result) }
+      return { kind: "call", callId: "n1", name: "read", arguments: { path: "/contract.md" } }
+    }, capabilities)
     const answer = await mind.run("read the contract")
     expect(answer.output).toBe("contents of /contract.md")
     expect(reads).toEqual(["/contract.md"])
@@ -131,28 +191,26 @@ describe("createRlmAgent", () => {
     const keys: string[] = []
     const failureInRequest: boolean[] = []
     let postToolCalls = 0
-    const mind = createRlmAgent({
-      capabilities: [
-        toolList([
-          {
-            spec: { name: "read", description: "read a file", inputSchema: { type: "object", properties: {} } },
-            run: () => {
-              reads.push("contract")
-              return Effect.succeed("contents")
-            }
+    const capabilities = [
+      toolList([
+        {
+          spec: { name: "read", description: "read a file", inputSchema: { type: "object", properties: {} } },
+          run: () => {
+            reads.push("contract")
+            return Effect.succeed("contents")
           }
-        ])
-      ],
-      infer: async ({ trajectory }, key) => {
-        keys.push(String(key))
-        failureInRequest.push(trajectory.some((event) => event.type === "TurnFailed"))
-        const returned = trajectory.find((event) => event.type === "ToolReturned")
-        if (returned === undefined) return { kind: "call", callId: "read-1", name: "read", arguments: {} }
-        postToolCalls += 1
-        if (postToolCalls === 1) throw new Error("provider connection ended")
-        return { kind: "complete", output: String((returned as { result?: unknown }).result) }
-      }
-    })
+        }
+      ])
+    ]
+    const mind = rlm(async ({ trajectory }, key) => {
+      keys.push(String(key))
+      failureInRequest.push(trajectory.some((event) => event.type === "TurnFailed"))
+      const returned = trajectory.find((event) => event.type === "ToolReturned")
+      if (returned === undefined) return { kind: "call", callId: "read-1", name: "read", arguments: {} }
+      postToolCalls += 1
+      if (postToolCalls === 1) throw new Error("provider connection ended")
+      return { kind: "complete", output: String((returned as { result?: unknown }).result) }
+    }, capabilities)
 
     const failed = await mind.run("read the contract")
     expect(failed).toMatchObject({ turn: "run-0", error: "provider connection ended" })
@@ -183,7 +241,7 @@ describe("createRlmAgent", () => {
   })
 
   test("only a failed active epoch can resume", async () => {
-    const mind = createRlmAgent({ infer: async () => ({ kind: "complete", output: "done" }) })
+    const mind = rlm(async () => ({ kind: "complete", output: "done" }))
     const completed = await mind.run("finish")
 
     await expect(mind.resume(completed.turn)).rejects.toThrow("active epoch is not failed")
@@ -192,13 +250,11 @@ describe("createRlmAgent", () => {
 
   test("a model-declared failure advances the inference key on resume", async () => {
     const keys: string[] = []
-    const mind = createRlmAgent({
-      infer: async (_request, key) => {
-        keys.push(String(key))
-        return keys.length === 1
-          ? { kind: "fail", error: "the task is invalid" }
-          : { kind: "complete", output: "reconsidered" }
-      }
+    const mind = rlm(async (_request, key) => {
+      keys.push(String(key))
+      return keys.length === 1
+        ? { kind: "fail", error: "the task is invalid" }
+        : { kind: "complete", output: "reconsidered" }
     })
 
     const failed = await mind.run("try")
@@ -210,14 +266,11 @@ describe("createRlmAgent", () => {
     const capabilities = [toolList([
       { spec: { name: "read", description: "read", inputSchema: {} }, run: () => Effect.succeed("ok") }
     ])]
-    const mind = createRlmAgent({
-      capabilities,
-      infer: async ({ trajectory }) => {
-        const returned = trajectory.find((e) => e.type === "ToolReturned") as { result?: { error?: string } } | undefined
-        if (returned !== undefined) return { kind: "complete", output: String(returned.result?.error) }
-        return { kind: "call", callId: "x1", name: "execute", arguments: { code: "return 1" } }
-      }
-    })
+    const mind = rlm(async ({ trajectory }) => {
+      const returned = trajectory.find((e) => e.type === "ToolReturned") as { result?: { error?: string } } | undefined
+      if (returned !== undefined) return { kind: "complete", output: String(returned.result?.error) }
+      return { kind: "call", callId: "x1", name: "execute", arguments: { code: "return 1" } }
+    }, capabilities)
     const answer = await mind.run("go")
     expect(answer.output).toContain("unknown tool: execute")
     expect(answer.output).toContain("read")
@@ -226,28 +279,26 @@ describe("createRlmAgent", () => {
   test("the workspace reads back what a spilled result put in the store", async () => {
     // The mounted workspace and the code reactor's spill path hold one store: a result too large
     // for the event spills, and the next body finds it by grep and slices it by ref.
-    const mind = createRlmAgent({
-      infer: async ({ trajectory }) => {
-        const start = trajectory.reduce((n, e, i) => (e.type === "MessageReceived" ? i : n), 0)
-        const returns = trajectory.slice(start).filter((e) => e.type === "ToolReturned") as ReadonlyArray<{ result?: { result?: unknown } }>
-        if (returns.length === 0) {
-          return { kind: "call", callId: "w1", name: "execute", arguments: { code: `return "a".repeat(20000) + "NEEDLE";` } }
-        }
-        if (returns.length === 1) {
-          return {
-            kind: "call",
-            callId: "w2",
-            name: "execute",
-            arguments: {
-              code: `const found = await workspace.grep({ pattern: "NEEDLE" });
+    const mind = rlm(async ({ trajectory }) => {
+      const start = trajectory.reduce((n, e, i) => (e.type === "MessageReceived" ? i : n), 0)
+      const returns = trajectory.slice(start).filter((e) => e.type === "ToolReturned") as ReadonlyArray<{ result?: { result?: unknown } }>
+      if (returns.length === 0) {
+        return { kind: "call", callId: "w1", name: "execute", arguments: { code: `return "a".repeat(20000) + "NEEDLE";` } }
+      }
+      if (returns.length === 1) {
+        return {
+          kind: "call",
+          callId: "w2",
+          name: "execute",
+          arguments: {
+            code: `const found = await workspace.grep({ pattern: "NEEDLE" });
                 const hit = found.matches[0];
                 const back = await workspace.read({ ref: hit.ref, offset: hit.offset, length: 6 });
                 return hit.ref + ":" + hit.offset + ":" + back.slice + ":" + back.size;`
-            }
           }
         }
-        return { kind: "complete", output: String(returns[1]!.result?.result ?? "") }
       }
+      return { kind: "complete", output: String(returns[1]!.result?.result ?? "") }
     })
     // The store holds the result's JSON, so the offset counts the opening quote too.
     const answer = await mind.run("spill then search")

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,21 +1,3 @@
-import { Effect, Layer } from "effect"
-import { KeyValueStore } from "effect/unstable/persistence"
-import type { Event } from "@clavia/tardigrade-core/event"
-import { assertSupportedBun } from "@clavia/tardigrade-core/runtime"
-import type { Actor } from "@clavia/tardigrade-core/actor"
-import type { Package } from "@clavia/tardigrade-code/packages"
-import { jsSandboxFor } from "@clavia/tardigrade-code/defaults"
-import { workspacePackage } from "@clavia/tardigrade-code/workspace"
-import type { SandboxPolicy } from "@clavia/tardigrade-code/sandbox"
-import { createHost, type Host, type LaneEnv } from "@clavia/tardigrade-host/host"
-import { type AgentPolicy, type RlmR } from "./turn"
-import { Infer, type InferRequest } from "./infer"
-import type { Action } from "./events"
-import { boundaryOf } from "./boundary"
-import { resumeTurn } from "./resume"
-import { agentsPackage } from "./spawn"
-import { agentOf, budgetFor, codeModeFor, compactionFor, reply, type Capability } from "./capability"
-
 export { type AgentPolicy, type AgentR, type RlmR, receive } from "./turn"
 
 // The parts a caller lists. An agent is capabilities over one log; the reactors underneath
@@ -40,6 +22,14 @@ export {
   type ModelPricing
 } from "./usage"
 
+// Where a settle left a turn. A caller driving its own host reads the answer here, because a
+// boundary is a projection of the log rather than a value the driver returns (boundary.ts).
+export { boundaryOf, type Boundary } from "./boundary"
+
+// The spawn package: a value with no lane in it, so the assembly that mounts it and the host
+// that binds Router, Self, and Facets per lane cannot disagree about placement (spawn.ts).
+export { agentsPackage, type SpawnOptions } from "./spawn"
+
 // The workspace the model reads its spilled values back through, and the optional SQL binding a
 // platform lights its third verb up with.
 export { workspacePackage, workspaceFor, WorkspaceSql, DEFAULT_WORKSPACE_POLICY, workspacePolicyOf, type WorkspacePolicy, type SqlRunner } from "@clavia/tardigrade-code/workspace"
@@ -47,121 +37,3 @@ export { workspacePackage, workspaceFor, WorkspaceSql, DEFAULT_WORKSPACE_POLICY,
 // The capability assembly: code mode is the default, and an agent measured against a fixed
 // tool list mounts its own (capability.ts).
 export { agentOf, renderOf, codeMode, codeModeFor, CODE_SYSTEM, codeSystemFor, toolList, reply, budget, budgetFor, compaction, compactionFor, type Capability, type NativeTool } from "./capability"
-
-export interface CreateAgentOptions {
-  readonly packages?: ReadonlyArray<Package>
-  // The mind: one inference over the request, one action out. The request carries the render
-  // (system, tools) the assembly derived for the attempt.
-  readonly infer: (request: InferRequest, key?: string) => Promise<Action>
-  // The root lane's history: an agent initialises from a persisted log, because the log is the
-  // only state there is. The next run derives from everything here, and work the log still owes
-  // settles on the first drive (index.test.ts, "an agent initialises from a log").
-  readonly log?: ReadonlyArray<Event>
-  // The work capabilities, code mode by default. An agent measured against a fixed tool list
-  // passes [toolList([...])]; reply, budget, and compaction are always mounted.
-  readonly capabilities?: ReadonlyArray<Capability<RlmR>>
-  // Every policy value the assembled agent applies: the give-up and repair ceilings, the default
-  // tool budget, the context caps, the spill bound, and the workspace's read and grep bounds.
-  // Absent fields take the exported
-  // defaults. The context policy reaches the render through the compaction capability, so the
-  // binding truncates against the numbers the guard fires on (capability.ts, compactionFor).
-  readonly policy?: Partial<AgentPolicy>
-  // The console cap of the sandbox this function binds. It is separate from `policy` because the
-  // sandbox is a seam, not a reactor: an assembly that brings its own Sandbox layer sets the cap
-  // there instead (packages/code/src/sandbox.ts, SandboxPolicy).
-  readonly sandbox?: Partial<SandboxPolicy>
-}
-
-export interface TurnResult {
-  readonly turn: string
-  readonly output?: string
-  readonly error?: string
-}
-
-export interface RlmAgent {
-  readonly run: (brief: string) => Promise<TurnResult>
-  readonly resume: (turn: string) => Promise<TurnResult>
-  readonly host: Host
-}
-
-const ROOT = "ag.root"
-
-// createRlmAgent is the library default: a hosted Recursive Language Model over an in-process
-// host, with spawn and a sandbox. It mounts the work capabilities plus
-// reply, budget, and compaction, and adds the host and the agents package. A caller who wants a
-// thinner assembly uses agentOf and their own host.
-export const createRlmAgent = (options: CreateAgentOptions): RlmAgent => {
-  assertSupportedBun()
-  const user = options.packages ?? []
-  const infer = Layer.succeed(Infer, {
-    react: (request: InferRequest, key?: string) => Effect.promise(() => options.infer(request, key))
-  })
-  // The in-process default spill store: bounded results survive for the life of the process, so
-  // replay within a run hydrates them (packages/code/src/store.ts). A durable agent provides its
-  // own KeyValueStore layer instead, and binds WorkspaceSql if it has a SQL surface.
-  const spillStore = KeyValueStore.layerMemory
-  const sandbox = jsSandboxFor(options.sandbox ?? {})
-
-  const layersFor = (_lane: string): LaneEnv<RlmR> => Layer.mergeAll(spillStore, sandbox, infer)
-
-  const policy = options.policy ?? {}
-  // This host takes no synchronous calls, so an escalatable spawn's ask and agents.continue
-  // refuse here. The spawn package reaches the same Router the host binds per lane, so its
-  // doors and the host's cannot disagree (packages/host/src/host.ts, createHost).
-  const refused = () => Effect.succeed({ error: "this host takes no synchronous calls" })
-
-  // The spawn package is a value with no lane in it: Router, Self, and Facets serve its methods
-  // from the environment the host binds per lane (spawn.ts, agentsPackage). A child with no
-  // stated budget takes the same ceiling this agent's own wall reads.
-  const spawn = agentsPackage({ budget: policy.budget ?? {} })
-  // The workspace reads the same store the spill path writes. This host binds no SQL surface,
-  // so it is the two-verb workspace (packages/code/src/workspace.ts, workspacePackage).
-  const workspace = workspacePackage({ policy: policy.workspace ?? {} })
-  // Every ag. lane runs the RLM default; anything else is a sink. Nothing in the assembly names
-  // a lane, so one actor serves them all: the lane arrives as Self, and the packages are values
-  // the whole host shares (capability.ts, codeModeFor).
-  const assembled = agentOf(
-    [
-      ...(options.capabilities ?? [codeModeFor(policy.code ?? {}, {}, [...user, spawn, workspace])]),
-      reply,
-      budgetFor(policy.budget ?? {}),
-      compactionFor(policy.context ?? {})
-    ],
-    policy.infer ?? {}
-  )
-  const actorFor = (lane: string): Actor<RlmR> | undefined => (lane.startsWith("ag.") ? assembled : undefined)
-  const host: Host = createHost<RlmR>({
-    principal: "mem",
-    actorFor,
-    call: refused,
-    resume: refused,
-    layersFor
-  })
-
-  if (options.log !== undefined && options.log.length > 0) host.seed(ROOT, options.log)
-
-  // Run ids continue past the seeded history, so a resumed agent's new run never wears an id
-  // the log already dedups.
-  let n = options.log?.length ?? 0
-  const resultOf = (turn: string): TurnResult => {
-    const boundary = boundaryOf(host.read(ROOT), turn)
-    if (boundary === undefined) return { turn, error: "the root never settled" }
-    if (boundary.kind === "completed") return { turn, output: boundary.output }
-    if (boundary.kind === "failed") return { turn, error: boundary.error }
-    return { turn, error: "the root parked on a budget ask with nobody to answer" }
-  }
-
-  const run = async (brief: string): Promise<TurnResult> => {
-    const id = `run-${n++}`
-    host.deliver(host.self(ROOT), { type: "MessageReceived", id, text: brief, at: n } as Event)
-    await host.drive()
-    return resultOf(id)
-  }
-
-  const resume = async (turn: string): Promise<TurnResult> => {
-    await resumeTurn(host, ROOT, turn)
-    return resultOf(turn)
-  }
-
-  return { run, resume, host }
-}


### PR DESCRIPTION
createRlmAgent bundled what the composition path now expresses directly: agentOf over capabilities, packages as values through codeModeFor, the spawn package as a plain value, and createHost. Its nine test cases were the spec of what it wired; they are rewritten compose-style first, and their passing is the proof the export is redundant.

- rewrite index.test.ts compose-style: spawn fan-out, seeding and continuation, second runs, toolList surface, failed-turn resume and its guards, unknown-tool answers, workspace spill reads
- delete createRlmAgent, CreateAgentOptions, RlmAgent, TurnResult; nothing else referenced them
- index.ts becomes a pure re-export surface; boundaryOf/Boundary and agentsPackage/SpawnOptions become explicit exports, which the compose path needs
- the Bun version guard stays at the runtime entry points (createBunHost, infer)
- bun run gate fully green