### PR TITLE
docs: rlm agent example

### DIFF
--- a/examples/rlm-agent.ts
+++ b/examples/rlm-agent.ts
@@ -1,0 +1,56 @@
+// A Recursive Language Model agent, assembled from the library's parts and run on the durable
+// Bun host: bun run examples/rlm-agent.ts. The agent acts by writing JavaScript; its code can
+// spawn child agents (agents.run) and read spilled values back (workspace.read). Set
+// MODEL_BASE_URL, MODEL_API_KEY, and MODEL_ID to an OpenAI-compatible endpoint before running;
+// add provider: "bedrock" to the infer options for Bedrock.
+
+// The workspace names resolve in this repository. Against the published package the last two
+// are "@clavia/tardigrade/model" and "@clavia/tardigrade/bun/host" (tools/publish.ts).
+import { agentOf, agentsPackage, boundaryOf, budget, codeModeFor, compaction, reply, workspacePackage } from "@clavia/tardigrade"
+import { infer } from "@clavia/tardigrade-model/model"
+import { createBunHost } from "@clavia/tardigrade-bun/host"
+
+// The work surface: code mode with the spawn and workspace packages in scope. The packages are
+// values, so the model's system fragment lists them and the assembly's requirements carry their
+// needs (Router, Self, and Facets for spawn; the spill store for workspace). The Bun host binds
+// all of those per lane.
+const rlm = agentOf([
+  codeModeFor({}, {}, [agentsPackage({ budget: {} }), workspacePackage({ policy: {} })]),
+  reply, // reports each turn's terminal to whoever asked
+  budget, // the per-turn code budget, inherited by spawned children
+  compaction // bounded model context over long investigations
+])
+
+const model = infer({
+  baseUrl: process.env.MODEL_BASE_URL!,
+  apiKey: process.env.MODEL_API_KEY!,
+  model: process.env.MODEL_ID!
+})
+
+// Every ag. lane runs the same assembly: the root, and every child a spawn births. The lane
+// arrives as Self at run time, so one actor value serves the whole family.
+const host = await createBunHost({
+  log: "agents.sqlite",
+  actorFor: (lane) => (lane.startsWith("ag.") ? rlm : undefined),
+  layersFor: () => model
+})
+
+// One ask: deliver a brief to the root, drive to quiescence, read the boundary the settle left.
+// The turn id is the dedup key, so redelivering this exact event is absorbed, and a crash
+// mid-run resumes from the log on the next drive.
+const root = "ag.root"
+const id = "run-1"
+await host.deliver(host.self(root), {
+  type: "MessageReceived",
+  id,
+  text: "Investigate the repository layout: spawn one child per top-level directory of your choosing and merge their reports.",
+  at: Date.now()
+})
+await host.drive()
+
+const boundary = boundaryOf(await host.read(root), id)
+if (boundary === undefined) console.log("the root never settled")
+else if (boundary.kind === "completed") console.log(boundary.output)
+else if (boundary.kind === "failed") console.log(`failed: ${boundary.error}`)
+else console.log("parked on a budget ask; answer it with agents.continue from a parent")
+await host.close()

--- a/platform/bun/src/host.ts
+++ b/platform/bun/src/host.ts
@@ -217,7 +217,7 @@ export const createBunHost = async <R = never>(options: BunHostOptions<R>): Prom
       Layer.succeed(KeyValueStore.KeyValueStore, store),
       Layer.succeed(Self, self(lane)),
       // Every lane's log lives in this one durable store, so the observe privilege is the same
-      // read the host serves itself (packages/core/src/logs.ts, Facets). A binding whose lanes
+      // read the host serves itself (packages/core/src/facets.ts, Facets). A binding whose lanes
       // are remote proxies or refuses instead.
       Layer.succeed(Facets, { read: (name: string) => readEffect(name) })
     )


### PR DESCRIPTION
The recursive-agent assembly lost its packaged form when createRlmAgent was deleted (#125); the composition is now the API. Add a runnable example showing it end to end on the durable Bun host: code mode with the spawn and workspace packages as values, reply, budget, and compaction mounted beside it, one brief delivered, the boundary read back.

- add examples/rlm-agent.ts, typechecked by the root tsconfig's examples include
- imports use the workspace names, with a comment giving the published unified paths
- fix a stale core/src/logs.ts citation in platform/bun/src/host.ts left by the Facets rename
- bun run gate fully green