### PR TITLE
refactor(agent)!: codeModeFor options object

### DIFF
--- a/packages/agent/src/capability.test.ts
+++ b/packages/agent/src/capability.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { Effect, Layer, Ref } from "effect"
+import { Context, Effect, Layer, Ref } from "effect"
 import { KeyValueStore } from "effect/unstable/persistence"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { EventLog, withWatermark } from "@clavia/tardigrade-core/event-log"
@@ -7,12 +7,16 @@ import { Router } from "@clavia/tardigrade-core/router"
 import { Facets } from "@clavia/tardigrade-core/facets"
 import { Self } from "@clavia/tardigrade-core/actor"
 import type { Package } from "@clavia/tardigrade-code/packages"
-import { agentOf, budget, CODE_SYSTEM, codeMode, codeModeFor, compaction, compactionFor, renderOf, reply, toolList } from "./capability"
+import { agentOf, budget, CODE_SYSTEM, codeMode, codeModeFor, compaction, compactionFor, renderOf, reply, toolList, type Capability } from "./capability"
 import { receive, type AgentR } from "./turn"
 import { Infer, type InferRequest } from "./infer"
 
 // The capability assembly end to end: the render the model sees is the composed derivation of
 // the mounted capabilities, and a call routes to the capability that declared its tool.
+
+// Ticker is a service no assembled agent provides, so a capability that requires it is
+// distinguishable at compile time from one that does not.
+class Ticker extends Context.Service<Ticker, string>()("agent/test/Ticker") {}
 
 const memoryLog = (initial: ReadonlyArray<Event> = []) =>
   Layer.effect(
@@ -142,7 +146,7 @@ describe("agentOf", () => {
   })
 
   test("codeModeFor takes a system fragment, and the bare capability renders the exported default", () => {
-    const overridden = renderOf([codeModeFor({}, { system: (events) => `the packages in scope are:\n${events.length}` })], [{ type: "PackageInstalled" }])
+    const overridden = renderOf([codeModeFor({ system: (events) => `the packages in scope are:\n${events.length}` })], [{ type: "PackageInstalled" }])
     expect(overridden.system).toBe("the packages in scope are:\n1")
     expect(renderOf([codeMode], []).system).toBe(CODE_SYSTEM)
   })
@@ -155,10 +159,35 @@ describe("agentOf", () => {
       description: "the team's notes",
       methods: { put: () => Effect.succeed(null) }
     }
-    const { system } = renderOf([codeModeFor({}, {}, [notes])], [])
+    const { system } = renderOf([codeModeFor({ packages: [notes] })], [])
     expect(system).toContain("notes: the team's notes")
     expect(system).not.toContain("none")
     // An explicit fragment still wins over the derivation.
-    expect(renderOf([codeModeFor({}, { system: "my own scope" }, [notes])], []).system).toBe("my own scope")
+    expect(renderOf([codeModeFor({ system: "my own scope", packages: [notes] })], []).system).toBe("my own scope")
+  })
+
+  test("a mounted package's requirements ride the capability's type", () => {
+    // Compile-time only: `packages` arrives as an option property, and the const type parameter
+    // still infers the tuple, so R is the spill store plus exactly what the listed packages
+    // require. A widened `ReadonlyArray<Package<Ticker>>` would fail the empty-scope assertions
+    // below (capability.ts, codeModeFor).
+    const ticker: Package<Ticker> = {
+      name: "ticker",
+      description: "the clock",
+      methods: {
+        now: () =>
+          Effect.gen(function* () {
+            return { tick: yield* Ticker }
+          })
+      }
+    }
+    const scoped: Capability<KeyValueStore.KeyValueStore | Ticker> = codeModeFor({ packages: [ticker] })
+    // The union is exactly that: too wide (P falling back to Package<unknown>) fails the line
+    // above, and too narrow (P collapsing to the empty tuple) fails the line below.
+    // @ts-expect-error a capability that requires Ticker cannot pass as one that does not
+    const narrowed: Capability<KeyValueStore.KeyValueStore> = codeModeFor({ packages: [ticker] })
+    const empty: Capability<KeyValueStore.KeyValueStore> = codeModeFor({})
+    const bare: Capability<KeyValueStore.KeyValueStore> = codeModeFor()
+    expect([scoped.name, narrowed.name, empty.name, bare.name]).toEqual(["code", "code", "code", "code"])
   })
 })

--- a/packages/agent/src/capability.ts
+++ b/packages/agent/src/capability.ts
@@ -181,31 +181,38 @@ const codeServe: Serve = (call, log, answer) => {
 }
 
 // codeModeFor is the code-execution capability: one `execute` tool, served by dispatching to
-// the code reactor and answered from its settle. The policy is the code lane's own
-// (packages/code/src/execute.ts, CodePolicy). `packages` are the values the code may name; the
+// the code reactor and answered from its settle. Every option has a default, so the bare call
+// is the whole capability on defaults. `packages` are the values the code may name; the
 // capability's R is the spill store plus what those packages need, and the model's fragment is
 // derived from the same values, so what the code can call and what the model is told cannot
-// drift. `render.system` replaces that derivation, as a string or as a projection of the log,
-// for a host that names its scope from its own events (capability.test.ts, "codeModeFor takes a
-// system fragment").
+// drift. `policy` is the code lane's own (packages/code/src/execute.ts, CodePolicy). `system`
+// replaces the derived fragment, as a string or as a projection of the log, for a host that
+// names its scope from its own events (capability.test.ts, "codeModeFor takes a system
+// fragment"). `packages` infers as a tuple, so a mixed list gives the union of what its members
+// require (capability.test.ts, "a mounted package's requirements ride the capability's type").
 export const codeModeFor = <
   const P extends ReadonlyArray<Package<never>> | ReadonlyArray<Package<unknown>> = readonly []
 >(
-  policy: Partial<CodePolicy>,
-  render: { readonly system?: Capability["system"] } = {},
-  packages: P = [] as unknown as P
-): Capability<KeyValueStore.KeyValueStore | PackageRequirements<P[number]>> => ({
-  name: "code",
-  keys: codeKeys,
-  reactors: [codeReactorFor(policy, packages)],
-  tools: () => [EXECUTE_TOOL],
-  system: render.system ?? codeSystemFor(packages as ReadonlyArray<Package<unknown>>),
-  serve: codeServe
-})
+  options: {
+    readonly policy?: Partial<CodePolicy>
+    readonly system?: Capability["system"]
+    readonly packages?: P
+  } = {}
+): Capability<KeyValueStore.KeyValueStore | PackageRequirements<P[number]>> => {
+  const packages = (options.packages ?? []) as unknown as P
+  return {
+    name: "code",
+    keys: codeKeys,
+    reactors: [codeReactorFor(options.policy ?? {}, packages)],
+    tools: () => [EXECUTE_TOOL],
+    system: options.system ?? codeSystemFor(packages as ReadonlyArray<Package<unknown>>),
+    serve: codeServe
+  }
+}
 
 // codeMode is that capability on defaults, with nothing in scope: the library default work
 // surface.
-export const codeMode: Capability<KeyValueStore.KeyValueStore> = codeModeFor({})
+export const codeMode: Capability<KeyValueStore.KeyValueStore> = codeModeFor()
 
 // A NativeTool is one named tool the model calls directly: its wire shape, and the effect that
 // runs it. The effect's failures are the tool's own answer, so a tool that throws returns an

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -27,7 +27,7 @@ type Settled = { readonly turn: string; readonly output?: string; readonly error
 
 // work is the default work surface these tests assemble against: code mode with the spawn and
 // workspace packages in scope. The packages are values, so the same list mounts on any host.
-const work = () => codeModeFor({}, {}, [agentsPackage({ budget: {} }), workspacePackage({ policy: {} })])
+const work = () => codeModeFor({ packages: [agentsPackage({ budget: {} }), workspacePackage({ policy: {} })] })
 
 // hosted binds one assembled actor to an in-process host and drives the root lane. It is the
 // test's own driver: deliver a brief, drive to quiescence, read the boundary the settle left.

--- a/packages/agent/src/turn.test.ts
+++ b/packages/agent/src/turn.test.ts
@@ -17,7 +17,7 @@ import { agentOf, budget, codeModeFor, compaction, reply, toolList } from "./cap
 // packages are values the assembly passes, so a test that needs one names it here
 // (capability.ts, codeModeFor).
 const agentWith = (packages: ReadonlyArray<Package>) =>
-  agentOf([codeModeFor({}, {}, packages), reply, budget, compaction])
+  agentOf([codeModeFor({ packages }), reply, budget, compaction])
 const rlmAgent = agentWith([])
 const inferReactor = rlmAgent.reactors[0]!
 const toolsReactor = rlmAgent.reactors[1]!


### PR DESCRIPTION
codeModeFor took (policy, render, packages) positionally, so the common consumer call reached its main argument past two placeholder objects: codeModeFor({}, {}, [pkg]). Take one options object instead, every field named and defaulted, so the common call reads codeModeFor({ packages: [...] }) and the bare call is the capability on defaults.

- codeModeFor({ policy?, system?, packages? }); codeMode is codeModeFor()
- const-generic inference of the package union holds in property position, pinned by a two-edge compile-time fixture (positive assignment plus @ts-expect-error)
- all in-repo call sites updated; none exist outside packages/agent
- bun run gate fully green