### PR TITLE
feat(server): self host api

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Effects have at-least-once execution. Each keyed result is recorded once. Provid
 ## Learn more
 
 - [Quickstart](docs/quickstart.md): build the event loop and its agent capabilities from first principles.
+- [Run the server](docs/how-to/server.md): host the HTTP server over a durable SQLite log, and read its API.
 - [Runtime and turn recovery](docs/explanations/runtime-and-recovery.md): understand runtime requirements, retry scopes, and failed-turn recovery.
 - [Why Tardigrade](docs/explanations/why.md): learn what the log-as-state model makes possible.
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@clavia/tardigrade-server",
+  "version": "0.0.1",
+  "private": true,
+  "license": "MIT",
+  "author": "Clavia, Inc.",
+  "description": "Self-hostable HTTP server for tardigrade.",
+  "homepage": "https://github.com/clavia-labs/tardigrade#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/clavia-labs/tardigrade.git",
+    "directory": "apps/server"
+  },
+  "bugs": {
+    "url": "https://github.com/clavia-labs/tardigrade/issues"
+  },
+  "engines": {
+    "bun": ">=1.4.0"
+  },
+  "type": "module",
+  "exports": {
+    "./*": "./src/*.ts"
+  },
+  "dependencies": {
+    "@clavia/tardigrade": "workspace:*",
+    "@clavia/tardigrade-bun": "workspace:*",
+    "@clavia/tardigrade-code": "workspace:*",
+    "@clavia/tardigrade-core": "workspace:*",
+    "@clavia/tardigrade-model": "workspace:*",
+    "@effect/platform-bun": "4.0.0-rc.110",
+    "effect": "4.0.0-rc.110"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "start": "bun run src/main.ts"
+  }
+}

--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -297,6 +297,12 @@ describe("the tree", () => {
   test("a spawned child hangs under the agent whose code briefed it", async () => {
     const read = await serving(async (base) => {
       await birth(base, "root", { id: "m1", text: "spawn call-1" })
+      // The root's turn can complete while the child's lane is still settling, so the tree read
+      // waits for the driver to rest; resting means every lane's owed work is done.
+      await until("the driver rests", async () => {
+        const health = (await (await fetch(`${base}/healthz`)).json()) as { status: string }
+        return health.status === "resting" ? health : undefined
+      })
       return {
         tree: (await (await fetch(`${base}/agents/root/tree`)).json()) as AgentNode,
         listed: (await (await fetch(`${base}/agents`)).json()) as ReadonlyArray<AgentSummary>,

--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+import { HttpServer } from "effect/unstable/http"
+import { BunHttpServer } from "@effect/platform-bun"
+import type { Event } from "@clavia/tardigrade-core/event"
+import { Infer, type InferRequest } from "@clavia/tardigrade"
+import type { Action } from "@clavia/tardigrade/events"
+
+import { openStreams, type EventRow } from "./api"
+import { layerConfig, readConfig } from "./config"
+import { layerAgents } from "./host"
+import { PROBLEM_CONTENT_TYPE, serve } from "./http"
+import type { AgentSummary, AgentNode, TurnView } from "./projections"
+
+// The API over a real Bun server on an ephemeral port, over a real durable host on a volatile
+// database, with the model seam bound to a scripted mind: every assertion here is about what a
+// client sees on the wire, and the only thing that is not real is the model (host.ts, AgentsOptions).
+
+const briefOf = (trajectory: ReadonlyArray<Event>): string => {
+  for (let i = trajectory.length - 1; i >= 0; i--) {
+    const event = trajectory[i]!
+    if (event.type === "MessageReceived") return String((event as { text?: unknown }).text ?? "")
+  }
+  return ""
+}
+
+// The scripted mind answers in one attempt, except on a brief that asks it to spawn: there it runs
+// one execution that briefs a child and answers with the child's answer, which is the shape the
+// library's own spawn test drives (packages/agent/src/index.test.ts, the scripted mind). The tool
+// call id is derived from the brief, so the child's id is stated by the test rather than by a
+// counter (packages/agent/src/spawn.ts, `sibling`).
+const scripted = ({ trajectory }: InferRequest): Action => {
+  const brief = briefOf(trajectory)
+  if (!brief.startsWith("spawn ")) return { kind: "complete", output: `ok: ${brief}` }
+  const start = trajectory.reduce((n, event, i) => (event.type === "MessageReceived" ? i : n), 0)
+  const returned = trajectory.slice(start).find((event) => event.type === "ToolReturned") as
+    | { result?: { result?: unknown } }
+    | undefined
+  if (returned !== undefined) return { kind: "complete", output: JSON.stringify(returned.result?.result ?? null) }
+  return {
+    kind: "call",
+    callId: brief.slice("spawn ".length),
+    name: "execute",
+    arguments: { code: `const a = await agents.run({ text: "hello child" }); return a.output;` }
+  }
+}
+
+const layerScripted: Layer.Layer<Infer> = Layer.succeed(Infer)({
+  react: (request: InferRequest) => Effect.succeed(scripted(request))
+})
+
+const config = layerConfig(readConfig({ TARDIGRADE_DB: ":memory:" }))
+
+const app = Layer.provideMerge(serve({ disableLogger: true, disableListenLog: true }), [
+  BunHttpServer.layer({ port: 0 }),
+  config,
+  Layer.provide(layerAgents({ infer: layerScripted }), config)
+])
+
+// Boots the process and hands the body its base URL. The body is plain fetch, because a client of
+// this API is plain fetch.
+const serving = <A>(body: (base: string) => Promise<A>): Promise<A> =>
+  Effect.gen(function*() {
+    const server = yield* HttpServer.HttpServer
+    const address = server.address
+    const port = address._tag === "TcpAddress" ? address.port : 0
+    return yield* Effect.promise(() => body(`http://127.0.0.1:${port}`))
+  }).pipe(Effect.provide(app), Effect.scoped, Effect.runPromise) as Promise<A>
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+// until polls a question the server answers asynchronously, which is how a client waits for an
+// outcome: the server drives continuously and never takes a wait (apps-server-spec.md,
+// "Principles").
+const until = async <A>(what: string, poll: () => Promise<A | undefined>, ms = 10_000): Promise<A> => {
+  const deadline = Date.now() + ms
+  for (;;) {
+    const answer = await poll()
+    if (answer !== undefined) return answer
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`)
+    await sleep(10)
+  }
+}
+
+const post = (base: string, path: string, body?: unknown) =>
+  fetch(`${base}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) })
+  })
+
+const birth = async (base: string, id: string, message: { id: string; text: string }) => {
+  const response = await post(base, `/agents/${id}/messages`, message)
+  expect(response.status).toBe(202)
+  expect(await response.json()).toEqual({ agent: id, turn: message.id })
+  return until(`turn ${message.id} of ${id}`, async () => {
+    const view = (await (await fetch(`${base}/agents/${id}/turns/${message.id}`)).json()) as TurnView
+    return view.status === "pending" ? undefined : view
+  })
+}
+
+describe("messages", () => {
+  test("a message births an agent and the server drives its turn to completed", async () => {
+    const view = await serving((base) => birth(base, "alpha", { id: "m1", text: "hello" }))
+    expect(view).toEqual({ turn: "m1", status: "completed", output: "ok: hello" })
+  })
+
+  test("a body with no id or no text is refused", async () => {
+    const problems = await serving(async (base) => {
+      const missingText = await post(base, "/agents/alpha/messages", { id: "m1" })
+      const missingId = await post(base, "/agents/alpha/messages", { text: "hello" })
+      return [
+        { status: missingText.status, type: missingText.headers.get("content-type"), body: await missingText.json() },
+        { status: missingId.status, type: missingId.headers.get("content-type"), body: await missingId.json() }
+      ]
+    })
+    for (const refused of problems) {
+      expect(refused.status).toBe(400)
+      expect(refused.type).toContain(PROBLEM_CONTENT_TYPE)
+      expect(refused.body).toMatchObject({ status: 400, title: "Invalid Message" })
+    }
+  })
+
+  test("a redelivered message id answers the same and writes nothing", async () => {
+    const counts = await serving(async (base) => {
+      await birth(base, "alpha", { id: "m1", text: "hello" })
+      const before = ((await (await fetch(`${base}/agents/alpha/events`)).json()) as ReadonlyArray<EventRow>).length
+      const again = await post(base, "/agents/alpha/messages", { id: "m1", text: "hello" })
+      expect(again.status).toBe(202)
+      expect(await again.json()).toEqual({ agent: "alpha", turn: "m1" })
+      await sleep(50)
+      const after = ((await (await fetch(`${base}/agents/alpha/events`)).json()) as ReadonlyArray<EventRow>).length
+      return [before, after]
+    })
+    expect(counts[1]).toBe(counts[0]!)
+  })
+})
+
+describe("the listing", () => {
+  test("an agent that has settled lists as resting", async () => {
+    const listed = await serving(async (base) => {
+      await birth(base, "alpha", { id: "m1", text: "hello" })
+      return (await (await fetch(`${base}/agents`)).json()) as ReadonlyArray<AgentSummary>
+    })
+    expect(listed).toHaveLength(1)
+    expect(listed[0]).toMatchObject({ id: "alpha", status: "resting" })
+    expect(listed[0]!.events).toBeGreaterThan(0)
+    expect(listed[0]!.parent).toBeUndefined()
+  })
+})
+
+describe("events", () => {
+  test("after and limit page the log, and types filters without renumbering it", async () => {
+    const read = await serving(async (base) => {
+      await birth(base, "alpha", { id: "m1", text: "hello" })
+      const json = async (path: string) => (await (await fetch(`${base}${path}`)).json()) as ReadonlyArray<EventRow>
+      const all = await json("/agents/alpha/events")
+      return {
+        all,
+        page: await json("/agents/alpha/events?after=1&limit=2"),
+        completed: await json("/agents/alpha/events?types=TurnCompleted"),
+        both: await json(`/agents/alpha/events?after=1&types=MessageReceived,TurnCompleted`),
+        empty: await json("/agents/alpha/events?types=NothingLikeThis")
+      }
+    })
+    expect(read.all.map((row) => row.seq)).toEqual(read.all.map((_, i) => i + 1))
+    expect(read.page.map((row) => row.seq)).toEqual([2, 3])
+    expect(read.page.map((row) => row.event)).toEqual(read.all.slice(1, 3).map((row) => row.event))
+    // The filtered row keeps the seq it has in the whole log, so `after` means the same place with
+    // a filter as without one.
+    expect(read.completed).toHaveLength(1)
+    const completed = read.all.find((row) => row.event.type === "TurnCompleted")!
+    expect(read.completed[0]!.seq).toBe(completed.seq)
+    expect(read.both.every((row) => row.seq > 1)).toBe(true)
+    // An existing agent's filtered empty page is a page, not a 404.
+    expect(read.empty).toEqual([])
+  })
+
+  test("a log that never existed is the only 404", async () => {
+    const answers = await serving(async (base) => {
+      await birth(base, "alpha", { id: "m1", text: "hello" })
+      const missing = await fetch(`${base}/agents/ghost/events`)
+      return { status: missing.status, type: missing.headers.get("content-type"), body: await missing.json() }
+    })
+    expect(answers.status).toBe(404)
+    expect(answers.type).toContain(PROBLEM_CONTENT_TYPE)
+    expect(answers.body).toMatchObject({ status: 404, title: "Unknown Agent" })
+  })
+})
+
+// framesOf parses an SSE byte stream into the pairs a client acts on. It is deliberately literal:
+// the assertions below are about the wire format, so nothing here normalizes it.
+const framesOf = (text: string): ReadonlyArray<{ readonly id: string; readonly data: string }> =>
+  text
+    .split("\n\n")
+    .filter((frame) => frame.startsWith("id:"))
+    .map((frame) => {
+      const lines = frame.split("\n")
+      return {
+        id: lines.find((line) => line.startsWith("id:"))!.slice(3).trim(),
+        data: lines.find((line) => line.startsWith("data:"))!.slice(5).trim()
+      }
+    })
+
+describe("the event stream", () => {
+  test("a reconnect replays from Last-Event-ID and then runs live, once each", async () => {
+    const read = await serving(async (base) => {
+      await birth(base, "alpha", { id: "m1", text: "hello" })
+      const before = (await (await fetch(`${base}/agents/alpha/events`)).json()) as ReadonlyArray<EventRow>
+      const abort = new AbortController()
+      const response = await fetch(`${base}/agents/alpha/events/stream?after=0`, {
+        // The header wins over the query, which is the whole of what a resuming EventSource can
+        // state: it replays the URL it was opened with and carries the id in the header.
+        headers: { "last-event-id": "2" },
+        signal: abort.signal
+      })
+      expect(response.status).toBe(200)
+      expect(response.headers.get("content-type")).toContain("text/event-stream")
+      const reader = response.body!.getReader()
+      const decoder = new TextDecoder()
+      let text = ""
+      const pump = (async () => {
+        for (;;) {
+          const chunk = await reader.read()
+          if (chunk.done) return
+          text += decoder.decode(chunk.value, { stream: true })
+        }
+      })().catch(() => undefined)
+
+      // The backlog past the resumed id arrives first.
+      await until("the replayed backlog", async () => (framesOf(text).length >= before.length - 2 ? true : undefined))
+      const replayed = framesOf(text)
+      expect(openStreams()).toBe(1)
+
+      // Then a message delivered while the stream is open arrives on it.
+      await post(base, "/agents/alpha/messages", { id: "m2", text: "again" })
+      await until("the live frames", async () => (framesOf(text).length > replayed.length ? true : undefined))
+      const live = framesOf(text)
+
+      abort.abort()
+      await pump
+      const closed = await until("the tail to close", async () => (openStreams() === 0 ? true : undefined), 5_000)
+      return { before, replayed, live, closed }
+    })
+
+    // Replay starts past the id the client held and repeats nothing.
+    expect(read.replayed[0]!.id).toBe("3")
+    expect(read.replayed.map((frame) => frame.id)).toEqual(read.before.slice(2).map((row) => String(row.seq)))
+    expect(JSON.parse(read.replayed[0]!.data)).toEqual(read.before[2]!.event as never)
+    // The live frames continue the same numbering, and every id appears exactly once.
+    const ids = read.live.map((frame) => frame.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids.map(Number)).toEqual(ids.map((_, i) => i + 3))
+    expect(read.live.some((frame) => JSON.parse(frame.data).id === "m2")).toBe(true)
+    // And the disconnect took the poll with it.
+    expect(read.closed).toBe(true)
+  })
+})
+
+describe("turns", () => {
+  test("`at` reads the log's prefix, which takes a completed turn back to pending", async () => {
+    const read = await serving(async (base) => {
+      await birth(base, "alpha", { id: "m1", text: "hello" })
+      const json = async (path: string) => (await (await fetch(`${base}${path}`)).json()) as ReadonlyArray<TurnView>
+      return { now: await json("/agents/alpha/turns"), atOne: await json("/agents/alpha/turns?at=1") }
+    })
+    expect(read.now).toEqual([{ turn: "m1", status: "completed", output: "ok: hello" }])
+    // One event stands before the cut: the message that asked for the turn, and nothing that
+    // answered it.
+    expect(read.atOne).toEqual([{ turn: "m1", status: "pending" }])
+  })
+
+  test("a turn nobody was asked to serve is a 404", async () => {
+    const answer = await serving(async (base) => {
+      await birth(base, "alpha", { id: "m1", text: "hello" })
+      const missing = await fetch(`${base}/agents/alpha/turns/m9`)
+      return { status: missing.status, body: await missing.json() }
+    })
+    expect(answer.status).toBe(404)
+    expect(answer.body).toMatchObject({ status: 404, title: "Unknown Turn" })
+  })
+
+  test("a turn that did not fail refuses to resume", async () => {
+    const answer = await serving(async (base) => {
+      await birth(base, "alpha", { id: "m1", text: "hello" })
+      const refused = await post(base, "/agents/alpha/turns/m1/resume")
+      return { status: refused.status, type: refused.headers.get("content-type"), body: await refused.json() }
+    })
+    expect(answer.status).toBe(409)
+    expect(answer.type).toContain(PROBLEM_CONTENT_TYPE)
+    expect(answer.body).toMatchObject({ status: 409, title: "Resume Refused" })
+    expect(String((answer.body as { detail?: unknown }).detail)).toContain("cannot resume")
+  })
+})
+
+describe("the tree", () => {
+  test("a spawned child hangs under the agent whose code briefed it", async () => {
+    const read = await serving(async (base) => {
+      await birth(base, "root", { id: "m1", text: "spawn call-1" })
+      return {
+        tree: (await (await fetch(`${base}/agents/root/tree`)).json()) as AgentNode,
+        listed: (await (await fetch(`${base}/agents`)).json()) as ReadonlyArray<AgentSummary>,
+        ghost: (await fetch(`${base}/agents/ghost/tree`)).status
+      }
+    })
+    expect(read.tree.id).toBe("root")
+    expect(read.tree.children).toHaveLength(1)
+    const child = read.tree.children[0]!
+    expect(child.parent).toBe("root")
+    expect(child.children).toEqual([])
+    // The child is an agent like any other: it lists, with the same parent the tree gave it.
+    expect(read.listed.map((summary) => summary.id).sort()).toEqual(["root", child.id].sort())
+    expect(read.listed.find((summary) => summary.id === child.id)!.parent).toBe("root")
+    expect(read.ghost).toBe(404)
+  })
+})

--- a/apps/server/src/api.ts
+++ b/apps/server/src/api.ts
@@ -1,0 +1,343 @@
+import { Duration, Effect, Layer, Stream } from "effect"
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import type { Event } from "@clavia/tardigrade-core/event"
+
+import { Agents, type Inbound } from "./host"
+import { problem } from "./problem"
+import { treeOf, turnsOf, type AgentNode, type AgentSummary } from "./projections"
+
+// The agent endpoints. A route is a lookup on the Agents service plus one projection, because the
+// read side is a pure function of a log (projections.ts) and the write side is one delivery
+// (host.ts). Nothing here holds state between requests: the SSE tail keeps a cursor for the
+// connection it serves and nothing else, so two processes reading the same log answer the same way.
+
+// The page size of GET /agents/:id/events when the caller states no `limit`
+// (apps-server-spec.md, "GET /agents/:id/events").
+export const DEFAULT_EVENT_LIMIT = 200
+
+// How often an SSE tail re-reads the log looking for growth. The host has no change feed, so the
+// tail polls; the interval is the delay a client sees between an event landing and the frame.
+export const DEFAULT_SSE_POLL = Duration.millis(50)
+
+// How long an idle tail waits before writing a comment frame. A proxy between the client and this
+// process closes a connection that says nothing, and a comment is the cheapest thing to say.
+export const DEFAULT_SSE_HEARTBEAT = Duration.seconds(15)
+
+export interface ApiOptions {
+  readonly limit?: number
+  readonly poll?: Duration.Input
+  readonly heartbeat?: Duration.Input
+}
+
+// EventRow is one row of GET /agents/:id/events. `seq` is the event's 1-based position in the whole
+// log, assigned before any filter runs, so a `types` filter narrows the rows without renumbering
+// them and `after` still means the same place (api.test.ts, "after and limit page the log, and
+// types filters without renumbering it").
+export interface EventRow {
+  readonly seq: number
+  readonly event: Event
+}
+
+const paramOf = (params: Readonly<Record<string, string | undefined>>, name: string): string =>
+  params[name] ?? ""
+
+const singleOf = (value: string | ReadonlyArray<string> | undefined): string | undefined =>
+  value === undefined ? undefined : typeof value === "string" ? value : value[0]
+
+// A query number is an integer at or above zero. Anything else is undefined here and a 400 at the
+// call site: a caller who wrote `after=soon` asked for something, and answering page one instead
+// hides the mistake behind plausible data.
+const integerOf = (raw: string | undefined): number | undefined => {
+  if (raw === undefined) return undefined
+  const trimmed = raw.trim()
+  return /^\d+$/.test(trimmed) ? Number(trimmed) : undefined
+}
+
+const invalidQuery = (name: string, raw: string) =>
+  problem({
+    status: 400,
+    kind: "invalid-query",
+    title: "Invalid Query",
+    detail: `\`${name}\` must be an integer at or above zero, got ${JSON.stringify(raw)}.`
+  })
+
+// An agent exists once its log has an event (apps-server-spec.md, "Principles"), so an empty log is
+// the only unknown agent there is.
+const unknownAgent = (id: string) =>
+  problem({
+    status: 404,
+    kind: "unknown-agent",
+    title: "Unknown Agent",
+    detail: `No agent named ${JSON.stringify(id)} has ever existed.`
+  })
+
+// inboundOf reads the delivery body. `id` and `text` are the message, and a body missing either is
+// refused rather than defaulted: the id is the dedup key end to end, so inventing one would turn a
+// retry into a second turn (apps-server-spec.md, "Principles").
+const inboundOf = (body: unknown): Inbound | undefined => {
+  if (typeof body !== "object" || body === null) return undefined
+  const { data, id, input, text } = body as Record<string, unknown>
+  if (typeof id !== "string" || id.length === 0) return undefined
+  if (typeof text !== "string") return undefined
+  return {
+    id,
+    text,
+    ...(input === undefined ? {} : { input }),
+    ...(data === undefined ? {} : { data })
+  }
+}
+
+// flatten lists a forest depth-first, parent before child. GET /agents is this listing rather than
+// the raw lane list because `parent` is a fact of the forest and only treeOf can see it
+// (projections.ts, summaryOf).
+const flatten = (nodes: ReadonlyArray<AgentNode>): ReadonlyArray<AgentSummary> =>
+  nodes.flatMap(({ children, ...summary }) => [summary, ...flatten(children)])
+
+const findNode = (nodes: ReadonlyArray<AgentNode>, id: string): AgentNode | undefined => {
+  for (const node of nodes) {
+    if (node.id === id) return node
+    const found = findNode(node.children, id)
+    if (found !== undefined) return found
+  }
+  return undefined
+}
+
+const logsOf = (entries: ReadonlyArray<{ readonly id: string; readonly events: ReadonlyArray<Event> }>) =>
+  new Map(entries.map((entry) => [entry.id, entry.events] as const))
+
+const frameOf = (seq: number, event: Event): string => `id: ${seq}\ndata: ${JSON.stringify(event)}\n\n`
+
+// A comment frame: the client's parser drops it and the bytes keep the connection alive.
+const HEARTBEAT = ": tardigrade\n\n"
+
+// openTails counts the SSE tails this process holds. A tail is a fiber that outlives its request
+// handler, so the count is what proves a disconnected client leaves nothing polling behind
+// (api.test.ts, "a reconnect replays from Last-Event-ID and then runs live, once each": the tail is
+// one while the client reads and zero once it aborts).
+let openTails = 0
+
+export const openStreams = (): number => openTails
+
+// tail is the SSE body: replay from `from`, then follow. One pull answers with every event past the
+// cursor, or, after `heartbeat` of silence, with a comment. The cursor is a count of events sent,
+// which is also the seq of the last one, so a reconnect carrying Last-Event-ID resumes exactly
+// where the dropped connection stopped and no event is sent twice (api.test.ts, "a reconnect
+// replays from Last-Event-ID and then runs live").
+//
+// The fiber that polls is the stream's own, and the counter is taken back inside an
+// acquireRelease, so the scope the response body ends closes the poll with it.
+const tail = (
+  read: (id: string) => Effect.Effect<ReadonlyArray<Event>>,
+  id: string,
+  from: number,
+  poll: Duration.Input,
+  heartbeat: Duration.Input
+): Stream.Stream<Uint8Array> => {
+  const pollMillis = Duration.toMillis(poll)
+  const heartbeatMillis = Duration.toMillis(heartbeat)
+  const step = (sent: number): Effect.Effect<readonly [string, number]> =>
+    Effect.gen(function*() {
+      let idle = 0
+      for (;;) {
+        const log = yield* read(id)
+        if (log.length > sent) {
+          const frames = log.slice(sent).map((event, i) => frameOf(sent + i + 1, event)).join("")
+          return [frames, log.length] as const
+        }
+        yield* Effect.sleep(poll)
+        idle += pollMillis
+        if (idle >= heartbeatMillis) return [HEARTBEAT, sent] as const
+      }
+    })
+  const frames = Stream.unfold(from, step)
+  return Stream.unwrap(
+    Effect.as(
+      Effect.acquireRelease(
+        Effect.sync(() => {
+          openTails += 1
+        }),
+        () =>
+          Effect.sync(() => {
+            openTails -= 1
+          })
+      ),
+      Stream.encodeText(frames)
+    )
+  )
+}
+
+// Deliver one message. The response is 202 whether the delivery started a turn or was absorbed as a
+// redelivery: the host dedups by message id, so a retrying client gets the same answer and never
+// learns it retried (host.test.ts, "redelivering one message id is absorbed").
+const layerMessages = HttpRouter.add(
+  "POST",
+  "/agents/:id/messages",
+  Effect.gen(function*() {
+    const id = paramOf(yield* HttpRouter.params, "id")
+    const request = yield* HttpServerRequest.HttpServerRequest
+    const body = yield* Effect.catch(request.json, () => Effect.succeed<unknown>(undefined))
+    const message = inboundOf(body)
+    if (message === undefined) {
+      return problem({
+        status: 400,
+        kind: "invalid-message",
+        title: "Invalid Message",
+        detail: "A message states an `id` (the dedup key, which becomes the turn id) and a `text`."
+      })
+    }
+    const agents = yield* Agents
+    return HttpServerResponse.jsonUnsafe(yield* agents.deliver(id, message), { status: 202 })
+  })
+)
+
+const layerList = HttpRouter.add(
+  "GET",
+  "/agents",
+  Effect.gen(function*() {
+    const agents = yield* Agents
+    const forest = treeOf(logsOf(yield* agents.list()))
+    return HttpServerResponse.jsonUnsafe(flatten(forest))
+  })
+)
+
+const layerEvents = (limit: number) =>
+  HttpRouter.add(
+    "GET",
+    "/agents/:id/events",
+    Effect.gen(function*() {
+      const id = paramOf(yield* HttpRouter.params, "id")
+      const agents = yield* Agents
+      const log = yield* agents.events(id)
+      if (log.length === 0) return unknownAgent(id)
+      const query = yield* HttpServerRequest.ParsedSearchParams
+      const rawAfter = singleOf(query["after"])
+      const after = integerOf(rawAfter)
+      if (rawAfter !== undefined && after === undefined) return invalidQuery("after", rawAfter)
+      const rawLimit = singleOf(query["limit"])
+      const page = integerOf(rawLimit)
+      if (rawLimit !== undefined && page === undefined) return invalidQuery("limit", rawLimit)
+      const types = singleOf(query["types"])?.split(",").map((type) => type.trim()).filter((type) => type.length > 0)
+      const rows: ReadonlyArray<EventRow> = log
+        .map((event, index): EventRow => ({ seq: index + 1, event }))
+        .filter((row) => row.seq > (after ?? 0) && (types === undefined || types.includes(row.event.type)))
+        .slice(0, page ?? limit)
+      return HttpServerResponse.jsonUnsafe(rows)
+    })
+  )
+
+const layerStream = (poll: Duration.Input, heartbeat: Duration.Input) =>
+  HttpRouter.add(
+    "GET",
+    "/agents/:id/events/stream",
+    Effect.gen(function*() {
+      const id = paramOf(yield* HttpRouter.params, "id")
+      const agents = yield* Agents
+      const log = yield* agents.events(id)
+      if (log.length === 0) return unknownAgent(id)
+      const query = yield* HttpServerRequest.ParsedSearchParams
+      const rawAfter = singleOf(query["after"])
+      const after = integerOf(rawAfter)
+      if (rawAfter !== undefined && after === undefined) return invalidQuery("after", rawAfter)
+      // Last-Event-ID is the browser's own resume and it wins: a reconnecting EventSource replays
+      // the URL it was opened with, so the query would otherwise take the stream back to where the
+      // first connection began.
+      const request = yield* HttpServerRequest.HttpServerRequest
+      const from = integerOf(request.headers["last-event-id"]) ?? after ?? 0
+      return HttpServerResponse.stream(tail(agents.events, id, from, poll, heartbeat), {
+        contentType: "text/event-stream",
+        headers: { "cache-control": "no-cache" }
+      })
+    })
+  )
+
+const layerTurns = HttpRouter.add(
+  "GET",
+  "/agents/:id/turns",
+  Effect.gen(function*() {
+    const id = paramOf(yield* HttpRouter.params, "id")
+    const agents = yield* Agents
+    const log = yield* agents.events(id)
+    if (log.length === 0) return unknownAgent(id)
+    const query = yield* HttpServerRequest.ParsedSearchParams
+    const rawAt = singleOf(query["at"])
+    const at = integerOf(rawAt)
+    if (rawAt !== undefined && at === undefined) return invalidQuery("at", rawAt)
+    // `at` is a seq, and a seq is a 1-based position, so `at` events stand before the cut and the
+    // prefix length is the seq itself (projections.ts, turnsOf).
+    return HttpServerResponse.jsonUnsafe(turnsOf(log, at))
+  })
+)
+
+const layerTurn = HttpRouter.add(
+  "GET",
+  "/agents/:id/turns/:turn",
+  Effect.gen(function*() {
+    const params = yield* HttpRouter.params
+    const id = paramOf(params, "id")
+    const turn = paramOf(params, "turn")
+    const agents = yield* Agents
+    const log = yield* agents.events(id)
+    if (log.length === 0) return unknownAgent(id)
+    const view = turnsOf(log).find((candidate) => candidate.turn === turn)
+    if (view === undefined) {
+      return problem({
+        status: 404,
+        kind: "unknown-turn",
+        title: "Unknown Turn",
+        detail: `Agent ${JSON.stringify(id)} was never asked to serve a turn named ${JSON.stringify(turn)}.`
+      })
+    }
+    return HttpServerResponse.jsonUnsafe(view)
+  })
+)
+
+const layerResume = HttpRouter.add(
+  "POST",
+  "/agents/:id/turns/:turn/resume",
+  Effect.gen(function*() {
+    const params = yield* HttpRouter.params
+    const id = paramOf(params, "id")
+    const turn = paramOf(params, "turn")
+    const agents = yield* Agents
+    // The library's guard is the API's 409: a turn resumes only from a failed active epoch, and its
+    // refusal carries the reason a caller acts on (host.ts, ResumeRefused).
+    return yield* agents.resume(id, turn).pipe(
+      Effect.as(HttpServerResponse.jsonUnsafe({ agent: id, turn }, { status: 202 })),
+      Effect.catch((refused) =>
+        Effect.succeed(
+          problem({ status: 409, kind: "resume-refused", title: "Resume Refused", detail: refused.detail })
+        )
+      )
+    )
+  })
+)
+
+const layerTree = HttpRouter.add(
+  "GET",
+  "/agents/:id/tree",
+  Effect.gen(function*() {
+    const id = paramOf(yield* HttpRouter.params, "id")
+    const agents = yield* Agents
+    // The forest is built over every log because parentage is a claim in the PARENT's log; a
+    // subtree cannot be derived from the subtree's own events (projections.ts, treeOf).
+    const node = findNode(treeOf(logsOf(yield* agents.list())), id)
+    if (node === undefined) return unknownAgent(id)
+    return HttpServerResponse.jsonUnsafe(node)
+  })
+)
+
+// layerApi is every agent endpoint, merged into whichever router builds it. It carries no gate of
+// its own: the bearer middleware is global to the router, so a route is inside it by being part of
+// the same application (http.ts, layerAuth; http.test.ts, "a token closes the API and leaves
+// healthz open").
+export const layerApi = (options: ApiOptions = {}) =>
+  Layer.mergeAll(
+    layerMessages,
+    layerList,
+    layerEvents(options.limit ?? DEFAULT_EVENT_LIMIT),
+    layerStream(options.poll ?? DEFAULT_SSE_POLL, options.heartbeat ?? DEFAULT_SSE_HEARTBEAT),
+    layerTurns,
+    layerTurn,
+    layerResume,
+    layerTree
+  )

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -1,0 +1,75 @@
+import { Context, Layer } from "effect"
+
+// The server's configuration is the environment and nothing else (apps-server-spec.md,
+// "Conventions"). One operator, one store, one process, so there is no config file to reconcile
+// with the environment and no precedence order to remember. Every default is an exported constant
+// and every value is a field on ServerConfig, so a consumer can read what the process resolved and
+// a test can supply its own without touching process.env (http.test.ts).
+
+// Where the HTTP server listens when PORT is absent.
+export const DEFAULT_PORT = 4111
+
+// Where the log lives when TARDIGRADE_DB is absent: a SQLite file beside the working directory.
+export const DEFAULT_DB = "agents.sqlite"
+
+// The model binding's coordinates. Absent values are absent rather than guessed: the model layer
+// decides what it can do without them, and the server does not invent an endpoint.
+export interface ModelConfig {
+  readonly baseUrl: string | undefined
+  readonly apiKey: string | undefined
+  readonly id: string | undefined
+  readonly provider: string | undefined
+}
+
+export interface ServerConfigValue {
+  readonly port: number
+  readonly db: string
+  // Absent leaves the API open, which is why the process is meant to bind to localhost. Present
+  // makes a bearer token required on every route except /healthz (http.ts).
+  readonly token: string | undefined
+  readonly model: ModelConfig
+}
+
+export class ServerConfig extends Context.Service<ServerConfig, ServerConfigValue>()(
+  "tardigrade/server/ServerConfig"
+) {}
+
+export type Env = Readonly<Record<string, string | undefined>>
+
+const text = (env: Env, name: string): string | undefined => {
+  const value = env[name]
+  if (value === undefined) return undefined
+  const trimmed = value.trim()
+  return trimmed.length === 0 ? undefined : trimmed
+}
+
+// A PORT that is not a number is an operator error, not a reason to fall back: silently listening
+// somewhere other than where the operator asked is worse than refusing to start.
+const port = (env: Env): number => {
+  const raw = text(env, "PORT")
+  if (raw === undefined) return DEFAULT_PORT
+  const value = Number(raw)
+  if (!Number.isInteger(value) || value < 0 || value > 65535) {
+    throw new Error(`PORT must be an integer between 0 and 65535, got ${JSON.stringify(raw)}`)
+  }
+  return value
+}
+
+// readConfig resolves the environment into the value the process runs on.
+export const readConfig = (env: Env): ServerConfigValue => ({
+  port: port(env),
+  db: text(env, "TARDIGRADE_DB") ?? DEFAULT_DB,
+  token: text(env, "TARDIGRADE_TOKEN"),
+  model: {
+    baseUrl: text(env, "MODEL_BASE_URL"),
+    apiKey: text(env, "MODEL_API_KEY"),
+    id: text(env, "MODEL_ID"),
+    provider: text(env, "MODEL_PROVIDER")
+  }
+})
+
+// layerConfig provides a resolved configuration; layerFromEnv reads one out of an environment.
+export const layerConfig = (value: ServerConfigValue): Layer.Layer<ServerConfig> =>
+  Layer.succeed(ServerConfig)(value)
+
+export const layerFromEnv = (env: Env): Layer.Layer<ServerConfig> => layerConfig(readConfig(env))

--- a/apps/server/src/host.test.ts
+++ b/apps/server/src/host.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test"
+import { Context, Effect, Layer } from "effect"
+import type { Event } from "@clavia/tardigrade-core/event"
+import { Infer, type InferRequest } from "@clavia/tardigrade"
+import type { Action } from "@clavia/tardigrade/events"
+
+import { layerConfig, readConfig } from "./config"
+import { Agents, layerAgents, ResumeRefused } from "./host"
+import { DriverGauge } from "./http"
+
+// The host service against a real durable host on a volatile database, with the model seam bound
+// to a scripted mind: no credentials, no network, and the turn loop is the library's own.
+
+// The scripted mind answers the brief in one attempt. It honors the Infer contract by ending the
+// turn rather than calling a tool, which is all these assertions need
+// (packages/agent/src/index.test.ts, the scripted mind).
+const briefOf = (trajectory: ReadonlyArray<Event>): string => {
+  for (let i = trajectory.length - 1; i >= 0; i--) {
+    const event = trajectory[i]!
+    if (event.type === "MessageReceived") return String((event as { text?: unknown }).text ?? "")
+  }
+  return ""
+}
+
+const scripted = (request: InferRequest): Action => ({ kind: "complete", output: `ok: ${briefOf(request.trajectory)}` })
+
+const layerScripted: Layer.Layer<Infer> = Layer.succeed(Infer)({
+  react: (request: InferRequest) => Effect.succeed(scripted(request))
+})
+
+// The database is ":memory:", so each test opens its own store and closes it with the scope.
+const config = layerConfig(readConfig({ TARDIGRADE_DB: ":memory:" }))
+
+// The body runs with both services the layer provides: the agents it drives, and the gauge
+// /healthz reads over the same driver (http.ts, DriverGauge).
+const running = <A, E>(
+  body: (agents: Context.Service.Shape<typeof Agents>) => Effect.Effect<A, E, DriverGauge>
+): Promise<A> =>
+  Effect.gen(function*() {
+    const agents = yield* Agents
+    return yield* body(agents)
+  }).pipe(
+    Effect.provide(Layer.provide(layerAgents({ infer: layerScripted }), config)),
+    Effect.scoped,
+    Effect.runPromise
+  ) as Promise<A>
+
+describe("the agents service", () => {
+  test("a delivered brief drives to a completed turn", async () => {
+    const types = await running((agents) =>
+      Effect.gen(function*() {
+        const accepted = yield* agents.deliver("alpha", { id: "m1", text: "hello" })
+        expect(accepted).toEqual({ agent: "alpha", turn: "m1" })
+        yield* agents.settled
+        const gauge = yield* DriverGauge
+        expect(yield* gauge.dirty).toBe(0)
+        expect(yield* gauge.resting).toBe(true)
+        return (yield* agents.events("alpha")).map((e) => e.type)
+      })
+    )
+    expect(types).toContain("TurnCompleted")
+  })
+
+  test("list names every agent lane with its log", async () => {
+    const listed = await running((agents) =>
+      Effect.gen(function*() {
+        yield* agents.deliver("alpha", { id: "m1", text: "hello" })
+        yield* agents.deliver("beta", { id: "m2", text: "hello" })
+        yield* agents.settled
+        return yield* agents.list()
+      })
+    )
+    expect(listed.map((entry) => entry.id)).toEqual(["alpha", "beta"])
+    expect(listed.every((entry) => entry.events.some((e) => e.type === "TurnCompleted"))).toBe(true)
+  })
+
+  test("a turn that did not fail refuses to resume", async () => {
+    const refused = await running((agents) =>
+      Effect.gen(function*() {
+        yield* agents.deliver("alpha", { id: "m1", text: "hello" })
+        yield* agents.settled
+        return yield* Effect.flip(agents.resume("alpha", "m1"))
+      })
+    )
+    expect(refused).toBeInstanceOf(ResumeRefused)
+    expect(refused.turn).toBe("m1")
+    expect(refused.detail).toContain("cannot resume")
+  })
+
+  test("redelivering one message id is absorbed", async () => {
+    const counts = await running((agents) =>
+      Effect.gen(function*() {
+        yield* agents.deliver("alpha", { id: "m1", text: "hello" })
+        yield* agents.settled
+        const before = (yield* agents.events("alpha")).length
+        yield* agents.deliver("alpha", { id: "m1", text: "hello" })
+        yield* agents.settled
+        return [before, (yield* agents.events("alpha")).length]
+      })
+    )
+    expect(counts[1]).toBe(counts[0]!)
+  })
+})

--- a/apps/server/src/host.ts
+++ b/apps/server/src/host.ts
@@ -75,7 +75,7 @@ export class Agents extends Context.Service<
 // the customization path (apps-server-spec.md, "Explicitly out of scope for v1").
 const assemblyOf = () =>
   agentOf([
-    codeModeFor({}, {}, [agentsPackage({ budget: {} }), workspacePackage({ policy: {} })]),
+    codeModeFor({ packages: [agentsPackage(), workspacePackage()] }),
     reply,
     budget,
     compaction

--- a/apps/server/src/host.ts
+++ b/apps/server/src/host.ts
@@ -1,0 +1,230 @@
+import { Clock, Context, Data, Effect, Layer } from "effect"
+import type { Event } from "@clavia/tardigrade-core/event"
+import { messageReceived } from "@clavia/tardigrade-core/message"
+import {
+  agentOf,
+  agentsPackage,
+  budget,
+  codeModeFor,
+  compaction,
+  Infer,
+  reply,
+  resumeTurn,
+  workspacePackage,
+  type RlmR
+} from "@clavia/tardigrade"
+import type { Action } from "@clavia/tardigrade/events"
+import { createBunHost, type BunHost } from "@clavia/tardigrade-bun/host"
+import { infer } from "@clavia/tardigrade-model/model"
+
+import { ServerConfig, type ServerConfigValue } from "./config"
+import { DriverGauge } from "./http"
+
+// The durable host, the assembly it runs, and the loop that drives it, behind one service. The
+// routes speak agent ids; the lane a host knows lives here and nowhere else, so a route can never
+// name a lane and the store can never see an id.
+
+// LANE_PREFIX is the id-to-lane map (apps-server-spec.md, "Resources"). A lane outside it belongs
+// to something other than an agent and never appears in a listing.
+export const LANE_PREFIX = "ag."
+
+export const laneOf = (id: string): string => `${LANE_PREFIX}${id}`
+
+// idOf is laneOf's inverse, undefined for a lane this server does not own.
+export const idOf = (lane: string): string | undefined =>
+  lane.startsWith(LANE_PREFIX) ? lane.slice(LANE_PREFIX.length) : undefined
+
+// Inbound is one delivered message: the canonical inbound's fields a client may state
+// (packages/core/src/message.ts, MessageReceived). `id` is the dedup key end to end and becomes
+// the turn id.
+export interface Inbound {
+  readonly id: string
+  readonly text: string
+  readonly input?: unknown
+  readonly data?: unknown
+}
+
+// ResumeRefused is the library's guard, typed: a turn resumes only from a failed active epoch
+// (packages/agent/src/resume.ts). `detail` is the library's own message, which the route renders
+// as the 409's detail (host.test.ts, "a turn that did not fail refuses to resume").
+export class ResumeRefused extends Data.TaggedError("ResumeRefused")<{
+  readonly id: string
+  readonly turn: string
+  readonly detail: string
+}> {}
+
+// The operations the HTTP surface has: deliver a message, read a log, list what exists, resume a
+// failed turn. Every one speaks an agent id. Reads return raw events because the projections are
+// pure functions of a log (projections.ts); a route joins the two.
+export class Agents extends Context.Service<
+  Agents,
+  {
+    readonly deliver: (id: string, message: Inbound) => Effect.Effect<{ agent: string; turn: string }>
+    readonly events: (id: string) => Effect.Effect<ReadonlyArray<Event>>
+    readonly list: () => Effect.Effect<ReadonlyArray<{ readonly id: string; readonly events: ReadonlyArray<Event> }>>
+    readonly resume: (id: string, turn: string) => Effect.Effect<void, ResumeRefused>
+    // settled resolves once the drive in flight, and the follow-up it coalesced, has finished. A
+    // client never waits on it (a delivery answers 202 and the client polls the turn); a test and
+    // a shutdown do (host.test.ts).
+    readonly settled: Effect.Effect<void>
+  }
+>()("tardigrade/server/Agents") {}
+
+// The assembly this server runs, one for every lane: code mode with the spawn and workspace
+// packages in scope, plus the three policy capabilities. v1 runs this one assembly and forking is
+// the customization path (apps-server-spec.md, "Explicitly out of scope for v1").
+const assemblyOf = () =>
+  agentOf([
+    codeModeFor({}, {}, [agentsPackage({ budget: {} }), workspacePackage({ policy: {} })]),
+    reply,
+    budget,
+    compaction
+  ])
+
+// The model binding the configured coordinates name. Absent coordinates are not an endpoint this
+// server invents: every attempt fails with what is missing, so the process still boots, still
+// answers /healthz, and says why a turn cannot run (config.ts, ModelConfig).
+const MISSING_MODEL = "no model is configured: set MODEL_BASE_URL, MODEL_API_KEY, and MODEL_ID"
+
+const layerInferFrom = (config: ServerConfigValue): Layer.Layer<Infer> => {
+  const { apiKey, baseUrl, id, provider } = config.model
+  if (baseUrl === undefined || apiKey === undefined || id === undefined) {
+    const failed: Action = { kind: "fail", error: MISSING_MODEL, failure: { cause: "inference_error", attempts: 1 } }
+    return Layer.succeed(Infer)({ react: () => Effect.succeed(failed) })
+  }
+  return infer({ baseUrl, apiKey, model: id, ...(provider === undefined ? {} : { provider }) })
+}
+
+export interface AgentsOptions {
+  // The model seam. Absent, the binding is derived from ServerConfig; present, it replaces that
+  // derivation whole, which is how a test runs a scripted mind with no credentials
+  // (host.test.ts). It is the one seam because Infer is the one place a turn leaves the process.
+  readonly infer?: Layer.Layer<Infer>
+}
+
+// make builds the host, recovers what a death interrupted, and returns the service pair. The
+// close is a scope finalizer, so the process that stops listening also stops writing.
+const make = (options: AgentsOptions) =>
+  Effect.gen(function*() {
+    const config = yield* ServerConfig
+    const assembly = assemblyOf()
+    const inferLayer = options.infer ?? layerInferFrom(config)
+    const host: BunHost = yield* Effect.acquireRelease(
+      Effect.promise(() =>
+        createBunHost<RlmR>({
+          log: config.db,
+          actorFor: (lane) => (idOf(lane) === undefined ? undefined : assembly),
+          layersFor: () => inferLayer,
+          keyOf: (event) => assembly.keyOf?.(event)
+        })
+      ),
+      (open) => Effect.promise(() => open.close())
+    )
+
+    // The drive loop. Deliveries request a drive rather than run one: drives are serialized, so
+    // two lanes never settle at once, and coalesced, so a request arriving mid-drive schedules
+    // exactly one follow-up pass however many arrive. The follow-up runs inside the same promise,
+    // so a caller awaiting a requested drive also awaits the work its own delivery enabled.
+    let driving: Promise<void> | undefined
+    let follow = false
+    let failure: unknown = undefined
+    const pump = async (): Promise<void> => {
+      try {
+        do {
+          follow = false
+          await host.drive()
+        } while (follow)
+      } catch (e) {
+        failure = e
+      } finally {
+        driving = undefined
+        follow = false
+      }
+    }
+    const request = (): Promise<void> => {
+      if (driving !== undefined) {
+        follow = true
+        return driving
+      }
+      driving = pump()
+      return driving
+    }
+
+    // A drive that threw is a defect the loop cannot report to the delivery that caused it, so it
+    // is held and raised by the next `settled`: the process dies on it rather than driving on
+    // over a broken host.
+    const settled = Effect.suspend(() =>
+      Effect.promise(() => driving ?? Promise.resolve()).pipe(
+        Effect.flatMap(() => {
+          if (failure === undefined) return Effect.void
+          const held = failure
+          failure = undefined
+          return Effect.die(held)
+        })
+      )
+    )
+
+    yield* Effect.promise(() => host.recover())
+
+    const read = (id: string) => Effect.promise(() => host.read(laneOf(id)))
+
+    const service: Context.Service.Shape<typeof Agents> = {
+      deliver: (id, message) =>
+        Effect.gen(function*() {
+          const at = yield* Clock.currentTimeMillis
+          yield* Effect.promise(() =>
+            host.deliver(
+              host.self(laneOf(id)),
+              messageReceived({
+                id: message.id,
+                text: message.text,
+                ...(message.input === undefined ? {} : { input: message.input }),
+                ...(message.data === undefined ? {} : { data: message.data }),
+                at
+              })
+            )
+          )
+          request()
+          return { agent: id, turn: message.id }
+        }),
+      events: read,
+      list: () =>
+        Effect.gen(function*() {
+          const lanes = yield* Effect.promise(() => host.lanes())
+          const ids = lanes.flatMap((lane) => {
+            const id = idOf(lane)
+            return id === undefined ? [] : [id]
+          })
+          return yield* Effect.forEach(ids, (id) => Effect.map(read(id), (events) => ({ id, events })))
+        }),
+      // resumeTurn drives through this loop rather than the host, so a resume is serialized with
+      // every other drive (packages/agent/src/resume.ts, TurnDriver).
+      resume: (id, turn) =>
+        Effect.tryPromise({
+          try: () =>
+            resumeTurn(
+              { read: host.read, deliver: host.deliver, drive: request, self: host.self },
+              laneOf(id),
+              turn
+            ),
+          catch: (e) =>
+            new ResumeRefused({ id, turn, detail: e instanceof Error ? e.message : String(e) })
+        }).pipe(Effect.asVoid),
+      settled
+    }
+
+    // dirty counts the drive passes owed, not lanes: 0 resting, 1 while a drive runs, 2 when that
+    // drive has already coalesced a follow-up. The host's own dirty set is private to it, and the
+    // number a client reads is the one this loop acts on.
+    const gauge: Context.Service.Shape<typeof DriverGauge> = {
+      resting: Effect.promise(() => host.resting()),
+      dirty: Effect.sync(() => (driving === undefined ? 0 : follow ? 2 : 1))
+    }
+
+    return Context.make(Agents, service).pipe(Context.add(DriverGauge, gauge))
+  })
+
+// layerAgents is the host, the assembly, and the driver: the Agents the routes consume and the
+// DriverGauge /healthz reads, built once and closed with the scope.
+export const layerAgents = (options: AgentsOptions = {}): Layer.Layer<Agents | DriverGauge, never, ServerConfig> =>
+  Layer.effectContext(make(options))

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+import { HttpClient, HttpClientRequest } from "effect/unstable/http"
+import { BunHttpServer } from "@effect/platform-bun"
+
+import { DEFAULT_DB, DEFAULT_PORT, layerConfig, readConfig, type ServerConfigValue } from "./config"
+import { Agents } from "./host"
+import { layerGaugeResting, serve, PROBLEM_CONTENT_TYPE, DriverGauge, type Health } from "./http"
+
+// The HTTP surface against a real Bun server on an ephemeral port, so the assertions are about
+// wire behavior rather than about the shape of a layer.
+
+// The conventions these tests are about hold over any host, so the agent routes get one that owns
+// nothing. The routes themselves are exercised against a real host in api.test.ts.
+const layerAgentsEmpty = Layer.succeed(Agents)({
+  deliver: (id, message) => Effect.succeed({ agent: id, turn: message.id }),
+  events: () => Effect.succeed([]),
+  list: () => Effect.succeed([]),
+  resume: () => Effect.void,
+  settled: Effect.void
+})
+
+const configOf = (overrides: Partial<ServerConfigValue> = {}): ServerConfigValue => ({
+  ...readConfig({}),
+  ...overrides
+})
+
+// Boots the application on port 0 and hands the body a client already pointed at it.
+const serving = <A, E>(
+  options: {
+    readonly config?: ServerConfigValue
+    readonly gauge?: Layer.Layer<DriverGauge>
+  },
+  body: (client: HttpClient.HttpClient) => Effect.Effect<A, E>
+): Promise<A> =>
+  Effect.gen(function*() {
+    const client = yield* HttpClient.HttpClient
+    return yield* body(client)
+  }).pipe(
+    Effect.provide(
+      Layer.provideMerge(serve({ disableLogger: true, disableListenLog: true }), [
+        BunHttpServer.layerTest,
+        layerConfig(options.config ?? configOf()),
+        options.gauge ?? layerGaugeResting,
+        layerAgentsEmpty
+      ])
+    ),
+    Effect.scoped,
+    Effect.runPromise
+  ) as Promise<A>
+
+describe("config", () => {
+  test("defaults are the exported constants", () => {
+    const config = readConfig({})
+    expect(config.port).toBe(DEFAULT_PORT)
+    expect(config.db).toBe(DEFAULT_DB)
+    expect(config.token).toBeUndefined()
+    expect(config.model).toEqual({
+      baseUrl: undefined,
+      apiKey: undefined,
+      id: undefined,
+      provider: undefined
+    })
+  })
+
+  test("the environment overrides every default", () => {
+    const config = readConfig({
+      PORT: "8080",
+      TARDIGRADE_DB: "/var/lib/agents.sqlite",
+      TARDIGRADE_TOKEN: "secret",
+      MODEL_BASE_URL: "https://api.example.com",
+      MODEL_API_KEY: "key",
+      MODEL_ID: "a-model",
+      MODEL_PROVIDER: "openai"
+    })
+    expect(config.port).toBe(8080)
+    expect(config.db).toBe("/var/lib/agents.sqlite")
+    expect(config.token).toBe("secret")
+    expect(config.model.baseUrl).toBe("https://api.example.com")
+    expect(config.model.provider).toBe("openai")
+  })
+
+  // Listening somewhere other than where the operator asked is worse than refusing to start.
+  test("a PORT that is not a port refuses to resolve", () => {
+    expect(() => readConfig({ PORT: "http" })).toThrow()
+    expect(() => readConfig({ PORT: "70000" })).toThrow()
+  })
+})
+
+describe("healthz", () => {
+  test("healthz reports the gauge", async () => {
+    const body = await serving({}, (client) =>
+      Effect.flatMap(client.get("/healthz"), (response) => response.json))
+    expect(body).toEqual({ status: "resting", dirty: 0 } satisfies Health)
+  })
+
+  test("a driving host with owed lanes reads through", async () => {
+    const gauge = Layer.succeed(DriverGauge)({
+      resting: Effect.succeed(false),
+      dirty: Effect.succeed(3)
+    })
+    const body = await serving({ gauge }, (client) =>
+      Effect.flatMap(client.get("/healthz"), (response) => response.json))
+    expect(body).toEqual({ status: "driving", dirty: 3 } satisfies Health)
+  })
+})
+
+describe("errors", () => {
+  test("an unmatched route is a problem document", async () => {
+    const response = await serving({}, (client) => client.get("/nope"))
+    expect(response.status).toBe(404)
+    expect(response.headers["content-type"]).toContain(PROBLEM_CONTENT_TYPE)
+  })
+})
+
+describe("auth", () => {
+  test("no token leaves every route open", async () => {
+    const response = await serving({}, (client) => client.get("/nope"))
+    expect(response.status).toBe(404)
+  })
+
+  test("a token closes the API and leaves healthz open", async () => {
+    const config = configOf({ token: "secret" })
+
+    const anonymous = await serving({ config }, (client) =>
+      Effect.gen(function*() {
+        const response = yield* client.get("/agents")
+        return { status: response.status, contentType: response.headers["content-type"], body: yield* response.json }
+      }))
+    expect(anonymous.status).toBe(401)
+    expect(anonymous.contentType).toContain(PROBLEM_CONTENT_TYPE)
+    expect(anonymous.body).toMatchObject({ status: 401, title: "Unauthorized" })
+
+    const wrong = await serving({ config }, (client) =>
+      client.execute(HttpClientRequest.bearerToken(HttpClientRequest.get("/agents"), "guess")))
+    expect(wrong.status).toBe(403)
+
+    const right = await serving({ config }, (client) =>
+      client.execute(HttpClientRequest.bearerToken(HttpClientRequest.get("/agents"), "secret")))
+    expect(right.status).toBe(200)
+
+    const health = await serving({ config }, (client) => client.get("/healthz"))
+    expect(health.status).toBe(200)
+  })
+})

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -1,0 +1,164 @@
+import { Context, Effect, Layer } from "effect"
+import { Headers, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+
+import { layerApi } from "./api"
+import { ServerConfig } from "./config"
+
+// The HTTP surface. Routes are layers over effect's own HttpRouter, so the server is assembled the
+// way the rest of the repository is assembled, and the Bun binding is the only platform-specific
+// piece (main.ts, http.test.ts). This module owns the conventions every later route inherits: the
+// error body, the bearer gate, and the health probe that reads the driver rather than the process.
+
+// The health probe's view of the host driver. The server never asks the driver to run; it asks what
+// the driver is doing, which is the whole of "the server drives continuously" from the client's
+// side (apps-server-spec.md, "Principles"). Two questions, because /healthz answers two: is the
+// driver resting, and how many lanes still owe work.
+export class DriverGauge extends Context.Service<
+  DriverGauge,
+  {
+    readonly resting: Effect.Effect<boolean>
+    readonly dirty: Effect.Effect<number>
+  }
+>()("tardigrade/server/DriverGauge") {}
+
+// A gauge for a process with no host attached. It reports a resting driver with nothing owed, which
+// is true of a server that has not been given one (http.test.ts, "healthz reports the gauge").
+export const layerGaugeResting: Layer.Layer<DriverGauge> = Layer.succeed(DriverGauge)({
+  resting: Effect.succeed(true),
+  dirty: Effect.succeed(0)
+})
+
+import { problem } from "./problem"
+export { problem, type Problem, PROBLEM_CONTENT_TYPE, PROBLEM_TYPE_BASE } from "./problem"
+
+// Paths the bearer gate lets through. /healthz is a liveness probe: a supervisor that has to hold a
+// credential to learn the process is up cannot tell an outage from a misconfiguration.
+export const UNAUTHENTICATED_PATHS: ReadonlyArray<string> = ["/healthz"]
+
+const pathOf = (url: string): string => {
+  const query = url.indexOf("?")
+  const path = query === -1 ? url : url.slice(0, query)
+  return path.length > 1 && path.endsWith("/") ? path.slice(0, -1) : path
+}
+
+const bearerOf = (headers: Headers.Headers): string | undefined => {
+  const header = headers["authorization"]
+  if (header === undefined) return undefined
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim())
+  return match?.[1]?.trim()
+}
+
+// Constant-time over the shared length, so a comparison does not leak the token a character at a
+// time. Lengths differing is already public through the response, so only the overlap is timed.
+const secretEquals = (a: string, b: string): boolean => {
+  let diff = a.length ^ b.length
+  const length = Math.min(a.length, b.length)
+  for (let i = 0; i < length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  return diff === 0
+}
+
+// The whole auth story for v1: TARDIGRADE_TOKEN absent leaves every route open, present makes a
+// matching bearer token required on everything but UNAUTHENTICATED_PATHS (apps-server-spec.md,
+// "Conventions"; http.test.ts, "a token closes the API and leaves healthz open").
+export const layerAuth = HttpRouter.middleware(
+  Effect.map(ServerConfig, (config) => (httpEffect) => {
+    const token = config.token
+    if (token === undefined) return httpEffect
+    return Effect.flatMap(HttpServerRequest.HttpServerRequest, (request) => {
+      if (UNAUTHENTICATED_PATHS.includes(pathOf(request.url))) return httpEffect
+      const presented = bearerOf(request.headers)
+      if (presented === undefined) {
+        return Effect.succeed(
+          HttpServerResponse.setHeader(
+            problem({
+              status: 401,
+              kind: "unauthorized",
+              title: "Unauthorized",
+              detail: "This server requires a bearer token."
+            }),
+            "www-authenticate",
+            "Bearer"
+          )
+        )
+      }
+      if (!secretEquals(presented, token)) {
+        return Effect.succeed(
+          problem({
+            status: 403,
+            kind: "forbidden",
+            title: "Forbidden",
+            detail: "The bearer token is not the one this server was started with."
+          })
+        )
+      }
+      return httpEffect
+    })
+  }),
+  { global: true }
+)
+
+export interface Health {
+  readonly status: "resting" | "driving"
+  readonly dirty: number
+}
+
+// 200 whenever the host answers, carrying the driver's state and the count of lanes that still owe
+// work (apps-server-spec.md, "GET /healthz").
+export const layerHealthz = HttpRouter.add(
+  "GET",
+  "/healthz",
+  Effect.gen(function*() {
+    const gauge = yield* DriverGauge
+    const body: Health = {
+      status: (yield* gauge.resting) ? "resting" : "driving",
+      dirty: yield* gauge.dirty
+    }
+    return HttpServerResponse.jsonUnsafe(body)
+  })
+)
+
+// A route the router did not match is a problem document like any other failure, so a client never
+// has to parse two error shapes.
+export const layerNotFound = HttpRouter.add(
+  "*",
+  "*",
+  Effect.succeed(
+    problem({
+      status: 404,
+      kind: "not-found",
+      title: "Not Found",
+      detail: "No route matches this path."
+    })
+  )
+)
+
+// Permissive on every origin, because the process is meant to bind to localhost and the voyager is
+// served from a Vite dev server on another port during development (apps-server-spec.md,
+// "Conventions"). An operator who exposes the port relies on TARDIGRADE_TOKEN, not on the browser.
+export const layerCors = HttpRouter.cors({
+  allowedHeaders: ["authorization", "content-type", "last-event-id"],
+  exposedHeaders: ["content-type"]
+})
+
+// The application: every route, plus the conventions that wrap them. Routes added by later modules
+// merge in here, and inherit the gate and the error shape by being part of the same router.
+//
+// The agent routes are suspended because api.ts reads this module's conventions and this module
+// reads its routes: whichever of the two a consumer imports first, the merge names `layerApi` after
+// both module bodies have run (api.test.ts imports api.ts first).
+export const layerApp = Layer.mergeAll(
+  layerApi(),
+  layerHealthz,
+  layerNotFound,
+  layerCors,
+  layerAuth
+)
+
+// serve starts the application on whichever HttpServer is provided, which is the only seam a
+// platform binding needs: Bun in main.ts, an ephemeral test server in http.test.ts. The request log
+// is on by default because an operator watching one process wants it, and off where a test would
+// otherwise print a line per request.
+export const serve = (options?: {
+  readonly disableLogger?: boolean | undefined
+  readonly disableListenLog?: boolean
+}) => HttpRouter.serve(layerApp, options)

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -1,0 +1,27 @@
+import { Layer } from "effect"
+import { BunHttpServer, BunRuntime } from "@effect/platform-bun"
+import { assertSupportedBun } from "@clavia/tardigrade-core/runtime"
+
+import { layerFromEnv, readConfig } from "./config"
+import { layerAgents } from "./host"
+import { serve } from "./http"
+
+// The entry point: environment to configuration to a listening Bun process. It holds no logic of
+// its own, so anything worth testing lives in config.ts or http.ts and is exercised without a
+// process (http.test.ts).
+
+// The process refuses to listen on a runtime the framework cannot keep its promises on, rather than
+// failing later inside a turn (packages/core/src/runtime.ts).
+assertSupportedBun()
+
+const config = readConfig(process.env)
+
+const configLayer = layerFromEnv(process.env)
+
+// The host is built from the same configuration the routes read, and closed with the scope the
+// server runs in, so the process that stops listening stops writing (host.ts, layerAgents).
+const agents = Layer.provide(layerAgents(), configLayer)
+
+const main = Layer.provide(serve(), [BunHttpServer.layer({ port: config.port }), configLayer, agents])
+
+BunRuntime.runMain(Layer.launch(main))

--- a/apps/server/src/problem.ts
+++ b/apps/server/src/problem.ts
@@ -1,0 +1,34 @@
+import { HttpServerResponse } from "effect/unstable/http"
+
+export const PROBLEM_CONTENT_TYPE = "application/problem+json"
+
+// The base of the `type` URI in a problem document. RFC 9457 wants a URI that identifies the error
+// kind; a client matches on it rather than on the human title.
+export const PROBLEM_TYPE_BASE = "https://tardigrade.dev/problems/"
+
+export interface Problem {
+  readonly type: string
+  readonly title: string
+  readonly status: number
+  readonly detail?: string
+}
+
+// problem renders an error as application/problem+json (apps-server-spec.md, "Conventions"). Every
+// failing route answers in this one shape, so a client parses errors once.
+export const problem = (options: {
+  readonly status: number
+  readonly title: string
+  readonly kind: string
+  readonly detail?: string | undefined
+}): HttpServerResponse.HttpServerResponse => {
+  const body: Problem = {
+    type: `${PROBLEM_TYPE_BASE}${options.kind}`,
+    title: options.title,
+    status: options.status,
+    ...(options.detail === undefined ? {} : { detail: options.detail })
+  }
+  return HttpServerResponse.jsonUnsafe(body, {
+    status: options.status,
+    contentType: PROBLEM_CONTENT_TYPE
+  })
+}

--- a/apps/server/src/projections.test.ts
+++ b/apps/server/src/projections.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "bun:test"
+import type { Event } from "@clavia/tardigrade-core/event"
+import { replyId } from "@clavia/tardigrade-core/message"
+
+import { statusOf, summaryOf, treeOf, turnsOf } from "./projections"
+
+// The projections are functions of an event array, so the fixtures are event arrays: the shapes
+// below are the ones an assembled agent writes (packages/agent/src/index.test.ts and
+// packages/code/src/events.ts), trimmed to the fields a projection reads.
+
+let clock = 0
+const at = () => ++clock
+
+const inbound = (id: string, text = "do the thing"): Event =>
+  ({ type: "MessageReceived", id, text, at: at() }) as Event
+
+const dispatched = (execId: string): Event =>
+  ({ type: "CodeDispatched", execId, code: "return 1", at: at() }) as Event
+
+const called = (callId: string, name = "agents"): Event =>
+  ({ type: "PackageCalled", callId, name, arguments: {}, at: at() }) as Event
+
+const blocked = (callId: string, awaiting: string): Event =>
+  ({ type: "BlockedOn", callId, awaiting, at: at() }) as Event
+
+const settledCode = (execId: string): Event =>
+  ({ type: "CodeSettled", execId, result: "ok", at: at() }) as Event
+
+const completed = (turn: string, output: string): Event =>
+  ({ type: "TurnCompleted", turn, output, at: at() }) as Event
+
+const failed = (turn: string, error: string): Event =>
+  ({ type: "TurnFailed", turn, error, at: at() }) as Event
+
+const requested = (turn: string, callId: string): Event =>
+  ({ type: "BudgetRequested", turn, callId, reason: "more calls", amount: 5, at: at() }) as Event
+
+const reply = (id: string, text = "done"): Event =>
+  ({ type: "MessageReceived", id: replyId(id), text, outcome: "completed", at: at() }) as Event
+
+describe("statusOf", () => {
+  test("an empty log rests", () => {
+    expect(statusOf([])).toBe("resting")
+  })
+
+  test("a settled turn rests", () => {
+    const log = [inbound("m1"), dispatched("t1"), settledCode("t1"), completed("m1", "42")]
+    expect(statusOf(log)).toBe("resting")
+  })
+
+  test("a fresh turn is working", () => {
+    expect(statusOf([inbound("m1")])).toBe("working")
+  })
+
+  test("an unsettled execution that can move is working", () => {
+    expect(statusOf([inbound("m1"), dispatched("t1"), called("t1.0")])).toBe("working")
+  })
+
+  test("an open BlockedOn with the reply away is blocked", () => {
+    const log = [inbound("m1"), dispatched("t1"), called("t1.0"), blocked("t1.0", replyId("t1.0"))]
+    expect(statusOf(log)).toBe("blocked")
+  })
+
+  test("a landed reply unblocks the lane", () => {
+    const log = [
+      inbound("m1"),
+      dispatched("t1"),
+      called("t1.0"),
+      blocked("t1.0", replyId("t1.0")),
+      reply("t1.0")
+    ]
+    expect(statusOf(log)).toBe("working")
+  })
+
+  test("a failed last turn with nothing owed is failed", () => {
+    const log = [inbound("m1"), dispatched("t1"), settledCode("t1"), failed("m1", "the tool exploded")]
+    expect(statusOf(log)).toBe("failed")
+  })
+
+  test("a failed turn followed by a live one is working, not failed", () => {
+    const log = [inbound("m1"), failed("m1", "boom"), inbound("m2")]
+    expect(statusOf(log)).toBe("working")
+  })
+})
+
+describe("summaryOf", () => {
+  test("a summary counts events and carries the last timestamp", () => {
+    const log = [inbound("m1"), completed("m1", "42")]
+    const summary = summaryOf("root", log)
+    expect(summary.id).toBe("root")
+    expect(summary.events).toBe(2)
+    expect(summary.lastAt).toBe(log[1]!["at"] as number)
+    expect(summary.status).toBe("resting")
+    expect("parent" in summary).toBe(false)
+  })
+
+  test("a summary carries the parent the caller supplies", () => {
+    expect(summaryOf("t1.0", [], "root").parent).toBe("root")
+  })
+
+  test("an empty log has no last timestamp", () => {
+    expect("lastAt" in summaryOf("root", [])).toBe(false)
+  })
+})
+
+describe("treeOf", () => {
+  // Two roots, and one of them three levels deep: root -> t1.0 -> t9.0. The claim is the parent's
+  // own PackageCalled, so a level is one call recorded one log up.
+  const forest = (): ReadonlyMap<string, ReadonlyArray<Event>> =>
+    new Map<string, ReadonlyArray<Event>>([
+      ["root", [inbound("m1"), dispatched("t1"), called("t1.0"), called("t1.1")]],
+      ["t1.0", [inbound("t1.0"), dispatched("t9"), called("t9.0")]],
+      ["t1.1", [inbound("t1.1")]],
+      ["t9.0", [inbound("t9.0")]],
+      ["other", [inbound("m2")]]
+    ])
+
+  test("three levels, two roots", () => {
+    const roots = treeOf(forest())
+    expect(roots.map((node) => node.id)).toEqual(["root", "other"])
+    const root = roots[0]!
+    expect(root.children.map((node) => node.id)).toEqual(["t1.0", "t1.1"])
+    expect(root.children[0]!.children.map((node) => node.id)).toEqual(["t9.0"])
+    expect(root.children[0]!.children[0]!.children).toEqual([])
+    expect(roots[1]!.children).toEqual([])
+  })
+
+  test("every node carries its own summary, and a child names its parent", () => {
+    const root = treeOf(forest())[0]!
+    expect(root.status).toBe("working")
+    const child = root.children[0]!
+    expect(child.parent).toBe("root")
+    expect(child.events).toBe(3)
+    expect(root.children[0]!.children[0]!.parent).toBe("t1.0")
+    expect("parent" in root).toBe(false)
+  })
+
+  test("a package call to a non-agent claims nothing", () => {
+    const logs = new Map<string, ReadonlyArray<Event>>([
+      ["root", [inbound("m1"), dispatched("t1"), called("t1.0", "workspace")]]
+    ])
+    expect(treeOf(logs).map((node) => node.id)).toEqual(["root"])
+  })
+
+  test("roots sort by first event time", () => {
+    const early = [inbound("a")]
+    const late = [inbound("b")]
+    const logs = new Map<string, ReadonlyArray<Event>>([["late", late], ["early", early]])
+    expect(treeOf(logs).map((node) => node.id)).toEqual(["early", "late"])
+  })
+})
+
+describe("turnsOf", () => {
+  test("one entry per inbound message, with its boundary", () => {
+    const log = [
+      inbound("m1"),
+      completed("m1", "42"),
+      inbound("m2"),
+      failed("m2", "boom"),
+      inbound("m3")
+    ]
+    expect(turnsOf(log)).toEqual([
+      { turn: "m1", status: "completed", output: "42" },
+      { turn: "m2", status: "failed", error: "boom" },
+      { turn: "m3", status: "pending" }
+    ])
+  })
+
+  test("a reply message is not a turn", () => {
+    const log = [inbound("m1"), reply("t1.0"), completed("m1", "42")]
+    expect(turnsOf(log).map((view) => view.turn)).toEqual(["m1"])
+  })
+
+  test("an unanswered budget ask is parked", () => {
+    const log = [inbound("m1"), requested("m1", "c1")]
+    expect(turnsOf(log)).toEqual([{ turn: "m1", status: "parked" }])
+  })
+
+  test("a prefix takes a turn back to pending", () => {
+    const log = [inbound("m1"), completed("m1", "42")]
+    expect(turnsOf(log)[0]!.status).toBe("completed")
+    expect(turnsOf(log, 1)).toEqual([{ turn: "m1", status: "pending" }])
+    expect(turnsOf(log, 0)).toEqual([])
+  })
+})

--- a/apps/server/src/projections.ts
+++ b/apps/server/src/projections.ts
@@ -1,0 +1,177 @@
+import type { Event } from "@clavia/tardigrade-core/event"
+import { REPLY_SUFFIX } from "@clavia/tardigrade-core/message"
+import { canProgress, factsOf } from "@clavia/tardigrade-code/projections"
+import { boundaryOf } from "@clavia/tardigrade/boundary"
+
+// The read side of the API. Every endpoint that answers a question about an agent answers it here,
+// as a pure function of that agent's events (apps-server-spec.md, "Principles": every read is a
+// projection of the log). Nothing in this module touches a store, a host, or a clock, so a route is
+// a lookup plus one of these calls, and a test is an array of events.
+//
+// The projections read the framework's own projections wherever one already answers the question:
+// the lane's owed work comes from the code lane (@clavia/tardigrade-code/projections), and a turn's
+// outcome comes from the agent's boundary (@clavia/tardigrade/boundary). The vocabulary the wire
+// speaks is the only thing added here.
+
+// AgentStatus is the summary vocabulary of GET /agents. Four answers, in the order they are
+// decided: an agent whose work cannot move is blocked, an agent that owes a transition is working,
+// an agent whose last turn died owing nothing is failed, and anything else rests.
+export type AgentStatus = "resting" | "working" | "blocked" | "failed"
+
+const numberAt = (event: Event): number | undefined => {
+  const at = (event as { at?: unknown }).at
+  return typeof at === "number" ? at : undefined
+}
+
+const idOf = (event: Event): string => String((event as { id?: unknown }).id ?? "")
+
+// inboundOf returns the ids of the turns a log was asked to serve, in log order. A reply is an
+// inbound event and never an inbound turn: it answers an id this agent sent out, under that id's
+// own `<id>.reply` name (@clavia/tardigrade-core/message, REPLY_SUFFIX), so listing it would report
+// a child's answer as a turn of the parent (projections.test.ts, "a reply message is not a turn").
+const inboundOf = (events: ReadonlyArray<Event>): ReadonlyArray<string> => {
+  const ids: string[] = []
+  const seen = new Set<string>()
+  for (const event of events) {
+    if (event.type !== "MessageReceived") continue
+    const id = idOf(event)
+    if (id === "" || id.endsWith(REPLY_SUFFIX) || seen.has(id)) continue
+    seen.add(id)
+    ids.push(id)
+  }
+  return ids
+}
+
+// statusOf reports what the agent is doing, decided in one order because the states overlap in the
+// log: a blocked lane also has a turn without a terminal, and a failed turn is only failed once
+// nothing is owed (apps-server-spec.md, "GET /agents").
+//
+// The first two answers are the code lane's own head-of-queue reading, not a second derivation of
+// it: `workOwed` is this head plus `canProgress`, so blocked is exactly the case that leaves
+// `workOwed` empty while an execution is still open (@clavia/tardigrade-code/projections). Blocked
+// means an open `BlockedOn` whose awaited reply has not landed; the moment it lands the same head
+// can progress and reads working again (projections.test.ts, "a landed reply unblocks the lane").
+//
+// A turn with no terminal and no owed execution is working as well: the model owes the next
+// transition, and no code has been dispatched yet (projections.test.ts, "a fresh turn is working").
+export const statusOf = (events: ReadonlyArray<Event>): AgentStatus => {
+  const head = factsOf(events).find((facts) => !facts.settled)
+  if (head !== undefined) return canProgress(head) ? "working" : "blocked"
+  const turns = inboundOf(events)
+  const last = turns[turns.length - 1]
+  if (last === undefined) return "resting"
+  const boundary = boundaryOf(events, last)
+  if (boundary === undefined) return "working"
+  return boundary.kind === "failed" ? "failed" : "resting"
+}
+
+// AgentSummary is one row of GET /agents: what an agent is, without its events. `parent` is absent
+// for a root, and `lastAt` for an agent whose events carry no timestamp.
+export interface AgentSummary {
+  readonly id: string
+  readonly parent?: string
+  readonly events: number
+  readonly lastAt?: number
+  readonly status: AgentStatus
+}
+
+// summaryOf projects one log into its row. `parent` is a parameter because a child's own log holds
+// no evidence of its parent: the claim is a `PackageCalled` in the PARENT's log, so parentage is a
+// fact of the forest and only `treeOf` can see it (projections.test.ts, "a summary carries the
+// parent the caller supplies").
+export const summaryOf = (id: string, events: ReadonlyArray<Event>, parent?: string): AgentSummary => {
+  let lastAt: number | undefined
+  for (const event of events) {
+    const at = numberAt(event)
+    if (at !== undefined) lastAt = at
+  }
+  return {
+    id,
+    ...(parent === undefined ? {} : { parent }),
+    events: events.length,
+    ...(lastAt === undefined ? {} : { lastAt }),
+    status: statusOf(events)
+  }
+}
+
+// AgentNode is a summary with the agents it spawned, the shape GET /agents/:id/tree serves.
+export interface AgentNode extends AgentSummary {
+  readonly children: ReadonlyArray<AgentNode>
+}
+
+// firstAt is the log's own start, the order the forest is listed in. A log with no timestamp sorts
+// last rather than first, so an untimed agent never displaces a real one.
+const firstAt = (events: ReadonlyArray<Event>): number => {
+  for (const event of events) {
+    const at = numberAt(event)
+    if (at !== undefined) return at
+  }
+  return Number.POSITIVE_INFINITY
+}
+
+// treeOf builds the spawn forest. X is the parent of Y when X's log records a `PackageCalled` whose
+// `callId` is Y's id: a spawn names its child by the call's own id and places it at `ag.<callId>`
+// (packages/agent/src/spawn.ts, `sibling`), so the recorded call IS the claim, and no id parsing is
+// needed to find it. Ids the map does not hold are calls to other packages and claim nothing
+// (projections.test.ts, "a package call to a non-agent claims nothing").
+//
+// Roots are the agents no log claims, sorted by first event time; children sort the same way, so
+// two runs of the same forest render identically (projections.test.ts, "three levels, two roots").
+export const treeOf = (logs: ReadonlyMap<string, ReadonlyArray<Event>>): ReadonlyArray<AgentNode> => {
+  const parents = new Map<string, string>()
+  for (const [id, events] of logs) {
+    for (const event of events) {
+      if (event.type !== "PackageCalled") continue
+      const callId = String((event as { callId?: unknown }).callId ?? "")
+      if (callId === id || !logs.has(callId) || parents.has(callId)) continue
+      parents.set(callId, id)
+    }
+  }
+  const order = (a: string, b: string): number =>
+    (firstAt(logs.get(a) ?? []) - firstAt(logs.get(b) ?? [])) || (a < b ? -1 : a > b ? 1 : 0)
+  const childrenOf = new Map<string, string[]>()
+  for (const [child, parent] of parents) {
+    const siblings = childrenOf.get(parent)
+    if (siblings === undefined) childrenOf.set(parent, [child])
+    else siblings.push(child)
+  }
+  // A claim cycle is not reachable through minted call ids, but the map is an argument, so the walk
+  // carries the guard rather than trusting its caller.
+  const walked = new Set<string>()
+  const node = (id: string, parent?: string): AgentNode => {
+    walked.add(id)
+    const events = logs.get(id) ?? []
+    const children = (childrenOf.get(id) ?? []).filter((child) => !walked.has(child)).sort(order)
+    return { ...summaryOf(id, events, parent), children: children.map((child) => node(child, id)) }
+  }
+  return [...logs.keys()].filter((id) => !parents.has(id)).sort(order).map((id) => node(id))
+}
+
+// TurnStatus is the turn vocabulary of GET /agents/:id/turns. `parked` is the budget ask nobody can
+// answer over HTTP (apps-server-spec.md, "Explicitly out of scope": budget escalation).
+export type TurnStatus = "pending" | "completed" | "failed" | "parked"
+
+export interface TurnView {
+  readonly turn: string
+  readonly status: TurnStatus
+  readonly output?: string
+  readonly error?: string
+}
+
+// turnsOf projects one turn per inbound message, in the order the messages arrived. `at` cuts the
+// log to a prefix first: any prefix of a log is a valid state, so time travel is this one argument
+// and never a stored mode (apps-server-spec.md, "Principles"). A prefix taken before a turn's
+// terminal reads that turn pending again (projections.test.ts, "a prefix takes a turn back to
+// pending"), and a prefix taken before a message drops its turn from the list entirely.
+export const turnsOf = (events: ReadonlyArray<Event>, at?: number): ReadonlyArray<TurnView> => {
+  const prefix = events.slice(0, at ?? events.length)
+  return inboundOf(prefix).map((turn): TurnView => {
+    const boundary = boundaryOf(prefix, turn)
+    if (boundary === undefined) return { turn, status: "pending" }
+    if (boundary.kind === "completed") return { turn, status: "completed", output: boundary.output }
+    if (boundary.kind === "failed") return { turn, status: "failed", error: boundary.error }
+    // A park is neither an output nor an error: the turn is alive and waiting on an answer the API
+    // has no door for, so the status carries the whole of what a client can act on.
+    return { turn, status: "parked" }
+  })
+}

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,19 @@
         "oxlint": "^1.69.0",
       },
     },
+    "apps/server": {
+      "name": "@clavia/tardigrade-server",
+      "version": "0.0.1",
+      "dependencies": {
+        "@clavia/tardigrade": "workspace:*",
+        "@clavia/tardigrade-bun": "workspace:*",
+        "@clavia/tardigrade-code": "workspace:*",
+        "@clavia/tardigrade-core": "workspace:*",
+        "@clavia/tardigrade-model": "workspace:*",
+        "@effect/platform-bun": "4.0.0-rc.110",
+        "effect": "4.0.0-rc.110",
+      },
+    },
     "packages/agent": {
       "name": "@clavia/tardigrade",
       "version": "0.0.1",
@@ -144,6 +157,12 @@
     "@clavia/tardigrade-host": ["@clavia/tardigrade-host@workspace:packages/host"],
 
     "@clavia/tardigrade-model": ["@clavia/tardigrade-model@workspace:platform/model"],
+
+    "@clavia/tardigrade-server": ["@clavia/tardigrade-server@workspace:apps/server"],
+
+    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-rc.110", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-rc.110" }, "peerDependencies": { "effect": "^4.0.0-rc.110" } }, "sha512-f4AcFTWVwGby9RvSitqAcG/McN8OCDy7LW8PYRG4NIOO2eYphlW73S5Z7jm3UDP+FmIwwzjfgfIfBYkfPR+YfA=="],
+
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-rc.111", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.3" }, "peerDependencies": { "effect": "^4.0.0-rc.111" } }, "sha512-iES0Q9vmjhaUKqeW9ceonuD45MUg/Ouk08LzRSptZ+B5qB0w9WlRjDmUz5TJmY2betNop5FRI5k4AD4mtQt3Bw=="],
 
     "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@4.0.0-rc.110", "", { "peerDependencies": { "effect": "^4.0.0-rc.110" } }, "sha512-Lam3gY1xszjQS/cebdLbWbtR21FtQI4ke7QHqbBQ6AyVJF0CGUtS/ePL9zNq6wHNmJ95FUDGS6W+Qx/l6RPSzA=="],
 
@@ -323,6 +342,8 @@
 
     "@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "beautiful-mermaid": ["beautiful-mermaid@1.1.3", "", { "dependencies": { "elkjs": "^0.11.0", "entities": "^7.0.1" } }, "sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
@@ -388,6 +409,8 @@
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
+
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,6 @@
 # tardigrade docs
 
 - [quickstart.md](quickstart.md): all the core concepts you need to get started.
+- [how-to/server.md](how-to/server.md): run the self-hostable server, its environment, and its endpoints.
 - [explanations/runtime-and-recovery.md](explanations/runtime-and-recovery.md): runtime requirements, retry scopes, and failed-turn recovery.
 - [explanations/why.md](explanations/why.md): why tardigrade exists. {transitions} = f(log), and what the log-as-state shape enables.

--- a/docs/how-to/server.md
+++ b/docs/how-to/server.md
@@ -1,0 +1,71 @@
+# Run the server
+
+The server is the self-hostable deployable: one Bun process that holds a durable SQLite log, runs the default agent assembly over it, and exposes HTTP. The assembly is code mode with the spawn and workspace packages in scope, plus reply, budget, and compaction. Everything the API answers is derived from the log, so the process keeps no state a restart could lose.
+
+## Run it
+
+```bash
+bun run --cwd apps/server start
+```
+
+The process opens the store, recovers whatever an earlier death interrupted, and listens. It drives continuously: a delivered message starts a turn and the loop settles it, so a client observes rather than asks for work.
+
+Configuration is the environment and nothing else. Every default is an exported constant in `apps/server/src/config.ts`.
+
+| Variable | Default | What it sets |
+| --- | --- | --- |
+| `PORT` | `4111` (`DEFAULT_PORT`) | The port the process listens on. A value that is not an integer between 0 and 65535 refuses to start. |
+| `TARDIGRADE_DB` | `agents.sqlite` (`DEFAULT_DB`) | The SQLite file that holds every log. A relative path resolves against the working directory. |
+| `TARDIGRADE_TOKEN` | absent | A bearer token required on every route except `/healthz`. Absent leaves the API open, which is why the process is meant to bind to localhost. |
+| `MODEL_BASE_URL` | absent | The OpenAI-compatible endpoint the model binding calls. |
+| `MODEL_API_KEY` | absent | The credential for that endpoint. |
+| `MODEL_ID` | absent | The model the binding asks for. |
+| `MODEL_PROVIDER` | absent | The protocol, when the endpoint is not OpenAI-compatible. `bedrock` selects Bedrock. |
+
+## Running without a model
+
+The process boots without model coordinates. It listens, answers `/healthz`, accepts messages, and every turn it drives fails with `no model is configured: set MODEL_BASE_URL, MODEL_API_KEY, and MODEL_ID`. The failure is an event in the log like any other, so `GET /agents/:id/turns/:turn` reports the turn as `failed` and carries that sentence as its error. Set the three variables and `POST /agents/:id/turns/:turn/resume` runs the same turn again from where it stopped. A server that refused to start without a model would hide the log an operator can already read.
+
+## Endpoints
+
+| Endpoint | Contract |
+| --- | --- |
+| `POST /agents/:id/messages` | Deliver one message, `{ id, text, input?, data? }`. Answers `202 { agent, turn }`, or `400` when the body states no `id` or no `text`. |
+| `GET /agents` | Every agent, parent before child, as a summary: id, parent, event count, last event time, and status (`resting`, `working`, `blocked`, `failed`). |
+| `GET /agents/:id/events` | The log as `{ seq, event }` rows. `after` starts the page past a sequence number, `limit` caps it (default 200, `DEFAULT_EVENT_LIMIT`), `types` filters by a comma list. |
+| `GET /agents/:id/events/stream` | The same log as `text/event-stream`, replayed from the cursor and then followed live. The tail re-reads every 50 milliseconds (`DEFAULT_SSE_POLL`) and writes a comment frame after 15 seconds of silence (`DEFAULT_SSE_HEARTBEAT`). |
+| `GET /agents/:id/turns` | Every turn boundary as `{ turn, status, output?, error? }`, where status is `pending`, `completed`, `failed`, or `parked`. `at` evaluates the projection over a prefix of the log. |
+| `GET /agents/:id/turns/:turn` | One turn's boundary, the same shape. This is the poll target for whether a run finished. |
+| `POST /agents/:id/turns/:turn/resume` | Resume a failed turn. `202` with the turn handle, `409` when the turn did not fail or belongs to a spent epoch, carrying the library's own reason. |
+| `GET /healthz` | `200` while the host answers, carrying `status` (`resting` or `driving`) and `dirty`, the count of drive passes owed. Open even when a token is set, so a supervisor can tell an outage from a misconfiguration. |
+
+Every failure is `application/problem+json`: `{ type, title, status, detail }`, where `type` is a URI under `https://tardigrade.dev/problems/` that a client matches on. A `404` on a read means the agent has never existed; an existing agent whose filter matches nothing answers `200 []`.
+
+## Creation is delivery
+
+There is no create endpoint, no registration, and no lifecycle. An agent exists once its log has an event, so `POST /agents/:id/messages` with an id nobody has used births that agent and starts its first turn. The same rule reads backwards: the only unknown agent is one with an empty log, which is what a `404` on any read reports.
+
+Children born by spawn get derived ids (`<execId>.<n>`) and appear in `GET /agents` and `GET /agents/:id/tree` like any other agent. Parentage is a claim in the parent's log, which is why the tree is derived across every log rather than from the subtree alone.
+
+## Redelivery is absorbed
+
+The message `id` is the dedup key end to end and becomes the turn id. Posting the same id twice answers `202` both times and starts one turn: the host absorbs the second delivery, and the client never learns it retried. An at-least-once caller, a webhook relay, or a shell script in a retry loop needs no care beyond keeping the id stable.
+
+## Streams resume where they dropped
+
+Each log event is one SSE event, and its `id:` field is the sequence number. A dropped connection resumes by sending `Last-Event-ID`, which the server prefers over the `after` query, because a reconnecting `EventSource` replays the URL it was opened with and that URL points at where the first connection began. The cursor is the count of events sent, so a resumed stream sends no event twice and skips none.
+
+## Time travel is a query
+
+Any prefix of a log is a valid state, so reading the past is a parameter rather than a mode. `GET /agents/:id/turns?at=<seq>` evaluates the turn projection over the first `<seq>` events, which is what the agent's outcome looked like at that point. Nothing is stored to make this work: the projection is a pure function of the events it is handed.
+
+## Out of scope
+
+The server runs one assembly, chosen in code, and forking is the customization path. Four things it does not do:
+
+- **Inbound sources.** Provider webhooks becoming messages arrive with the `Package.source` spec that defines them.
+- **Connections and credential storage.** The door's values arrive with that same spec.
+- **Per-agent assembly configuration.** Capabilities and packages as a wire format reopen every composition question, so the assembly stays a code decision in `apps/server/src/host.ts`.
+- **Budget answers over HTTP.** A parked turn reports `parked`; answering the ask needs the synchronous call doors the in-process host refuses, and waits on a consumer shape that needs them.
+
+Multi-tenancy, quotas, and users are outside the frame entirely: one store, one operator.

--- a/examples/rlm-agent.ts
+++ b/examples/rlm-agent.ts
@@ -15,7 +15,7 @@ import { createBunHost } from "@clavia/tardigrade-bun/host"
 // needs (Router, Self, and Facets for spawn; the spill store for workspace). The Bun host binds
 // all of those per lane.
 const rlm = agentOf([
-  codeModeFor({}, {}, [agentsPackage({ budget: {} }), workspacePackage({ policy: {} })]),
+  codeModeFor({ packages: [agentsPackage(), workspacePackage()] }),
   reply, // reports each turn's terminal to whoever asked
   budget, // the per-turn code budget, inherited by spawned children
   compaction // bounded model context over long investigations
@@ -24,7 +24,8 @@ const rlm = agentOf([
 const model = infer({
   baseUrl: process.env.MODEL_BASE_URL!,
   apiKey: process.env.MODEL_API_KEY!,
-  model: process.env.MODEL_ID!
+  model: process.env.MODEL_ID!,
+  ...(process.env.MODEL_PROVIDER === undefined ? {} : { provider: process.env.MODEL_PROVIDER })
 })
 
 // Every ag. lane runs the same assembly: the root, and every child a spawn births. The lane

--- a/knip.json
+++ b/knip.json
@@ -20,6 +20,11 @@
       "project": [
         "src/**/*.ts"
       ]
+    },
+    "apps/*": {
+      "project": [
+        "src/**/*.ts"
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   },
   "workspaces": [
     "packages/*",
-    "platform/*"
+    "platform/*",
+    "apps/*"
   ],
   "scripts": {
     "gate": "bun run tools/gate.ts",

--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -105,6 +105,16 @@ describe("the bun host", () => {
     await second.close()
   })
 
+  test("lanes names every lane the log holds", async () => {
+    const h = await createBunHost(options(freshPath()))
+    expect(await h.lanes()).toEqual([])
+    await h.deliver("bun:echo", { type: "MessageReceived", id: "m1", text: "go", at: 1 } as Event)
+    await h.seed("other", [{ type: "MessageReceived", id: "m2", text: "go", at: 2 } as Event])
+    await h.drive()
+    expect(await h.lanes()).toEqual(["echo", "other"])
+    await h.close()
+  })
+
   test("a batch appends atomically: a mid-batch key collision absorbs that row only", async () => {
     const h = await createBunHost(options(freshPath()))
     await h.seed("echo", [{ type: "Done", id: "a", at: 1 } as Event])

--- a/platform/bun/src/host.ts
+++ b/platform/bun/src/host.ts
@@ -65,6 +65,10 @@ export type BunHostOptions<R> = {
 export interface BunHost {
   readonly seed: (lane: string, events: ReadonlyArray<Event>) => Promise<void>
   readonly read: (lane: string) => Promise<ReadonlyArray<Event>>
+  // lanes names every lane the log holds, ordered by name. An app that lists what exists asks the
+  // host rather than the database, so the store stays this module's (host.test.ts, "lanes names
+  // every lane the log holds").
+  readonly lanes: () => Promise<ReadonlyArray<string>>
   readonly deliver: (address: string, event: Event) => Promise<void>
   readonly wake: (lane: string) => Promise<void>
   readonly drive: () => Promise<void>
@@ -237,10 +241,17 @@ export const createBunHost = async <R = never>(options: BunHostOptions<R>): Prom
     }
   }
 
+  const lanesEffect: Effect.Effect<ReadonlyArray<string>, never> = sql<{
+    lane: string
+  }>`SELECT DISTINCT lane FROM events ORDER BY lane`.pipe(
+    Effect.map((rows) => rows.map((row) => row.lane)),
+    Effect.orDie
+  )
+
   const lanesMap = async (): Promise<Map<string, ReadonlyArray<Event>>> => {
-    const rows = await runtime.runPromise(sql<{ lane: string }>`SELECT DISTINCT lane FROM events`.pipe(Effect.orDie))
+    const lanes = await runtime.runPromise(lanesEffect)
     const map = new Map<string, ReadonlyArray<Event>>()
-    for (const row of rows) map.set(row.lane, await runtime.runPromise(readEffect(row.lane)))
+    for (const lane of lanes) map.set(lane, await runtime.runPromise(readEffect(lane)))
     return map
   }
 
@@ -284,6 +295,7 @@ export const createBunHost = async <R = never>(options: BunHostOptions<R>): Prom
   return {
     seed: (lane, events) => runtime.runPromise(appendEffect(lane, events)),
     read: (lane) => runtime.runPromise(readEffect(lane)),
+    lanes: () => runtime.runPromise(lanesEffect),
     deliver: (address, event) => runtime.runPromise(deliverEffect(address, event)),
     wake: (lane) => {
       dirty.add(lane)

--- a/tools/gate.ts
+++ b/tools/gate.ts
@@ -12,6 +12,8 @@ const pkg = (name: string) => `${root}packages/${name}`
 const packages = ["core", "code", "agent", "host"]
 const platformPkg = (name: string) => `${root}platform/${name}`
 const platforms = ["model", "bun"]
+const appPkg = (name: string) => `${root}apps/${name}`
+const apps = ["server"]
 
 const tasks: ReadonlyArray<Task> = [
   { id: "lint", cmd: ["bun", "--bun", "node_modules/.bin/oxlint"] },
@@ -21,8 +23,10 @@ const tasks: ReadonlyArray<Task> = [
   { id: "typecheck:tools", cmd: ["bun", "--bun", "node_modules/.bin/tsc", "--noEmit"] },
   ...packages.map((name) => ({ id: `typecheck:${name}`, cwd: pkg(name), cmd: ["bun", "run", "typecheck"] })),
   ...platforms.map((name) => ({ id: `typecheck:platform-${name}`, cwd: platformPkg(name), cmd: ["bun", "run", "typecheck"] })),
+  ...apps.map((name) => ({ id: `typecheck:app-${name}`, cwd: appPkg(name), cmd: ["bun", "run", "typecheck"] })),
   ...packages.map((name) => ({ id: `test:${name}`, cwd: pkg(name), cmd: ["bun", "test"] })),
   ...platforms.map((name) => ({ id: `test:platform-${name}`, cwd: platformPkg(name), cmd: ["bun", "test"] })),
+  ...apps.map((name) => ({ id: `test:app-${name}`, cwd: appPkg(name), cmd: ["bun", "test"] })),
   { id: "knip", cmd: ["bun", "--bun", "node_modules/.bin/knip"] }
 ]
 


### PR DESCRIPTION
The self-hostable deployable: one Bun process wrapping createBunHost, running the default agent assembly (code mode with the spawn and workspace packages, reply, budget, compaction), exposing HTTP over it. Creation is delivery: POST /agents/:id/messages births the agent, every write is idempotent by the caller's message id, and every read is a projection of the log. This is a new tier beside packages/ and platform/: an application that owns its dependencies and imports the workspace packages as a consumer.

- apps/server: config from env with exported defaults, bearer auth (TARDIGRADE_TOKEN), problem+json errors, /healthz with a driver gauge
- Effect-native HTTP: effect/unstable/http router as layers; @effect/platform-bun (pinned to the repo's effect rc) is the one added dependency, for the Bun serving layer
- pure projections over the log: agent status, spawn forest by PackageCalled claims, turn boundaries with ?at= time travel
- the Agents service: id-to-lane mapping in one module, serialized-and-coalesced drive loop, recover at boot, host closed by scope finalizer, Infer injectable for tests
- eight endpoints per the spec, including SSE with Last-Event-ID resume and a leak-tested disconnect path
- BunHost gains lanes() so the server never reads the SQLite file directly
- e2e over real HTTP with a scripted mind on :memory:, no model credentials anywhere in CI; 42 app-server tests
- docs/how-to/server.md with the verified run command and the no-model first-run behavior; indexed from both READMEs
- bun run gate fully green (18 tasks)

Known gaps filed or noted: parked turns lack an ask payload and a status value (#128); the docs linter only scans top-level docs/*.md, so the new how-to page was checked against its rules by hand.