### PR TITLE
feat(voyager): trajectory explorer ui

### DIFF
--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -137,13 +137,13 @@ describe("messages", () => {
 })
 
 describe("the listing", () => {
-  test("an agent that has settled lists as resting", async () => {
+  test("an agent that has settled lists as settled", async () => {
     const listed = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
       return (await (await fetch(`${base}/agents`)).json()) as ReadonlyArray<AgentSummary>
     })
     expect(listed).toHaveLength(1)
-    expect(listed[0]).toMatchObject({ id: "alpha", status: "resting" })
+    expect(listed[0]).toMatchObject({ id: "alpha", status: "settled" })
     expect(listed[0]!.events).toBeGreaterThan(0)
     expect(listed[0]!.parent).toBeUndefined()
   })

--- a/apps/server/src/projections.test.ts
+++ b/apps/server/src/projections.test.ts
@@ -39,21 +39,21 @@ const reply = (id: string, text = "done"): Event =>
   ({ type: "MessageReceived", id: replyId(id), text, outcome: "completed", at: at() }) as Event
 
 describe("statusOf", () => {
-  test("an empty log rests", () => {
-    expect(statusOf([])).toBe("resting")
+  test("an empty log is settled", () => {
+    expect(statusOf([])).toBe("settled")
   })
 
-  test("a settled turn rests", () => {
+  test("a turn with a terminal is settled", () => {
     const log = [inbound("m1"), dispatched("t1"), settledCode("t1"), completed("m1", "42")]
-    expect(statusOf(log)).toBe("resting")
+    expect(statusOf(log)).toBe("settled")
   })
 
-  test("a fresh turn is working", () => {
-    expect(statusOf([inbound("m1")])).toBe("working")
+  test("a fresh turn is running", () => {
+    expect(statusOf([inbound("m1")])).toBe("running")
   })
 
-  test("an unsettled execution that can move is working", () => {
-    expect(statusOf([inbound("m1"), dispatched("t1"), called("t1.0")])).toBe("working")
+  test("an unsettled execution that can move is running", () => {
+    expect(statusOf([inbound("m1"), dispatched("t1"), called("t1.0")])).toBe("running")
   })
 
   test("an open BlockedOn with the reply away is blocked", () => {
@@ -69,7 +69,7 @@ describe("statusOf", () => {
       blocked("t1.0", replyId("t1.0")),
       reply("t1.0")
     ]
-    expect(statusOf(log)).toBe("working")
+    expect(statusOf(log)).toBe("running")
   })
 
   test("a failed last turn with nothing owed is failed", () => {
@@ -77,9 +77,9 @@ describe("statusOf", () => {
     expect(statusOf(log)).toBe("failed")
   })
 
-  test("a failed turn followed by a live one is working, not failed", () => {
+  test("a failed turn followed by a live one is running, not failed", () => {
     const log = [inbound("m1"), failed("m1", "boom"), inbound("m2")]
-    expect(statusOf(log)).toBe("working")
+    expect(statusOf(log)).toBe("running")
   })
 })
 
@@ -90,7 +90,7 @@ describe("summaryOf", () => {
     expect(summary.id).toBe("root")
     expect(summary.events).toBe(2)
     expect(summary.lastAt).toBe(log[1]!["at"] as number)
-    expect(summary.status).toBe("resting")
+    expect(summary.status).toBe("settled")
     expect("parent" in summary).toBe(false)
   })
 
@@ -127,7 +127,7 @@ describe("treeOf", () => {
 
   test("every node carries its own summary, and a child names its parent", () => {
     const root = treeOf(forest())[0]!
-    expect(root.status).toBe("working")
+    expect(root.status).toBe("running")
     const child = root.children[0]!
     expect(child.parent).toBe("root")
     expect(child.events).toBe(3)

--- a/apps/server/src/projections.ts
+++ b/apps/server/src/projections.ts
@@ -14,9 +14,9 @@ import { boundaryOf } from "@clavia/tardigrade/boundary"
 // speaks is the only thing added here.
 
 // AgentStatus is the summary vocabulary of GET /agents. Four answers, in the order they are
-// decided: an agent whose work cannot move is blocked, an agent that owes a transition is working,
-// an agent whose last turn died owing nothing is failed, and anything else rests.
-export type AgentStatus = "resting" | "working" | "blocked" | "failed"
+// decided: an agent whose work cannot move is blocked, an agent that owes a transition is running,
+// an agent whose last turn died owing nothing is failed, and anything else has settled.
+export type AgentStatus = "settled" | "running" | "blocked" | "failed"
 
 const numberAt = (event: Event): number | undefined => {
   const at = (event as { at?: unknown }).at
@@ -50,19 +50,19 @@ const inboundOf = (events: ReadonlyArray<Event>): ReadonlyArray<string> => {
 // it: `workOwed` is this head plus `canProgress`, so blocked is exactly the case that leaves
 // `workOwed` empty while an execution is still open (@clavia/tardigrade-code/projections). Blocked
 // means an open `BlockedOn` whose awaited reply has not landed; the moment it lands the same head
-// can progress and reads working again (projections.test.ts, "a landed reply unblocks the lane").
+// can progress and reads running again (projections.test.ts, "a landed reply unblocks the lane").
 //
-// A turn with no terminal and no owed execution is working as well: the model owes the next
-// transition, and no code has been dispatched yet (projections.test.ts, "a fresh turn is working").
+// A turn with no terminal and no owed execution is running as well: the model owes the next
+// transition, and no code has been dispatched yet (projections.test.ts, "a fresh turn is running").
 export const statusOf = (events: ReadonlyArray<Event>): AgentStatus => {
   const head = factsOf(events).find((facts) => !facts.settled)
-  if (head !== undefined) return canProgress(head) ? "working" : "blocked"
+  if (head !== undefined) return canProgress(head) ? "running" : "blocked"
   const turns = inboundOf(events)
   const last = turns[turns.length - 1]
-  if (last === undefined) return "resting"
+  if (last === undefined) return "settled"
   const boundary = boundaryOf(events, last)
-  if (boundary === undefined) return "working"
-  return boundary.kind === "failed" ? "failed" : "resting"
+  if (boundary === undefined) return "running"
+  return boundary.kind === "failed" ? "failed" : "settled"
 }
 
 // AgentSummary is one row of GET /agents: what an agent is, without its events. `parent` is absent

--- a/apps/voyager/dev/fixture.ts
+++ b/apps/voyager/dev/fixture.ts
@@ -1,0 +1,96 @@
+import { Effect, Layer } from "effect"
+import { BunHttpServer, BunRuntime } from "@effect/platform-bun"
+import { Infer, type InferRequest } from "@clavia/tardigrade"
+import type { Action } from "@clavia/tardigrade/events"
+import type { Event } from "@clavia/tardigrade-core/event"
+import { layerConfig, readConfig } from "@clavia/tardigrade-server/config"
+import { layerAgents } from "@clavia/tardigrade-server/host"
+import { serve } from "@clavia/tardigrade-server/http"
+
+// The development server: the real apps/server process, on a volatile database, with the model seam
+// bound to a scripted mind. It is the same seam the server's own tests use
+// (apps/server/src/api.test.ts), so the UI develops against real projections, a real driver, and a
+// real SSE tail, and needs no model credentials.
+//
+// Every agent this fixture serves is invented by the script below. Nothing here is imported by the
+// app; the app only ever speaks HTTP.
+
+// Where the fixture listens, matching the client's DEFAULT_API_URL (src/api.ts).
+export const FIXTURE_PORT = 4111
+
+// How many children the spawning brief asks for. The forest is worth looking at only when it has a
+// shape, and this is the number that gives it one.
+export const FIXTURE_FANOUT = 3
+
+// The prefix a brief carries to ask the scripted mind to spawn rather than answer.
+export const SPAWN_BRIEF = "spawn "
+
+const briefOf = (trajectory: ReadonlyArray<Event>): string => {
+  for (let i = trajectory.length - 1; i >= 0; i--) {
+    const event = trajectory[i]!
+    if (event.type === "MessageReceived") return String((event as { text?: unknown }).text ?? "")
+  }
+  return ""
+}
+
+// The scripted mind answers a plain brief in one attempt, and answers a `spawn <name>` brief by
+// running one execution that briefs FIXTURE_FANOUT children and reporting what they said. The tool
+// call id is the brief's own name, so the children's ids are stated by the caller rather than by a
+// counter (packages/agent/src/spawn.ts, `sibling`).
+const scripted = ({ trajectory }: InferRequest): Action => {
+  const brief = briefOf(trajectory)
+  if (!brief.startsWith(SPAWN_BRIEF)) return { kind: "complete", output: `ok: ${brief}` }
+  const start = trajectory.reduce((n, event, i) => (event.type === "MessageReceived" ? i : n), 0)
+  const returned = trajectory.slice(start).find((event) => event.type === "ToolReturned") as
+    | { result?: { result?: unknown } }
+    | undefined
+  if (returned !== undefined) return { kind: "complete", output: JSON.stringify(returned.result?.result ?? null) }
+  return {
+    kind: "call",
+    callId: brief.slice(SPAWN_BRIEF.length),
+    name: "execute",
+    arguments: {
+      code: `const kids = await Promise.all([${
+        Array.from({ length: FIXTURE_FANOUT }, (_, i) => `agents.run({ text: "survey shard ${i + 1}" })`).join(", ")
+      }]); return kids.map((k) => k.output);`
+    }
+  }
+}
+
+const layerScripted: Layer.Layer<Infer> = Layer.succeed(Infer)({
+  react: (request: InferRequest) => Effect.succeed(scripted(request))
+})
+
+// ":memory:" means the run starts empty every time the fixture boots, which is what a development
+// loop wants: the forest on screen is the forest this session made.
+const config = layerConfig(readConfig({ TARDIGRADE_DB: ":memory:", PORT: String(FIXTURE_PORT) }))
+
+const agents = Layer.provide(layerAgents({ infer: layerScripted }), config)
+
+const app = Layer.provideMerge(serve({ disableLogger: true }), [
+  BunHttpServer.layer({ port: FIXTURE_PORT }),
+  config,
+  agents
+])
+
+// The briefs the fixture delivers at boot, so the UI has a forest before anyone types anything. The
+// server dedups by message id, so re-running a brief costs nothing (apps/server/src/host.ts).
+export const FIXTURE_BRIEFS: ReadonlyArray<{ readonly agent: string; readonly id: string; readonly text: string }> = [
+  { agent: "root", id: "m1", text: `${SPAWN_BRIEF}survey` },
+  { agent: "root", id: "m2", text: "summarize the survey" },
+  { agent: "deriver", id: "m3", text: "derive the shape of the log" }
+]
+
+const post = (agent: string, body: unknown) =>
+  fetch(`http://127.0.0.1:${FIXTURE_PORT}/agents/${encodeURIComponent(agent)}/messages`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  })
+
+const seed = Effect.promise(async () => {
+  for (const { agent, ...message } of FIXTURE_BRIEFS) await post(agent, message)
+  console.log(`fixture: seeded ${FIXTURE_BRIEFS.length} briefs on http://127.0.0.1:${FIXTURE_PORT}`)
+})
+
+BunRuntime.runMain(Layer.launch(Layer.effectDiscard(seed).pipe(Layer.provideMerge(app))))

--- a/apps/voyager/index.html
+++ b/apps/voyager/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>voyager</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&display=swap"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/voyager/package.json
+++ b/apps/voyager/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@clavia/tardigrade-voyager",
+  "version": "0.0.1",
+  "private": true,
+  "license": "MIT",
+  "author": "Clavia, Inc.",
+  "description": "Trajectory explorer for the tardigrade server.",
+  "homepage": "https://github.com/clavia-labs/tardigrade#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/clavia-labs/tardigrade.git",
+    "directory": "apps/voyager"
+  },
+  "bugs": {
+    "url": "https://github.com/clavia-labs/tardigrade/issues"
+  },
+  "engines": {
+    "bun": ">=1.4.0"
+  },
+  "type": "module",
+  "dependencies": {
+    "@base-ui-components/react": "1.0.0-rc.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@clavia/tardigrade": "workspace:*",
+    "@clavia/tardigrade-core": "workspace:*",
+    "@clavia/tardigrade-server": "workspace:*",
+    "@effect/platform-bun": "4.0.0-rc.110",
+    "@types/react": "^19.2.16",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.2",
+    "effect": "4.0.0-rc.110",
+    "vite": "^8.0.16"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.node.json --noEmit",
+    "test": "bun test",
+    "dev": "vite",
+    "dev:fixture": "bun run dev/fixture.ts",
+    "build": "vite build",
+    "preview": "vite preview"
+  }
+}

--- a/apps/voyager/src/Agent.tsx
+++ b/apps/voyager/src/Agent.tsx
@@ -1,0 +1,307 @@
+import { Fragment, useEffect, useRef, useState, type ReactElement } from "react"
+
+import { events, stream, VoyagerError, type AgentStatus, type EventRow } from "./api"
+import { fieldsOf, merged, momentsOf, stampOf, type Moment } from "./narrative"
+import { navigate, useRoute } from "./nav"
+import { BOTTOM_SLACK_PX, FIELD_WIDTH, LOG_POLL_MS, SCRUB_DIM, SUMMARY_WIDTH } from "./policy"
+import { useTheme } from "./theme"
+
+// The center pane: one agent's log as a flat chronological list under its own header and the seq
+// scrubber (mock.html, the main element). The pane holds cursors only: which agent, where the scrub
+// sits, which row is open. Every fact on it is the server's, read through src/api.ts.
+
+const errorOf = (error: unknown): VoyagerError =>
+  error instanceof VoyagerError ? error : new VoyagerError({ title: String(error), status: 0 })
+
+const lastSeq = (rows: ReadonlyArray<EventRow>): number => rows[rows.length - 1]?.seq ?? 0
+
+// useLog holds the pane's rows. The first read is the whole log and the stream carries it forward
+// from that seq; when the browser gives up reconnecting, the same rows keep filling from `events`,
+// which is an ordinary fetch and survives what EventSource cannot (src/api.ts, stream).
+const useLog = (id: string, pollMs: number) => {
+  const [rows, setRows] = useState<ReadonlyArray<EventRow>>([])
+  const [problem, setProblem] = useState<VoyagerError | undefined>(undefined)
+  const [dropped, setDropped] = useState(false)
+  const [loaded, setLoaded] = useState(false)
+  // The stream's resume point and the poll's cursor are the same number, read outside render so a
+  // poll started once does not restart on every append.
+  const seen = useRef(0)
+
+  useEffect(() => {
+    let attached = true
+    let unsubscribe: (() => void) | undefined
+    setRows([])
+    setLoaded(false)
+    const read = async () => {
+      try {
+        const first = await events(id)
+        if (!attached) return
+        seen.current = lastSeq(first)
+        setRows(first)
+        setProblem(undefined)
+        setLoaded(true)
+        setDropped(false)
+        unsubscribe = stream(id, {
+          after: seen.current,
+          onEvent: (row) => {
+            seen.current = Math.max(seen.current, row.seq)
+            setRows((held) => merged(held, [row]))
+          },
+          onError: () => setDropped(true)
+        })
+      } catch (error) {
+        if (!attached) return
+        setProblem(errorOf(error))
+        setLoaded(true)
+      }
+    }
+    void read()
+    return () => {
+      attached = false
+      unsubscribe?.()
+    }
+  }, [id])
+
+  useEffect(() => {
+    if (!dropped) return
+    const timer = setInterval(() => {
+      void events(id, { after: seen.current })
+        .then((batch) => {
+          seen.current = Math.max(seen.current, lastSeq(batch))
+          setRows((held) => merged(held, batch))
+        })
+        .catch((error: unknown) => setProblem(errorOf(error)))
+    }, pollMs)
+    return () => clearInterval(timer)
+  }, [id, dropped, pollMs])
+
+  return { rows, problem, dropped, loaded }
+}
+
+// The theme toggle is the one icon in the app. Type, dots, and hairlines do everything else, and an
+// icon earns its way in only by a recorded decision; this is that decision, because the sun and the
+// moon name the two themes in one glyph and no word does (voyager-design-system.md, "No icons").
+const ThemeToggle = (): ReactElement => {
+  const { theme, toggle } = useTheme()
+  return (
+    <button
+      type="button"
+      className="icon-button"
+      onClick={toggle}
+      aria-label={theme === "dark" ? "Switch to the light theme" : "Switch to the dark theme"}
+      title="Toggle theme"
+    >
+      {theme === "dark" ? (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" />
+        </svg>
+      ) : (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
+        </svg>
+      )}
+    </button>
+  )
+}
+
+// The scrub is the log's seq axis: the track is a well, the handle is the moss dot, and the readout
+// follows it. Dragging navigates with `replace`, so a drag leaves one history entry rather than
+// forty (src/nav.ts, navigate).
+const Scrub = ({
+  max,
+  onScrub,
+  position
+}: {
+  readonly max: number
+  readonly onScrub: (seq: number) => void
+  readonly position: number
+}): ReactElement => {
+  const fraction = max === 0 ? 1 : position / max
+  return (
+    <div className="scrub-well">
+      <div className="scrub-track">
+        <div className="scrub-fill" style={{ width: `${fraction * 100}%` }} />
+        <input
+          className="scrub-input"
+          type="range"
+          min={0}
+          max={max}
+          step={1}
+          value={position}
+          aria-label="scrub the log by seq"
+          disabled={max === 0}
+          onChange={(changed) => onScrub(Number(changed.target.value))}
+        />
+      </div>
+      <span className="mono scrub-readout">
+        seq {position} / {max}
+      </span>
+    </div>
+  )
+}
+
+// An opened row's fields, hanging off the row on one hairline: the event's own names on the left,
+// its values on the page's own ground on the right. There is no card, because the expansion is the
+// row saying more rather than a second surface (mock.html, .ev-detail). The keys and values are
+// src/narrative.ts's answer, so what a type shows is a tested fact rather than a render decision.
+const Detail = ({ moment }: { readonly moment: Moment }): ReactElement => (
+  <div className="event-detail fade-in">
+    {fieldsOf(moment.event).map((field) => (
+      <Fragment key={field.key}>
+        <span className="mono event-key">{field.key}</span>
+        <span
+          className={`mono event-value${field.kind === "code" ? " event-code" : ""}`}
+          style={{ maxWidth: FIELD_WIDTH }}
+        >
+          {field.value}
+        </span>
+      </Fragment>
+    ))}
+  </div>
+)
+
+const Row = ({
+  dimmed,
+  moment,
+  onToggle,
+  open
+}: {
+  readonly dimmed: boolean
+  readonly moment: Moment
+  readonly onToggle: () => void
+  readonly open: boolean
+}): ReactElement => {
+  const stamp = stampOf(moment.event.type)
+  return (
+    <div style={{ opacity: dimmed ? SCRUB_DIM : 1 }}>
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={open}
+        className={`event-row${open ? " event-row-open" : ""}`}
+        onClick={onToggle}
+        onKeyDown={(pressed) => {
+          if (pressed.key !== "Enter" && pressed.key !== " ") return
+          pressed.preventDefault()
+          onToggle()
+        }}
+      >
+        <span className="mono event-stamp" style={{ background: stamp.bg, color: stamp.fg }}>
+          {moment.event.type}
+        </span>
+        <span className="event-text" style={{ maxWidth: SUMMARY_WIDTH }}>{moment.summary}</span>
+        <span className="mono event-time">
+          {moment.time}
+          {moment.duration === undefined ? "" : ` · ${moment.duration}`}
+        </span>
+      </div>
+      {!open ? null : <Detail moment={moment} />}
+    </div>
+  )
+}
+
+const Problem = ({ problem }: { readonly problem: VoyagerError }): ReactElement => (
+  <div className="problem" style={{ margin: "0 var(--space-5) var(--space-3)" }}>
+    <div className="problem-title">{problem.title}</div>
+    {problem.detail === undefined ? null : <div className="problem-detail">{problem.detail}</div>}
+  </div>
+)
+
+const Head = ({ id, status }: { readonly id: string; readonly status: AgentStatus | undefined }): ReactElement => (
+  <div className="agent-head">
+    <span className="mono" style={{ fontSize: "var(--text-dense)", fontWeight: 500 }}>{id}</span>
+    {status === undefined ? null : (
+      <span className={`chip chip-${status}${status === "running" ? " breathe" : ""}`}>{status}</span>
+    )}
+    <span style={{ marginLeft: "auto" }} />
+    <ThemeToggle />
+  </div>
+)
+
+export const Agent = ({ id, status }: { readonly id: string; readonly status: AgentStatus | undefined }): ReactElement => {
+  const route = useRoute()
+  // The scrub's own cursor. The URL carries it so a view is shareable, and the pane holds it so a
+  // drag renders from one place: `navigate` publishes the URL synchronously, and a control that read
+  // its value back out of that publication would render one step behind the handle (src/nav.ts).
+  const [at, setAt] = useState<number | undefined>(route.at)
+  const [opened, setOpened] = useState<number | undefined>(undefined)
+  const { dropped, loaded, problem, rows } = useLog(id, LOG_POLL_MS)
+
+  const pane = useRef<HTMLDivElement | null>(null)
+  // Whether the reader is at the log's end. Auto-scroll follows a live log only from there; a reader
+  // who has scrolled up is reading, and the log must not pull the page away from them.
+  const atEnd = useRef(true)
+
+  useEffect(() => {
+    setOpened(undefined)
+    atEnd.current = true
+  }, [id])
+
+  // A route the pane did not write is one it must follow: a shared link, or a back button
+  // (src/nav.ts, useRoute). A scrub of its own lands here already equal and changes nothing.
+  useEffect(() => {
+    setAt(route.at)
+  }, [route.at])
+
+  useEffect(() => {
+    const element = pane.current
+    if (element === null || !atEnd.current) return
+    element.scrollTop = element.scrollHeight
+  }, [rows])
+
+  const max = lastSeq(rows)
+  const position = at === undefined ? max : Math.min(at, max)
+  const moments = momentsOf(rows)
+
+  // Scrubbing states a past moment, and the log keeps arriving behind it: the rows past the position
+  // dim rather than disappear. A drag replaces rather than pushes, so forty steps do not cost forty
+  // back presses.
+  const onScrub = (seq: number) => {
+    setAt(seq === max ? undefined : seq)
+    navigate({ at: seq === max ? undefined : seq }, { replace: true })
+  }
+
+  // An agent the server has never heard of has no log to scrub, so the pane is its header and the
+  // problem document verbatim (apps/server/src/problem.ts).
+  if (problem !== undefined && problem.status === 404) {
+    return (
+      <>
+        <Head id={id} status={status} />
+        <Problem problem={problem} />
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Head id={id} status={status} />
+      <Scrub max={max} position={position} onScrub={onScrub} />
+      {problem === undefined ? null : <Problem problem={problem} />}
+      {!dropped ? null : <div className="mono stream-note">stream dropped; polling</div>}
+      <div
+        ref={pane}
+        className="events"
+        onScroll={() => {
+          const element = pane.current
+          if (element === null) return
+          atEnd.current = element.scrollHeight - element.scrollTop - element.clientHeight <= BOTTOM_SLACK_PX
+        }}
+      >
+        {moments.length === 0
+          ? loaded && problem === undefined
+            ? <div className="mono pane-empty">no events yet</div>
+            : null
+          : moments.map((moment) => (
+              <Row
+                key={moment.seq}
+                moment={moment}
+                dimmed={moment.seq > position}
+                open={opened === moment.seq}
+                onToggle={() => setOpened(opened === moment.seq ? undefined : moment.seq)}
+              />
+            ))}
+      </div>
+    </>
+  )
+}

--- a/apps/voyager/src/App.tsx
+++ b/apps/voyager/src/App.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState, type ReactElement } from "react"
+
+import { Agent } from "./Agent"
+import { listAgents, VoyagerError, type AgentSummary } from "./api"
+import { useRoute } from "./nav"
+import { ROSTER_POLL_MS } from "./policy"
+import { Rail } from "./Rail"
+import { EMPTY_ROSTER, rosterOf, type Roster } from "./roster"
+
+// The app: one screen, two panes. The rail lists the run's roots and the center pane reads the
+// selected agent's log (mock.html). The reader chooses on the left and reads on the right, and
+// there is nowhere else to go: voyager reads a run and never writes to it.
+
+interface Reading {
+  readonly roster: Roster
+  // When the listing was read, so every age on screen is measured from one instant.
+  readonly at: number
+}
+
+// useRoster polls GET /agents once for the whole screen: the rail's rows and totals, and the
+// header's status chip, are the same listing read twice rather than two calls. The last good
+// reading survives a failure, so a server restart dims the rail rather than blanking it.
+const useRoster = (intervalMs: number) => {
+  const [reading, setReading] = useState<Reading>({ roster: EMPTY_ROSTER, at: Date.now() })
+  const [summaries, setSummaries] = useState<ReadonlyArray<AgentSummary>>([])
+  const [problem, setProblem] = useState<VoyagerError | undefined>(undefined)
+
+  useEffect(() => {
+    let live = true
+    const read = async () => {
+      try {
+        const all = await listAgents()
+        if (!live) return
+        setSummaries(all)
+        setReading({ roster: rosterOf(all), at: Date.now() })
+        setProblem(undefined)
+      } catch (error) {
+        if (!live) return
+        setProblem(error instanceof VoyagerError ? error : new VoyagerError({ title: String(error), status: 0 }))
+      }
+    }
+    void read()
+    const timer = setInterval(read, intervalMs)
+    return () => {
+      live = false
+      clearInterval(timer)
+    }
+  }, [intervalMs])
+
+  return { reading, summaries, problem }
+}
+
+export const App = (): ReactElement => {
+  const route = useRoute()
+  const { problem, reading, summaries } = useRoster(ROSTER_POLL_MS)
+  const status = summaries.find((summary) => summary.id === route.agent)?.status
+  return (
+    <div style={{ height: "100%", display: "flex", overflow: "hidden" }}>
+      <Rail roster={reading.roster} now={reading.at} problem={problem} selected={route.agent} />
+      <main style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+        {route.agent === undefined ? (
+          <div className="mono pane-empty">select a run</div>
+        ) : (
+          <Agent id={route.agent} status={status} />
+        )}
+      </main>
+    </div>
+  )
+}

--- a/apps/voyager/src/Rail.tsx
+++ b/apps/voyager/src/Rail.tsx
@@ -1,0 +1,90 @@
+import { useState, type ReactElement } from "react"
+
+import type { VoyagerError } from "./api"
+import { navigate } from "./nav"
+import { RAIL_WIDTH } from "./policy"
+import { agoOf, countsOf, matches, totalsOf, type Roster, type RootRow } from "./roster"
+
+// The rail: the run's roots and nothing else (mock.html, the aside). A root is a run, and the tree
+// under it is the run's own business, so the rail lists the six things a reader chooses between
+// rather than the twenty-four agents behind them.
+
+const Row = ({
+  now,
+  row,
+  selected
+}: {
+  readonly now: number
+  readonly row: RootRow
+  readonly selected: boolean
+}): ReactElement => {
+  const open = () => navigate({ agent: row.id, at: undefined })
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-current={selected ? "true" : undefined}
+      className={`rail-row${selected ? " rail-row-selected" : ""}`}
+      onClick={open}
+      onKeyDown={(pressed) => {
+        if (pressed.key !== "Enter" && pressed.key !== " ") return
+        pressed.preventDefault()
+        open()
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
+        <span className="mono rail-id">{row.id}</span>
+        <span className="mono rail-meta">{row.lastAt === undefined ? "" : agoOf(row.lastAt, now)}</span>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
+        <span className={`chip chip-${row.status}${row.status === "running" ? " breathe" : ""}`}>{row.status}</span>
+        <span className="mono rail-meta">{countsOf(row)}</span>
+      </div>
+    </div>
+  )
+}
+
+export const Rail = ({
+  now,
+  problem,
+  roster,
+  selected
+}: {
+  readonly now: number
+  readonly problem: VoyagerError | undefined
+  readonly roster: Roster
+  readonly selected: string | undefined
+}): ReactElement => {
+  // The search is the rail's own state and reads ids alone: a reader who knows the id types it, and
+  // nobody's prose is searched (mock.html, "search id…").
+  const [query, setQuery] = useState("")
+  const rows = roster.roots.filter((row) => matches(row.id, query))
+  return (
+    <aside className="rail" style={{ width: RAIL_WIDTH }}>
+      <div style={{ padding: "var(--space-4) var(--space-4) var(--space-1)" }}>
+        <div style={{ fontWeight: 600, fontSize: 14, letterSpacing: "-0.01em" }}>voyager</div>
+      </div>
+      <div className="mono rail-totals">{totalsOf(roster)}</div>
+      <div style={{ padding: "0 var(--space-3) 10px" }}>
+        <input
+          className="input rail-search"
+          value={query}
+          placeholder="search id…"
+          aria-label="search id"
+          onChange={(changed) => setQuery(changed.target.value)}
+        />
+      </div>
+      {problem === undefined ? null : (
+        <div className="problem" style={{ margin: "0 var(--space-3) 10px" }}>
+          <div className="problem-title">{problem.title}</div>
+          {problem.detail === undefined ? null : <div className="problem-detail">{problem.detail}</div>}
+        </div>
+      )}
+      <div style={{ flex: 1, overflowY: "auto", minHeight: 0 }}>
+        {rows.map((row) => (
+          <Row key={row.id} row={row} now={now} selected={row.id === selected} />
+        ))}
+      </div>
+    </aside>
+  )
+}

--- a/apps/voyager/src/api.test.ts
+++ b/apps/voyager/src/api.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test"
+
+import { agentPath, DEFAULT_API_URL, problemOf, url, VoyagerError } from "./api"
+
+// The two things the client decides on its own: where a call goes, and what a failure says. Both
+// are pure, so neither needs a server. Everything else this module does is fetch.
+
+describe("url", () => {
+  test("drops undefined params and keeps the stated ones", () => {
+    expect(url("/agents/a/events", { after: 40, limit: undefined }, DEFAULT_API_URL))
+      .toBe("http://localhost:4111/agents/a/events?after=40")
+  })
+
+  test("a base with a trailing slash does not double it", () => {
+    expect(url("/healthz", {}, "http://127.0.0.1:4111/")).toBe("http://127.0.0.1:4111/healthz")
+  })
+
+  test("an agent id is encoded into the path", () => {
+    expect(agentPath("ag/one two")).toBe("/agents/ag%2Fone%20two")
+  })
+})
+
+describe("problemOf", () => {
+  test("a problem document surfaces its own title and detail", () => {
+    const error = problemOf(404, "Not Found", {
+      type: "https://tardigrade.dev/problems/unknown-agent",
+      title: "Unknown Agent",
+      status: 404,
+      detail: 'No agent named "ghost" has ever existed.'
+    })
+    expect(error).toBeInstanceOf(VoyagerError)
+    expect(error.title).toBe("Unknown Agent")
+    expect(error.detail).toBe('No agent named "ghost" has ever existed.')
+    expect(error.status).toBe(404)
+  })
+
+  test("a body that is not a problem document falls back to the status line", () => {
+    const error = problemOf(502, "Bad Gateway", "<html>")
+    expect(error.title).toBe("Bad Gateway")
+    expect(error.detail).toBeUndefined()
+    expect(error.status).toBe(502)
+  })
+})

--- a/apps/voyager/src/api.ts
+++ b/apps/voyager/src/api.ts
@@ -1,0 +1,239 @@
+// The client. Every screen reads the server through this module and nothing else, so the wire
+// shapes are stated once and the app holds no second idea of what an agent is (voyager-spec.md,
+// "Stack").
+//
+// The types are copies of the server's projections (apps/server/src/projections.ts, api.ts). They
+// are copied rather than imported because the browser bundle would otherwise pull the server's
+// effect graph in behind them; a shared package replaces the copy when one earns its keep.
+
+// Event is the log's own entry, kept structural here. The narrative reads `type` and whichever
+// fields the type carries, and the server ships the event verbatim, so narrowing belongs to the
+// screen that renders a given type rather than to the transport.
+export interface Event {
+  readonly type: string
+  readonly [field: string]: unknown
+}
+
+// AgentStatus is the summary vocabulary of GET /agents (projections.ts, statusOf). The four words
+// are the server's own; the app renders them and holds no second vocabulary.
+export type AgentStatus = "settled" | "running" | "blocked" | "failed"
+
+// AgentSummary is one row of GET /agents. `parent` is absent for a root, `lastAt` for an agent
+// whose events carry no timestamp.
+export interface AgentSummary {
+  readonly id: string
+  readonly parent?: string
+  readonly events: number
+  readonly lastAt?: number
+  readonly status: AgentStatus
+}
+
+// AgentNode is a summary with the agents it spawned, the shape GET /agents/:id/tree serves.
+export interface AgentNode extends AgentSummary {
+  readonly children: ReadonlyArray<AgentNode>
+}
+
+// TurnStatus is the turn vocabulary of GET /agents/:id/turns. `parked` is a turn waiting on a
+// budget answer the API has no door for; it is alive, never failed.
+export type TurnStatus = "pending" | "completed" | "failed" | "parked"
+
+export interface TurnView {
+  readonly turn: string
+  readonly status: TurnStatus
+  readonly output?: string
+  readonly error?: string
+}
+
+// EventRow is one row of GET /agents/:id/events. `seq` is the event's 1-based position in the whole
+// log, assigned before any filter runs, so `after` means the same place under a `types` filter.
+export interface EventRow {
+  readonly seq: number
+  readonly event: Event
+}
+
+// Health is GET /healthz: the driver's state and the count of drive passes owed.
+export interface Health {
+  readonly status: "resting" | "driving"
+  readonly dirty: number
+}
+
+export interface Accepted {
+  readonly agent: string
+  readonly turn: string
+}
+
+// Where the server listens when VITE_API_URL is absent, matching the server's own DEFAULT_PORT
+// (apps/server/src/config.ts).
+export const DEFAULT_API_URL = "http://localhost:4111"
+
+// The localStorage key the bearer token is pasted into. The token is the server's whole auth story
+// (apps/server/src/http.ts, layerAuth), so the app stores one string and sends it on every fetch.
+export const TOKEN_KEY = "voyager.token"
+
+const trimSlash = (url: string): string => (url.endsWith("/") ? url.slice(0, -1) : url)
+
+// The server address. A query param wins over the build's env so one build can point at another
+// process without a rebuild (voyager-spec.md, "Conventions").
+export const apiUrl = (): string => {
+  const fromEnv = import.meta.env?.VITE_API_URL
+  const configured = typeof fromEnv === "string" && fromEnv.length > 0 ? fromEnv : DEFAULT_API_URL
+  if (typeof location === "undefined") return trimSlash(configured)
+  const stated = new URLSearchParams(location.search).get("api")
+  return trimSlash(stated !== null && stated.length > 0 ? stated : configured)
+}
+
+export const token = (): string | undefined => {
+  if (typeof localStorage === "undefined") return undefined
+  const stored = localStorage.getItem(TOKEN_KEY)
+  return stored === null || stored.length === 0 ? undefined : stored
+}
+
+// Query is the search params a call may state. An undefined value is not sent, so a caller passes
+// its options straight through without assembling a string.
+export type Query = Readonly<Record<string, string | number | undefined>>
+
+// url builds one endpoint's address. Path segments are encoded because an agent id is a minted call
+// id and a turn id is a client-supplied message id; neither is guaranteed to be path-safe.
+export const url = (path: string, query: Query = {}, base = apiUrl()): string => {
+  const search = new URLSearchParams()
+  for (const [name, value] of Object.entries(query)) {
+    if (value !== undefined) search.set(name, String(value))
+  }
+  const suffix = search.size === 0 ? "" : `?${search.toString()}`
+  return `${trimSlash(base)}${path}${suffix}`
+}
+
+export const agentPath = (id: string): string => `/agents/${encodeURIComponent(id)}`
+
+// VoyagerError is what a failed call throws. `title` and `detail` are the problem document's own
+// words and the UI renders them verbatim; a response that is not a problem document still lands
+// here, with the status line standing in for the title, so a screen handles one error shape
+// (apps/server/src/problem.ts).
+export class VoyagerError extends Error {
+  readonly title: string
+  readonly detail: string | undefined
+  readonly status: number
+
+  constructor(options: { title: string; detail?: string | undefined; status: number }) {
+    super(options.detail === undefined ? options.title : `${options.title}: ${options.detail}`)
+    this.name = "VoyagerError"
+    this.title = options.title
+    this.detail = options.detail
+    this.status = options.status
+  }
+}
+
+// problemOf reads a failed response's body as RFC 9457. A body that is not one, or is not JSON at
+// all, yields the status text: the app invents no error prose either way.
+export const problemOf = (status: number, statusText: string, body: unknown): VoyagerError => {
+  const fallback = statusText.length > 0 ? statusText : `Request failed with status ${status}`
+  if (typeof body !== "object" || body === null) {
+    return new VoyagerError({ title: fallback, status })
+  }
+  const { detail, title } = body as { title?: unknown; detail?: unknown }
+  return new VoyagerError({
+    title: typeof title === "string" && title.length > 0 ? title : fallback,
+    ...(typeof detail === "string" && detail.length > 0 ? { detail } : {}),
+    status
+  })
+}
+
+const authorized = (headers: Record<string, string> = {}): Record<string, string> => {
+  const bearer = token()
+  return bearer === undefined ? headers : { ...headers, authorization: `Bearer ${bearer}` }
+}
+
+const request = async <A>(path: string, query: Query, init?: RequestInit): Promise<A> => {
+  const headers = authorized(init?.body === undefined ? {} : { "content-type": "application/json" })
+  const response = await fetch(url(path, query), { ...init, headers })
+  const body = await response.json().catch(() => undefined)
+  if (!response.ok) throw problemOf(response.status, response.statusText, body)
+  return body as A
+}
+
+export const listAgents = (): Promise<ReadonlyArray<AgentSummary>> => request("/agents", {})
+
+export const tree = (id: string): Promise<AgentNode> => request(`${agentPath(id)}/tree`, {})
+
+export interface EventsOptions {
+  // The seq to read past. The server numbers events from 1, so `after: 40` starts at 41.
+  readonly after?: number
+  readonly limit?: number
+  // Event type names, sent as one comma-joined `types` param.
+  readonly types?: ReadonlyArray<string>
+}
+
+export const events = (id: string, opts: EventsOptions = {}): Promise<ReadonlyArray<EventRow>> =>
+  request(`${agentPath(id)}/events`, {
+    after: opts.after,
+    limit: opts.limit,
+    types: opts.types === undefined || opts.types.length === 0 ? undefined : opts.types.join(",")
+  })
+
+// `at` cuts the log to a prefix before the projection runs, which is the whole of time travel: any
+// prefix of a log is a valid state (projections.ts, turnsOf).
+export const turns = (id: string, at?: number): Promise<ReadonlyArray<TurnView>> =>
+  request(`${agentPath(id)}/turns`, { at })
+
+export const turn = (id: string, turnId: string): Promise<TurnView> =>
+  request(`${agentPath(id)}/turns/${encodeURIComponent(turnId)}`, {})
+
+// send delivers one message. `messageId` is the dedup key end to end and becomes the turn id, so a
+// double-click on the composer costs nothing (apps/server/src/host.ts, Inbound).
+export const send = (id: string, message: string, messageId = crypto.randomUUID()): Promise<Accepted> =>
+  request(`${agentPath(id)}/messages`, {}, {
+    method: "POST",
+    body: JSON.stringify({ id: messageId, text: message })
+  })
+
+export const resume = (id: string, turnId: string): Promise<Accepted> =>
+  request(`${agentPath(id)}/turns/${encodeURIComponent(turnId)}/resume`, {}, { method: "POST" })
+
+export const health = (): Promise<Health> => request("/healthz", {})
+
+export interface StreamOptions {
+  // Where the first connection starts. A reconnect ignores it: the browser replays the same URL
+  // with a Last-Event-ID header, and the server prefers that header, so a resume lands where the
+  // dropped connection stopped rather than back at `after` (apps/server/src/api.ts, layerStream).
+  readonly after?: number
+  readonly onEvent: (row: EventRow) => void
+  readonly onError?: (error: VoyagerError) => void
+}
+
+// The EventSource readyState that means the connection is gone for good.
+const CLOSED = 2
+
+// stream follows one agent's log and returns the unsubscribe. Reconnection is the browser's, and
+// so is the Last-Event-ID it carries; this function adds only the frame decoding and the seq, which
+// the server puts in the frame's `id` field.
+//
+// The bearer token cannot ride this call: EventSource sends no headers, and the server reads the
+// token from `authorization` alone (apps/server/src/http.ts, bearerOf). Against a server started
+// with TARDIGRADE_TOKEN the stream is refused and `onError` reports it; the screens fall back to
+// polling `events`, which is an ordinary fetch and carries the header.
+export const stream = (id: string, options: StreamOptions): (() => void) => {
+  const source = new EventSource(url(`${agentPath(id)}/events/stream`, { after: options.after }))
+  source.onmessage = (frame: MessageEvent<string>) => {
+    const seq = Number(frame.lastEventId)
+    if (!Number.isFinite(seq)) return
+    try {
+      options.onEvent({ seq, event: JSON.parse(frame.data) as Event })
+    } catch {
+      options.onError?.(new VoyagerError({ title: "Unreadable Event", status: 0 }))
+    }
+  }
+  source.onerror = () => {
+    // The browser reconnects on its own unless it has given up, so only a closed source is a
+    // failure the screen has to show.
+    if (source.readyState === CLOSED) {
+      options.onError?.(
+        new VoyagerError({
+          title: "Stream Closed",
+          detail: `The event stream for ${id} ended and will not reconnect.`,
+          status: 0
+        })
+      )
+    }
+  }
+  return () => source.close()
+}

--- a/apps/voyager/src/main.tsx
+++ b/apps/voyager/src/main.tsx
@@ -1,0 +1,21 @@
+import { StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+
+import { App } from "./App"
+import { applyTheme, chosenTheme } from "./theme"
+import "./tun.css"
+
+// The entry point. The token sheet resolves the system's preference on its own, so the only thing
+// applied here is a choice the reader has already made, and it is applied before the first render
+// rather than after it: a theme must not flash (src/tun.css, src/theme.ts).
+const chosen = chosenTheme()
+if (chosen !== undefined) applyTheme(chosen)
+
+const root = document.getElementById("root")
+if (root === null) throw new Error("voyager: index.html has no #root element")
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+)

--- a/apps/voyager/src/narrative.test.ts
+++ b/apps/voyager/src/narrative.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, test } from "bun:test"
+
+import type { Event, EventRow } from "./api"
+import {
+  clockOf,
+  fieldsOf,
+  FOLDED,
+  instantOf,
+  merged,
+  momentsOf,
+  spanOf,
+  stampOf,
+  summaryOf,
+  TIME_FIELDS,
+  truncate
+} from "./narrative"
+
+// The event list's decisions that are pure: what a row says, what an opened row lists, what its
+// stamp is colored, which events fold into a duration rather than render, and how two readings of
+// one log fold together.
+
+const at = 1
+
+describe("summaryOf", () => {
+  const cases: ReadonlyArray<readonly [Event, string]> = [
+    [{ type: "MessageReceived", id: "m1", text: "spawn survey", at }, "spawn survey"],
+    [
+      { type: "MessageReceived", id: "survey.0.reply", text: "ok", outcome: "completed", from: "bun:ag.survey.0", at },
+      "reply · outcome: completed · from bun:ag.survey.0"
+    ],
+    [{ type: "ModelCalled", callId: "m1/infer/1", ordinal: 1, turn: "m1", at }, "attempt 2 · m1"],
+    [{ type: "TextReturned", text: "thinking it over", at }, "thinking it over"],
+    [
+      { type: "ToolCalled", callId: "survey", name: "execute", arguments: { code: "const a = 1\nreturn a" }, at },
+      "execute · const a = 1 return a"
+    ],
+    [{ type: "ToolReturned", callId: "survey", result: { result: [1] }, at }, 'survey · {"result":[1]}'],
+    [{ type: "CodeDispatched", execId: "survey", code: "one\ntwo\nthree", at }, "survey · 3 lines"],
+    [{ type: "CodeDispatched", execId: "solo", code: "return 1", at }, "solo · 1 line"],
+    [
+      { type: "PackageCalled", callId: "survey.0", name: "agents.run", arguments: { text: "shard 1" }, at },
+      'agents.run · {"text":"shard 1"}'
+    ],
+    [{ type: "BlockedOn", callId: "survey.0", awaiting: "survey.0.reply", at }, "awaiting survey.0.reply"],
+    [{ type: "TurnCompleted", output: "the answer", at }, "the answer"],
+    [{ type: "TurnFailed", error: "no mind", cause: "inference_error", at }, "inference_error · no mind"],
+    [{ type: "TurnResumed", turn: "m1", failedEpoch: 0, epoch: 1, at }, "m1 · epoch 0 to 1"],
+    [{ type: "ReplyDelivered", turn: "m1", to: "bun:ag.root", at }, "to bun:ag.root"],
+    [{ type: "ReplyDelivered", turn: "m1", at }, "no replyTo"],
+    [{ type: "BudgetExhausted", budget: 40, used: 41, at }, "used 41 of 40"],
+    [{ type: "BudgetRequested", callId: "b1", reason: "one more shard", amount: 10, at }, "asks 10 · one more shard"],
+    [{ type: "BudgetGranted", amount: 10, at }, "granted 10"],
+    [{ type: "BudgetDenied", reason: "the run is over budget", at }, "the run is over budget"],
+    [{ type: "CompactionCompleted", keepFrom: "m2", summary: "surveyed three shards", at }, "keep from m2 · surveyed three shards"]
+  ]
+
+  for (const [event, expected] of cases) {
+    test(`${event.type} reads as one line`, () => {
+      expect(summaryOf(event)).toBe(expected)
+    })
+  }
+
+  test("a type the app has never seen renders its field names", () => {
+    expect(summaryOf({ type: "SomethingNew", weight: 3, colour: "moss" } as Event)).toBe("weight, colour")
+  })
+
+  test("a summary is cut at the stated length", () => {
+    const event: Event = { type: "TurnCompleted", output: "x".repeat(2000), at }
+    expect(summaryOf(event, 10)).toBe(`${"x".repeat(9)}…`)
+  })
+})
+
+describe("truncate", () => {
+  test("a shorter line survives whole", () => {
+    expect(truncate("  two   words ", 40)).toBe("two words")
+  })
+})
+
+describe("stampOf", () => {
+  test("the four the mock names keep their voices", () => {
+    expect(stampOf("MessageReceived")).toEqual({ fg: "var(--ink-2)", bg: "var(--sunken)" })
+    expect(stampOf("CodeDispatched")).toEqual({ fg: "var(--run)", bg: "var(--run-wash)" })
+    expect(stampOf("PackageCalled")).toEqual({ fg: "var(--wait)", bg: "var(--wait-wash)" })
+    expect(stampOf("TurnCompleted")).toEqual({ fg: "var(--ok)", bg: "var(--ok-wash)" })
+  })
+
+  test("a failure is the rust and an unknown type is neutral", () => {
+    expect(stampOf("TurnFailed").fg).toBe("var(--fail)")
+    expect(stampOf("SomethingNew")).toEqual(stampOf("MessageReceived"))
+  })
+})
+
+describe("spanOf", () => {
+  test("one unit per ladder step", () => {
+    expect(spanOf(0)).toBe("0ms")
+    expect(spanOf(940)).toBe("940ms")
+    expect(spanOf(58_000)).toBe("58s")
+    expect(spanOf(24 * 60_000)).toBe("24m")
+    expect(spanOf(3 * 3_600_000)).toBe("3h")
+  })
+})
+
+describe("clockOf", () => {
+  test("an instant reads as the hours and minutes on the reader's own clock", () => {
+    expect(clockOf(new Date(2024, 0, 1, 14, 2).getTime())).toBe("14:02")
+  })
+})
+
+describe("instantOf", () => {
+  test("an expanded instant carries the second and the millisecond", () => {
+    expect(instantOf(new Date(2024, 0, 1, 14, 2, 11, 480).getTime())).toBe("14:02:11.480")
+  })
+
+  test("every part is padded, so the column stays one width", () => {
+    expect(instantOf(new Date(2024, 0, 1, 9, 5, 3, 7).getTime())).toBe("09:05:03.007")
+  })
+})
+
+const stamped = new Date(2024, 0, 1, 14, 2, 11, 480).getTime()
+const keysOf = (event: Event) => fieldsOf(event).map((field) => field.key)
+
+describe("fieldsOf", () => {
+  test("a message lists its id and its instant, and drops the text the row already is", () => {
+    expect(fieldsOf({ type: "MessageReceived", id: "m1", text: "spawn survey", at: stamped })).toEqual([
+      { key: "id", value: "m1", kind: "text" },
+      { key: "at", value: "14:02:11.480", kind: "text" }
+    ])
+  })
+
+  test("a text the row had to cut is kept whole, because the cut line is not the value", () => {
+    const text = "x".repeat(500)
+    const fields = fieldsOf({ type: "MessageReceived", id: "m1", text, at: stamped })
+    expect(fields.map((field) => field.key)).toEqual(["id", "at", "text"])
+    expect(fields[2]?.value).toBe(text)
+  })
+
+  test("a reply leads with the ids that correlate it", () => {
+    const event: Event = {
+      type: "MessageReceived",
+      id: "survey.0.reply",
+      text: "ok",
+      outcome: "completed",
+      from: "bun:ag.survey.0",
+      at: stamped
+    }
+    expect(keysOf(event)).toEqual(["id", "from", "outcome", "at", "text"])
+  })
+
+  test("only a dispatched code body sits in the well", () => {
+    const event: Event = { type: "CodeDispatched", execId: "survey", code: "const a = 1\nreturn a", at: stamped }
+    expect(fieldsOf(event)).toEqual([
+      { key: "execId", value: "survey", kind: "text" },
+      { key: "at", value: "14:02:11.480", kind: "text" },
+      { key: "code", value: "const a = 1\nreturn a", kind: "code" }
+    ])
+  })
+
+  test("a code body carried as a tool argument is a payload, not a well", () => {
+    const event: Event = {
+      type: "ToolCalled",
+      callId: "survey",
+      name: "execute",
+      arguments: { code: "return 1" },
+      at: stamped
+    }
+    expect(fieldsOf(event).map((field) => [field.key, field.kind])).toEqual([
+      ["callId", "text"],
+      ["name", "text"],
+      ["at", "text"],
+      ["arguments", "text"]
+    ])
+  })
+
+  test("an object renders as compact JSON on one line while it fits", () => {
+    const event: Event = { type: "PackageCalled", callId: "t1.0", name: "agents.run", arguments: { text: "shard 1" }, at: stamped }
+    expect(fieldsOf(event).at(-1)).toEqual({ key: "arguments", value: '{"text":"shard 1"}', kind: "text" })
+  })
+
+  test("an object past the inline length is indented in the same cell", () => {
+    const event: Event = { type: "ToolReturned", callId: "t1", result: { text: "y".repeat(40) }, at: stamped }
+    expect(fieldsOf(event, 20).at(-1)?.value).toBe(`{\n  "text": "${"y".repeat(40)}"\n}`)
+  })
+
+  test("a type the app has never seen lists its own keys in insertion order", () => {
+    expect(keysOf({ type: "SomethingNew", weight: 3, colour: "moss", at: stamped } as Event)).toEqual([
+      "weight",
+      "colour",
+      "at"
+    ])
+  })
+
+  test("a field a type's order does not name still renders, after the ones it does", () => {
+    const event: Event = { type: "TurnCompleted", turn: "m1", output: "two\nlines", at: stamped, lane: "agent" }
+    expect(keysOf(event)).toEqual(["turn", "at", "output", "lane"])
+  })
+
+  test("an output the row states verbatim is the row's line and not a field of its own", () => {
+    expect(keysOf({ type: "TurnCompleted", turn: "m1", output: "done", at: stamped })).toEqual(["turn", "at"])
+  })
+
+  test("an absent optional is not a field, and the instant is the only clock", () => {
+    expect(keysOf({ type: "ReplyDelivered", turn: "m1", to: undefined, at: stamped })).toEqual(["turn", "at"])
+    expect(TIME_FIELDS).toEqual(["at"])
+  })
+
+  test("a number and a null read as themselves", () => {
+    const event: Event = { type: "BudgetExhausted", budget: 40, used: 41, turn: null as unknown as string, at: stamped }
+    expect(fieldsOf(event).map((field) => field.value)).toEqual(["40", "41", "null", "14:02:11.480"])
+  })
+
+  test("the host's own stamp sits between the event's ids and its payload", () => {
+    const event: Event = {
+      type: "CodeDispatched",
+      execId: "survey",
+      code: "return 1",
+      turn: "m1",
+      traceparent: "00-abc-def-01",
+      at: stamped
+    }
+    expect(keysOf(event)).toEqual(["execId", "turn", "traceparent", "at", "code"])
+  })
+})
+
+const row = (seq: number, event: Event): EventRow => ({ seq, event })
+
+const minute = 60_000
+const start = new Date(2024, 0, 1, 14, 0).getTime()
+
+describe("momentsOf", () => {
+  const log: ReadonlyArray<EventRow> = [
+    row(1, { type: "MessageReceived", id: "m1", text: "go", at: start }),
+    row(2, { type: "CodeDispatched", execId: "t1", code: "x", at: start + minute }),
+    row(3, { type: "PackageCalled", callId: "t1.0", name: "agents.run", arguments: {}, at: start + 2 * minute }),
+    row(4, { type: "PackageReturned", callId: "t1.0", result: {}, at: start + 5 * minute }),
+    row(5, { type: "CodeSettled", execId: "t1", result: 1, at: start + 6 * minute }),
+    row(6, { type: "PackageCalled", callId: "t1.1", name: "agents.run", arguments: {}, at: start + 7 * minute }),
+    row(7, { type: "TurnCompleted", turn: "m1", output: "done", at: start + 10 * minute })
+  ]
+
+  test("the ends of a pair fold away and every other event renders", () => {
+    expect(momentsOf(log).map((moment) => [moment.seq, moment.event.type])).toEqual([
+      [1, "MessageReceived"],
+      [2, "CodeDispatched"],
+      [3, "PackageCalled"],
+      [6, "PackageCalled"],
+      [7, "TurnCompleted"]
+    ])
+    expect(FOLDED).toEqual(["CodeSettled", "PackageReturned"])
+  })
+
+  test("a dispatch spans to its settle, a call to its return, and a turn back to its message", () => {
+    expect(momentsOf(log).map((moment) => moment.duration)).toEqual([undefined, "5m", "3m", undefined, "10m"])
+  })
+
+  test("a seq the screen has not seen yet leaves the row with a time and no span", () => {
+    const open = momentsOf([log[0]!, log[1]!])
+    expect(open[1]?.duration).toBeUndefined()
+    expect(open[1]?.time).toBe("14:01")
+  })
+
+  test("an event with no timestamp still renders", () => {
+    const moments = momentsOf([row(1, { type: "TextReturned", text: "hm" })])
+    expect(moments[0]?.time).toBe("")
+    expect(moments[0]?.summary).toBe("hm")
+  })
+})
+
+describe("merged", () => {
+  test("a redelivered seq lands once and the log stays in order", () => {
+    const held = [row(1, { type: "A" }), row(2, { type: "B" })]
+    const next = merged(held, [row(2, { type: "B" }), row(3, { type: "C" })])
+    expect(next.map((each) => each.seq)).toEqual([1, 2, 3])
+  })
+})

--- a/apps/voyager/src/narrative.ts
+++ b/apps/voyager/src/narrative.ts
@@ -1,0 +1,338 @@
+import type { Event, EventRow } from "./api"
+import { FIELD_INLINE_CHARS, SUMMARY_CHARS } from "./policy"
+
+// The event list's projections: what a row says, what color its stamp carries, how long the thing
+// it names took, and which events are ends rather than rows. Every function here is pure, so the
+// screen is these answers rendered and the tests are arrays of events.
+
+// Stamp is the chip that carries an event type verbatim. The type is a machine value, so it is set
+// in mono and never translated: a reader who has seen the log sees the same word here.
+export interface Stamp {
+  readonly fg: string
+  readonly bg: string
+}
+
+const NEUTRAL: Stamp = { fg: "var(--ink-2)", bg: "var(--sunken)" }
+const DISPATCH: Stamp = { fg: "var(--run)", bg: "var(--run-wash)" }
+const AWAIT: Stamp = { fg: "var(--wait)", bg: "var(--wait-wash)" }
+const DONE: Stamp = { fg: "var(--ok)", bg: "var(--ok-wash)" }
+const BROKEN: Stamp = { fg: "var(--fail)", bg: "var(--fail-wash)" }
+
+// The stamp palette. Color is spent on the data's voice alone, so a type reads as one of four
+// voices rather than as its own hue: prose is neutral, dispatched work is the run's amber, waiting
+// on another party is the indigo, a terminal that landed is the green, and a terminal that died is
+// the rust (mock.html, the event rows; voyager-design-system.md, principle 1).
+const STAMPS: Readonly<Record<string, Stamp>> = {
+  MessageReceived: NEUTRAL,
+  ModelCalled: NEUTRAL,
+  TextReturned: NEUTRAL,
+  CompactionCompleted: NEUTRAL,
+  ReplyDelivered: NEUTRAL,
+  CodeDispatched: DISPATCH,
+  ToolCalled: DISPATCH,
+  TurnResumed: DISPATCH,
+  PackageCalled: AWAIT,
+  BlockedOn: AWAIT,
+  BudgetRequested: AWAIT,
+  BudgetGranted: AWAIT,
+  BudgetDenied: AWAIT,
+  BudgetExhausted: AWAIT,
+  ToolReturned: DONE,
+  TurnCompleted: DONE,
+  TurnFailed: BROKEN
+}
+
+// stampOf is a row's chip color. A type the app has never heard of is neutral: an unknown event
+// still renders, because the log's alphabet is open and a reader must see what landed
+// (packages/core/src/event.ts).
+export const stampOf = (type: string): Stamp => STAMPS[type] ?? NEUTRAL
+
+const str = (value: unknown): string | undefined => (typeof value === "string" ? value : undefined)
+const num = (value: unknown): number | undefined => (typeof value === "number" ? value : undefined)
+
+// truncate flattens a value onto one line and cuts it to `chars`. Newlines are collapsed rather
+// than escaped: a row is one line high, and a code body must not be able to change that.
+export const truncate = (text: string, chars: number): string => {
+  const flat = text.replace(/\s+/gu, " ").trim()
+  return flat.length <= chars ? flat : `${flat.slice(0, Math.max(0, chars - 1))}…`
+}
+
+// preview renders any payload as one line: a string as itself, anything else as its JSON.
+const preview = (value: unknown, chars: number): string => {
+  if (value === undefined) return ""
+  const text = typeof value === "string" ? value : JSON.stringify(value)
+  return text === undefined ? String(value) : truncate(text, chars)
+}
+
+// A code body previews as its source rather than as the JSON object carrying it, because the source
+// is what the reader recognizes (`execute · const kids = await Promise.all(…)`).
+const argumentsPreview = (value: unknown, chars: number): string => {
+  if (typeof value === "object" && value !== null && "code" in value) {
+    const code = (value as { readonly code: unknown }).code
+    if (typeof code === "string") return truncate(code, chars)
+  }
+  return preview(value, chars)
+}
+
+const line = (parts: ReadonlyArray<string | undefined>, chars: number): string =>
+  truncate(parts.filter((part) => part !== undefined && part !== "").join(" · "), chars)
+
+// summaryOf is the one line a row shows for an event: what a reader needs to decide whether to open
+// it. The known alphabet is the agent lane's and the code lane's (packages/agent/src/events.ts,
+// packages/code/src/events.ts); a type from neither renders its field names, so an event the app has
+// never seen still says what it carries rather than nothing.
+export const summaryOf = (event: Event, chars: number = SUMMARY_CHARS): string => {
+  switch (event.type) {
+    case "MessageReceived": {
+      // A reply is an inbound message answering an id this agent sent out, and it reads as the
+      // answer it is (packages/core/src/message.ts, replyEvent).
+      const outcome = str(event.outcome)
+      const from = str(event.from)
+      if (outcome !== undefined) {
+        return line(["reply", `outcome: ${outcome}`, from === undefined ? undefined : `from ${from}`], chars)
+      }
+      return line([str(event.text) ?? ""], chars)
+    }
+    case "ModelCalled":
+      return line([`attempt ${(num(event.ordinal) ?? 0) + 1}`, str(event.turn)], chars)
+    case "TextReturned":
+      return line([str(event.text) ?? ""], chars)
+    case "ToolCalled":
+      return line([str(event.name), argumentsPreview(event.arguments, chars)], chars)
+    case "ToolReturned":
+      return line([str(event.callId), preview(event.result, chars)], chars)
+    case "CodeDispatched": {
+      const code = str(event.code) ?? ""
+      const lines = code.length === 0 ? 0 : code.split("\n").length
+      return line([str(event.execId), `${lines} ${lines === 1 ? "line" : "lines"}`], chars)
+    }
+    case "PackageCalled":
+      return line([str(event.name), preview(event.arguments, chars)], chars)
+    case "BlockedOn":
+      return line([`awaiting ${str(event.awaiting) ?? ""}`], chars)
+    case "TurnCompleted":
+      return line([preview(event.output, chars)], chars)
+    case "TurnFailed":
+      return line([str(event.cause) ?? "failed", str(event.error)], chars)
+    case "TurnResumed":
+      return line([str(event.turn), `epoch ${String(num(event.failedEpoch))} to ${String(num(event.epoch))}`], chars)
+    case "ReplyDelivered": {
+      const to = str(event.to)
+      return line([to === undefined ? "no replyTo" : `to ${to}`], chars)
+    }
+    case "BudgetExhausted":
+      return line([`used ${String(num(event.used))} of ${String(num(event.budget))}`], chars)
+    case "BudgetRequested":
+      return line([`asks ${String(num(event.amount))}`, str(event.reason)], chars)
+    case "BudgetGranted":
+      return line([`granted ${String(num(event.amount))}`], chars)
+    case "BudgetDenied":
+      return line([str(event.reason) ?? "denied"], chars)
+    case "CompactionCompleted":
+      return line([`keep from ${str(event.keepFrom) ?? ""}`, preview(event.summary, chars)], chars)
+    default:
+      return line([Object.keys(event).filter((field) => field !== "type").join(", ")], chars)
+  }
+}
+
+const pad = (value: number, width: number): string => String(value).padStart(width, "0")
+
+// clockOf is the wall clock of an event, in the reader's own zone. The log stores epoch
+// milliseconds and a reader compares rows against the clock on their wall, so the row shows hours
+// and minutes and the expansion shows the second and the millisecond too (instantOf).
+export const clockOf = (at: number): string => {
+  const when = new Date(at)
+  return `${pad(when.getHours(), 2)}:${pad(when.getMinutes(), 2)}`
+}
+
+// instantOf is the same wall clock to the millisecond, which is the resolution the log orders by.
+// An expanded field states the instant rather than the epoch number, because no reader reads an
+// epoch and the ordering of two events a few milliseconds apart is what the field is opened for.
+export const instantOf = (at: number): string => {
+  const when = new Date(at)
+  return `${clockOf(at)}:${pad(when.getSeconds(), 2)}.${pad(when.getMilliseconds(), 3)}`
+}
+
+// Field is one line of an opened row: the event's own field name and the value rendered for
+// reading. `kind` is "code" for a source body, which is the one payload that reads as a block and
+// the one that sits in a well (src/tun.css, .event-code).
+export interface Field {
+  readonly key: string
+  readonly value: string
+  readonly kind: "text" | "code"
+}
+
+// STAMP is what the host writes onto every event it records, whatever lane minted it: the turn the
+// event belongs to, the trace it belongs to, and the instant. It closes each order, between the
+// event's own ids and the payload they name.
+const STAMP: ReadonlyArray<string> = ["turn", "traceparent", "at"]
+
+// The field order per event type: what names the event, then when it happened, then what it
+// carries. A reader opens a row to find an id to follow or a payload to read, and those are the two
+// ends of the list. The orders name the lanes' own fields (packages/core/src/message.ts,
+// packages/agent/src/events.ts, packages/code/src/events.ts). A field an order does not name still
+// renders, after the named ones and in the event's own key order, so a type this table is behind on
+// hides nothing; a type it lists not at all falls back to that order entirely.
+const ORDER: Readonly<Record<string, ReadonlyArray<string>>> = {
+  MessageReceived: ["id", "from", "replyTo", "outcome", "source", "chat", "sender", ...STAMP, "text", "input", "output", "data"],
+  ModelCalled: ["callId", "ordinal", "epoch", ...STAMP],
+  TextReturned: [...STAMP, "text"],
+  ToolCalled: ["callId", "name", ...STAMP, "arguments", "usage"],
+  ToolReturned: ["callId", ...STAMP, "result"],
+  CodeDispatched: ["execId", ...STAMP, "code"],
+  CodeSettled: ["execId", ...STAMP, "result", "error", "logs"],
+  PackageCalled: ["callId", "name", ...STAMP, "arguments"],
+  PackageReturned: ["callId", ...STAMP, "result"],
+  BlockedOn: ["callId", "awaiting", ...STAMP],
+  TurnCompleted: ["epoch", ...STAMP, "output", "usage"],
+  TurnFailed: ["epoch", "cause", "attempts", "attemptKey", ...STAMP, "error", "usage", "policy"],
+  TurnResumed: ["failedEpoch", "epoch", ...STAMP],
+  ReplyDelivered: ["to", ...STAMP],
+  BudgetExhausted: ["budget", "used", ...STAMP],
+  BudgetRequested: ["callId", "amount", "reason", ...STAMP],
+  BudgetGranted: ["callId", "amount", ...STAMP],
+  BudgetDenied: ["callId", "reason", ...STAMP],
+  CompactionCompleted: ["keepFrom", ...STAMP, "summary"]
+}
+
+// TIME_FIELDS are the fields whose number is an instant rather than a quantity. The lanes stamp
+// every event with `at` and nothing else carries a clock.
+export const TIME_FIELDS: ReadonlyArray<string> = ["at"]
+
+// valueOf renders one field for the value cell. A string is itself, so a code body keeps its own
+// line breaks and the cell wraps them. Anything else is its JSON, on one line while it fits within
+// `inlineChars` and indented past that, because a long object is read by its shape.
+const valueOf = (value: unknown, inlineChars: number): string => {
+  if (typeof value === "string") return value
+  if (value === null || typeof value !== "object") return String(value)
+  const compact = JSON.stringify(value)
+  if (compact === undefined) return String(value)
+  return compact.length <= inlineChars ? compact : JSON.stringify(value, null, 2)
+}
+
+// fieldsOf is what an opened row shows: the event's own fields, in the order its type states, each
+// rendered for reading. `type` is dropped because the stamp already says it, and a field whose
+// rendered value is the summary string verbatim is dropped because the row above already is that
+// line. A summary the row had to cut is not verbatim, so the long text stays and the reader gets
+// the whole of it. Nothing else is dropped: ids, correlation keys, instants, and payloads are what
+// a row is opened for.
+export const fieldsOf = (event: Event, inlineChars: number = FIELD_INLINE_CHARS): ReadonlyArray<Field> => {
+  const own = Object.keys(event).filter((field) => field !== "type" && event[field] !== undefined)
+  const order = ORDER[event.type] ?? []
+  const keys = [...order.filter((field) => own.includes(field)), ...own.filter((field) => !order.includes(field))]
+  const summary = summaryOf(event)
+  const fields: Array<Field> = []
+  for (const key of keys) {
+    const raw = event[key]
+    const value = TIME_FIELDS.includes(key) && typeof raw === "number" ? instantOf(raw) : valueOf(raw, inlineChars)
+    if (value === summary) continue
+    fields.push({ key, value, kind: event.type === "CodeDispatched" && key === "code" ? "code" : "text" })
+  }
+  return fields
+}
+
+// merged folds new rows into the log the screen holds. The stream and the polling fallback both
+// land here, and both can redeliver a seq the screen already has (a reconnect replays from the last
+// id the browser saw), so the merge is by seq and the result stays in log order.
+export const merged = (rows: ReadonlyArray<EventRow>, next: ReadonlyArray<EventRow>): ReadonlyArray<EventRow> => {
+  if (next.length === 0) return rows
+  const bySeq = new Map(rows.map((row) => [row.seq, row]))
+  for (const row of next) bySeq.set(row.seq, row)
+  return [...bySeq.values()].sort((a, b) => a.seq - b.seq)
+}
+
+// spanOf renders an elapsed time in one unit, the same ladder the ages use. Under a second reads in
+// milliseconds, because a dispatch that returns instantly is a fact worth seeing.
+export const spanOf = (ms: number): string => {
+  if (ms < 1000) return `${Math.max(0, Math.round(ms))}ms`
+  const seconds = Math.round(ms / 1000)
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `${minutes}m`
+  return `${Math.round(minutes / 60)}h`
+}
+
+// The events that are the end of a pair and nothing else. They carry no summary a reader wants as
+// its own row: `CodeSettled` says what the dispatch returned and `PackageReturned` what the call
+// answered, so each is folded into the duration on the row that opened it. Every other type renders.
+export const FOLDED: ReadonlyArray<string> = ["CodeSettled", "PackageReturned"]
+
+// Moment is one rendered row: the log's own event, plus the three things the row states about it.
+export interface Moment {
+  readonly seq: number
+  readonly event: Event
+  readonly summary: string
+  readonly time: string
+  // Absent when the pair has no end yet, which is the honest answer while the work is still
+  // running: an open dispatch shows a time and no span.
+  readonly duration: string | undefined
+}
+
+const at = (event: Event): number | undefined => num(event["at"])
+const key = (event: Event, field: string): string | undefined => str(event[field])
+
+// endsOf indexes every span's closing timestamp by the id that names the span: an execution by its
+// `execId`, a package call by its `callId`, and a turn by the inbound message's `id`. A turn is
+// indexed by its start rather than its end, which is why `spansOf` reads it in the other direction.
+const endsOf = (rows: ReadonlyArray<EventRow>) => {
+  const execs = new Map<string, number>()
+  const calls = new Map<string, number>()
+  const turns = new Map<string, number>()
+  for (const { event } of rows) {
+    const when = at(event)
+    if (when === undefined) continue
+    const id =
+      event.type === "CodeSettled"
+        ? key(event, "execId")
+        : event.type === "PackageReturned"
+          ? key(event, "callId")
+          : event.type === "MessageReceived"
+            ? key(event, "id")
+            : undefined
+    if (id === undefined) continue
+    if (event.type === "CodeSettled") execs.set(id, when)
+    else if (event.type === "PackageReturned") calls.set(id, when)
+    else if (!turns.has(id)) turns.set(id, when)
+  }
+  return { execs, calls, turns }
+}
+
+// momentsOf is the whole list: the log in log order, with the pair-halves folded away and each
+// remaining row carrying the span it opened. A `CodeDispatched` spans to its `CodeSettled`, a
+// `PackageCalled` to its `PackageReturned`, and a `TurnCompleted` back to the `MessageReceived`
+// that opened its turn (packages/code/src/events.ts, packages/agent/src/events.ts). The three ids
+// are the lanes' own correlation keys, so nothing here parses an id or guesses a pairing, and a
+// span whose other half is outside the rows the screen holds simply has no duration.
+export const momentsOf = (rows: ReadonlyArray<EventRow>): ReadonlyArray<Moment> => {
+  const { calls, execs, turns } = endsOf(rows)
+  const spanOfRow = (event: Event): number | undefined => {
+    const when = at(event)
+    if (when === undefined) return undefined
+    if (event.type === "CodeDispatched") {
+      const end = execs.get(key(event, "execId") ?? "")
+      return end === undefined ? undefined : end - when
+    }
+    if (event.type === "PackageCalled") {
+      const end = calls.get(key(event, "callId") ?? "")
+      return end === undefined ? undefined : end - when
+    }
+    if (event.type === "TurnCompleted") {
+      const start = turns.get(key(event, "turn") ?? "")
+      return start === undefined ? undefined : when - start
+    }
+    return undefined
+  }
+  return rows
+    .filter(({ event }) => !FOLDED.includes(event.type))
+    .map(({ event, seq }): Moment => {
+      const when = at(event)
+      const span = spanOfRow(event)
+      return {
+        seq,
+        event,
+        summary: summaryOf(event),
+        time: when === undefined ? "" : clockOf(when),
+        duration: span === undefined ? undefined : spanOf(span)
+      }
+    })
+}

--- a/apps/voyager/src/nav.ts
+++ b/apps/voyager/src/nav.ts
@@ -1,0 +1,54 @@
+import { useCallback, useSyncExternalStore } from "react"
+
+// The URL is the app's only navigation state. `?agent=` chooses the screen and `?at=` the scrub
+// position, so a view is shareable and survives a refresh (voyager-spec.md, "Conventions"). There
+// is no routing library: two params and pushState are the whole of it.
+
+// The params the app reads. Anything else in the query belongs to something other than navigation
+// and is preserved untouched by `navigate`.
+export interface Route {
+  readonly agent: string | undefined
+  readonly at: number | undefined
+}
+
+const parse = (search: string): Route => {
+  const params = new URLSearchParams(search)
+  const agent = params.get("agent")
+  const at = params.get("at")
+  const seq = at === null ? Number.NaN : Number(at)
+  return {
+    agent: agent === null || agent.length === 0 ? undefined : agent,
+    at: Number.isInteger(seq) && seq >= 0 ? seq : undefined
+  }
+}
+
+export const routeOf = (search: string): Route => parse(search)
+
+// navigate writes the route into the URL and tells the subscribers. History gets one entry per
+// agent change and none per scrub step: dragging a slider should not fill the back button.
+export const navigate = (next: Partial<Route>, options: { readonly replace?: boolean } = {}): void => {
+  const params = new URLSearchParams(location.search)
+  const write = (name: string, value: string | number | undefined) => {
+    if (value === undefined) params.delete(name)
+    else params.set(name, String(value))
+  }
+  if ("agent" in next) write("agent", next.agent)
+  if ("at" in next) write("at", next.at)
+  const search = params.toString()
+  const href = `${location.pathname}${search.length === 0 ? "" : `?${search}`}`
+  if (options.replace === true) history.replaceState(null, "", href)
+  else history.pushState(null, "", href)
+  dispatchEvent(new PopStateEvent("popstate"))
+}
+
+const subscribe = (onChange: () => void): (() => void) => {
+  addEventListener("popstate", onChange)
+  return () => removeEventListener("popstate", onChange)
+}
+
+// useRoute re-renders on a back button press and on every `navigate`, which dispatches the same
+// event the browser does so both paths take one code path.
+export const useRoute = (): Route => {
+  const snapshot = useCallback(() => location.search, [])
+  return routeOf(useSyncExternalStore(subscribe, snapshot, () => ""))
+}

--- a/apps/voyager/src/policy.ts
+++ b/apps/voyager/src/policy.ts
@@ -1,0 +1,41 @@
+// The app's tuning numbers, in one place because a consumer must be able to see and set every
+// policy value the app applies (AGENTS.md, "Design"). A screen imports the default and takes an
+// override at the call site rather than reading a literal.
+
+// The rail's width in pixels (mock.html, the aside). It is a number here because the layout
+// measures against it.
+export const RAIL_WIDTH = 320
+
+// How often the rail re-reads GET /agents for the roster: the roots, their counts, and the totals.
+// The server publishes no change feed for the listing, so the rail polls, and this is both the
+// delay between a run changing and the rail saying so and the resolution of the age column.
+export const ROSTER_POLL_MS = 2000
+
+// How often the event list re-reads the log after the stream is gone for good. The stream is the
+// live path and this is the fallback, so the interval matches the rail's (src/api.ts, stream).
+export const LOG_POLL_MS = 2000
+
+// The opacity a row drops to when the scrub sits before it. The row stays legible, so a reader sees
+// what the agent did not know yet rather than losing it.
+export const SCRUB_DIM = 0.4
+
+// The widest a summary line grows before the ellipsis takes over, in pixels (mock.html, .ev-text).
+// The cut is the browser's, so it lands on the glyph rather than on a character count.
+export const SUMMARY_WIDTH = 680
+
+// The longest summary string the app puts in the DOM. The visible ellipsis is SUMMARY_WIDTH's, and
+// this cap only keeps a megabyte-long code body out of a text node that shows one line of it.
+export const SUMMARY_CHARS = 400
+
+// The widest a field value grows in an opened row, in pixels (mock.html, .ev-val). The wrap is the
+// browser's, so a long id or a long code line breaks on the glyph and the column keeps its measure.
+export const FIELD_WIDTH = 660
+
+// The longest compact JSON a field value keeps on one line. Past it the value is indented, because
+// a long object is read by its shape and a single line of it is read by nobody.
+export const FIELD_INLINE_CHARS = 120
+
+// How near the list's end still counts as being at the end. Auto-scroll follows a live log only
+// from the bottom, and a reader who has scrolled up is reading; this is the slack that a fractional
+// scroll position is allowed to leave.
+export const BOTTOM_SLACK_PX = 24

--- a/apps/voyager/src/roster.test.ts
+++ b/apps/voyager/src/roster.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test"
+
+import type { AgentSummary } from "./api"
+import { agoOf, countsOf, matches, rosterOf, totalsOf } from "./roster"
+
+// The rail's decisions: which agents are rows, how big each root's family is, what the two mono
+// lines say, and how an age reads. All pure, so none of them needs a server or a DOM.
+
+const summary = (id: string, parent?: string, events = 1): AgentSummary => ({
+  id,
+  ...(parent === undefined ? {} : { parent }),
+  events,
+  status: "settled"
+})
+
+describe("rosterOf", () => {
+  const listing = [
+    summary("root", undefined, 34),
+    summary("t1.0", "root", 19),
+    summary("t1.0.1", "t1.0", 9),
+    summary("t1.1", "root", 12),
+    summary("alone", undefined, 29)
+  ]
+
+  test("the rows are the roots, in the order the listing published them", () => {
+    expect(rosterOf(listing).roots.map((row) => row.id)).toEqual(["root", "alone"])
+  })
+
+  test("a root's family is every agent under it, at any depth", () => {
+    const roots = rosterOf(listing).roots
+    expect(roots[0]?.family).toBe(3)
+    expect(roots[1]?.family).toBe(0)
+  })
+
+  test("the totals count every agent and every event, not just the roots", () => {
+    const roster = rosterOf(listing)
+    expect(roster.agents).toBe(5)
+    expect(roster.events).toBe(103)
+    expect(totalsOf(roster)).toBe("2 runs · 5 agents · 103 events")
+  })
+
+  test("an empty listing is an empty rail", () => {
+    expect(totalsOf(rosterOf([]))).toBe("0 runs · 0 agents · 0 events")
+  })
+
+  test("a parent that claims its own ancestor still resolves to one root", () => {
+    const cycle = [summary("a", "b"), summary("b", "a"), summary("c")]
+    expect(rosterOf(cycle).roots.map((row) => row.id)).toEqual(["c"])
+  })
+})
+
+describe("countsOf", () => {
+  const row = { id: "root", status: "settled" as const, events: 34, lastAt: undefined }
+
+  test("a root that spawned nothing says nothing about agents", () => {
+    expect(countsOf({ ...row, family: 0 })).toBe("34 ev")
+  })
+
+  test("a root with a family states its size", () => {
+    expect(countsOf({ ...row, family: 9 })).toBe("34 ev · 9 agents")
+  })
+})
+
+describe("matches", () => {
+  test("the search reads ids, case-folded, anywhere in the id", () => {
+    expect(matches("PR-shepherd", " shep ")).toBe(true)
+    expect(matches("pr-shepherd", "deploy")).toBe(false)
+    expect(matches("pr-shepherd", "")).toBe(true)
+  })
+})
+
+describe("agoOf", () => {
+  const now = 1_700_000_000_000
+
+  test("seconds under a minute, minutes under an hour, hours beyond", () => {
+    expect(agoOf(now, now)).toBe("0s")
+    expect(agoOf(now - 59_000, now)).toBe("59s")
+    expect(agoOf(now - 60_000, now)).toBe("1m")
+    expect(agoOf(now - 3_600_000, now)).toBe("1h")
+  })
+
+  test("a timestamp ahead of the reader's clock reads as no age at all", () => {
+    expect(agoOf(now + 5_000, now)).toBe("0s")
+  })
+})

--- a/apps/voyager/src/roster.ts
+++ b/apps/voyager/src/roster.ts
@@ -1,0 +1,90 @@
+import type { AgentStatus, AgentSummary } from "./api"
+
+// The rail's projections. GET /agents answers with every agent and its parent, and the rail shows
+// roots alone, so these functions turn one flat listing into the rows and the totals the rail
+// renders. They are pure, so the screen holds no arithmetic of its own.
+
+// RootRow is one rail row: the root's own facts plus the size of the family it started.
+export interface RootRow {
+  readonly id: string
+  readonly status: AgentStatus
+  readonly events: number
+  readonly lastAt: number | undefined
+  // The agents this root spawned, at any depth, not counting the root. Zero for a root that ran
+  // alone, and the rail then omits the segment.
+  readonly family: number
+}
+
+// Roster is the whole rail: the rows and the three numbers above them.
+export interface Roster {
+  readonly roots: ReadonlyArray<RootRow>
+  readonly agents: number
+  readonly events: number
+}
+
+export const EMPTY_ROSTER: Roster = { roots: [], agents: 0, events: 0 }
+
+// rootOf walks an agent's parents to the root of its family. Parentage is the server's fact: only
+// the forest can see it, and a summary states it (apps/server/src/projections.ts, treeOf). The
+// guard stops a claim cycle, which minted call ids cannot produce but an argument can.
+const rootOf = (id: string, parents: ReadonlyMap<string, string | undefined>): string => {
+  const walked = new Set<string>([id])
+  let here = id
+  for (;;) {
+    const parent = parents.get(here)
+    if (parent === undefined || walked.has(parent)) return here
+    walked.add(parent)
+    here = parent
+  }
+}
+
+// rosterOf projects the listing into the rail. The roots keep the order GET /agents published, which
+// is first event time, so two polls of one run render identically.
+export const rosterOf = (summaries: ReadonlyArray<AgentSummary>): Roster => {
+  const parents = new Map(summaries.map((summary) => [summary.id, summary.parent]))
+  const family = new Map<string, number>()
+  for (const summary of summaries) {
+    if (summary.parent === undefined) continue
+    const root = rootOf(summary.id, parents)
+    family.set(root, (family.get(root) ?? 0) + 1)
+  }
+  return {
+    roots: summaries
+      .filter((summary) => summary.parent === undefined)
+      .map((summary) => ({
+        id: summary.id,
+        status: summary.status,
+        events: summary.events,
+        lastAt: summary.lastAt,
+        family: family.get(summary.id) ?? 0
+      })),
+    agents: summaries.length,
+    events: summaries.reduce((sum, summary) => sum + summary.events, 0)
+  }
+}
+
+// matches is the search: an id contains the query, case-folded. The search reads ids alone, so a
+// reader who knows what they are looking for finds it and nobody else's prose is scanned.
+export const matches = (id: string, query: string): boolean =>
+  id.toLowerCase().includes(query.trim().toLowerCase())
+
+// agoOf renders an age in one unit: seconds under a minute, minutes under an hour, hours beyond. A
+// timestamp ahead of the reader's clock reads as 0s rather than a negative age, because the
+// server's clock and the browser's are two clocks.
+export const agoOf = (at: number, now: number): string => {
+  const seconds = Math.max(0, Math.round((now - at) / 1000))
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m`
+  return `${Math.floor(minutes / 60)}h`
+}
+
+// countsOf is a rail row's second line, after the chip: how many events the root holds and how big
+// its family is. A root that spawned nothing says nothing about agents (mock.html, the rail row).
+export const countsOf = (row: RootRow): string =>
+  row.family === 0 ? `${row.events} ev` : `${row.events} ev · ${row.family} agents`
+
+// totalsOf is the mono line under the wordmark: the run in three numbers, runs first because a run
+// is what a root is (mock.html, "6 runs · 24 agents · 987 events").
+export const totalsOf = (roster: Roster): string =>
+  `${roster.roots.length} runs · ${roster.agents} agents · ${roster.events} events`

--- a/apps/voyager/src/theme.test.ts
+++ b/apps/voyager/src/theme.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+
+import { chosenTheme, THEME_KEY } from "./theme"
+
+// The one theme decision that is not the document's: what a stored value means. A record the app
+// did not write, or one it wrote in an older vocabulary, is no choice at all and the system
+// preference keeps deciding.
+
+const store = new Map<string, string>()
+
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  value: {
+    getItem: (key: string): string | null => store.get(key) ?? null,
+    setItem: (key: string, value: string): void => void store.set(key, value)
+  }
+})
+
+describe("chosenTheme", () => {
+  beforeEach(() => store.clear())
+
+  test("no record is no choice", () => {
+    expect(chosenTheme()).toBeUndefined()
+  })
+
+  test("a recorded theme is the choice", () => {
+    store.set(THEME_KEY, "dark")
+    expect(chosenTheme()).toBe("dark")
+  })
+
+  test("a record the app cannot read is no choice", () => {
+    store.set(THEME_KEY, "moss")
+    expect(chosenTheme()).toBeUndefined()
+  })
+})

--- a/apps/voyager/src/theme.ts
+++ b/apps/voyager/src/theme.ts
@@ -1,0 +1,46 @@
+import { useState } from "react"
+
+// The theme. Both themes are designed and neither is the default: the token sheet resolves the
+// system preference on its own, and this module records the reader's explicit choice as the
+// [data-theme] attribute that overrides it (src/tun.css).
+
+export type Theme = "light" | "dark"
+
+// Where the choice is kept. It is the reader's, not the run's, so it lives in the browser and never
+// on the wire.
+export const THEME_KEY = "voyager.theme"
+
+const isTheme = (value: unknown): value is Theme => value === "light" || value === "dark"
+
+// chosenTheme is the reader's recorded choice, absent while they have made none and the system
+// preference is still deciding.
+export const chosenTheme = (): Theme | undefined => {
+  if (typeof localStorage === "undefined") return undefined
+  const stored = localStorage.getItem(THEME_KEY)
+  return isTheme(stored) ? stored : undefined
+}
+
+const systemTheme = (): Theme =>
+  typeof matchMedia === "function" && matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+
+// applyTheme writes the choice onto the document, which is the whole of the switch: every color is
+// a token and the attribute chooses the token set.
+export const applyTheme = (theme: Theme): void => {
+  document.documentElement.dataset["theme"] = theme
+}
+
+// useTheme reports the theme in force and the flip. The first answer is the recorded choice, or the
+// system's if there is none, so the toggle always moves the reader to the other theme rather than
+// to whichever one the attribute happens to be missing.
+export const useTheme = (): { readonly theme: Theme; readonly toggle: () => void } => {
+  const [theme, setTheme] = useState<Theme>(() => chosenTheme() ?? systemTheme())
+  return {
+    theme,
+    toggle: () => {
+      const next: Theme = theme === "dark" ? "light" : "dark"
+      setTheme(next)
+      applyTheme(next)
+      if (typeof localStorage !== "undefined") localStorage.setItem(THEME_KEY, next)
+    }
+  }
+}

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -1,0 +1,573 @@
+/* Tun, the voyager design system (voyager-design-system.md). Both themes are designed on their own
+   ground, so a component references only a token and never a literal color. Light is the bare
+   :root, dark is the same token set redefined; the resolution order is stated once, below. */
+
+:root {
+  --bg: #fafaf9;
+  --surface: #ffffff;
+  --sunken: #f2f2f0;
+  --hair: #e7e7e4;
+  --ink: #1a1c1b;
+  --ink-2: #565a57;
+  --faint: #9a9e9a;
+
+  --moss: #4f7a5c;
+  --moss-ink: #3d6249;
+  --moss-wash: #eef3ef;
+
+  --run: #a07617;
+  --run-wash: #f7f0dd;
+  --ok: #567a5c;
+  --ok-wash: #edf2ee;
+  --wait: #5b6ea8;
+  --wait-wash: #eceff7;
+  --fail: #b3452e;
+  --fail-wash: #f9ece8;
+
+  --shadow: 0 1px 2px rgb(26 28 27 / 6%), 0 8px 24px rgb(26 28 27 / 8%);
+
+  --sans: "IBM Plex Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --text-meta: 12px;
+  --text-dense: 13px;
+  --text-read: 15px;
+  --text-pane: 18px;
+  --text-page: 22px;
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+
+  --row-h: 36px;
+  --gutter: 8px;
+  --measure: 65ch;
+  --radius: 6px;
+  --radius-chip: 999px;
+
+  --ease: cubic-bezier(0.23, 1, 0.32, 1);
+  --fast: 120ms;
+  --base: 180ms;
+  --breath: 2.4s;
+
+  color-scheme: light;
+}
+
+/* The theme resolves system-first: the operating system's preference decides, and the
+   [data-theme] attribute overrides it in either direction. The dark media block therefore excludes
+   an explicit light choice, and the explicit dark attribute restates the same values so it wins
+   under a light system. */
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg: #131514;
+    --surface: #1b1d1c;
+    --sunken: #0e100f;
+    --hair: #2a2d2b;
+    --ink: #e8eae8;
+    --ink-2: #a3a8a4;
+    --faint: #6b706c;
+
+    --moss: #7fae8c;
+    --moss-ink: #93c2a0;
+    --moss-wash: #22302a;
+
+    --run: #d0a83e;
+    --run-wash: #2e2a1c;
+    --ok: #85ad8d;
+    --ok-wash: #1f2a23;
+    --wait: #8ea0d6;
+    --wait-wash: #232838;
+    --fail: #d97757;
+    --fail-wash: #33231e;
+
+    --shadow: 0 1px 2px rgb(0 0 0 / 40%), 0 8px 24px rgb(0 0 0 / 48%);
+
+    color-scheme: dark;
+  }
+}
+
+:root[data-theme="dark"] {
+  --bg: #131514;
+  --surface: #1b1d1c;
+  --sunken: #0e100f;
+  --hair: #2a2d2b;
+  --ink: #e8eae8;
+  --ink-2: #a3a8a4;
+  --faint: #6b706c;
+
+  --moss: #7fae8c;
+  --moss-ink: #93c2a0;
+  --moss-wash: #22302a;
+
+  --run: #d0a83e;
+  --run-wash: #2e2a1c;
+  --ok: #85ad8d;
+  --ok-wash: #1f2a23;
+  --wait: #8ea0d6;
+  --wait-wash: #232838;
+  --fail: #d97757;
+  --fail-wash: #33231e;
+
+  --shadow: 0 1px 2px rgb(0 0 0 / 40%), 0 8px 24px rgb(0 0 0 / 48%);
+
+  color-scheme: dark;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: var(--text-dense);
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--moss);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--moss-ink);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+  color: inherit;
+}
+
+:focus-visible {
+  outline: 2px solid var(--moss);
+  outline-offset: 2px;
+}
+
+/* Machine values are mono and their digits align, so a column of seqs reads as a column. */
+.mono {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+
+/* A working agent breathes and nothing else moves at rest (voyager-design-system.md, principle 4). */
+@keyframes breathe {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.55;
+  }
+}
+
+.breathe {
+  animation: breathe var(--breath) ease-in-out infinite;
+}
+
+/* Reduced motion drops the breathing and keeps opacity fades: the dot stays legible at full
+   strength rather than freezing mid-pulse. */
+@media (prefers-reduced-motion: reduce) {
+  .breathe {
+    animation: none;
+    opacity: 1;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+
+/* The chip: the state voice. Soft wash fill, state-colored text, one size. A running chip breathes
+   whole rather than through a leading dot, which is the shape the frozen mock draws (mock.html). */
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 18px;
+  padding: 0 7px;
+  border-radius: var(--radius-chip);
+  font-family: var(--mono);
+  font-size: 10.5px;
+  white-space: nowrap;
+}
+
+/* One class per word of the status vocabulary the server publishes (apps/server/src/projections.ts,
+   AgentStatus). The app renames nothing on the way in. */
+.chip-running {
+  background: var(--run-wash);
+  color: var(--run);
+}
+
+.chip-settled {
+  background: var(--ok-wash);
+  color: var(--ok);
+}
+
+.chip-blocked {
+  background: var(--wait-wash);
+  color: var(--wait);
+}
+
+.chip-failed {
+  background: var(--fail-wash);
+  color: var(--fail);
+}
+
+.input {
+  height: 32px;
+  min-width: 0;
+  padding: 0 10px;
+  border: 1px solid var(--hair);
+  border-radius: var(--radius);
+  background: var(--bg);
+  font-size: var(--text-meta);
+  outline: none;
+}
+
+.input:focus {
+  border-color: var(--moss);
+}
+
+/* The problem banner renders the problem document's title and detail verbatim: the app writes no
+   error prose of its own (apps/server/src/problem.ts). */
+.problem {
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius);
+  background: var(--fail-wash);
+  color: var(--fail);
+}
+
+.problem-title {
+  font-weight: 600;
+}
+
+.problem-detail {
+  margin-top: var(--space-1);
+  font-size: var(--text-meta);
+  color: var(--ink-2);
+}
+
+/* The reading surface: 15px on 1.6 with a 65ch measure (voyager-design-system.md, principle 3). */
+.reading {
+  font-size: var(--text-read);
+  line-height: 1.6;
+  max-width: var(--measure);
+}
+
+/* The rail: the run's roots on --surface, behind the one hairline that divides the screen. Its
+   width is a number the layout measures against and lives with the other policy (src/policy.ts). */
+.rail {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  min-height: 0;
+  background: var(--surface);
+  border-right: 1px solid var(--hair);
+}
+
+.rail-totals {
+  padding: 0 var(--space-4) 10px;
+  font-size: 11px;
+  color: var(--faint);
+}
+
+.rail-search {
+  width: 100%;
+  height: 30px;
+}
+
+/* A rail row is two lines: the id and its age, then the state chip and the counts. Selected is the
+   moss wash with the 2px moss inset; hover is the sunken wash. */
+.rail-row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--space-2) 14px;
+  cursor: pointer;
+  transition: background var(--fast) var(--ease);
+}
+
+.rail-row:hover {
+  background: var(--sunken);
+}
+
+.rail-row-selected,
+.rail-row-selected:hover {
+  background: var(--moss-wash);
+  box-shadow: inset 2px 0 0 var(--moss);
+}
+
+.rail-id {
+  flex: 1;
+  min-width: 0;
+  font-size: 12.5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rail-meta {
+  font-size: 11px;
+  color: var(--faint);
+}
+
+/* The pane's header: who this agent is, what it is doing, and the theme toggle at the right edge. */
+.agent-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-4) var(--space-5) 10px;
+}
+
+/* The borderless icon button, which the theme toggle is the only user of. */
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--faint);
+  cursor: pointer;
+  transition: color var(--fast) var(--ease);
+}
+
+.icon-button:hover {
+  color: var(--ink-2);
+}
+
+.icon-button:active {
+  transform: scale(0.97);
+}
+
+/* The scrub: a --sunken well holding a hairline track, the moss fill behind the handle, and the
+   mono readout that follows it (voyager-design-system.md, "Scrub"). */
+.scrub-well {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  height: 32px;
+  margin: 0 var(--space-5) var(--space-3);
+  padding: 0 var(--space-3);
+  background: var(--sunken);
+  border-radius: var(--radius);
+}
+
+.scrub-track {
+  position: relative;
+  flex: 1;
+  height: 3px;
+  background: var(--hair);
+  border-radius: 2px;
+}
+
+.scrub-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  height: 3px;
+  background: var(--moss);
+  border-radius: 2px;
+  opacity: 0.4;
+}
+
+/* The range input carries the behavior and nothing else: its track is transparent so the well's own
+   track shows through, and the thumb is the moss dot. */
+.scrub-input {
+  position: absolute;
+  inset: -12px 0;
+  width: 100%;
+  margin: 0;
+  background: none;
+  appearance: none;
+  cursor: pointer;
+}
+
+.scrub-input::-webkit-slider-runnable-track {
+  height: 3px;
+  background: none;
+}
+
+.scrub-input::-webkit-slider-thumb {
+  width: 11px;
+  height: 11px;
+  margin-top: -4px;
+  border: none;
+  border-radius: var(--radius-chip);
+  background: var(--moss);
+  appearance: none;
+}
+
+.scrub-input::-moz-range-track {
+  height: 3px;
+  background: none;
+}
+
+.scrub-input::-moz-range-thumb {
+  width: 11px;
+  height: 11px;
+  border: none;
+  border-radius: var(--radius-chip);
+  background: var(--moss);
+}
+
+.scrub-input:disabled {
+  cursor: default;
+}
+
+.scrub-readout {
+  font-size: 11px;
+  color: var(--ink-2);
+}
+
+/* The line the pane shows when the stream is gone for good and the log is filling by poll. */
+.stream-note {
+  padding: 0 var(--space-5) var(--space-2);
+  font-size: 11px;
+  color: var(--faint);
+}
+
+/* The event list: the log in log order, one row per event. */
+.events {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  padding: 0 var(--space-4) var(--space-4);
+}
+
+.event-row {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: 9px var(--space-2);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--fast) var(--ease);
+}
+
+.event-row:hover {
+  background: var(--sunken);
+}
+
+/* The stamp carries the event type verbatim, so it is mono and it is wide enough for the longest
+   name the log can hold rather than truncating one (mock.html, the event rows). */
+.event-stamp {
+  display: inline-flex;
+  align-items: center;
+  height: 24px;
+  padding: 0 10px;
+  border-radius: var(--radius-chip);
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+/* One row is one line high, whatever the payload holds. The ellipsis is the browser's, at the width
+   src/policy.ts states. */
+.event-text {
+  flex: 1;
+  min-width: 0;
+  font-size: 14.5px;
+  line-height: 1.55;
+  color: var(--ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* The clock and the span never crowd the summary: they hold their width and take the space left. */
+.event-time {
+  flex-shrink: 0;
+  margin-top: 4px;
+  margin-left: auto;
+  padding-left: var(--space-4);
+  font-size: 11px;
+  color: var(--faint);
+}
+
+/* An open row stops clamping its summary: the reader asked for the whole line. */
+.event-row-open .event-text {
+  white-space: pre-wrap;
+  overflow: visible;
+  text-overflow: clip;
+}
+
+/* An opened row's fields hang under it on one hairline: names in the left column, values in the
+   right, both on the page's own ground. No card and no fill, so the expansion reads as the row
+   continuing rather than as a second surface (mock.html, .ev-detail). */
+.event-detail {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 5px 20px;
+  margin: 2px 0 10px 10px;
+  padding-left: 18px;
+  border-left: 1px solid var(--hair);
+}
+
+.event-key {
+  font-size: 11.5px;
+  color: var(--faint);
+}
+
+/* A value wraps rather than scrolls, and it keeps the line breaks the payload had. Its measure is
+   a number the layout applies at the call site (src/policy.ts, FIELD_WIDTH). */
+.event-value {
+  font-size: 12.5px;
+  color: var(--ink);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* A source body is the one payload that reads as a block, so it alone sits in a well. */
+.event-code {
+  padding: 8px 10px;
+  border-radius: 4px;
+  background: var(--sunken);
+  line-height: 1.5;
+}
+
+/* Entrances only, opacity only (voyager-design-system.md, principle 4). */
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+.fade-in {
+  animation: fade-in var(--base) var(--ease) both;
+}
+
+/* The quiet line a pane with nothing to show stands on. */
+.pane-empty {
+  padding: var(--space-7) 0;
+  text-align: center;
+  font-size: var(--text-meta);
+  color: var(--faint);
+}

--- a/apps/voyager/tsconfig.json
+++ b/apps/voyager/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["es2023", "dom", "dom.iterable"],
+    "types": ["bun", "vite/client"],
+    "jsx": "react-jsx",
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src"]
+}

--- a/apps/voyager/tsconfig.node.json
+++ b/apps/voyager/tsconfig.node.json
@@ -1,0 +1,7 @@
+{
+  // The pieces that run under Bun rather than in the browser: the build config and the development
+  // fixture. They are a separate project because the browser project adds the DOM library, and the
+  // fixture reaches into apps/server, whose sources are written against Bun's globals alone.
+  "extends": "../../tsconfig.base.json",
+  "include": ["dev", "vite.config.ts"]
+}

--- a/apps/voyager/vite.config.ts
+++ b/apps/voyager/vite.config.ts
@@ -1,0 +1,9 @@
+import react from "@vitejs/plugin-react"
+import { defineConfig } from "vite"
+
+// The build. The app is static: it reads one server over HTTP and holds no server of its own, so
+// the output is a directory apps/server can serve at `/` (voyager-spec.md, build phase 4).
+export default defineConfig({
+  plugins: [react()],
+  build: { outDir: "dist", emptyOutDir: true }
+})

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,26 @@
         "effect": "4.0.0-rc.110",
       },
     },
+    "apps/voyager": {
+      "name": "@clavia/tardigrade-voyager",
+      "version": "0.0.1",
+      "dependencies": {
+        "@base-ui-components/react": "1.0.0-rc.0",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+      },
+      "devDependencies": {
+        "@clavia/tardigrade": "workspace:*",
+        "@clavia/tardigrade-core": "workspace:*",
+        "@clavia/tardigrade-server": "workspace:*",
+        "@effect/platform-bun": "4.0.0-rc.110",
+        "@types/react": "^19.2.16",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.2",
+        "effect": "4.0.0-rc.110",
+        "vite": "^8.0.16",
+      },
+    },
     "packages/agent": {
       "name": "@clavia/tardigrade",
       "version": "0.0.1",
@@ -144,6 +164,12 @@
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
 
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@base-ui-components/react": ["@base-ui-components/react@1.0.0-rc.0", "", { "dependencies": { "@babel/runtime": "^7.28.4", "@base-ui-components/utils": "0.2.2", "@floating-ui/react-dom": "^2.1.6", "@floating-ui/utils": "^0.2.10", "reselect": "^5.1.1", "tabbable": "^6.3.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-9lhUFbJcbXvc9KulLev1WTFxS/alJRBWDH/ibKSQaNvmDwMFS2gKp1sTeeldYSfKuS/KC1w2MZutc0wHu2hRHQ=="],
+
+    "@base-ui-components/utils": ["@base-ui-components/utils@0.2.2", "", { "dependencies": { "@babel/runtime": "^7.28.4", "@floating-ui/utils": "^0.2.10", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-rNJCD6TFy3OSRDKVHJDzLpxO3esTV1/drRtWNUpe7rCpPN9HZVHUCuP+6rdDYDGWfXnQHbqi05xOyRP2iZAlkw=="],
+
     "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
 
     "@clavia/tardigrade": ["@clavia/tardigrade@workspace:packages/agent"],
@@ -160,6 +186,8 @@
 
     "@clavia/tardigrade-server": ["@clavia/tardigrade-server@workspace:apps/server"],
 
+    "@clavia/tardigrade-voyager": ["@clavia/tardigrade-voyager@workspace:apps/voyager"],
+
     "@effect/platform-bun": ["@effect/platform-bun@4.0.0-rc.110", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-rc.110" }, "peerDependencies": { "effect": "^4.0.0-rc.110" } }, "sha512-f4AcFTWVwGby9RvSitqAcG/McN8OCDy7LW8PYRG4NIOO2eYphlW73S5Z7jm3UDP+FmIwwzjfgfIfBYkfPR+YfA=="],
 
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-rc.111", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.3" }, "peerDependencies": { "effect": "^4.0.0-rc.111" } }, "sha512-iES0Q9vmjhaUKqeW9ceonuD45MUg/Ouk08LzRSptZ+B5qB0w9WlRjDmUz5TJmY2betNop5FRI5k4AD4mtQt3Bw=="],
@@ -171,6 +199,14 @@
     "@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
+    "@floating-ui/core": ["@floating-ui/core@1.8.0", "", { "dependencies": { "@floating-ui/utils": "^0.2.12" } }, "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.8.0", "", { "dependencies": { "@floating-ui/core": "^1.8.0", "@floating-ui/utils": "^0.2.12" } }, "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.9", "", { "dependencies": { "@floating-ui/dom": "^1.8.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
@@ -302,6 +338,38 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.78.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Sb5ocmLSuYeOuXd+CFOToGKp/gjXUEWDnvIGwhnh8aq8wY4TMmEnKnvbogSW7RdMZv77JSARduS7/gv+khYEjA=="],
 
+    "@rolldown/binding-android-arm-eabi": ["@rolldown/binding-android-arm-eabi@1.2.5", "", { "os": "android", "cpu": "arm" }, "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.5", "", { "os": "android", "cpu": "arm64" }, "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.2.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.2.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.2.5", "", { "os": "linux", "cpu": "arm" }, "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.2.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.2.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.2.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.2.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.2.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.5", "", { "os": "linux", "cpu": "x64" }, "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.2.5", "", { "os": "none", "cpu": "arm64" }, "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.5", "", { "os": "win32", "cpu": "x64" }, "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
     "@smithy/core": ["@smithy/core@3.33.2", "", { "dependencies": { "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w=="],
 
     "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.5.2", "", { "dependencies": { "@smithy/core": "^3.33.2", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg=="],
@@ -342,13 +410,21 @@
 
     "@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
+    "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.4", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@6.1.0", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "oxc-transform-react": "^0.145.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler", "oxc-transform-react"] }, "sha512-qd2BzUBehkov86WFhg0JkEFEYyCLG9uPCe6qWTY/kRlss9OvJrOF2UbIWT7p+8IzZHkEu0DNGHc4HSv+JdDLsw=="],
 
     "beautiful-mermaid": ["beautiful-mermaid@1.1.3", "", { "dependencies": { "elkjs": "^0.11.0", "entities": "^7.0.1" } }, "sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
@@ -366,15 +442,43 @@
 
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "get-tsconfig": ["get-tsconfig@4.14.1", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A=="],
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "knip": ["knip@6.32.2", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.1", "jiti": "^2.7.0", "oxc-parser": "^0.143.0", "oxc-resolver": "11.24.2", "picomatch": "^4.0.5", "smol-toml": "^1.7.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.17", "unbash": "^4.0.9", "yaml": "^2.9.0", "zod": "^4.4.3" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-WXTXbmocrw7gqm1A1TQvFN0OgJ7hUSU6E1g6SPRIzzHFogUBhXByc7cYeOFVtJ2uODg7DP4VbESYBYnfbtBYsg=="],
 
+    "lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.33.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.33.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.33.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.33.0", "", { "os": "linux", "cpu": "arm" }, "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.33.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
+
     "msgpackr": ["msgpackr@2.0.5", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA=="],
 
     "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
+
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
@@ -388,15 +492,33 @@
 
     "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
 
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
 
     "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
+    "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
+
+    "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
+
+    "reselect": ["reselect@5.2.0", "", {}, "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="],
+
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "rolldown": ["rolldown@1.2.5", "", { "dependencies": { "@oxc-project/types": "=0.146.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm-eabi": "1.2.5", "@rolldown/binding-android-arm64": "1.2.5", "@rolldown/binding-darwin-arm64": "1.2.5", "@rolldown/binding-darwin-x64": "1.2.5", "@rolldown/binding-freebsd-x64": "1.2.5", "@rolldown/binding-linux-arm-gnueabihf": "1.2.5", "@rolldown/binding-linux-arm64-gnu": "1.2.5", "@rolldown/binding-linux-arm64-musl": "1.2.5", "@rolldown/binding-linux-ppc64-gnu": "1.2.5", "@rolldown/binding-linux-s390x-gnu": "1.2.5", "@rolldown/binding-linux-x64-gnu": "1.2.5", "@rolldown/binding-linux-x64-musl": "1.2.5", "@rolldown/binding-openharmony-arm64": "1.2.5", "@rolldown/binding-win32-arm64-msvc": "1.2.5", "@rolldown/binding-win32-x64-msvc": "1.2.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "smol-toml": ["smol-toml@1.8.0", "", {}, "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ=="],
 
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
+
+    "tabbable": ["tabbable@6.5.0", "", {}, "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
@@ -408,6 +530,10 @@
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "vite": ["vite@8.2.2", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.26", "rolldown": "~1.2.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0 || ^0.5.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q=="],
+
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
     "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
@@ -417,5 +543,7 @@
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1111.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.8", "@aws-sdk/nested-clients": "^3.997.43", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A=="],
+
+    "rolldown/@oxc-project/types": ["@oxc-project/types@0.146.0", "", {}, "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA=="],
   }
 }

--- a/docs/how-to/server.md
+++ b/docs/how-to/server.md
@@ -31,7 +31,7 @@ The process boots without model coordinates. It listens, answers `/healthz`, acc
 | Endpoint | Contract |
 | --- | --- |
 | `POST /agents/:id/messages` | Deliver one message, `{ id, text, input?, data? }`. Answers `202 { agent, turn }`, or `400` when the body states no `id` or no `text`. |
-| `GET /agents` | Every agent, parent before child, as a summary: id, parent, event count, last event time, and status (`resting`, `working`, `blocked`, `failed`). |
+| `GET /agents` | Every agent, parent before child, as a summary: id, parent, event count, last event time, and status (`settled`, `running`, `blocked`, `failed`). |
 | `GET /agents/:id/events` | The log as `{ seq, event }` rows. `after` starts the page past a sequence number, `limit` caps it (default 200, `DEFAULT_EVENT_LIMIT`), `types` filters by a comma list. |
 | `GET /agents/:id/events/stream` | The same log as `text/event-stream`, replayed from the cursor and then followed live. The tail re-reads every 50 milliseconds (`DEFAULT_SSE_POLL`) and writes a comment frame after 15 seconds of silence (`DEFAULT_SSE_HEARTBEAT`). |
 | `GET /agents/:id/turns` | Every turn boundary as `{ turn, status, output?, error? }`, where status is `pending`, `completed`, `failed`, or `parked`. `at` evaluates the projection over a prefix of the log. |

--- a/knip.json
+++ b/knip.json
@@ -25,6 +25,20 @@
       "project": [
         "src/**/*.ts"
       ]
+    },
+    "apps/voyager": {
+      "entry": [
+        "src/api.ts",
+        "src/nav.ts",
+        "src/policy.ts"
+      ],
+      "project": [
+        "src/**/*.{ts,tsx}",
+        "dev/**/*.ts"
+      ],
+      "ignoreDependencies": [
+        "@base-ui-components/react"
+      ]
     }
   }
 }

--- a/tools/gate.ts
+++ b/tools/gate.ts
@@ -13,7 +13,10 @@ const packages = ["core", "code", "agent", "host"]
 const platformPkg = (name: string) => `${root}platform/${name}`
 const platforms = ["model", "bun"]
 const appPkg = (name: string) => `${root}apps/${name}`
-const apps = ["server"]
+const apps = ["server", "voyager"]
+// Apps that ship a bundle. A typecheck proves the sources agree; only a build proves the bundler
+// can resolve and emit them.
+const bundled = ["voyager"]
 
 const tasks: ReadonlyArray<Task> = [
   { id: "lint", cmd: ["bun", "--bun", "node_modules/.bin/oxlint"] },
@@ -27,6 +30,7 @@ const tasks: ReadonlyArray<Task> = [
   ...packages.map((name) => ({ id: `test:${name}`, cwd: pkg(name), cmd: ["bun", "test"] })),
   ...platforms.map((name) => ({ id: `test:platform-${name}`, cwd: platformPkg(name), cmd: ["bun", "test"] })),
   ...apps.map((name) => ({ id: `test:app-${name}`, cwd: appPkg(name), cmd: ["bun", "test"] })),
+  ...bundled.map((name) => ({ id: `build:app-${name}`, cwd: appPkg(name), cmd: ["bun", "run", "build"] })),
   { id: "knip", cmd: ["bun", "--bun", "node_modules/.bin/knip"] }
 ]
 


### PR DESCRIPTION
The server exposes a run's whole history, and reading it meant sqlite3 and grep. The voyager is the read surface: a Vite app that lists the runs a store holds and renders one run's events as a legible timeline. It consumes only the published HTTP API, so it is also the first consumer proving that surface.

The shape is two panes and nothing else. The left rail lists root runs (id, age, state chip, event and family counts) with an id search. The center shows the selected run's events: a chip carrying the event's own type stamp, a one-line summary held to 680px, and time with duration pinned right. Clicking a row hangs a field list under it behind one hairline, keys and values in mono, no card; only a code payload gets a well. The app is read-only: creation stays with the API.

- apps/voyager: Vite, React, Base UI for behavior only; no styled component library and no icon set
- Tun, the design system this ships with: two hand-picked palettes resolved system-first with a data-theme override, IBM Plex Sans and Mono with machine values always mono, moss for the product's voice and four state colors for the data's
- pure projections over the log: the rail roster with family sizes, the event list with durations derived from the log's own pairs (CodeDispatched to its settle, PackageCalled to its return, TurnCompleted back to its message), and per-type field derivation with an insertion-order fallback so an unknown event type hides nothing
- SSE live streaming with a polling fallback, and ?at= time travel through the seq scrubber
- dev/fixture.ts boots the real server in-process with a scripted mind, so the UI develops and CI runs with no model credentials
- status vocabulary renamed end to end, working to running and resting to settled, in the server projections, its tests, the docs page, and the UI; no client-side mapping
- bun run gate fully green (21 tasks, including typecheck, tests, and the production build)

The only icon in the app is the sun/moon theme toggle, recorded as the design system's one exception.