### PR TITLE
feat(voyager): window brush and chrome

### DIFF
--- a/apps/voyager/package.json
+++ b/apps/voyager/package.json
@@ -20,6 +20,7 @@
   "type": "module",
   "dependencies": {
     "@base-ui-components/react": "1.0.0-rc.0",
+    "@phosphor-icons/react": "^2.1.10",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },

--- a/apps/voyager/src/Agent.tsx
+++ b/apps/voyager/src/Agent.tsx
@@ -1,14 +1,17 @@
+import { Moon, Sun } from "@phosphor-icons/react"
 import { Fragment, useEffect, useRef, useState, type ReactElement } from "react"
 
 import { events, stream, VoyagerError, type AgentStatus, type EventRow } from "./api"
 import { fieldsOf, merged, momentsOf, stampOf, type Moment } from "./narrative"
-import { navigate, useRoute } from "./nav"
-import { BOTTOM_SLACK_PX, FIELD_WIDTH, LOG_POLL_MS, SCRUB_DIM, SUMMARY_WIDTH } from "./policy"
+import { navigate, useRoute, type Route } from "./nav"
+import { BOTTOM_SLACK_PX, FIELD_WIDTH, ICON_SIZE, LOG_POLL_MS, SUMMARY_WIDTH } from "./policy"
 import { useTheme } from "./theme"
+import { axisOf, defaultWindowOf, FULL_WINDOW, shared, shownIn, type Window } from "./window"
+import { WindowBrush } from "./WindowBrush"
 
-// The center pane: one agent's log as a flat chronological list under its own header and the seq
-// scrubber (mock.html, the main element). The pane holds cursors only: which agent, where the scrub
-// sits, which row is open. Every fact on it is the server's, read through src/api.ts.
+// The center pane: one agent's log as a flat chronological list under its own header and the window
+// brush (mock.html, the main element). The pane holds cursors only: which agent, which range the
+// window holds, which row is open. Every fact on it is the server's, read through src/api.ts.
 
 const errorOf = (error: unknown): VoyagerError =>
   error instanceof VoyagerError ? error : new VoyagerError({ title: String(error), status: 0 })
@@ -78,68 +81,33 @@ const useLog = (id: string, pollMs: number) => {
   return { rows, problem, dropped, loaded }
 }
 
-// The theme toggle is the one icon in the app. Type, dots, and hairlines do everything else, and an
-// icon earns its way in only by a recorded decision; this is that decision, because the sun and the
-// moon name the two themes in one glyph and no word does (voyager-design-system.md, "No icons").
+// The theme toggle. An icon earns its place only by a recorded decision, and this is one of the two
+// the system records: the sun and the moon name the two themes in one glyph and no word does
+// (voyager-design-system.md, the icon policy). The glyph is Phosphor's at the light weight, which
+// every icon in the app shares.
 const ThemeToggle = (): ReactElement => {
   const { theme, toggle } = useTheme()
   return (
     <button
       type="button"
-      className="icon-button"
+      className="icon-btn"
       onClick={toggle}
       aria-label={theme === "dark" ? "Switch to the light theme" : "Switch to the dark theme"}
       title="Toggle theme"
     >
       {theme === "dark" ? (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" />
-        </svg>
+        <Moon size={ICON_SIZE} weight="light" aria-hidden="true" />
       ) : (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" aria-hidden="true">
-          <circle cx="12" cy="12" r="4" />
-          <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
-        </svg>
+        <Sun size={ICON_SIZE} weight="light" aria-hidden="true" />
       )}
     </button>
   )
 }
 
-// The scrub is the log's seq axis: the track is a well, the handle is the moss dot, and the readout
-// follows it. Dragging navigates with `replace`, so a drag leaves one history entry rather than
-// forty (src/nav.ts, navigate).
-const Scrub = ({
-  max,
-  onScrub,
-  position
-}: {
-  readonly max: number
-  readonly onScrub: (seq: number) => void
-  readonly position: number
-}): ReactElement => {
-  const fraction = max === 0 ? 1 : position / max
-  return (
-    <div className="scrub-well">
-      <div className="scrub-track">
-        <div className="scrub-fill" style={{ width: `${fraction * 100}%` }} />
-        <input
-          className="scrub-input"
-          type="range"
-          min={0}
-          max={max}
-          step={1}
-          value={position}
-          aria-label="scrub the log by seq"
-          disabled={max === 0}
-          onChange={(changed) => onScrub(Number(changed.target.value))}
-        />
-      </div>
-      <span className="mono scrub-readout">
-        seq {position} / {max}
-      </span>
-    </div>
-  )
-}
+// windowOf reads the window a URL states. An edge the link omits is that end of the log, so a
+// half-written link still opens a window rather than nothing.
+const windowOf = (route: Route): Window | undefined =>
+  route.from === undefined && route.to === undefined ? undefined : { from: route.from ?? 0, to: route.to ?? 1 }
 
 // An opened row's fields, hanging off the row on one hairline: the event's own names on the left,
 // its values on the page's own ground on the right. There is no card, because the expansion is the
@@ -162,19 +130,17 @@ const Detail = ({ moment }: { readonly moment: Moment }): ReactElement => (
 )
 
 const Row = ({
-  dimmed,
   moment,
   onToggle,
   open
 }: {
-  readonly dimmed: boolean
   readonly moment: Moment
   readonly onToggle: () => void
   readonly open: boolean
 }): ReactElement => {
   const stamp = stampOf(moment.event.type)
   return (
-    <div style={{ opacity: dimmed ? SCRUB_DIM : 1 }}>
+    <div>
       <div
         role="button"
         tabIndex={0}
@@ -190,7 +156,11 @@ const Row = ({
         <span className="mono event-stamp" style={{ background: stamp.bg, color: stamp.fg }}>
           {moment.event.type}
         </span>
-        <span className="event-text" style={{ maxWidth: SUMMARY_WIDTH }}>{moment.summary}</span>
+        {/* A collapsed line takes the pane's whole width; only the wrapped line an open row shows
+            keeps a measure (src/policy.ts, SUMMARY_WIDTH). */}
+        <span className="event-text" style={open ? { maxWidth: SUMMARY_WIDTH } : undefined}>
+          {moment.summary}
+        </span>
         <span className="mono event-time">
           {moment.time}
           {moment.duration === undefined ? "" : ` · ${moment.duration}`}
@@ -221,10 +191,10 @@ const Head = ({ id, status }: { readonly id: string; readonly status: AgentStatu
 
 export const Agent = ({ id, status }: { readonly id: string; readonly status: AgentStatus | undefined }): ReactElement => {
   const route = useRoute()
-  // The scrub's own cursor. The URL carries it so a view is shareable, and the pane holds it so a
-  // drag renders from one place: `navigate` publishes the URL synchronously, and a control that read
-  // its value back out of that publication would render one step behind the handle (src/nav.ts).
-  const [at, setAt] = useState<number | undefined>(route.at)
+  // The window's own edges. The URL carries them so a view is shareable, and the pane holds them so
+  // a drag renders from one place: `navigate` publishes the URL synchronously, and a control that
+  // read its value back out of that publication would render one step behind the handle (src/nav.ts).
+  const [window, setWindow] = useState<Window | undefined>(windowOf(route))
   const [opened, setOpened] = useState<number | undefined>(undefined)
   const { dropped, loaded, problem, rows } = useLog(id, LOG_POLL_MS)
 
@@ -232,17 +202,21 @@ export const Agent = ({ id, status }: { readonly id: string; readonly status: Ag
   // Whether the reader is at the log's end. Auto-scroll follows a live log only from there; a reader
   // who has scrolled up is reading, and the log must not pull the page away from them.
   const atEnd = useRef(true)
+  // Whether this agent's log has been given its opening window. The default is read once, from the
+  // first full reading; recomputing it as events arrive would move the window under the reader.
+  const seeded = useRef(false)
 
   useEffect(() => {
     setOpened(undefined)
     atEnd.current = true
+    seeded.current = false
   }, [id])
 
   // A route the pane did not write is one it must follow: a shared link, or a back button
-  // (src/nav.ts, useRoute). A scrub of its own lands here already equal and changes nothing.
+  // (src/nav.ts, useRoute). A drag of its own lands here already equal and changes nothing.
   useEffect(() => {
-    setAt(route.at)
-  }, [route.at])
+    setWindow(windowOf(route))
+  }, [route.from, route.to])
 
   useEffect(() => {
     const element = pane.current
@@ -250,19 +224,31 @@ export const Agent = ({ id, status }: { readonly id: string; readonly status: Ag
     element.scrollTop = element.scrollHeight
   }, [rows])
 
-  const max = lastSeq(rows)
-  const position = at === undefined ? max : Math.min(at, max)
   const moments = momentsOf(rows)
+  const axis = axisOf(moments)
 
-  // Scrubbing states a past moment, and the log keeps arriving behind it: the rows past the position
-  // dim rather than disappear. A drag replaces rather than pushes, so forty steps do not cost forty
-  // back presses.
-  const onScrub = (seq: number) => {
-    setAt(seq === max ? undefined : seq)
-    navigate({ at: seq === max ? undefined : seq }, { replace: true })
+  // The opening window, written into the URL so the view a reader arrives at is the view they can
+  // share. A link that already states a window keeps it.
+  useEffect(() => {
+    if (seeded.current || !loaded || rows.length === 0) return
+    seeded.current = true
+    if (window !== undefined) return
+    const next = shared(defaultWindowOf(momentsOf(rows)))
+    setWindow(next)
+    navigate({ from: next.from, to: next.to }, { replace: true })
+  }, [loaded, rows, window])
+
+  const held = window ?? FULL_WINDOW
+  const shown = shownIn(moments, axis, held)
+
+  // A drag replaces rather than pushes, so forty steps do not cost forty back presses.
+  const onWindow = (next: Window) => {
+    setWindow(next)
+    const link = shared(next)
+    navigate({ from: link.from, to: link.to }, { replace: true })
   }
 
-  // An agent the server has never heard of has no log to scrub, so the pane is its header and the
+  // An agent the server has never heard of has no log to read, so the pane is its header and the
   // problem document verbatim (apps/server/src/problem.ts).
   if (problem !== undefined && problem.status === 404) {
     return (
@@ -276,7 +262,7 @@ export const Agent = ({ id, status }: { readonly id: string; readonly status: Ag
   return (
     <>
       <Head id={id} status={status} />
-      <Scrub max={max} position={position} onScrub={onScrub} />
+      <WindowBrush axis={axis} moments={moments} shown={shown} window={held} onChange={onWindow} />
       {problem === undefined ? null : <Problem problem={problem} />}
       {!dropped ? null : <div className="mono stream-note">stream dropped; polling</div>}
       <div
@@ -288,15 +274,14 @@ export const Agent = ({ id, status }: { readonly id: string; readonly status: Ag
           atEnd.current = element.scrollHeight - element.scrollTop - element.clientHeight <= BOTTOM_SLACK_PX
         }}
       >
-        {moments.length === 0
+        {shown.length === 0
           ? loaded && problem === undefined
-            ? <div className="mono pane-empty">no events yet</div>
+            ? <div className="mono pane-empty">{moments.length === 0 ? "no events yet" : "no events in the window"}</div>
             : null
-          : moments.map((moment) => (
+          : shown.map((moment) => (
               <Row
                 key={moment.seq}
                 moment={moment}
-                dimmed={moment.seq > position}
                 open={opened === moment.seq}
                 onToggle={() => setOpened(opened === moment.seq ? undefined : moment.seq)}
               />

--- a/apps/voyager/src/App.tsx
+++ b/apps/voyager/src/App.tsx
@@ -17,9 +17,9 @@ interface Reading {
   readonly at: number
 }
 
-// useRoster polls GET /agents once for the whole screen: the rail's rows and totals, and the
-// header's status chip, are the same listing read twice rather than two calls. The last good
-// reading survives a failure, so a server restart dims the rail rather than blanking it.
+// useRoster polls GET /agents once for the whole screen: the rail's rows and the header's status
+// chip are the same listing read twice rather than two calls. The last good reading survives a
+// failure, so a server restart holds the rail rather than blanking it.
 const useRoster = (intervalMs: number) => {
   const [reading, setReading] = useState<Reading>({ roster: EMPTY_ROSTER, at: Date.now() })
   const [summaries, setSummaries] = useState<ReadonlyArray<AgentSummary>>([])

--- a/apps/voyager/src/Rail.tsx
+++ b/apps/voyager/src/Rail.tsx
@@ -1,13 +1,23 @@
+import { SidebarSimple } from "@phosphor-icons/react"
 import { useState, type ReactElement } from "react"
 
 import type { VoyagerError } from "./api"
 import { navigate } from "./nav"
-import { RAIL_WIDTH } from "./policy"
-import { agoOf, countsOf, matches, totalsOf, type Roster, type RootRow } from "./roster"
+import { COLLAPSED_RAIL_WIDTH, ICON_SIZE, RAIL_WIDTH } from "./policy"
+import { agoOf, countsOf, matches, type Roster, type RootRow } from "./roster"
 
 // The rail: the run's roots and nothing else (mock.html, the aside). A root is a run, and the tree
 // under it is the run's own business, so the rail lists the six things a reader chooses between
 // rather than the twenty-four agents behind them.
+
+// Where the collapsed state is kept. It is the reader's shape of the screen, not the run's, so it
+// lives in the browser and never on the wire (src/theme.ts, THEME_KEY).
+const RAIL_KEY = "voyager.rail"
+
+const storedCollapsed = (): boolean => {
+  if (typeof localStorage === "undefined") return false
+  return localStorage.getItem(RAIL_KEY) === "collapsed"
+}
 
 const Row = ({
   now,
@@ -18,7 +28,9 @@ const Row = ({
   readonly row: RootRow
   readonly selected: boolean
 }): ReactElement => {
-  const open = () => navigate({ agent: row.id, at: undefined })
+  // Choosing a run clears the window: the edges are fractions of the log a reader was looking at,
+  // and they name nothing in the log they are moving to (src/nav.ts, Route).
+  const open = () => navigate({ agent: row.id, from: undefined, to: undefined })
   return (
     <div
       role="button"
@@ -58,14 +70,31 @@ export const Rail = ({
   // The search is the rail's own state and reads ids alone: a reader who knows the id types it, and
   // nobody's prose is searched (mock.html, "search id…").
   const [query, setQuery] = useState("")
+  // Collapsed keeps the toggle and hides the list, and it survives a reload because a reader who
+  // closed the rail wants the pane wide on the next visit too.
+  const [collapsed, setCollapsed] = useState(storedCollapsed)
   const rows = roster.roots.filter((row) => matches(row.id, query))
+  const label = collapsed ? "Expand the run list" : "Collapse the run list"
   return (
-    <aside className="rail" style={{ width: RAIL_WIDTH }}>
-      <div style={{ padding: "var(--space-4) var(--space-4) var(--space-1)" }}>
-        <div style={{ fontWeight: 600, fontSize: 14, letterSpacing: "-0.01em" }}>voyager</div>
+    <aside className={`rail${collapsed ? " rail-collapsed" : ""}`} style={{ width: collapsed ? COLLAPSED_RAIL_WIDTH : RAIL_WIDTH }}>
+      <div className="rail-head">
+        <div className="rail-only rail-wordmark">voyager</div>
+        <button
+          type="button"
+          className="icon-btn"
+          aria-label={label}
+          aria-expanded={!collapsed}
+          title={label}
+          onClick={() => {
+            const next = !collapsed
+            setCollapsed(next)
+            if (typeof localStorage !== "undefined") localStorage.setItem(RAIL_KEY, next ? "collapsed" : "open")
+          }}
+        >
+          <SidebarSimple size={ICON_SIZE} weight="light" aria-hidden="true" />
+        </button>
       </div>
-      <div className="mono rail-totals">{totalsOf(roster)}</div>
-      <div style={{ padding: "0 var(--space-3) 10px" }}>
+      <div className="rail-only" style={{ padding: "0 var(--space-3) 10px" }}>
         <input
           className="input rail-search"
           value={query}
@@ -75,12 +104,12 @@ export const Rail = ({
         />
       </div>
       {problem === undefined ? null : (
-        <div className="problem" style={{ margin: "0 var(--space-3) 10px" }}>
+        <div className="problem rail-only" style={{ margin: "0 var(--space-3) 10px" }}>
           <div className="problem-title">{problem.title}</div>
           {problem.detail === undefined ? null : <div className="problem-detail">{problem.detail}</div>}
         </div>
       )}
-      <div style={{ flex: 1, overflowY: "auto", minHeight: 0 }}>
+      <div className="rail-only" style={{ flex: 1, overflowY: "auto", minHeight: 0 }}>
         {rows.map((row) => (
           <Row key={row.id} row={row} now={now} selected={row.id === selected} />
         ))}

--- a/apps/voyager/src/WindowBrush.tsx
+++ b/apps/voyager/src/WindowBrush.tsx
@@ -1,0 +1,192 @@
+import { Check, Copy } from "@phosphor-icons/react"
+import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent, type ReactElement } from "react"
+
+import { clockOf, type Moment } from "./narrative"
+import {
+  COPY_CONFIRM_MS,
+  ICON_SIZE,
+  WINDOW_BAR_BASE,
+  WINDOW_BAR_MIN,
+  WINDOW_KEY_STEP,
+  WINDOW_MARKS,
+  WINDOW_TRACK_HEIGHT
+} from "./policy"
+import { bucketsOf, copyTextOf, instantAt, moved, readoutOf, type Axis, type Window } from "./window"
+
+// The window brush: the log's density in one strip, and two handles that cut the list to a range.
+// It filters rather than dims, so what the reader sees below is exactly what the handles hold, and
+// what the copy control writes out (mock.html, #window).
+
+// copyText puts one string on the clipboard and answers whether it landed. The clipboard API
+// rejects when the page is not a secure context or the document lost focus, so the textarea path is
+// what makes the confirmation honest rather than optimistic.
+const copyText = async (text: string): Promise<boolean> => {
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    const area = document.createElement("textarea")
+    area.value = text
+    area.style.position = "fixed"
+    area.style.opacity = "0"
+    document.body.appendChild(area)
+    area.select()
+    const ok = document.execCommand("copy")
+    area.remove()
+    return ok
+  }
+}
+
+// The copy control. The glyph swaps through React state rather than through a style, because an
+// inline `display` outranks the class rules that would otherwise do the swap.
+const CopyButton = ({ text, confirmMs }: { readonly text: string; readonly confirmMs: number }): ReactElement => {
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    if (!copied) return
+    const timer = setTimeout(() => setCopied(false), confirmMs)
+    return () => clearTimeout(timer)
+  }, [copied, confirmMs])
+
+  return (
+    <button
+      type="button"
+      className={`icon-btn${copied ? " icon-btn-done" : ""}`}
+      aria-label="Copy the window's events"
+      title="Copy the window's events"
+      onClick={() => {
+        void copyText(text).then((ok) => {
+          if (ok) setCopied(true)
+        })
+      }}
+    >
+      {copied ? (
+        <Check size={ICON_SIZE} weight="light" aria-hidden="true" />
+      ) : (
+        <Copy size={ICON_SIZE} weight="light" aria-hidden="true" />
+      )}
+    </button>
+  )
+}
+
+const Handle = ({
+  edge,
+  fraction,
+  onDrag,
+  onStep
+}: {
+  readonly edge: "from" | "to"
+  readonly fraction: number
+  readonly onDrag: (event: ReactPointerEvent<HTMLDivElement>) => void
+  readonly onStep: (delta: number) => void
+}): ReactElement => (
+  <div
+    role="slider"
+    tabIndex={0}
+    aria-label={edge === "from" ? "Window start" : "Window end"}
+    aria-valuemin={0}
+    aria-valuemax={1}
+    aria-valuenow={fraction}
+    className="window-handle"
+    style={{ left: `${fraction * 100}%` }}
+    onPointerDown={onDrag}
+    onKeyDown={(pressed) => {
+      const delta = pressed.key === "ArrowLeft" ? -WINDOW_KEY_STEP : pressed.key === "ArrowRight" ? WINDOW_KEY_STEP : 0
+      if (delta === 0) return
+      pressed.preventDefault()
+      onStep(delta)
+    }}
+  >
+    <div className="window-grip" />
+  </div>
+)
+
+export const WindowBrush = ({
+  axis,
+  moments,
+  onChange,
+  shown,
+  window
+}: {
+  readonly axis: Axis
+  readonly moments: ReadonlyArray<Moment>
+  readonly onChange: (next: Window) => void
+  readonly shown: ReadonlyArray<Moment>
+  readonly window: Window
+}): ReactElement => {
+  const track = useRef<HTMLDivElement | null>(null)
+  const buckets = bucketsOf(moments, axis)
+  const peak = Math.max(1, ...buckets)
+  const readout = readoutOf(axis, window, shown.length, moments.length)
+
+  // A drag reads the pointer against the track's own box, so the handle lands where the cursor is
+  // rather than where the last render put it.
+  const grab = (edge: "from" | "to") => (pressed: ReactPointerEvent<HTMLDivElement>) => {
+    pressed.preventDefault()
+    const box = track.current?.getBoundingClientRect()
+    if (box === undefined || box.width === 0) return
+    let held = window
+    const move = (moving: PointerEvent) => {
+      held = moved(held, edge, (moving.clientX - box.left) / box.width)
+      onChange(held)
+    }
+    const up = () => {
+      removeEventListener("pointermove", move)
+      removeEventListener("pointerup", up)
+    }
+    addEventListener("pointermove", move)
+    addEventListener("pointerup", up)
+  }
+
+  return (
+    <div className="window">
+      <div className="window-head">
+        <span className="window-eyebrow">window</span>
+        <span className="window-actions">
+          <span className="mono window-readout">
+            {readout.range} <span className="window-count">· {readout.count}</span>
+          </span>
+          <CopyButton text={copyTextOf(shown)} confirmMs={COPY_CONFIRM_MS} />
+        </span>
+      </div>
+      <div ref={track} className="window-track" style={{ height: WINDOW_TRACK_HEIGHT }}>
+        <div className="window-bars">
+          {buckets.map((count, index) => {
+            const middle = (index + 0.5) / buckets.length
+            const inside = middle >= window.from && middle <= window.to
+            const height = count === 0 ? WINDOW_BAR_MIN : WINDOW_BAR_BASE + (count / peak) * (100 - WINDOW_BAR_BASE)
+            return (
+              <div
+                // The buckets are a fixed-length strip in axis order, so the index is the identity.
+                key={index}
+                className={`window-bar${inside ? " window-bar-inside" : ""}`}
+                style={{ height: `${height}%` }}
+              />
+            )
+          })}
+        </div>
+        <div
+          className="window-selection"
+          style={{ left: `${window.from * 100}%`, right: `${(1 - window.to) * 100}%` }}
+        />
+        <Handle
+          edge="from"
+          fraction={window.from}
+          onDrag={grab("from")}
+          onStep={(delta) => onChange(moved(window, "from", window.from + delta))}
+        />
+        <Handle
+          edge="to"
+          fraction={window.to}
+          onDrag={grab("to")}
+          onStep={(delta) => onChange(moved(window, "to", window.to + delta))}
+        />
+      </div>
+      <div className="mono window-marks">
+        {Array.from({ length: WINDOW_MARKS }, (_, index) => index / (WINDOW_MARKS - 1)).map((fraction) => (
+          <span key={fraction}>{clockOf(instantAt(axis, fraction))}</span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/voyager/src/narrative.ts
+++ b/apps/voyager/src/narrative.ts
@@ -263,6 +263,9 @@ export interface Moment {
   readonly event: Event
   readonly summary: string
   readonly time: string
+  // The instant the row is placed at on the window's axis, in epoch milliseconds. Absent for an
+  // event the host stamped no clock on, which the window then holds outside every bucket.
+  readonly at: number | undefined
   // Absent when the pair has no end yet, which is the honest answer while the work is still
   // running: an open dispatch shows a time and no span.
   readonly duration: string | undefined
@@ -330,6 +333,7 @@ export const momentsOf = (rows: ReadonlyArray<EventRow>): ReadonlyArray<Moment> 
       return {
         seq,
         event,
+        at: when,
         summary: summaryOf(event),
         time: when === undefined ? "" : clockOf(when),
         duration: span === undefined ? undefined : spanOf(span)

--- a/apps/voyager/src/nav.ts
+++ b/apps/voyager/src/nav.ts
@@ -1,31 +1,41 @@
 import { useCallback, useSyncExternalStore } from "react"
 
-// The URL is the app's only navigation state. `?agent=` chooses the screen and `?at=` the scrub
-// position, so a view is shareable and survives a refresh (voyager-spec.md, "Conventions"). There
-// is no routing library: two params and pushState are the whole of it.
+// The URL is the app's only navigation state. `?agent=` chooses the screen and `?from=` and `?to=`
+// carry the window's two edges, so a view is shareable and survives a refresh (voyager-spec.md,
+// "Conventions"). There is no routing library: three params and pushState are the whole of it.
 
 // The params the app reads. Anything else in the query belongs to something other than navigation
 // and is preserved untouched by `navigate`.
+//
+// The window's edges are fractions of the log's time span, 0 at the first event and 1 at the last.
+// A fraction is what the handle is dragged to, so the URL states the position the reader chose
+// rather than a seq the app would have to derive from it.
 export interface Route {
   readonly agent: string | undefined
-  readonly at: number | undefined
+  readonly from: number | undefined
+  readonly to: number | undefined
+}
+
+const fraction = (raw: string | null): number | undefined => {
+  if (raw === null) return undefined
+  const value = Number(raw)
+  return Number.isFinite(value) && value >= 0 && value <= 1 ? value : undefined
 }
 
 const parse = (search: string): Route => {
   const params = new URLSearchParams(search)
   const agent = params.get("agent")
-  const at = params.get("at")
-  const seq = at === null ? Number.NaN : Number(at)
   return {
     agent: agent === null || agent.length === 0 ? undefined : agent,
-    at: Number.isInteger(seq) && seq >= 0 ? seq : undefined
+    from: fraction(params.get("from")),
+    to: fraction(params.get("to"))
   }
 }
 
 export const routeOf = (search: string): Route => parse(search)
 
 // navigate writes the route into the URL and tells the subscribers. History gets one entry per
-// agent change and none per scrub step: dragging a slider should not fill the back button.
+// agent change and none per drag step: moving a handle should not fill the back button.
 export const navigate = (next: Partial<Route>, options: { readonly replace?: boolean } = {}): void => {
   const params = new URLSearchParams(location.search)
   const write = (name: string, value: string | number | undefined) => {
@@ -33,7 +43,8 @@ export const navigate = (next: Partial<Route>, options: { readonly replace?: boo
     else params.set(name, String(value))
   }
   if ("agent" in next) write("agent", next.agent)
-  if ("at" in next) write("at", next.at)
+  if ("from" in next) write("from", next.from)
+  if ("to" in next) write("to", next.to)
   const search = params.toString()
   const href = `${location.pathname}${search.length === 0 ? "" : `?${search}`}`
   if (options.replace === true) history.replaceState(null, "", href)

--- a/apps/voyager/src/policy.ts
+++ b/apps/voyager/src/policy.ts
@@ -6,25 +6,69 @@
 // measures against it.
 export const RAIL_WIDTH = 320
 
-// How often the rail re-reads GET /agents for the roster: the roots, their counts, and the totals.
-// The server publishes no change feed for the listing, so the rail polls, and this is both the
-// delay between a run changing and the rail saying so and the resolution of the age column.
+// The width the rail keeps when it is collapsed, in pixels. It holds the toggle and nothing else,
+// so a reader can always open the list again from where they closed it.
+export const COLLAPSED_RAIL_WIDTH = 48
+
+// The size every icon renders at, in pixels (voyager-design-system.md, the icon policy). One number
+// for the whole set, because a second size would be a second style.
+export const ICON_SIZE = 15
+
+// How often the rail re-reads GET /agents for the roster: the roots and their counts. The server
+// publishes no change feed for the listing, so the rail polls, and this is both the delay between a
+// run changing and the rail saying so and the resolution of the age column.
 export const ROSTER_POLL_MS = 2000
 
 // How often the event list re-reads the log after the stream is gone for good. The stream is the
 // live path and this is the fallback, so the interval matches the rail's (src/api.ts, stream).
 export const LOG_POLL_MS = 2000
 
-// The opacity a row drops to when the scrub sits before it. The row stays legible, so a reader sees
-// what the agent did not know yet rather than losing it.
-export const SCRUB_DIM = 0.4
+// How many bars the window's density strip holds. Each bar counts the events whose time falls in
+// its slice of the log's span, so the strip's resolution is this number and nothing else.
+export const WINDOW_BUCKETS = 56
 
-// The widest a summary line grows before the ellipsis takes over, in pixels (mock.html, .ev-text).
-// The cut is the browser's, so it lands on the glyph rather than on a character count.
+// The closest the two window handles come, as a fraction of the track. The handles cannot cross,
+// and a window narrower than this shows no events while still being draggable back open.
+export const WINDOW_MIN_GAP = 0.02
+
+// How many events the window opens on when the log is longer than that. A reader arrives at the
+// log's end, which is where a live run is, and drags left for the history.
+export const DEFAULT_WINDOW_EVENTS = 50
+
+// How many decimal places a window edge keeps in the URL. A drag reads the pointer to the pixel and
+// a shared link needs only the position, so the fraction is rounded before it is written.
+export const WINDOW_URL_DECIMALS = 4
+
+// How far an arrow key moves a window handle, as a fraction of the track. A drag is the pointer's
+// resolution and this is the keyboard's.
+export const WINDOW_KEY_STEP = 0.02
+
+// The density strip's height in pixels (mock.html, #track).
+export const WINDOW_TRACK_HEIGHT = 34
+
+// How many clock marks stand under the track. They divide the span evenly, first and last included.
+export const WINDOW_MARKS = 4
+
+// The height a bar takes as a percentage of the track: an empty bucket keeps WINDOW_BAR_MIN so the
+// strip reads as a strip, and a bucket holding anything starts at WINDOW_BAR_BASE and grows with
+// its share of the busiest bucket.
+export const WINDOW_BAR_MIN = 6
+export const WINDOW_BAR_BASE = 12
+
+// How long the copy control shows the check before returning to the copy glyph, in milliseconds.
+export const COPY_CONFIRM_MS = 1200
+
+// The column the event type is padded to in copied text. The times, types, and summaries then line
+// up in a plain-text editor, which is where the copied window is read.
+export const COPY_TYPE_WIDTH = 16
+
+// The widest an opened row's wrapped summary grows, in pixels (mock.html, .ev-row.open .ev-text). A
+// collapsed row takes the pane's whole width, so collapsing the rail buys visible text; only the
+// wrapped line keeps a measure.
 export const SUMMARY_WIDTH = 680
 
-// The longest summary string the app puts in the DOM. The visible ellipsis is SUMMARY_WIDTH's, and
-// this cap only keeps a megabyte-long code body out of a text node that shows one line of it.
+// The longest summary string the app puts in the DOM. The visible ellipsis is the pane's, and this
+// cap only keeps a megabyte-long code body out of a text node that shows one line of it.
 export const SUMMARY_CHARS = 400
 
 // The widest a field value grows in an opened row, in pixels (mock.html, .ev-val). The wrap is the

--- a/apps/voyager/src/roster.test.ts
+++ b/apps/voyager/src/roster.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test"
 
 import type { AgentSummary } from "./api"
-import { agoOf, countsOf, matches, rosterOf, totalsOf } from "./roster"
+import { agoOf, countsOf, matches, rosterOf } from "./roster"
 
-// The rail's decisions: which agents are rows, how big each root's family is, what the two mono
-// lines say, and how an age reads. All pure, so none of them needs a server or a DOM.
+// The rail's decisions: which agents are rows, how big each root's family is, what a row's counts
+// say, and how an age reads. All pure, so none of them needs a server or a DOM.
 
 const summary = (id: string, parent?: string, events = 1): AgentSummary => ({
   id,
@@ -32,15 +32,12 @@ describe("rosterOf", () => {
     expect(roots[1]?.family).toBe(0)
   })
 
-  test("the totals count every agent and every event, not just the roots", () => {
-    const roster = rosterOf(listing)
-    expect(roster.agents).toBe(5)
-    expect(roster.events).toBe(103)
-    expect(totalsOf(roster)).toBe("2 runs · 5 agents · 103 events")
+  test("a root keeps its own event count, which is the only count the rail states", () => {
+    expect(rosterOf(listing).roots.map((row) => row.events)).toEqual([34, 29])
   })
 
   test("an empty listing is an empty rail", () => {
-    expect(totalsOf(rosterOf([]))).toBe("0 runs · 0 agents · 0 events")
+    expect(rosterOf([]).roots).toEqual([])
   })
 
   test("a parent that claims its own ancestor still resolves to one root", () => {

--- a/apps/voyager/src/roster.ts
+++ b/apps/voyager/src/roster.ts
@@ -1,8 +1,8 @@
 import type { AgentStatus, AgentSummary } from "./api"
 
 // The rail's projections. GET /agents answers with every agent and its parent, and the rail shows
-// roots alone, so these functions turn one flat listing into the rows and the totals the rail
-// renders. They are pure, so the screen holds no arithmetic of its own.
+// roots alone, so these functions turn one flat listing into the rows the rail renders. They are
+// pure, so the screen holds no arithmetic of its own.
 
 // RootRow is one rail row: the root's own facts plus the size of the family it started.
 export interface RootRow {
@@ -15,14 +15,14 @@ export interface RootRow {
   readonly family: number
 }
 
-// Roster is the whole rail: the rows and the three numbers above them.
+// Roster is the whole rail: the rows, and nothing above them. The rail states a run's counts on the
+// run's own row and states no total, because a sum of unrelated runs answers no question a reader
+// has (mock.html, the aside).
 export interface Roster {
   readonly roots: ReadonlyArray<RootRow>
-  readonly agents: number
-  readonly events: number
 }
 
-export const EMPTY_ROSTER: Roster = { roots: [], agents: 0, events: 0 }
+export const EMPTY_ROSTER: Roster = { roots: [] }
 
 // rootOf walks an agent's parents to the root of its family. Parentage is the server's fact: only
 // the forest can see it, and a summary states it (apps/server/src/projections.ts, treeOf). The
@@ -57,9 +57,7 @@ export const rosterOf = (summaries: ReadonlyArray<AgentSummary>): Roster => {
         events: summary.events,
         lastAt: summary.lastAt,
         family: family.get(summary.id) ?? 0
-      })),
-    agents: summaries.length,
-    events: summaries.reduce((sum, summary) => sum + summary.events, 0)
+      }))
   }
 }
 
@@ -83,8 +81,3 @@ export const agoOf = (at: number, now: number): string => {
 // its family is. A root that spawned nothing says nothing about agents (mock.html, the rail row).
 export const countsOf = (row: RootRow): string =>
   row.family === 0 ? `${row.events} ev` : `${row.events} ev · ${row.family} agents`
-
-// totalsOf is the mono line under the wordmark: the run in three numbers, runs first because a run
-// is what a root is (mock.html, "6 runs · 24 agents · 987 events").
-export const totalsOf = (roster: Roster): string =>
-  `${roster.roots.length} runs · ${roster.agents} agents · ${roster.events} events`

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -285,12 +285,33 @@ textarea {
   min-height: 0;
   background: var(--surface);
   border-right: 1px solid var(--hair);
+  transition: width var(--base) var(--ease);
 }
 
-.rail-totals {
-  padding: 0 var(--space-4) 10px;
-  font-size: 11px;
-  color: var(--faint);
+/* The rail's header: the wordmark and the toggle that closes the list. Collapsed, the toggle is all
+   that is left, and it centers on the narrow column. */
+.rail-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-4) var(--space-3) 10px var(--space-4);
+}
+
+.rail-wordmark {
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: -0.01em;
+}
+
+/* Everything a collapsed rail hides. The toggle is outside the class, so the rail can always be
+   opened again from where it was closed. */
+.rail-collapsed .rail-only {
+  display: none;
+}
+
+.rail-collapsed .rail-head {
+  justify-content: center;
+  padding-left: var(--space-3);
 }
 
 .rail-search {
@@ -299,7 +320,7 @@ textarea {
 }
 
 /* A rail row is two lines: the id and its age, then the state chip and the counts. Selected is the
-   moss wash with the 2px moss inset; hover is the sunken wash. */
+   moss wash; hover is the sunken wash. */
 .rail-row {
   display: flex;
   flex-direction: column;
@@ -313,10 +334,10 @@ textarea {
   background: var(--sunken);
 }
 
+/* Selection is the wash alone: the moss says chosen, and a second mark would say it twice. */
 .rail-row-selected,
 .rail-row-selected:hover {
   background: var(--moss-wash);
-  box-shadow: inset 2px 0 0 var(--moss);
 }
 
 .rail-id {
@@ -341,8 +362,10 @@ textarea {
   padding: var(--space-4) var(--space-5) 10px;
 }
 
-/* The borderless icon button, which the theme toggle is the only user of. */
-.icon-button {
+/* The borderless icon button every icon in the app sits on: 15px of Phosphor at the light weight,
+   tinted faint, brightening to ink-2 on hover, with the press scale
+   (voyager-design-system.md, the icon policy). */
+.icon-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -357,91 +380,114 @@ textarea {
   transition: color var(--fast) var(--ease);
 }
 
-.icon-button:hover {
+.icon-btn:hover {
   color: var(--ink-2);
 }
 
-.icon-button:active {
+.icon-btn:active {
   transform: scale(0.97);
 }
 
-/* The scrub: a --sunken well holding a hairline track, the moss fill behind the handle, and the
-   mono readout that follows it (voyager-design-system.md, "Scrub"). */
-.scrub-well {
+/* The copy control while it confirms. The glyph itself is swapped in React rather than by a rule,
+   because a display an element carries inline outranks any class that would hide it. */
+.icon-btn-done {
+  color: var(--ok);
+}
+
+/* The window brush: the eyebrow and the readout, then the density strip the handles cut, then the
+   clock marks (mock.html, #window). */
+.window {
+  margin: 0 var(--space-5) 10px;
+  user-select: none;
+}
+
+.window-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.window-eyebrow {
+  font-size: 11px;
+  color: var(--faint);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.window-actions {
   display: flex;
   align-items: center;
-  gap: var(--space-3);
-  height: 32px;
-  margin: 0 var(--space-5) var(--space-3);
-  padding: 0 var(--space-3);
-  background: var(--sunken);
-  border-radius: var(--radius);
+  gap: var(--space-2);
 }
 
-.scrub-track {
-  position: relative;
-  flex: 1;
-  height: 3px;
-  background: var(--hair);
-  border-radius: 2px;
-}
-
-.scrub-fill {
-  position: absolute;
-  inset: 0 auto 0 0;
-  height: 3px;
-  background: var(--moss);
-  border-radius: 2px;
-  opacity: 0.4;
-}
-
-/* The range input carries the behavior and nothing else: its track is transparent so the well's own
-   track shows through, and the thumb is the moss dot. */
-.scrub-input {
-  position: absolute;
-  inset: -12px 0;
-  width: 100%;
-  margin: 0;
-  background: none;
-  appearance: none;
-  cursor: pointer;
-}
-
-.scrub-input::-webkit-slider-runnable-track {
-  height: 3px;
-  background: none;
-}
-
-.scrub-input::-webkit-slider-thumb {
-  width: 11px;
-  height: 11px;
-  margin-top: -4px;
-  border: none;
-  border-radius: var(--radius-chip);
-  background: var(--moss);
-  appearance: none;
-}
-
-.scrub-input::-moz-range-track {
-  height: 3px;
-  background: none;
-}
-
-.scrub-input::-moz-range-thumb {
-  width: 11px;
-  height: 11px;
-  border: none;
-  border-radius: var(--radius-chip);
-  background: var(--moss);
-}
-
-.scrub-input:disabled {
-  cursor: default;
-}
-
-.scrub-readout {
-  font-size: 11px;
+.window-readout {
+  font-size: 11.5px;
   color: var(--ink-2);
+}
+
+.window-count {
+  color: var(--faint);
+}
+
+.window-track {
+  position: relative;
+}
+
+/* One bar per bucket, each as tall as that slice of the log is busy. The strip is the log's own
+   density and not decoration, so an empty bucket keeps a floor and says so (src/window.ts). */
+.window-bars {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  gap: 1px;
+}
+
+.window-bar {
+  flex: 1;
+  border-radius: 1px 1px 0 0;
+  background: var(--hair);
+  transition: background var(--fast) var(--ease);
+}
+
+.window-bar-inside {
+  background: var(--moss);
+  opacity: 0.55;
+}
+
+.window-selection {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background: color-mix(in oklab, var(--moss) 12%, transparent);
+  border-left: 2px solid var(--moss);
+  border-right: 2px solid var(--moss);
+  pointer-events: none;
+}
+
+.window-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 12px;
+  margin-left: -6px;
+  cursor: ew-resize;
+}
+
+.window-grip {
+  width: 2px;
+  height: 100%;
+  margin: 0 auto;
+  background: var(--moss);
+}
+
+.window-marks {
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--space-1);
+  font-size: 10px;
+  color: var(--faint);
 }
 
 /* The line the pane shows when the stream is gone for good and the log is filling by poll. */
@@ -508,7 +554,8 @@ textarea {
   color: var(--faint);
 }
 
-/* An open row stops clamping its summary: the reader asked for the whole line. */
+/* An open row stops clamping its summary and wraps it instead: the reader asked for the whole line,
+   and it alone keeps a measure (src/policy.ts, SUMMARY_WIDTH). */
 .event-row-open .event-text {
   white-space: pre-wrap;
   overflow: visible;

--- a/apps/voyager/src/window.test.ts
+++ b/apps/voyager/src/window.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test"
+
+import type { EventRow } from "./api"
+import { momentsOf } from "./narrative"
+import { DEFAULT_WINDOW_EVENTS, WINDOW_MIN_GAP } from "./policy"
+import { axisOf, bucketsOf, copyTextOf, defaultWindowOf, moved, shownIn } from "./window"
+
+// The window's decisions that are pure: where the axis runs, how dense each bucket is, which range
+// the brush opens on, what a handle a drag pushed lands on, and what the copied window reads as.
+
+const minute = 60_000
+const start = Date.UTC(2026, 0, 1, 14, 0, 0)
+
+const log = (count: number, spacing = minute): ReadonlyArray<EventRow> =>
+  Array.from({ length: count }, (_, index) => ({
+    seq: index + 1,
+    event: { type: "TextReturned", text: `line ${index}`, at: start + index * spacing }
+  }))
+
+describe("bucketsOf", () => {
+  test("a bucket counts the events whose instant falls in its slice", () => {
+    const moments = momentsOf(log(4))
+    expect(bucketsOf(moments, axisOf(moments), 3)).toEqual([1, 1, 2])
+  })
+
+  test("a burst stands above the quiet stretches around it", () => {
+    const rows: ReadonlyArray<EventRow> = [
+      { seq: 1, event: { type: "TextReturned", at: start } },
+      ...Array.from({ length: 8 }, (_, index) => ({
+        seq: index + 2,
+        event: { type: "TextReturned", at: start + 5 * minute + index * 1000 }
+      })),
+      { seq: 10, event: { type: "TextReturned", at: start + 10 * minute } }
+    ]
+    const moments = momentsOf(rows)
+    const buckets = bucketsOf(moments, axisOf(moments), 4)
+    expect(buckets).toEqual([1, 0, 8, 1])
+    expect(buckets.reduce((sum, count) => sum + count, 0)).toBe(moments.length)
+  })
+
+  test("a log of one instant has no span and still divides", () => {
+    const moments = momentsOf(log(3, 0))
+    expect(bucketsOf(moments, axisOf(moments), 2)).toEqual([3, 0])
+  })
+})
+
+describe("defaultWindowOf", () => {
+  test("a log no longer than the default opens whole", () => {
+    const moments = momentsOf(log(DEFAULT_WINDOW_EVENTS))
+    expect(defaultWindowOf(moments)).toEqual({ from: 0, to: 1 })
+  })
+
+  test("a longer log opens on its last events, and the window holds exactly those", () => {
+    const moments = momentsOf(log(DEFAULT_WINDOW_EVENTS + 20))
+    const window = defaultWindowOf(moments)
+    expect(window.to).toBe(1)
+    expect(window.from).toBeGreaterThan(0)
+    expect(shownIn(moments, axisOf(moments), window)).toHaveLength(DEFAULT_WINDOW_EVENTS)
+  })
+
+  test("the count is the caller's to state", () => {
+    const moments = momentsOf(log(10))
+    expect(shownIn(moments, axisOf(moments), defaultWindowOf(moments, 4))).toHaveLength(4)
+  })
+})
+
+describe("shownIn", () => {
+  test("an event the host stamped no clock on is never hidden", () => {
+    const moments = momentsOf([...log(4), { seq: 5, event: { type: "TextReturned", text: "no clock" } }])
+    const shown = shownIn(moments, axisOf(moments), { from: 0, to: 0.1 })
+    expect(shown.map((moment) => moment.seq)).toEqual([1, 5])
+  })
+})
+
+describe("moved", () => {
+  test("a handle stops at the track's ends", () => {
+    expect(moved({ from: 0.2, to: 1 }, "from", -3)).toEqual({ from: 0, to: 1 })
+    expect(moved({ from: 0, to: 0.5 }, "to", 4)).toEqual({ from: 0, to: 1 })
+  })
+
+  test("the handles cannot cross and keep the stated gap", () => {
+    expect(moved({ from: 0.2, to: 0.5 }, "from", 0.9)).toEqual({ from: 0.5 - WINDOW_MIN_GAP, to: 0.5 })
+    expect(moved({ from: 0.2, to: 0.5 }, "to", 0)).toEqual({ from: 0.2, to: 0.2 + WINDOW_MIN_GAP })
+  })
+})
+
+describe("copyTextOf", () => {
+  test("one line per event: the clock, the type, and the line the row shows", () => {
+    const moments = momentsOf([
+      { seq: 1, event: { type: "TextReturned", text: "thinking it over", at: start } },
+      { seq: 2, event: { type: "BlockedOn", callId: "t1.0", awaiting: "t1.0.reply", at: start + minute } }
+    ])
+    expect(copyTextOf(moments, 12).split("\n")).toEqual([
+      `${moments[0]?.time}  TextReturned  thinking it over`,
+      `${moments[1]?.time}  BlockedOn     awaiting t1.0.reply`
+    ])
+  })
+
+  test("an empty window copies as an empty string", () => {
+    expect(copyTextOf([])).toBe("")
+  })
+})

--- a/apps/voyager/src/window.ts
+++ b/apps/voyager/src/window.ts
@@ -1,0 +1,128 @@
+import { clockOf, type Moment } from "./narrative"
+import {
+  COPY_TYPE_WIDTH,
+  DEFAULT_WINDOW_EVENTS,
+  WINDOW_BUCKETS,
+  WINDOW_MIN_GAP,
+  WINDOW_URL_DECIMALS
+} from "./policy"
+
+// The window's arithmetic: where the log's events sit on one time axis, how dense each slice of it
+// is, which events a window holds, and what the copied window reads as. Every function here is
+// pure, so the brush is these answers rendered and the tests are arrays of moments.
+
+// Window is the brush's two edges, as fractions of the log's time span: 0 is the first event's
+// instant and 1 is the last. The URL carries the same two numbers (src/nav.ts, Route).
+export interface Window {
+  readonly from: number
+  readonly to: number
+}
+
+export const FULL_WINDOW: Window = { from: 0, to: 1 }
+
+// Axis is the span the fractions are measured against. `span` is never zero, so a log of one event
+// still divides: every instant in it maps to fraction 0.
+export interface Axis {
+  readonly lo: number
+  readonly hi: number
+  readonly span: number
+}
+
+const stamps = (moments: ReadonlyArray<Moment>): ReadonlyArray<number> =>
+  moments.map((moment) => moment.at).filter((at): at is number => at !== undefined)
+
+// axisOf reads the axis off the log itself. An empty log, or one the host stamped no clock on, has
+// a zero-length axis at the epoch, which renders as an empty strip rather than as NaN.
+export const axisOf = (moments: ReadonlyArray<Moment>): Axis => {
+  const times = stamps(moments)
+  const lo = times.length === 0 ? 0 : Math.min(...times)
+  const hi = times.length === 0 ? 0 : Math.max(...times)
+  return { lo, hi, span: hi - lo === 0 ? 1 : hi - lo }
+}
+
+// fractionOf places one instant on the axis, clamped to the track's ends.
+const fractionOf = (axis: Axis, at: number): number =>
+  Math.min(1, Math.max(0, (at - axis.lo) / axis.span))
+
+// instantAt is the inverse: the clock a handle sits over.
+export const instantAt = (axis: Axis, fraction: number): number => axis.lo + axis.span * fraction
+
+// bucketsOf counts the events in each slice of the axis. The strip draws these counts, so a bar's
+// height is the log's own density in that slice and a burst of polling is visible as one.
+export const bucketsOf = (
+  moments: ReadonlyArray<Moment>,
+  axis: Axis,
+  count: number = WINDOW_BUCKETS
+): ReadonlyArray<number> => {
+  const counts = Array.from({ length: count }, () => 0)
+  for (const at of stamps(moments)) {
+    const index = Math.min(count - 1, Math.max(0, Math.floor(fractionOf(axis, at) * count)))
+    counts[index] = (counts[index] ?? 0) + 1
+  }
+  return counts
+}
+
+// holds is the window's membership test. An event the host stamped no clock on sits at no fraction,
+// so no window can hide it: the alternative is an event that is invisible at every handle position.
+const holds = (window: Window, axis: Axis, moment: Moment): boolean => {
+  if (moment.at === undefined) return true
+  const fraction = fractionOf(axis, moment.at)
+  return fraction >= window.from && fraction <= window.to
+}
+
+export const shownIn = (moments: ReadonlyArray<Moment>, axis: Axis, window: Window): ReadonlyArray<Moment> =>
+  moments.filter((moment) => holds(window, axis, moment))
+
+// defaultWindowOf is where the brush opens: the last `events` events of a longer log, and the whole
+// of a shorter one. A reader arrives at the end, which is where a live run is writing.
+export const defaultWindowOf = (
+  moments: ReadonlyArray<Moment>,
+  events: number = DEFAULT_WINDOW_EVENTS
+): Window => {
+  const times = stamps(moments)
+  if (times.length <= events) return FULL_WINDOW
+  const axis = axisOf(moments)
+  const first = times[times.length - events]
+  return first === undefined ? FULL_WINDOW : { from: fractionOf(axis, first), to: 1 }
+}
+
+// moved answers where a dragged handle lands. The handles cannot cross and cannot close nearer than
+// `gap`, so the pushed-away edge holds its ground rather than the two swapping roles mid-drag.
+export const moved = (
+  window: Window,
+  edge: "from" | "to",
+  fraction: number,
+  gap: number = WINDOW_MIN_GAP
+): Window => {
+  const held = Math.min(1, Math.max(0, fraction))
+  return edge === "from"
+    ? { from: Math.min(held, window.to - gap), to: window.to }
+    : { from: window.from, to: Math.max(held, window.from + gap) }
+}
+
+// shared is the window as the URL states it: the same two edges at the resolution a link needs
+// (src/nav.ts, Route).
+export const shared = (window: Window, decimals: number = WINDOW_URL_DECIMALS): Window => ({
+  from: Number(window.from.toFixed(decimals)),
+  to: Number(window.to.toFixed(decimals))
+})
+
+// readoutOf is the mono line beside the eyebrow: the window's two clocks and how much of the log it
+// holds.
+export const readoutOf = (
+  axis: Axis,
+  window: Window,
+  shown: number,
+  total: number
+): { readonly range: string; readonly count: string } => ({
+  range: `${clockOf(instantAt(axis, window.from))} → ${clockOf(instantAt(axis, window.to))}`,
+  count: `${shown}/${total}`
+})
+
+// copyTextOf renders the window's events as plain text, one line per event: the clock, the event's
+// own type, and the line the row shows. The type is padded so the three columns align wherever the
+// text is pasted (src/policy.ts, COPY_TYPE_WIDTH).
+export const copyTextOf = (moments: ReadonlyArray<Moment>, typeWidth: number = COPY_TYPE_WIDTH): string =>
+  moments
+    .map((moment) => `${moment.time}  ${moment.event.type.padEnd(typeWidth)}  ${moment.summary}`)
+    .join("\n")

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@base-ui-components/react": "1.0.0-rc.0",
+        "@phosphor-icons/react": "^2.1.10",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
       },
@@ -337,6 +338,8 @@
     "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.78.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zcuXFVrEFHIafRfkCQT8w/Xe41o07ozl/vwHq7p94vB29xVzsB0sZGYORU1jhcYKv3Lr0J3HbJ2T4fHH5rWmvA=="],
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.78.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Sb5ocmLSuYeOuXd+CFOToGKp/gjXUEWDnvIGwhnh8aq8wY4TMmEnKnvbogSW7RdMZv77JSARduS7/gv+khYEjA=="],
+
+    "@phosphor-icons/react": ["@phosphor-icons/react@2.1.10", "", { "peerDependencies": { "react": ">= 16.8", "react-dom": ">= 16.8" } }, "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA=="],
 
     "@rolldown/binding-android-arm-eabi": ["@rolldown/binding-android-arm-eabi@1.2.5", "", { "os": "android", "cpu": "arm" }, "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA=="],
 


### PR DESCRIPTION
The trajectory explorer landed with a single-handle prefix scrubber that only dimmed rows. Replace it with a window brush that scopes the list to a time range, and finish the chrome the design settled on.

- window brush: two moss handles over a density strip whose bar heights are the real event count per bucket, a mono from-to readout with shown/total, clock marks at the quarters, and bars inside the selection tinted; the window filters the list rather than dimming it
- the window rides the URL as two fractions of the log's span (from, to), written in replace mode so dragging does not fill history; the old at param and its dimming are gone
- a copy control beside the readout copies the window's events as text and swaps to a check for 1.2s, confirming only when the copy succeeded (clipboard API with a textarea fallback)
- icons come from Phosphor at the light weight, replacing every hand-drawn path: sun and moon, copy and check, sidebar
- the rail collapses to 48px and persists the choice; its totals line is gone and selection is the moss wash with no inset bar
- a collapsed row's summary now uses the full pane, so collapsing the rail buys visible content; only wrapped text keeps its measure
- bun run gate fully green