### PR TITLE
feat(cli): tdg command

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Effects have at-least-once execution. Each keyed result is recorded once. Provid
 
 - [Quickstart](docs/quickstart.md): build the event loop and its agent capabilities from first principles.
 - [Run the server](docs/how-to/server.md): host the HTTP server over a durable SQLite log, and read its API.
+- [Use the command line](docs/how-to/cli.md): drive a server with `tdg`, and serve the API and the UI from one process.
 - [Runtime and turn recovery](docs/explanations/runtime-and-recovery.md): understand runtime requirements, retry scopes, and failed-turn recovery.
 - [Why Tardigrade](docs/explanations/why.md): learn what the log-as-state model makes possible.
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@clavia/tardigrade-cli",
+  "version": "0.0.1",
+  "private": true,
+  "license": "MIT",
+  "author": "Clavia, Inc.",
+  "description": "The tdg command: run an agent, watch its log, and serve the API and the UI at one URL.",
+  "homepage": "https://github.com/clavia-labs/tardigrade#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/clavia-labs/tardigrade.git",
+    "directory": "apps/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/clavia-labs/tardigrade/issues"
+  },
+  "engines": {
+    "bun": ">=1.4.0"
+  },
+  "type": "module",
+  "exports": {
+    "./*": "./src/*.ts"
+  },
+  "dependencies": {
+    "@clavia/tardigrade-client": "workspace:*",
+    "@clavia/tardigrade-core": "workspace:*",
+    "@clavia/tardigrade-server": "workspace:*",
+    "@effect/platform-bun": "4.0.0-rc.110",
+    "effect": "4.0.0-rc.110"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "start": "bun run src/main.ts"
+  },
+  "devDependencies": {
+    "@clavia/tardigrade": "workspace:*"
+  }
+}

--- a/apps/cli/src/assets.test.ts
+++ b/apps/cli/src/assets.test.ts
@@ -1,0 +1,69 @@
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+import {
+  ASSET_CANDIDATES,
+  AssetsMissing,
+  assetsIn,
+  BUILD_COMMAND,
+  INDEX_FILE,
+  INSTALLED_ASSETS,
+  REPO_ASSETS,
+  resolveAssets
+} from "./assets"
+
+// Where the UI comes from. The rule is first match wins, and no match is a failure that names the
+// command to run, because a process that listened without a UI would report the miss as a blank
+// page.
+
+const built = (): string => {
+  const directory = mkdtempSync(join(tmpdir(), "tardigrade-assets-"))
+  writeFileSync(join(directory, INDEX_FILE), "<!doctype html>")
+  return directory
+}
+
+describe("assetsIn", () => {
+  test("the first directory holding an index wins", () => {
+    const first = built()
+    const second = built()
+    expect(assetsIn([join(tmpdir(), "tardigrade-absent"), first, second])).toBe(first)
+  })
+
+  test("a directory without an index is not a build", () => {
+    const empty = mkdtempSync(join(tmpdir(), "tardigrade-empty-"))
+    expect(() => assetsIn([empty])).toThrow(AssetsMissing)
+  })
+
+  test("the failure names the command that makes a build", () => {
+    try {
+      assetsIn([join(tmpdir(), "tardigrade-absent")])
+      expect.unreachable()
+    } catch (failure) {
+      expect(failure).toBeInstanceOf(AssetsMissing)
+      expect((failure as AssetsMissing).message).toContain(BUILD_COMMAND)
+      expect((failure as AssetsMissing).looked).toHaveLength(1)
+    }
+  })
+})
+
+describe("resolveAssets", () => {
+  test("a stated directory is taken as stated", () => {
+    const directory = built()
+    expect(resolveAssets(directory)).toBe(directory)
+  })
+
+  test("a stated directory is still checked", () => {
+    expect(() => resolveAssets(join(tmpdir(), "tardigrade-absent"))).toThrow(AssetsMissing)
+  })
+
+  // Two layouts, tried in order: the build staged in a published package, then the build vite
+  // writes inside this repository. Neither can be a prefix of the other, or a repository checkout
+  // would serve the voyager's source index in place of its build.
+  test("the candidates are the two layouts a build arrives in", () => {
+    expect(ASSET_CANDIDATES).toEqual([INSTALLED_ASSETS, REPO_ASSETS])
+    expect(REPO_ASSETS.startsWith(INSTALLED_ASSETS)).toBe(false)
+    expect(INSTALLED_ASSETS.startsWith(REPO_ASSETS)).toBe(false)
+  })
+})

--- a/apps/cli/src/assets.ts
+++ b/apps/cli/src/assets.ts
@@ -1,0 +1,61 @@
+import { existsSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+// Where the UI `tdg dev` serves comes from. The voyager is a static build: `vite build` writes a
+// directory whose entry is one HTML file, and serving it needs no bundler and no second process, so
+// the command reads it off the disk it was installed from (assets.test.ts).
+//
+// Two layouts hold that directory, and the command tries them in order. Installed, the build is
+// staged beside the sources at publish time (tools/publish.ts, STAGED_ASSETS) under a name the
+// repository has no directory for, so the two candidates can never match the same place. In this
+// repository, the build is where vite wrote it, which is apps/voyager/dist, and the source beside
+// it holds an index of its own that vite serves rather than a build. Nothing is fetched and nothing
+// is proxied: hot reload stays the voyager's own dev script (docs/how-to/cli.md).
+
+// The file whose presence proves a directory is a build rather than an empty folder.
+export const INDEX_FILE = "index.html"
+
+// Where the published package stages the build, relative to this module.
+export const INSTALLED_ASSETS = "../../ui/"
+
+// Where vite writes the build inside this repository, relative to this module.
+export const REPO_ASSETS = "../../voyager/dist/"
+
+// What to run when neither layout holds a build.
+export const BUILD_COMMAND = "bun run --cwd apps/voyager build"
+
+export const ASSET_CANDIDATES: ReadonlyArray<string> = [INSTALLED_ASSETS, REPO_ASSETS]
+
+// AssetsMissing names every place that was looked in, so an operator can see which layout was
+// expected rather than guess. It is thrown before the server starts listening: a UI-less process
+// answering the API at a URL that serves nothing at `/` is the confusing state this avoids.
+export class AssetsMissing extends Error {
+  readonly looked: ReadonlyArray<string>
+
+  constructor(looked: ReadonlyArray<string>) {
+    super(
+      `the voyager build is missing. Run \`${BUILD_COMMAND}\`, then start again. Looked in: ${looked.join(", ")}`
+    )
+    this.name = "AssetsMissing"
+    this.looked = looked
+  }
+}
+
+const holdsIndex = (directory: string): boolean => existsSync(`${directory}/${INDEX_FILE}`)
+
+// assetsIn is the resolution rule as a pure function of the places to look, so a test states its
+// own places (assets.test.ts).
+export const assetsIn = (candidates: ReadonlyArray<string>): string => {
+  const found = candidates.find(holdsIndex)
+  if (found === undefined) throw new AssetsMissing(candidates)
+  return found
+}
+
+// resolveAssets answers the directory to serve. A stated directory is taken as stated, and is still
+// checked for the index file, so a typo fails at boot rather than as a blank page.
+export const resolveAssets = (stated?: string | undefined): string =>
+  assetsIn(
+    stated === undefined
+      ? ASSET_CANDIDATES.map((candidate) => fileURLToPath(new URL(candidate, import.meta.url)).replace(/\/$/, ""))
+      : [stated.replace(/\/$/, "")]
+  )

--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, test } from "bun:test"
+import { Cause, Console, Effect, Exit, Layer, Option } from "effect"
+import { CliError, Command } from "effect/unstable/cli"
+import { BunServices } from "@effect/platform-bun"
+import { ProblemError, type Accepted, type AgentSummary, type Client, type EventRow, type TurnView } from "@clavia/tardigrade-client"
+
+import { problemLine, tdg } from "./commands"
+import { Cli, type CliServices } from "./services"
+
+// The command tree, driven the way a shell drives it: real arguments through the real parser, over
+// a client this file wrote. Nothing here spawns a process, and nothing here reaches a network.
+
+const agents: ReadonlyArray<AgentSummary> = [
+  { id: "root", events: 2, lastAt: 0, status: "settled" }
+]
+
+const events: ReadonlyArray<EventRow> = [
+  { seq: 1, event: { type: "MessageReceived", text: "hello" } },
+  { seq: 2, event: { type: "TurnCompleted", output: "ok" } }
+]
+
+interface Recorded {
+  readonly delivered: Array<{ agent: string; id: string; text: string }>
+  readonly asked: Array<{ agent: string; options: unknown }>
+}
+
+const refuse = () => Promise.reject(new Error("this command should not have called that"))
+
+// A client whose answers are stated per case. Its methods are the derived client's own, so a
+// handler that compiles against this one compiles against the real one (packages/client).
+const clientOf = (
+  recorded: Recorded,
+  answers: {
+    readonly list?: ReadonlyArray<AgentSummary>
+    readonly events?: ReadonlyArray<EventRow>
+    readonly turns?: ReadonlyArray<TurnView>
+    readonly fail?: ProblemError
+  }
+): Client => {
+  let read = 0
+  return {
+    baseUrl: "http://localhost:0",
+    list: () => (answers.fail === undefined ? Promise.resolve(answers.list ?? []) : Promise.reject(answers.fail)),
+    events: (agent, options) => {
+      recorded.asked.push({ agent, options })
+      return answers.fail === undefined ? Promise.resolve(answers.events ?? []) : Promise.reject(answers.fail)
+    },
+    turn: (_agent, _turn) => {
+      const views = answers.turns ?? []
+      const view = views[Math.min(read++, views.length - 1)]
+      return view === undefined ? refuse() : Promise.resolve(view)
+    },
+    deliver: (agent, message) => {
+      recorded.delivered.push({ agent, id: message.id, text: message.text })
+      return answers.fail === undefined
+        ? Promise.resolve({ agent, turn: message.id } satisfies Accepted)
+        : Promise.reject(answers.fail)
+    },
+    tree: refuse,
+    turns: refuse,
+    resume: refuse,
+    health: refuse,
+    follow: () => () => {}
+  }
+}
+
+interface Ran {
+  readonly lines: ReadonlyArray<string>
+  readonly failure: CliError.CliError | undefined
+  readonly failed: boolean
+  readonly recorded: Recorded
+}
+
+// drive runs one invocation and answers with what it printed and whether it failed. `renderErrors`
+// is off so a case reads the failure rather than the terminal, which is the same value the runner
+// renders (Command.run).
+const drive = async (
+  args: ReadonlyArray<string>,
+  options: {
+    readonly answers?: Parameters<typeof clientOf>[1]
+    readonly env?: Record<string, string | undefined>
+    readonly ids?: ReadonlyArray<string>
+  } = {}
+): Promise<Ran> => {
+  const lines: Array<string> = []
+  const recorded: Recorded = { delivered: [], asked: [] }
+  const minted = [...(options.ids ?? ["minted-1", "minted-2", "minted-3"])]
+  const services: CliServices = {
+    env: options.env ?? {},
+    openClient: () => clientOf(recorded, options.answers ?? {}),
+    mintId: () => minted.shift() ?? "exhausted"
+  }
+  const capture: Console.Console = Object.assign(Object.create(console), {
+    log: (...parts: ReadonlyArray<unknown>) => {
+      lines.push(parts.map((part) => String(part)).join(" "))
+    },
+    error: () => {}
+  })
+  const exit = await Command.runWith(tdg, { version: "test", renderErrors: false })([...args]).pipe(
+    Effect.provideService(Console.Console, capture),
+    Effect.provide(Layer.mergeAll(BunServices.layer, Layer.succeed(Cli)(services))),
+    Effect.runPromiseExit
+  )
+  return {
+    lines,
+    failed: Exit.isFailure(exit),
+    failure: Exit.isFailure(exit) ? Option.getOrUndefined(Cause.findErrorOption(exit.cause)) : undefined,
+    recorded
+  }
+}
+
+// What the runner would render. A parse refusal arrives as ShowHelp carrying the refusals it would
+// print under the help, so the message a case asserts on is the one a person reads (CliError).
+const failureText = (ran: Ran): string =>
+  ran.failure === undefined
+    ? ""
+    : ran.failure._tag === "ShowHelp"
+    ? ran.failure.errors.map((nested) => nested.message).join("\n")
+    : ran.failure.message
+
+describe("parsing", () => {
+  test("the root with no subcommand prints its help", async () => {
+    const ran = await drive([])
+    expect(ran.lines.join("\n")).toContain("tdg")
+    expect(ran.lines.join("\n")).toContain("dev")
+    expect(ran.lines.join("\n")).toContain("events")
+  })
+
+  test("a command's help names its flags", async () => {
+    const ran = await drive(["events", "--help"])
+    const help = ran.lines.join("\n")
+    expect(help).toContain("--after")
+    expect(help).toContain("--limit")
+    expect(help).toContain("--types")
+    expect(help).toContain("--json")
+  })
+
+  test("an unknown command fails", async () => {
+    const ran = await drive(["fly"])
+    expect(ran.failed).toBe(true)
+  })
+
+  test("a missing argument fails", async () => {
+    const ran = await drive(["events"])
+    expect(ran.failed).toBe(true)
+    expect(failureText(ran).toLowerCase()).toContain("agent")
+  })
+
+  test("an unknown flag fails", async () => {
+    const ran = await drive(["ls", "--loud"])
+    expect(ran.failed).toBe(true)
+    expect(failureText(ran)).toContain("loud")
+  })
+
+  test("a flag that wants a number refuses a word", async () => {
+    const ran = await drive(["events", "root", "--after", "soon"])
+    expect(ran.failed).toBe(true)
+  })
+})
+
+describe("ls", () => {
+  test("the human rendering is a table", async () => {
+    const ran = await drive(["ls"], { answers: { list: agents } })
+    expect(ran.failed).toBe(false)
+    const lines = (ran.lines[0] ?? "").split("\n")
+    expect(lines[0]).toContain("AGENT")
+    expect(lines[1]).toContain("root")
+  })
+
+  test("--json prints the client's value verbatim", async () => {
+    const ran = await drive(["ls", "--json"], { answers: { list: agents } })
+    expect(JSON.parse(ran.lines[0] ?? "")).toEqual(agents)
+  })
+})
+
+describe("events", () => {
+  test("the human rendering is one line per event", async () => {
+    const ran = await drive(["events", "root"], { answers: { events } })
+    const lines = (ran.lines[0] ?? "").split("\n")
+    expect(lines).toHaveLength(3)
+    expect(lines[1]).toContain("MessageReceived")
+  })
+
+  test("--json prints the rows verbatim", async () => {
+    const ran = await drive(["events", "root", "--json"], { answers: { events } })
+    expect(JSON.parse(ran.lines[0] ?? "")).toEqual(events)
+  })
+
+  test("the paging flags reach the client", async () => {
+    const ran = await drive(
+      ["events", "root", "--after", "3", "--limit", "5", "--types", "MessageReceived, TurnCompleted"],
+      { answers: { events } }
+    )
+    expect(ran.recorded.asked[0]).toEqual({
+      agent: "root",
+      options: { after: 3, limit: 5, types: ["MessageReceived", "TurnCompleted"] }
+    })
+  })
+})
+
+describe("send", () => {
+  test("the turn handle is printed and nothing is waited on", async () => {
+    const ran = await drive(["send", "root", "do the thing"])
+    expect(ran.lines[0]).toBe("root minted-1")
+    expect(ran.recorded.delivered).toEqual([{ agent: "root", id: "minted-1", text: "do the thing" }])
+  })
+
+  test("a stated id is the id, so a retry is absorbed", async () => {
+    const ran = await drive(["send", "root", "again", "--id", "m1"])
+    expect(ran.recorded.delivered[0]?.id).toBe("m1")
+  })
+
+  test("--json prints the handle verbatim", async () => {
+    const ran = await drive(["send", "root", "again", "--json", "--id", "m1"])
+    expect(JSON.parse(ran.lines[0] ?? "")).toEqual({ agent: "root", turn: "m1" })
+  })
+})
+
+describe("run", () => {
+  test("a pending turn is polled until it settles, and the output is printed", async () => {
+    const ran = await drive(
+      ["run", "summarize", "--agent", "root", "--id", "m1", "--poll", "1"],
+      {
+        answers: {
+          turns: [
+            { turn: "m1", status: "pending" },
+            { turn: "m1", status: "completed", output: "the summary" }
+          ]
+        }
+      }
+    )
+    expect(ran.failed).toBe(false)
+    expect(ran.lines[0]).toBe("root m1 completed\nthe summary")
+  })
+
+  test("an agent nobody named is minted, so a run births its own agent", async () => {
+    const ran = await drive(["run", "hello", "--poll", "1"], {
+      answers: { turns: [{ turn: "minted-2", status: "completed", output: "hi" }] }
+    })
+    expect(ran.recorded.delivered).toEqual([{ agent: "minted-1", id: "minted-2", text: "hello" }])
+  })
+
+  test("a failed turn prints its error and exits non-zero", async () => {
+    const ran = await drive(["run", "hello", "--agent", "root", "--id", "m1", "--poll", "1"], {
+      answers: { turns: [{ turn: "m1", status: "failed", error: "no model is configured" }] }
+    })
+    expect(ran.lines[0]).toBe("root m1 failed\nno model is configured")
+    expect(ran.failed).toBe(true)
+  })
+
+  test("a turn that never settles gives up rather than hanging", async () => {
+    const ran = await drive(["run", "hello", "--agent", "root", "--id", "m1", "--poll", "1", "--timeout", "0"], {
+      answers: { turns: [{ turn: "m1", status: "pending" }] }
+    })
+    expect(ran.failed).toBe(true)
+    expect(failureText(ran)).toContain("still pending")
+  })
+})
+
+describe("failures", () => {
+  const problem = new ProblemError({
+    type: "https://tardigrade.dev/problems/unknown-agent",
+    title: "Unknown Agent",
+    status: 404,
+    detail: "No agent named \"ghost\" has ever existed."
+  })
+
+  test("a problem document prints its title, status, and detail", () => {
+    expect(problemLine(problem)).toBe("Unknown Agent (404): No agent named \"ghost\" has ever existed.")
+  })
+
+  // A call that never reached a response has no status line to quote.
+  test("an unreachable server prints its title alone", () => {
+    expect(problemLine(new ProblemError({ title: "Server Unreachable", status: 0 }))).toBe("Server Unreachable")
+  })
+
+  test("a failed call exits non-zero carrying the server's words", async () => {
+    const ran = await drive(["events", "ghost"], { answers: { fail: problem } })
+    expect(ran.failed).toBe(true)
+    expect(failureText(ran)).toContain("Unknown Agent (404)")
+  })
+})

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -209,7 +209,7 @@ export const lsCommand = Command.make("ls", remote, (flags) =>
     const agents = yield* call(() => client.list())
     yield* Console.log(flags.json ? jsonOf(agents) : agentsTable(agents))
   })).pipe(
-    Command.withDescription("List the runs a store holds, parent before child."),
+    Command.withDescription("List every agent a store holds, parent before child. A spawned child is an agent like any other, so a run that spawned nine lists ten rows."),
     Command.withAlias("list")
   )
 

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -1,0 +1,258 @@
+import { Clock, Console, Effect, Layer, Option } from "effect"
+import { Argument, CliError, Command, Flag } from "effect/unstable/cli"
+import { NO_ANSWER, ProblemError, type Client, type TurnView } from "@clavia/tardigrade-client"
+
+import { resolveRemote, resolveServer } from "./config"
+import { dev } from "./dev"
+import { agentsTable, DEFAULT_DETAIL_WIDTH, eventsTable, jsonOf, turnLines } from "./render"
+import { Cli } from "./services"
+
+// The command tree. Every command is a declaration: its flags, its arguments, and its description
+// are values, so the help a person reads and the completions a shell installs are generated from
+// the same tree the parser runs (commands.test.ts). A handler is a few lines over the derived
+// client (packages/client) and holds no wire knowledge of its own.
+
+// How often `tdg run` asks whether the turn it delivered has left `pending`. The server answers a
+// delivery with 202 and settles the turn on its own loop, so waiting is polling; this is the delay
+// a person sees between the turn finishing and the command printing.
+export const DEFAULT_POLL_MILLIS = 200
+
+// How long `tdg run` waits before it gives up and says so. A turn that outlives this is still
+// running on the server, and its output is still one `tdg events` away, so the number bounds the
+// command rather than the work.
+export const DEFAULT_TIMEOUT_MILLIS = 300_000
+
+// The turn status a run is asked for. Everything else, `failed` and `parked` alike, leaves the
+// command with a non-zero exit: a script that ran an agent and got no answer should not read as
+// success (commands.test.ts, "a failed turn prints its error and exits non-zero").
+export const SETTLED: TurnView["status"] = "completed"
+
+// problemLine is the whole of what a failed call prints. The four fields are the server's own words
+// (packages/client/src/problem.ts), and a status of NO_ANSWER means the call never reached a
+// response, so there is no status line to quote.
+export const problemLine = (error: ProblemError): string => {
+  const where = error.status === NO_ANSWER ? error.title : `${error.title} (${error.status})`
+  return error.detail === undefined ? where : `${where}: ${error.detail}`
+}
+
+// userErrorOf carries a failure into the CLI's own channel. The runner renders the message and
+// leaves the exit code non-zero, so a caller sees the server's sentence rather than a stack trace
+// (commands.test.ts, "a problem document prints its title, status, and detail").
+const userErrorOf = (cause: unknown): CliError.UserError =>
+  new CliError.UserError({
+    cause,
+    userMessage: cause instanceof ProblemError ? problemLine(cause) : String(cause)
+  })
+
+const call = <A>(promise: () => Promise<A>): Effect.Effect<A, CliError.UserError> =>
+  Effect.tryPromise({ try: promise, catch: userErrorOf })
+
+// The flags a command that talks to a server takes. They are values rather than a shape repeated
+// per command, so `--url` means the same thing everywhere it appears.
+const url = Flag.string("url").pipe(
+  Flag.withDescription("The server to call. Defaults to the client's own default base URL."),
+  Flag.optional
+)
+
+const token = Flag.string("token").pipe(
+  Flag.withDescription("The bearer token to present. Defaults to TARDIGRADE_TOKEN."),
+  Flag.optional
+)
+
+const json = Flag.boolean("json").pipe(
+  Flag.withDescription("Print the client's value verbatim as JSON instead of a table."),
+  Flag.withDefault(false)
+)
+
+const messageId = Flag.string("id").pipe(
+  Flag.withDescription(
+    "The message id, which is also the turn id and the dedup key. A fresh one is minted per invocation, so state it to make a retry absorbed rather than duplicated."
+  ),
+  Flag.optional
+)
+
+const remote = { url, token, json }
+
+// clientOf resolves where to call and opens the client, which is the one place the two sources meet
+// (config.ts, resolveRemote).
+const clientOf = (flags: {
+  readonly url: Option.Option<string>
+  readonly token: Option.Option<string>
+}) =>
+  Effect.map(Cli, (cli) => {
+    const resolved = resolveRemote({ url: stated(flags.url), token: stated(flags.token) }, cli.env)
+    return cli.openClient({ baseUrl: resolved.baseUrl, token: resolved.token })
+  })
+
+const stated = (option: Option.Option<string>): string | undefined => Option.getOrUndefined(option)
+
+const settle = (
+  client: Client,
+  agent: string,
+  turn: string,
+  pollMillis: number,
+  timeoutMillis: number
+): Effect.Effect<TurnView, CliError.UserError> =>
+  Effect.gen(function*() {
+    const started = yield* Clock.currentTimeMillis
+    for (;;) {
+      const view = yield* call(() => client.turn(agent, turn))
+      if (view.status !== "pending") return view
+      if ((yield* Clock.currentTimeMillis) - started >= timeoutMillis) {
+        return yield* Effect.fail(
+          userErrorOf(
+            `turn ${turn} on agent ${agent} was still pending after ${timeoutMillis}ms. It is still running: read it with \`tdg events ${agent}\`.`
+          )
+        )
+      }
+      yield* Effect.sleep(pollMillis)
+    }
+  })
+
+export const devCommand = Command.make("dev", {
+  port: Flag.integer("port").pipe(
+    Flag.withDescription("The port to listen on. Defaults to PORT, then the server's own default."),
+    Flag.optional
+  ),
+  db: Flag.string("db").pipe(
+    Flag.withDescription("The SQLite file that holds every log. Defaults to TARDIGRADE_DB."),
+    Flag.optional
+  ),
+  ui: Flag.string("ui").pipe(
+    Flag.withDescription("The directory holding the built UI. Defaults to the build shipped beside this command."),
+    Flag.optional
+  )
+}, (flags) =>
+  Effect.flatMap(Cli, (cli) =>
+    Effect.flatMap(
+      Effect.try({
+        try: () =>
+          dev({
+            config: resolveServer(
+              { port: Option.getOrUndefined(flags.port), db: stated(flags.db) },
+              cli.env
+            ),
+            assets: stated(flags.ui)
+          }),
+        catch: userErrorOf
+      }),
+      (layer) => Effect.mapError(Layer.launch(layer), userErrorOf)
+    ))).pipe(
+      Command.withDescription(
+        "Boot the API and serve the built UI at one URL, ungated on loopback. One process, one port: the API paths are the server's own and everything else is the UI."
+      ),
+      Command.withExamples([
+        { command: "tdg dev", description: "Listen on PORT, or on the server's default port" },
+        { command: "tdg dev --port 8080 --db runs.sqlite", description: "Listen elsewhere, on another store" }
+      ])
+    )
+
+export const runCommand = Command.make("run", {
+  brief: Argument.string("brief").pipe(Argument.withDescription("What to ask the agent to do")),
+  agent: Flag.string("agent").pipe(
+    Flag.withDescription("The agent to deliver to. A fresh id is minted per invocation, which births a new agent."),
+    Flag.optional
+  ),
+  id: messageId,
+  poll: Flag.integer("poll").pipe(
+    Flag.withDescription("Milliseconds between turn reads while waiting."),
+    Flag.withDefault(DEFAULT_POLL_MILLIS)
+  ),
+  timeout: Flag.integer("timeout").pipe(
+    Flag.withDescription("Milliseconds to wait for the turn to leave pending."),
+    Flag.withDefault(DEFAULT_TIMEOUT_MILLIS)
+  ),
+  ...remote
+}, (flags) =>
+  Effect.gen(function*() {
+    const cli = yield* Cli
+    const client = yield* clientOf(flags)
+    const agent = stated(flags.agent) ?? cli.mintId()
+    const id = stated(flags.id) ?? cli.mintId()
+    const accepted = yield* call(() => client.deliver(agent, { id, text: flags.brief }))
+    const view = yield* settle(client, accepted.agent, accepted.turn, flags.poll, flags.timeout)
+    yield* Console.log(flags.json ? jsonOf(view) : turnLines(accepted.agent, view))
+    if (view.status !== SETTLED) {
+      return yield* Effect.fail(userErrorOf(`turn ${view.turn} on agent ${accepted.agent} is ${view.status}`))
+    }
+  })).pipe(
+    Command.withDescription(
+      "Deliver a brief, wait for the turn to settle, and print what it answered. Exits non-zero unless the turn completed."
+    ),
+    Command.withExamples([
+      { command: "tdg run \"summarize the log\"", description: "Brief a new agent and wait for its answer" },
+      { command: "tdg run \"and again\" --agent surveyor", description: "Brief an agent that already exists" }
+    ])
+  )
+
+export const sendCommand = Command.make("send", {
+  agent: Argument.string("agent").pipe(Argument.withDescription("The agent to deliver to")),
+  brief: Argument.string("brief").pipe(Argument.withDescription("What to ask the agent to do")),
+  id: messageId,
+  ...remote
+}, (flags) =>
+  Effect.gen(function*() {
+    const cli = yield* Cli
+    const client = yield* clientOf(flags)
+    const id = stated(flags.id) ?? cli.mintId()
+    const accepted = yield* call(() => client.deliver(flags.agent, { id, text: flags.brief }))
+    yield* Console.log(flags.json ? jsonOf(accepted) : `${accepted.agent} ${accepted.turn}`)
+  })).pipe(
+    Command.withDescription(
+      "Deliver a brief and print the turn handle without waiting. The turn settles on the server's own loop."
+    )
+  )
+
+export const lsCommand = Command.make("ls", remote, (flags) =>
+  Effect.gen(function*() {
+    const client = yield* clientOf(flags)
+    const agents = yield* call(() => client.list())
+    yield* Console.log(flags.json ? jsonOf(agents) : agentsTable(agents))
+  })).pipe(
+    Command.withDescription("List the runs a store holds, parent before child."),
+    Command.withAlias("list")
+  )
+
+export const eventsCommand = Command.make("events", {
+  agent: Argument.string("agent").pipe(Argument.withDescription("The agent whose log to read")),
+  after: Flag.integer("after").pipe(
+    Flag.withDescription("Start past this sequence number. The server numbers events from 1."),
+    Flag.optional
+  ),
+  limit: Flag.integer("limit").pipe(
+    Flag.withDescription("Cap the rows read. Defaults to the server's own page size."),
+    Flag.optional
+  ),
+  types: Flag.string("types").pipe(
+    Flag.withDescription("Keep only these event types, as a comma list."),
+    Flag.optional
+  ),
+  width: Flag.integer("width").pipe(
+    Flag.withDescription("How wide the detail column may run before it is cut."),
+    Flag.withDefault(DEFAULT_DETAIL_WIDTH)
+  ),
+  ...remote
+}, (flags) =>
+  Effect.gen(function*() {
+    const client = yield* clientOf(flags)
+    const types = stated(flags.types)?.split(",").map((type) => type.trim()).filter((type) => type.length > 0)
+    const rows = yield* call(() =>
+      client.events(flags.agent, {
+        after: Option.getOrUndefined(flags.after),
+        limit: Option.getOrUndefined(flags.limit),
+        types
+      })
+    )
+    yield* Console.log(flags.json ? jsonOf(rows) : eventsTable(rows, flags.width))
+  })).pipe(
+    Command.withDescription("Print an agent's log, one line per event.")
+  )
+
+// The root. It has no handler, so `tdg` with no subcommand renders the help the declaration
+// generates, and an unknown subcommand fails with the module's own message and a non-zero exit.
+export const tdg = Command.make("tdg").pipe(
+  Command.withDescription(
+    "The tardigrade command. Every read is a projection of a durable log, and every failure is the server's own problem document."
+  ),
+  Command.withSubcommands([devCommand, runCommand, sendCommand, lsCommand, eventsCommand])
+)

--- a/apps/cli/src/config.test.ts
+++ b/apps/cli/src/config.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test"
+import { DEFAULT_BASE_URL } from "@clavia/tardigrade-client"
+import { DEFAULT_DB, DEFAULT_PORT } from "@clavia/tardigrade-server/config"
+
+import { resolveRemote, resolveServer } from "./config"
+
+// Configuration resolves in one place, and the order is the whole of what these assert: a flag
+// beats the environment, the environment beats the default, and a blank variable is not a value.
+
+describe("resolveRemote", () => {
+  test("an empty environment is the client's own default", () => {
+    expect(resolveRemote({}, {})).toEqual({ baseUrl: DEFAULT_BASE_URL, token: undefined })
+  })
+
+  test("the environment carries the token", () => {
+    expect(resolveRemote({}, { TARDIGRADE_TOKEN: "secret" }).token).toBe("secret")
+  })
+
+  test("a flag beats the environment", () => {
+    const resolved = resolveRemote(
+      { url: "https://agents.example.com", token: "stated" },
+      { TARDIGRADE_TOKEN: "secret" }
+    )
+    expect(resolved).toEqual({ baseUrl: "https://agents.example.com", token: "stated" })
+  })
+
+  test("a blank value is an absent one", () => {
+    expect(resolveRemote({ url: "   " }, { TARDIGRADE_TOKEN: "" })).toEqual({
+      baseUrl: DEFAULT_BASE_URL,
+      token: undefined
+    })
+  })
+})
+
+describe("resolveServer", () => {
+  test("an empty environment is the server's own defaults", () => {
+    const config = resolveServer({}, {})
+    expect(config.port).toBe(DEFAULT_PORT)
+    expect(config.db).toBe(DEFAULT_DB)
+    expect(config.token).toBeUndefined()
+  })
+
+  test("the environment is the server's surface, model coordinates included", () => {
+    const config = resolveServer({}, {
+      PORT: "8080",
+      TARDIGRADE_DB: "runs.sqlite",
+      MODEL_BASE_URL: "https://api.example.com",
+      MODEL_API_KEY: "key",
+      MODEL_ID: "a-model"
+    })
+    expect(config.port).toBe(8080)
+    expect(config.db).toBe("runs.sqlite")
+    expect(config.model.id).toBe("a-model")
+  })
+
+  test("a flag beats the environment", () => {
+    const config = resolveServer(
+      { port: 9000, db: "other.sqlite" },
+      { PORT: "8080", TARDIGRADE_DB: "runs.sqlite" }
+    )
+    expect(config.port).toBe(9000)
+    expect(config.db).toBe("other.sqlite")
+  })
+
+  // `tdg dev` is the local command and binds loopback (dev.ts, DEV_HOST), so the token the server
+  // would gate on is dropped rather than carried: a server meant to be reachable by anyone else is
+  // the server run directly.
+  test("the token is dropped, so the local server is ungated", () => {
+    expect(resolveServer({}, { TARDIGRADE_TOKEN: "secret" }).token).toBeUndefined()
+  })
+
+  // The reader is the server's own, so a value it refuses is a value this command refuses.
+  test("a PORT that is not a port refuses to resolve", () => {
+    expect(() => resolveServer({}, { PORT: "http" })).toThrow()
+  })
+})

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -1,0 +1,62 @@
+import { DEFAULT_BASE_URL } from "@clavia/tardigrade-client"
+import { readConfig, type Env, type ServerConfigValue } from "@clavia/tardigrade-server/config"
+
+// Where a value comes from, decided once. The environment is the server's own surface (PORT,
+// TARDIGRADE_DB, TARDIGRADE_TOKEN, MODEL_*), read by the server's own reader, and a flag stated on
+// the command line beats it. Nothing else is consulted: there is no config file and no
+// precedence order beyond those two (config.test.ts).
+
+export type { Env }
+
+// An empty or blank variable is an absent one, matching the server's reader: an exported variable
+// nobody set should not shadow a default.
+const text = (value: string | undefined): string | undefined => {
+  if (value === undefined) return undefined
+  const trimmed = value.trim()
+  return trimmed.length === 0 ? undefined : trimmed
+}
+
+// What a command that talks to a server over HTTP resolves to.
+export interface Remote {
+  readonly baseUrl: string
+  readonly token: string | undefined
+}
+
+export interface RemoteFlags {
+  readonly url?: string | undefined
+  readonly token?: string | undefined
+}
+
+// resolveRemote answers where to call and what to present. The base URL falls back to the client's
+// own default rather than to anything derived from PORT: PORT says where a server this machine
+// starts listens, and a command may be pointed at a server on another machine, so the two are
+// stated separately (config.test.ts, "a flag beats the environment").
+export const resolveRemote = (flags: RemoteFlags, env: Env): Remote => ({
+  baseUrl: text(flags.url) ?? DEFAULT_BASE_URL,
+  token: text(flags.token) ?? text(env["TARDIGRADE_TOKEN"])
+})
+
+export interface ServerFlags {
+  readonly port?: number | undefined
+  readonly db?: string | undefined
+}
+
+// resolveServer answers what `tdg dev` boots on. It starts from the server's own reader, so a
+// variable the server honours is a variable this command honours and the two can never disagree,
+// and then lets a flag win. A PORT that is not a port still refuses to resolve, because the reader
+// is the server's (apps/server/src/config.ts, readConfig).
+//
+// The token is dropped, `TARDIGRADE_TOKEN` in the environment included. `tdg dev` is the local
+// command: it binds loopback (dev.ts, DEV_HOST) and what keeps it private is the interface rather
+// than a secret. A server meant to be reachable by anyone else is the server run directly with a
+// token set (docs/how-to/server.md; config.test.ts, "the token is dropped, so the local server is
+// ungated").
+export const resolveServer = (flags: ServerFlags, env: Env): ServerConfigValue => {
+  const base = readConfig(env)
+  return {
+    ...base,
+    port: flags.port ?? base.port,
+    db: text(flags.db) ?? base.db,
+    token: undefined
+  }
+}

--- a/apps/cli/src/dev.test.ts
+++ b/apps/cli/src/dev.test.ts
@@ -1,0 +1,157 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, setDefaultTimeout, test } from "bun:test"
+import { Console, Effect, Exit, Layer } from "effect"
+import { HttpServer } from "effect/unstable/http"
+import { Command } from "effect/unstable/cli"
+import { BunServices } from "@effect/platform-bun"
+import { Infer } from "@clavia/tardigrade"
+import type { Action } from "@clavia/tardigrade/events"
+import { PROBLEM_CONTENT_TYPE } from "@clavia/tardigrade-client/contract"
+
+import { tdg } from "./commands"
+import { resolveServer } from "./config"
+import { dev, DEV_HOST } from "./dev"
+import { layerCli } from "./services"
+
+// Every case here boots a real server on an ephemeral port, so it competes with every other task in
+// a parallel gate run. Bun's default per-test budget is tuned for a pure function and times out
+// under that load; this is the budget a boot actually needs. It stays tight on purpose: a case that
+// wants longer than this is hanging rather than busy.
+const BOOT_MS = 20_000
+
+setDefaultTimeout(BOOT_MS)
+
+// One process end to end: the API the server declares and the UI the voyager builds, on one port,
+// driven by the command a person types. The model seam is bound to a scripted mind, which is the
+// same seam the server's own tests use (apps/server/src/api.test.ts), so this runs with no model
+// credentials and reaches a completed turn anyway.
+
+const INDEX = "<!doctype html><title>voyager</title>"
+
+const SCRIPT = "console.log(\"voyager\")"
+
+// A directory shaped like the build vite writes: one index and one hashed asset beside it.
+const buildDirectory = (): string => {
+  const root = mkdtempSync(join(tmpdir(), "tardigrade-dev-"))
+  writeFileSync(join(root, "index.html"), INDEX)
+  mkdirSync(join(root, "assets"))
+  writeFileSync(join(root, "assets", "app-abc123.js"), SCRIPT)
+  return root
+}
+
+const layerScripted: Layer.Layer<Infer> = Layer.succeed(Infer)({
+  react: () => Effect.succeed({ kind: "complete", output: "the scripted answer" } satisfies Action)
+})
+
+// booted starts the whole command on an ephemeral port and hands the body its base URL. ":memory:"
+// keeps the store to this process, so the case owns every event it reads.
+const booted = <A>(
+  body: (baseUrl: string, hostname: string) => Promise<A>,
+  env: Record<string, string | undefined> = {}
+): Promise<A> =>
+  Effect.gen(function*() {
+    const server = yield* HttpServer.HttpServer
+    const address = server.address
+    const port = address._tag === "TcpAddress" ? address.port : 0
+    const hostname = address._tag === "TcpAddress" ? address.hostname : ""
+    return yield* Effect.promise(() => body(`http://${hostname}:${port}`, hostname))
+  }).pipe(
+    Effect.provide(
+      dev({
+        config: resolveServer({ port: 0, db: ":memory:" }, env),
+        assets: buildDirectory(),
+        agents: { infer: layerScripted },
+        disableLogger: true,
+        disableListenLog: true
+      })
+    ),
+    Effect.scoped,
+    Effect.runPromise
+  ) as Promise<A>
+
+// Runs one invocation against the booted server through the real client, capturing what it printed.
+const drive = async (baseUrl: string, args: ReadonlyArray<string>) => {
+  const lines: Array<string> = []
+  const capture: Console.Console = Object.assign(Object.create(console), {
+    log: (...parts: ReadonlyArray<unknown>) => {
+      lines.push(parts.map((part) => String(part)).join(" "))
+    },
+    error: () => {}
+  })
+  const exit = await Command.runWith(tdg, { version: "test", renderErrors: false })([...args, "--url", baseUrl]).pipe(
+    Effect.provideService(Console.Console, capture),
+    Effect.provide(Layer.mergeAll(BunServices.layer, layerCli)),
+    Effect.runPromiseExit
+  )
+  return { lines, failed: Exit.isFailure(exit) }
+}
+
+describe("tdg dev", () => {
+  test("the API answers and the UI is served from one port", async () => {
+    const seen = await booted(async (baseUrl) => {
+      const health = await fetch(`${baseUrl}/healthz`)
+      const index = await fetch(`${baseUrl}/`, { headers: { accept: "text/html" } })
+      const asset = await fetch(`${baseUrl}/assets/app-abc123.js`)
+      // A path the router does not own, asked for by something that renders HTML, is the UI's own
+      // route: a deep link into the explorer is not a 404.
+      const deep = await fetch(`${baseUrl}/agents/root`, { headers: { accept: "text/html" } })
+      // The same path asked for as JSON is still the API's answer, so a script sees the problem
+      // document rather than a page.
+      const ghost = await fetch(`${baseUrl}/agents/ghost/events`, { headers: { accept: "application/json" } })
+      return {
+        health: { status: health.status, body: await health.json() },
+        index: { status: index.status, body: await index.text(), type: index.headers.get("content-type") },
+        asset: { status: asset.status, body: await asset.text(), type: asset.headers.get("content-type") },
+        deep: { status: deep.status, body: await deep.text() },
+        ghost: { status: ghost.status, type: ghost.headers.get("content-type") }
+      }
+    })
+    expect(seen.health).toEqual({ status: 200, body: { status: "resting", dirty: 0 } })
+    expect(seen.index.status).toBe(200)
+    expect(seen.index.body).toBe(INDEX)
+    expect(seen.index.type).toContain("text/html")
+    expect(seen.asset.status).toBe(200)
+    expect(seen.asset.body).toBe(SCRIPT)
+    expect(seen.asset.type).toContain("javascript")
+    expect(seen.deep.body).toBe(INDEX)
+    expect(seen.ghost.status).toBe(404)
+    expect(seen.ghost.type).toContain(PROBLEM_CONTENT_TYPE)
+  })
+
+  // `tdg dev` is the local command: it binds loopback and carries no gate, so `TARDIGRADE_TOKEN` in
+  // the environment changes nothing about it. A browser puts no bearer header on a top-level
+  // navigation, and a server meant to be reachable by anyone else is the server run directly with
+  // the token set (docs/how-to/server.md).
+  test("the API answers without a token, on loopback", async () => {
+    const seen = await booted(async (baseUrl, hostname) => {
+      const listed = await fetch(`${baseUrl}/agents`)
+      const index = await fetch(`${baseUrl}/`, { headers: { accept: "text/html" } })
+      return {
+        hostname,
+        listed: { status: listed.status, body: await listed.json() },
+        index: index.status
+      }
+    }, { TARDIGRADE_TOKEN: "secret" })
+    expect(seen.hostname).toBe(DEV_HOST)
+    expect(seen.listed).toEqual({ status: 200, body: [] })
+    expect(seen.index).toBe(200)
+  })
+
+  test("run drives a brief to a completed turn with no model credentials", async () => {
+    const seen = await booted(async (baseUrl) => {
+      const ran = await drive(baseUrl, ["run", "survey the log", "--agent", "root", "--id", "m1", "--poll", "10"])
+      const listed = await drive(baseUrl, ["ls", "--json"])
+      const logged = await drive(baseUrl, ["events", "root", "--types", "MessageReceived"])
+      const ghost = await drive(baseUrl, ["events", "ghost"])
+      return { ran, listed, logged, ghost }
+    })
+    expect(seen.ran.failed).toBe(false)
+    expect(seen.ran.lines[0]).toBe("root m1 completed\nthe scripted answer")
+    expect(JSON.parse(seen.listed.lines[0] ?? "")).toMatchObject([{ id: "root", status: "settled" }])
+    expect(seen.logged.lines[0]).toContain("MessageReceived")
+    expect(seen.logged.lines[0]).toContain("survey the log")
+    expect(seen.ghost.failed).toBe(true)
+  })
+})

--- a/apps/cli/src/dev.ts
+++ b/apps/cli/src/dev.ts
@@ -1,0 +1,74 @@
+import { Effect, Layer } from "effect"
+import { HttpRouter, HttpStaticServer } from "effect/unstable/http"
+import { BunHttpServer } from "@effect/platform-bun"
+import { layerConfig, type ServerConfigValue } from "@clavia/tardigrade-server/config"
+import { layerAgents, type AgentsOptions } from "@clavia/tardigrade-server/host"
+import { layerApp } from "@clavia/tardigrade-server/http"
+
+import { resolveAssets } from "./assets"
+
+// One process: the server's own application, plus the voyager's build at `/`. The API paths are the
+// server's, unchanged, because the application layer is the server's own; this module adds one
+// fallback beside it (dev.test.ts, "the API answers and the UI is served from one port").
+
+// The interface this command binds. It is stated rather than defaulted, and there is no flag to
+// widen it: the process is ungated, so what keeps it private is the interface rather than a secret,
+// and a server meant to be reachable by anyone else is the server run directly with a token
+// (docs/how-to/server.md, dev.test.ts, "the API answers without a token, on loopback").
+export const DEV_HOST = "127.0.0.1"
+
+// The status that means the router matched nothing. It is the seam the UI is served through: the
+// declared routes answer first, and only a path none of them owns reaches the build.
+export const UNMATCHED = 404
+
+// layerVoyager serves a built directory under whatever the router did not match. It is a middleware
+// rather than a `GET /*` route because the server already answers every unmatched path with a
+// problem document (apps/server/src/http.ts, layerNotFound), and two catch-alls in one router is an
+// ambiguity rather than a fallback.
+//
+// A path that names a file is served as that file. A path that names nothing is served the index
+// when the caller accepts HTML, which is what makes a deep link into the UI work and what keeps an
+// API 404 a problem document for a caller that asked for JSON (dev.test.ts, "the API answers and
+// the UI is served from one port").
+export const layerVoyager = (root: string) =>
+  HttpRouter.middleware(
+    Effect.map(
+      HttpStaticServer.make({ root, spa: true }),
+      (assets) => (httpEffect) =>
+        Effect.flatMap(httpEffect, (response) =>
+          response.status === UNMATCHED
+            ? Effect.orElseSucceed(assets, () => response)
+            : Effect.succeed(response))
+    ),
+    { global: true }
+  )
+
+export interface DevOptions {
+  readonly config: ServerConfigValue
+  // Where the built UI lives. Absent, the two layouts a build can arrive in are tried in order
+  // (assets.ts, ASSET_CANDIDATES).
+  readonly assets?: string | undefined
+  // The model seam, which a test binds to a scripted mind (apps/server/src/host.ts, AgentsOptions).
+  readonly agents?: AgentsOptions | undefined
+  readonly disableLogger?: boolean | undefined
+  readonly disableListenLog?: boolean | undefined
+}
+
+// dev is the whole command: resolve the build, open the store, listen on loopback. It answers a
+// Layer rather than a running process, so the caller owns the scope and the process that stops
+// listening stops writing (apps/server/src/host.ts, layerAgents).
+export const dev = (options: DevOptions) => {
+  const root = resolveAssets(options.assets)
+  const config = layerConfig(options.config)
+  const agents = Layer.provide(layerAgents(options.agents ?? {}), config)
+  // provideMerge rather than provide: the listening server stays visible in the layer's own
+  // services, which is what lets a caller read the address it was given when it asked for port 0
+  // (dev.test.ts).
+  return Layer.provideMerge(
+    HttpRouter.serve(Layer.mergeAll(layerApp(), layerVoyager(root)), {
+      disableLogger: options.disableLogger ?? false,
+      disableListenLog: options.disableListenLog ?? false
+    }),
+    [BunHttpServer.layer({ port: options.config.port, hostname: DEV_HOST }), config, agents]
+  )
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env bun
+import { Effect, Layer } from "effect"
+import { Command } from "effect/unstable/cli"
+import { BunRuntime, BunServices } from "@effect/platform-bun"
+import { assertSupportedBun } from "@clavia/tardigrade-core/runtime"
+
+import { tdg } from "./commands"
+import { layerCli } from "./services"
+import { versionIn } from "./version"
+
+// The entry point: arguments in, one command run, an exit code out. It holds no logic of its own,
+// so everything worth testing lives in commands.ts, config.ts, or render.ts and is exercised
+// without a process (commands.test.ts).
+
+// The process refuses to run on a runtime the framework cannot keep its promises on, rather than
+// failing later inside a turn (packages/core/src/runtime.ts).
+assertSupportedBun()
+
+const version = await versionIn(import.meta.url)
+
+Command.run(tdg, { version }).pipe(
+  Effect.provide(Layer.mergeAll(BunServices.layer, layerCli)),
+  BunRuntime.runMain
+)

--- a/apps/cli/src/render.test.ts
+++ b/apps/cli/src/render.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test"
+import type { AgentSummary, EventRow } from "@clavia/tardigrade-client"
+
+import { agentsTable, ABSENT, DEFAULT_DETAIL_WIDTH, ELLIPSIS, eventsTable, table, turnLines } from "./render"
+
+// The human rendering. A table is plain aligned text, so these assert on columns rather than on
+// escape sequences, and a value the projection did not carry reads as absent rather than as empty.
+
+const agents: ReadonlyArray<AgentSummary> = [
+  { id: "root", events: 12, lastAt: 0, status: "settled" },
+  { id: "root.1", parent: "root", events: 3, status: "running" }
+]
+
+describe("table", () => {
+  test("columns are padded to the widest cell and the last is not", () => {
+    const lines = table(["A", "BB"], [["x", "y"], ["longer", "z"]]).split("\n")
+    expect(lines).toEqual(["A       BB", "x       y", "longer  z"])
+  })
+})
+
+describe("agentsTable", () => {
+  test("a run is one row, and an absent field reads as absent", () => {
+    const lines = agentsTable(agents).split("\n")
+    expect(lines[0]).toContain("AGENT")
+    expect(lines[1]).toContain("root")
+    expect(lines[1]).toContain("settled")
+    expect(lines[1]).toContain("1970-01-01T00:00:00.000Z")
+    expect(lines[1]).toContain(ABSENT)
+    expect(lines[2]).toContain("root.1")
+  })
+
+  test("an empty store says so", () => {
+    expect(agentsTable([])).toBe("no agents")
+  })
+})
+
+describe("eventsTable", () => {
+  const rows: ReadonlyArray<EventRow> = [
+    { seq: 7, event: { type: "MessageReceived", id: "m1", text: "hello" } },
+    { seq: 8, event: { type: "Settled" } }
+  ]
+
+  test("one line per event, carrying its sequence number", () => {
+    const lines = eventsTable(rows).split("\n")
+    expect(lines).toHaveLength(3)
+    expect(lines[1]).toContain("7")
+    expect(lines[1]).toContain("MessageReceived")
+    expect(lines[1]).toContain("\"text\":\"hello\"")
+    expect(lines[2]).toContain("Settled")
+  })
+
+  test("a detail wider than the column is cut and marked", () => {
+    const wide: EventRow = { seq: 1, event: { type: "ToolReturned", result: "x".repeat(DEFAULT_DETAIL_WIDTH * 2) } }
+    const line = eventsTable([wide]).split("\n")[1] ?? ""
+    expect(line).toContain(ELLIPSIS)
+    expect(line.length).toBeLessThan(DEFAULT_DETAIL_WIDTH * 2)
+  })
+
+  test("a stated width is the width", () => {
+    const wide: EventRow = { seq: 1, event: { type: "T", result: "x".repeat(50) } }
+    const line = eventsTable([wide], 20).split("\n")[1] ?? ""
+    expect(line.endsWith(ELLIPSIS)).toBe(true)
+  })
+
+  test("an empty log says so", () => {
+    expect(eventsTable([])).toBe("no events")
+  })
+})
+
+describe("turnLines", () => {
+  test("a completed turn prints its output under its handle", () => {
+    expect(turnLines("root", { turn: "m1", status: "completed", output: "ok" })).toBe("root m1 completed\nok")
+  })
+
+  test("a failed turn prints its error", () => {
+    expect(turnLines("root", { turn: "m1", status: "failed", error: "no model" })).toBe("root m1 failed\nno model")
+  })
+
+  test("a pending turn is its handle alone", () => {
+    expect(turnLines("root", { turn: "m1", status: "pending" })).toBe("root m1 pending")
+  })
+})

--- a/apps/cli/src/render.ts
+++ b/apps/cli/src/render.ts
@@ -1,0 +1,83 @@
+import type { AgentSummary, EventRow, TurnView } from "@clavia/tardigrade-client"
+
+// What a command puts on stdout. Two renderings of the same value: aligned text for a person and
+// the client's own value for a pipe (`--json`), which is why every function here takes what the
+// client answered and nothing else. No colour and no icons: a table that is only readable on a
+// terminal that understands escapes is not readable in a log, a pager, or a pull request
+// (render.test.ts).
+
+// How wide an event's detail column is allowed to run before it is cut. A log line is meant to be
+// scanned, and one event carrying a whole tool payload would push every other column off screen.
+// `tdg events --width` sets it, and `--json` is the rendering with no cut at all.
+export const DEFAULT_DETAIL_WIDTH = 96
+
+// What stands in a cell whose value the projection did not carry.
+export const ABSENT = "-"
+
+export const jsonOf = (value: unknown): string => JSON.stringify(value, undefined, 2)
+
+// table lays out rows under headers, padding each column to its widest cell. Two spaces separate
+// columns, so a value containing one space still reads as one cell.
+export const table = (headers: ReadonlyArray<string>, rows: ReadonlyArray<ReadonlyArray<string>>): string => {
+  const widths = headers.map((header, column) =>
+    rows.reduce((width, row) => Math.max(width, (row[column] ?? "").length), header.length)
+  )
+  const line = (cells: ReadonlyArray<string>) =>
+    cells.map((cell, column) => (column === cells.length - 1 ? cell : cell.padEnd(widths[column] ?? 0)))
+      .join("  ")
+      .trimEnd()
+  return [line(headers), ...rows.map(line)].join("\n")
+}
+
+// The mark a cut leaves, so a reader can tell a cut value from a short one.
+export const ELLIPSIS = "..."
+
+const truncate = (value: string, width: number): string =>
+  value.length <= width ? value : `${value.slice(0, Math.max(width - ELLIPSIS.length, 0))}${ELLIPSIS}`
+
+const timeOf = (at: number | undefined): string =>
+  at === undefined ? ABSENT : new Date(at).toISOString()
+
+// The runs a store holds. `events` is the count of events in the log, which is the size of the
+// thing every other read projects from, and `last` is when the log last grew.
+export const agentsTable = (agents: ReadonlyArray<AgentSummary>): string =>
+  agents.length === 0
+    ? "no agents"
+    : table(
+      ["AGENT", "STATUS", "EVENTS", "LAST", "PARENT"],
+      agents.map((agent) => [
+        agent.id,
+        agent.status,
+        String(agent.events),
+        timeOf(agent.lastAt),
+        agent.parent ?? ABSENT
+      ])
+    )
+
+// The fields of an event other than its type, as one compact object. The type is already a column,
+// and what remains is what tells two events of one type apart.
+const detailOf = (row: EventRow): string => {
+  const { type: _type, ...rest } = row.event
+  const keys = Object.keys(rest)
+  return keys.length === 0 ? "" : JSON.stringify(rest)
+}
+
+// One line per event, which is what makes the log greppable. `seq` is the event's position in the
+// whole log and survives a `--types` filter, so a filtered listing still names real positions
+// (apps/server/src/api.ts, "events").
+export const eventsTable = (rows: ReadonlyArray<EventRow>, width = DEFAULT_DETAIL_WIDTH): string =>
+  rows.length === 0
+    ? "no events"
+    : table(
+      ["SEQ", "TYPE", "DETAIL"],
+      rows.map((row) => [String(row.seq), row.event.type, truncate(detailOf(row), width)])
+    )
+
+// A turn's boundary as a person reads it: the status word, then whichever of output or error the
+// projection carried.
+export const turnLines = (agent: string, view: TurnView): string => {
+  const head = `${agent} ${view.turn} ${view.status}`
+  if (view.output !== undefined) return `${head}\n${view.output}`
+  if (view.error !== undefined) return `${head}\n${view.error}`
+  return head
+}

--- a/apps/cli/src/render.ts
+++ b/apps/cli/src/render.ts
@@ -38,7 +38,7 @@ const truncate = (value: string, width: number): string =>
 const timeOf = (at: number | undefined): string =>
   at === undefined ? ABSENT : new Date(at).toISOString()
 
-// The runs a store holds. `events` is the count of events in the log, which is the size of the
+// Every agent a store holds, parent before child. `events` is the count of events in the log, which is the size of the
 // thing every other read projects from, and `last` is when the log last grew.
 export const agentsTable = (agents: ReadonlyArray<AgentSummary>): string =>
   agents.length === 0

--- a/apps/cli/src/services.ts
+++ b/apps/cli/src/services.ts
@@ -1,0 +1,26 @@
+import { Context, Layer } from "effect"
+import { makeClient, type Client, type ClientOptions } from "@clavia/tardigrade-client"
+
+import type { Env } from "./config"
+
+// The two things a command reads that are not its own arguments: the environment it resolves
+// configuration from, and the client it calls a server with. They are one service so that a test
+// drives a real command tree against a client it wrote, with an environment it stated, and no
+// process to spawn (commands.test.ts).
+
+export interface CliServices {
+  readonly env: Env
+  readonly openClient: (options: ClientOptions) => Client
+  // Where the invocation's message id comes from. A retried invocation carrying the same id is
+  // absorbed by the server rather than started twice (docs/how-to/server.md, "Redelivery is
+  // absorbed"), so the id is minted once per delivery and is stated in the help.
+  readonly mintId: () => string
+}
+
+export class Cli extends Context.Service<Cli, CliServices>()("tardigrade/cli/Cli") {}
+
+export const layerCli: Layer.Layer<Cli> = Layer.succeed(Cli)({
+  env: process.env,
+  openClient: makeClient,
+  mintId: () => crypto.randomUUID()
+})

--- a/apps/cli/src/version.ts
+++ b/apps/cli/src/version.ts
@@ -1,0 +1,37 @@
+import { readFile } from "node:fs/promises"
+import { fileURLToPath } from "node:url"
+
+// What `tdg --version` answers. The number is read off the manifest the command was installed from
+// rather than written down here, because a copy of a version is a copy that rots
+// (version.test.ts).
+//
+// Two layouts hold that manifest, the same two the UI arrives in (assets.ts). Installed, the
+// command sits at `src/cli/` under the package root. In this repository, it sits at
+// `apps/cli/src/`, and the version that matters is the workspace root's, since that is the one the
+// publish tool stamps on the package (tools/publish.ts).
+
+export const INSTALLED_MANIFEST = "../../package.json"
+
+export const REPO_MANIFEST = "../../../package.json"
+
+export const MANIFEST_CANDIDATES: ReadonlyArray<string> = [INSTALLED_MANIFEST, REPO_MANIFEST]
+
+// What is reported when no manifest can be read, which is a command running from somewhere neither
+// layout describes.
+export const UNKNOWN_VERSION = "0.0.0-unknown"
+
+const versionOf = async (path: string): Promise<string | undefined> => {
+  const raw: unknown = await readFile(path, "utf8").then(JSON.parse).catch(() => undefined)
+  if (typeof raw !== "object" || raw === null) return undefined
+  const version = (raw as { version?: unknown }).version
+  return typeof version === "string" ? version : undefined
+}
+
+// versionIn reads the first manifest that answers, relative to the module that asks.
+export const versionIn = async (from: string): Promise<string> => {
+  for (const candidate of MANIFEST_CANDIDATES) {
+    const found = await versionOf(fileURLToPath(new URL(candidate, from)))
+    if (found !== undefined) return found
+  }
+  return UNKNOWN_VERSION
+}

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, setDefaultTimeout, test } from "bun:test"
 import { Effect, Layer } from "effect"
 import { HttpServer } from "effect/unstable/http"
 import { BunHttpServer } from "@effect/platform-bun"
@@ -12,6 +12,14 @@ import type { EventRow } from "@clavia/tardigrade-client/contract"
 import { layerAgents } from "./host"
 import { PROBLEM_CONTENT_TYPE, serve } from "./http"
 import type { AgentSummary, AgentNode, TurnView } from "./projections"
+
+// Every case here boots a real server on an ephemeral port, so it competes with every other task in
+// a parallel gate run. Bun's default per-test budget is tuned for a pure function and times out
+// under that load; this is the budget a boot actually needs. It stays tight on purpose: a case that
+// wants longer than this is hanging rather than busy.
+const BOOT_MS = 20_000
+
+setDefaultTimeout(BOOT_MS)
 
 // The API over a real Bun server on an ephemeral port, over a real durable host on a volatile
 // database, with the model seam bound to a scripted mind: every assertion here is about what a

--- a/apps/server/src/contract.test.ts
+++ b/apps/server/src/contract.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, setDefaultTimeout, test } from "bun:test"
 import { Effect, Layer } from "effect"
 import { HttpBody, HttpClient } from "effect/unstable/http"
 import { OpenApi } from "effect/unstable/httpapi"
@@ -43,10 +43,13 @@ const serving = <A, E>(
     Effect.runPromise
   ) as Promise<A>
 
-// A case here boots a real server on an ephemeral port, so it competes with every other task in a
-// parallel gate run. The default per-test budget is tuned for a pure function and times out under
-// that load; this is the budget a boot actually needs.
+// Every case here boots a real server on an ephemeral port, so it competes with every other task in
+// a parallel gate run. Bun's default per-test budget is tuned for a pure function and times out
+// under that load; this is the budget a boot actually needs. It stays tight on purpose: a case that
+// wants longer than this is hanging rather than busy.
 const BOOT_MS = 20_000
+
+setDefaultTimeout(BOOT_MS)
 
 // Every route the server answers, as method and OpenAPI path. The stream is absent because it is
 // not a declared endpoint (api.ts, layerStream).
@@ -100,7 +103,7 @@ describe("the OpenAPI document", () => {
     expect(answers.page.status).toBe(200)
     expect(answers.page.type).toContain("text/html")
     expect(answers.page.body).toContain("Scalar")
-  }, BOOT_MS)
+  })
 
   // The document describes the door rather than opening it, so a token does not close it
   // (http.ts, UNAUTHENTICATED_PATHS).
@@ -113,7 +116,7 @@ describe("the OpenAPI document", () => {
         return [document.status, page.status, gated.status]
       }))
     expect(statuses).toEqual([200, 200, 401])
-  }, BOOT_MS)
+  })
 })
 
 describe("problem documents", () => {
@@ -145,7 +148,7 @@ describe("problem documents", () => {
     // An endpoint declaring two failures encodes the one the value names, so the 404 does not
     // render as the 400 beside it (contract.ts, problemKind).
     expect(failures[2]!.body).toMatchObject({ title: "Unknown Agent" })
-  }, BOOT_MS)
+  })
 
   // A Schema in the declaration refusing input is a failure like any other, so it answers in the
   // same shape rather than as the empty 400 the framework renders by default (contract.ts,
@@ -190,5 +193,5 @@ describe("problem documents", () => {
     expect(details[4]).toContain("`id` is not a value it accepts")
     // A body that is not an object at all names no field, so the sentence stops at the part.
     expect(details[5]).toBe("The request body is not what this endpoint accepts.")
-  }, BOOT_MS)
+  })
 })

--- a/apps/server/src/host.test.ts
+++ b/apps/server/src/host.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, setDefaultTimeout, test } from "bun:test"
 import { Context, Effect, Layer } from "effect"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { Infer, type InferRequest } from "@clavia/tardigrade"
@@ -7,6 +7,14 @@ import type { Action } from "@clavia/tardigrade/events"
 import { layerConfig, readConfig } from "./config"
 import { Agents, layerAgents, ResumeRefused } from "./host"
 import { DriverGauge } from "./http"
+
+// Every case here opens a real store on disk and drives a real host, so it competes with every
+// other task in a parallel gate run. Bun's default per-test budget is tuned for a pure function and
+// times out under that load; this is the budget a boot actually needs. It stays tight on purpose: a
+// case that wants longer than this is hanging rather than busy.
+const BOOT_MS = 20_000
+
+setDefaultTimeout(BOOT_MS)
 
 // The host service against a real durable host on a volatile database, with the model seam bound
 // to a scripted mind: no credentials, no network, and the turn loop is the library's own.

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, setDefaultTimeout, test } from "bun:test"
 import { Effect, Layer } from "effect"
 import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { BunHttpServer } from "@effect/platform-bun"
@@ -6,6 +6,14 @@ import { BunHttpServer } from "@effect/platform-bun"
 import { DEFAULT_DB, DEFAULT_PORT, layerConfig, readConfig, type ServerConfigValue } from "./config"
 import { Agents } from "./host"
 import { ALLOWED_HEADERS, layerGaugeResting, serve, PROBLEM_CONTENT_TYPE, DriverGauge, type Health } from "./http"
+
+// Every case here boots a real server on an ephemeral port, so it competes with every other task in
+// a parallel gate run. Bun's default per-test budget is tuned for a pure function and times out
+// under that load; this is the budget a boot actually needs. It stays tight on purpose: a case that
+// wants longer than this is hanging rather than busy.
+const BOOT_MS = 20_000
+
+setDefaultTimeout(BOOT_MS)
 
 // The HTTP surface against a real Bun server on an ephemeral port, so the assertions are about
 // wire behavior rather than about the shape of a layer.

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,20 @@
         "oxlint": "^1.69.0",
       },
     },
+    "apps/cli": {
+      "name": "@clavia/tardigrade-cli",
+      "version": "0.0.1",
+      "dependencies": {
+        "@clavia/tardigrade-client": "workspace:*",
+        "@clavia/tardigrade-core": "workspace:*",
+        "@clavia/tardigrade-server": "workspace:*",
+        "@effect/platform-bun": "4.0.0-rc.110",
+        "effect": "4.0.0-rc.110",
+      },
+      "devDependencies": {
+        "@clavia/tardigrade": "workspace:*",
+      },
+    },
     "apps/server": {
       "name": "@clavia/tardigrade-server",
       "version": "0.0.1",
@@ -186,6 +200,8 @@
     "@clavia/tardigrade": ["@clavia/tardigrade@workspace:packages/agent"],
 
     "@clavia/tardigrade-bun": ["@clavia/tardigrade-bun@workspace:platform/bun"],
+
+    "@clavia/tardigrade-cli": ["@clavia/tardigrade-cli@workspace:apps/cli"],
 
     "@clavia/tardigrade-client": ["@clavia/tardigrade-client@workspace:packages/client"],
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,5 +2,6 @@
 
 - [quickstart.md](quickstart.md): all the core concepts you need to get started.
 - [how-to/server.md](how-to/server.md): run the self-hostable server, its environment, and its endpoints.
+- [how-to/cli.md](how-to/cli.md): drive a server from the command line with `tdg`.
 - [explanations/runtime-and-recovery.md](explanations/runtime-and-recovery.md): runtime requirements, retry scopes, and failed-turn recovery.
 - [explanations/why.md](explanations/why.md): why tardigrade exists. {transitions} = f(log), and what the log-as-state shape enables.

--- a/docs/how-to/cli.md
+++ b/docs/how-to/cli.md
@@ -22,7 +22,7 @@ bun run --cwd apps/cli start -- --help
 | `tdg dev` | Boot the API and serve the built UI at one URL. One process, one port, one thing to stop. |
 | `tdg run "<brief>"` | Deliver a brief, wait for the turn to settle, and print what it answered. |
 | `tdg send <agent> "<brief>"` | Deliver a brief and print the turn handle without waiting. |
-| `tdg ls` | The runs a store holds, parent before child, as a table. |
+| `tdg ls` | Every agent a store holds, parent before child, as a table. |
 | `tdg events <agent>` | The log, one line per event. |
 
 `tdg --help` prints the tree and `tdg <command> --help` prints one command. A command nobody declared exits non-zero and says which command it looked like.

--- a/docs/how-to/cli.md
+++ b/docs/how-to/cli.md
@@ -1,0 +1,80 @@
+# Use the command line
+
+`tdg` is the front door to a running server. It is a few lines over the derived client (`packages/client`), so a command it can send is a route the server declared, and the values it prints are the client's own. The command tree is a declaration: each command states its flags, its arguments, and its description as values, so the help a person reads, the errors a mistake gets, and the completions a shell installs all come from the same tree the parser runs.
+
+## Run it
+
+```bash
+bun add @clavia/tardigrade
+bunx tdg --help
+```
+
+Inside this repository the same command runs from the workspace:
+
+```bash
+bun run --cwd apps/cli start -- --help
+```
+
+## The commands
+
+| Command | What it does |
+| --- | --- |
+| `tdg dev` | Boot the API and serve the built UI at one URL. One process, one port, one thing to stop. |
+| `tdg run "<brief>"` | Deliver a brief, wait for the turn to settle, and print what it answered. |
+| `tdg send <agent> "<brief>"` | Deliver a brief and print the turn handle without waiting. |
+| `tdg ls` | The runs a store holds, parent before child, as a table. |
+| `tdg events <agent>` | The log, one line per event. |
+
+`tdg --help` prints the tree and `tdg <command> --help` prints one command. A command nobody declared exits non-zero and says which command it looked like.
+
+## Configuration resolves in one place
+
+A flag beats the environment, and the environment is the server's own surface, read by the server's own reader (`apps/server/src/config.ts`, `readConfig`), so a variable the server honours is a variable this command honours. There is no config file and no third source.
+
+| What | Flag | Environment | Default |
+| --- | --- | --- | --- |
+| The server to call | `--url` | absent | `DEFAULT_BASE_URL` (`packages/client/src/client.ts`) |
+| The bearer token the remote commands present | `--token` | `TARDIGRADE_TOKEN` | absent |
+| The port `tdg dev` listens on | `--port` | `PORT` | `DEFAULT_PORT` (`apps/server/src/config.ts`) |
+| The store `tdg dev` opens | `--db` | `TARDIGRADE_DB` | `DEFAULT_DB` (`apps/server/src/config.ts`) |
+| The model binding | absent | `MODEL_BASE_URL`, `MODEL_API_KEY`, `MODEL_ID`, `MODEL_PROVIDER` | absent |
+
+The model is yours. This framework ships no provider, no endpoint, and no key, so a turn runs against whatever `MODEL_BASE_URL`, `MODEL_API_KEY`, and `MODEL_ID` name, on your account, with `MODEL_PROVIDER` naming a protocol other than the OpenAI-compatible default. A server with those unset still boots and still answers every read, and a turn it is asked to run fails saying which variables are missing.
+
+`--url` has no variable of its own because `PORT` says where a server this machine starts listens, and a command may be pointed at a server on another machine. Point it with `--url` and the two stay separate things. The token is a remote-command value for the same reason: it is what a command presents to a server, and `tdg dev` gates nothing.
+
+## One process serves the API and the UI
+
+`tdg dev` boots the server's own application and serves the voyager's build under whatever the API does not own. The API paths are unchanged: the declared routes answer first, and a path none of them matches falls through to the build. A path that names a file is served as that file, and a path that names nothing is served the index when the caller accepts HTML, which is what makes a deep link into the explorer work while a client asking for JSON still reads the problem document.
+
+The build is found rather than configured. A published install carries the assets staged beside the sources at publish time, and inside this repository the build is where vite wrote it, so `bun run --cwd apps/voyager build` is what makes `tdg dev` serve a UI here. A build in neither place is a failure raised before the process listens, naming the command to run and the places that were looked in (`apps/cli/src/assets.ts`, `BUILD_COMMAND`). Hot reload stays the voyager's own dev script: this command serves a build and proxies nothing.
+
+`tdg dev` is the local command: it binds loopback (`DEV_HOST`) and runs ungated, so it takes no token and ignores `TARDIGRADE_TOKEN`, and what keeps it private is the interface it listens on rather than a secret. A server meant to be reachable by anyone else is the server run directly with `TARDIGRADE_TOKEN` set, which [Run the server](server.md) covers; `--token` stays on `ls`, `events`, `run`, and `send`, since those may be pointed at one.
+
+## Running without a model
+
+The server boots without model coordinates and every turn it drives fails with the sentence the server already gives. `tdg dev` boots the same way, and `tdg run` reports that failure as the turn's error and exits non-zero, so the first run is honest rather than silent. Set the three variables and the same brief runs.
+
+## Waiting, and what a retry costs
+
+`tdg send` returns as soon as the server has accepted the message, because a delivery answers `202` and the turn settles on the server's own loop. `tdg run` waits: it delivers, then reads the turn every `DEFAULT_POLL_MILLIS` until it leaves `pending`, and gives up after `DEFAULT_TIMEOUT_MILLIS` while saying that the turn is still running (`apps/cli/src/commands.ts`). `--poll` and `--timeout` set both. The exit code is zero only when the turn completed.
+
+Both commands mint a message id per invocation unless `--id` states one. The id is the dedup key end to end and becomes the turn id, so an invocation retried with the same `--id` is absorbed by the server rather than started twice, and an invocation retried without one starts a second turn. `tdg run` also mints the agent when `--agent` states none, which births a new agent, since an agent exists once its log has an event.
+
+## Output for people, and for pipes
+
+Every command prints aligned plain text by default and takes `--json`, which prints the client's value verbatim on standard output. There is no colour and there are no icons, so a table reads the same in a terminal, a pager, and a log. `tdg events` cuts its detail column at `DEFAULT_DETAIL_WIDTH` characters and `--width` sets that; `--json` is the rendering with no cut at all.
+
+## Failures
+
+A failed call prints the server's own problem document as its title, its status, and its detail, and exits non-zero. A call that never reached a response prints its title alone, because there is no status to quote. A stack trace is never what a caller sees.
+
+## Shell completions
+
+The tree generates its own completions:
+
+```bash
+tdg --completions zsh > ~/.zsh/completions/_tdg
+```
+
+`bash`, `fish`, and `sh` are the others. The script it prints carries its own installation note in a comment at the top.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clavia/tardigrade-client",
   "version": "0.0.1",
-  "private": false,
+  "private": true,
   "license": "MIT",
   "author": "Clavia, Inc.",
   "description": "The declared HTTP API of the tardigrade server, and the client derived from it.",

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, describe, expect, test } from "bun:test"
+import { beforeEach, describe, expect, test } from "bun:test"
 
 import { makeClient, UNEXPECTED_RESPONSE_TITLE } from "./client"
 import { PROBLEM_CONTENT_TYPE, PROBLEM_TYPE_BASE } from "./contract"
@@ -19,16 +19,14 @@ const emptyList = () => new Response("[]", { status: 200, headers: { "content-ty
 
 let answer: () => Response = emptyList
 
-const realFetch = globalThis.fetch
-globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+// The stand-in is stated to the client rather than assigned to `globalThis`. The transport reads
+// its default once per process, so a global assigned after any other fetch-backed request would
+// never be consulted and these calls would reach whatever owns the port.
+const stub = ((input: string | URL | Request, init?: RequestInit) => {
   const headers = new Headers(init?.headers ?? {})
   calls.push({ url: String(input), headers: Object.fromEntries(headers.entries()) })
   return Promise.resolve(answer())
 }) as typeof globalThis.fetch
-
-afterAll(() => {
-  globalThis.fetch = realFetch
-})
 
 beforeEach(() => {
   calls.length = 0
@@ -41,13 +39,22 @@ const problemAnswer = (status: number, document: unknown) => () =>
   new Response(JSON.stringify(document), { status, headers: { "content-type": PROBLEM_CONTENT_TYPE } })
 
 describe("the address a call goes to", () => {
+  // The transport reads its default fetch once per process, so a stated one is the only way a
+  // caller routes requests elsewhere: a global assigned later is never consulted (client.ts,
+  // ClientOptions.fetch).
+  test("sends every request through the stated fetch", async () => {
+    await makeClient({ baseUrl: "http://localhost:4111", fetch: stub }).list()
+    expect(calls).toHaveLength(1)
+    expect(lastUrl().pathname).toBe("/agents")
+  })
+
   test("an agent id is encoded into the path", async () => {
-    await makeClient({ baseUrl: "http://localhost:4111" }).events("ag/one two")
+    await makeClient({ baseUrl: "http://localhost:4111" , fetch: stub }).events("ag/one two")
     expect(lastUrl().pathname).toBe("/agents/ag%2Fone%20two/events")
   })
 
   test("a stated option is a query param and an absent one is absent", async () => {
-    await makeClient({ baseUrl: "http://localhost:4111" }).events("root", { after: 40, types: ["MessageReceived", "TurnEnded"] })
+    await makeClient({ baseUrl: "http://localhost:4111" , fetch: stub }).events("root", { after: 40, types: ["MessageReceived", "TurnEnded"] })
     const url = lastUrl()
     expect(url.searchParams.get("after")).toBe("40")
     expect(url.searchParams.get("types")).toBe("MessageReceived,TurnEnded")
@@ -55,21 +62,21 @@ describe("the address a call goes to", () => {
   })
 
   test("a base with a trailing slash does not double it", async () => {
-    await makeClient({ baseUrl: "http://127.0.0.1:4111/" }).list()
+    await makeClient({ baseUrl: "http://127.0.0.1:4111/" , fetch: stub }).list()
     expect(calls[0]!.url).toBe("http://127.0.0.1:4111/agents")
   })
 })
 
 describe("the token", () => {
   test("rides an authorization header on every request", async () => {
-    const client = makeClient({ baseUrl: "http://localhost:4111", token: "shh" })
+    const client = makeClient({ baseUrl: "http://localhost:4111", token: "shh" , fetch: stub })
     await client.list()
     await client.events("root")
     expect(calls.map((call) => call.headers["authorization"])).toEqual(["Bearer shh", "Bearer shh"])
   })
 
   test("no token means no header", async () => {
-    await makeClient({ baseUrl: "http://localhost:4111" }).list()
+    await makeClient({ baseUrl: "http://localhost:4111" , fetch: stub }).list()
     expect(calls[0]!.headers["authorization"]).toBeUndefined()
   })
 })
@@ -83,7 +90,7 @@ describe("a failed call", () => {
       detail: 'No agent named "ghost" has ever existed.'
     }
     answer = problemAnswer(404, document)
-    const failure = await makeClient({ baseUrl: "http://localhost:4111" }).events("ghost").catch((error: unknown) => error)
+    const failure = await makeClient({ baseUrl: "http://localhost:4111" , fetch: stub }).events("ghost").catch((error: unknown) => error)
     expect(failure).toBeInstanceOf(ProblemError)
     const problem = failure as ProblemError
     expect(problem.type).toBe(document.type)
@@ -101,7 +108,7 @@ describe("a failed call", () => {
       status: 401,
       detail: "This server requires a bearer token."
     })
-    const failure = await makeClient({ baseUrl: "http://localhost:4111" }).list().catch((error: unknown) => error) as ProblemError
+    const failure = await makeClient({ baseUrl: "http://localhost:4111" , fetch: stub }).list().catch((error: unknown) => error) as ProblemError
     expect(failure.title).toBe("Unauthorized")
     expect(failure.status).toBe(401)
     expect(failure.detail).toBe("This server requires a bearer token.")
@@ -109,7 +116,7 @@ describe("a failed call", () => {
 
   test("a body that is not a problem document falls back to the status", async () => {
     answer = () => new Response("<html>", { status: 502, headers: { "content-type": "text/html" } })
-    const failure = await makeClient({ baseUrl: "http://localhost:4111" }).list().catch((error: unknown) => error) as ProblemError
+    const failure = await makeClient({ baseUrl: "http://localhost:4111" , fetch: stub }).list().catch((error: unknown) => error) as ProblemError
     expect(failure.title).toBe(UNEXPECTED_RESPONSE_TITLE)
     expect(failure.status).toBe(502)
   })

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -43,6 +43,12 @@ export interface ClientOptions {
   readonly token?: string | undefined
   // How the tail opens a connection. The default is `globalThis.EventSource`.
   readonly eventSource?: OpenEventSource | undefined
+  // How a request reaches the network. The default is the platform's own fetch, read through
+  // FetchHttpClient's reference. A caller states this to route requests somewhere else: a test
+  // stub, a proxy, or a runtime whose fetch is not the global one. Patching `globalThis.fetch`
+  // does not work, because the reference resolves its default once per process
+  // (client.test.ts, "sends every request through the stated fetch").
+  readonly fetch?: typeof globalThis.fetch | undefined
 }
 
 export interface EventsOptions {
@@ -129,7 +135,12 @@ export const makeClient = (options: ClientOptions = {}): Client => {
       ...(token === undefined
         ? {}
         : { transformClient: (client: HttpClient.HttpClient) => HttpClient.mapRequest(client, HttpClientRequest.bearerToken(token)) })
-    }).pipe(Effect.provide(FetchHttpClient.layer))
+    }).pipe(
+      Effect.provide(FetchHttpClient.layer),
+      options.fetch === undefined
+        ? (self) => self
+        : Effect.provideService(FetchHttpClient.Fetch, options.fetch)
+    )
   )
   return {
     baseUrl,

--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, setDefaultTimeout, test } from "bun:test"
 import { mkdtempSync, readFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -20,6 +20,14 @@ import {
   DEFAULT_BUN_WORKSPACE_SQL_DOC,
   WORKSPACE_TABLE
 } from "./workspace"
+
+// Every case here opens a real store on disk and drives a real host, so it competes with every
+// other task in a parallel gate run. Bun's default per-test budget is tuned for a pure function and
+// times out under that load; this is the budget a boot actually needs. It stays tight on purpose: a
+// case that wants longer than this is hanging rather than busy.
+const BOOT_MS = 20_000
+
+setDefaultTimeout(BOOT_MS)
 
 // The bun binding against the reference host's contract, plus the two behaviors only physics
 // can show: a reopened database keeps the log, and recover() settles work a death interrupted.

--- a/platform/bun/src/runtime.test.ts
+++ b/platform/bun/src/runtime.test.ts
@@ -1,4 +1,11 @@
-import { expect, test } from "bun:test"
+import { expect, setDefaultTimeout, test } from "bun:test"
+
+// This case waits out a ten second response on purpose: the deadline it proves is the one that
+// keeps a slow answer from being cut off, so the wall clock is the assertion. The budget is that
+// floor plus room for a parallel gate run, and no more, so a hang still fails rather than waits.
+const DEADLINE_MS = 25_000
+
+setDefaultTimeout(DEADLINE_MS)
 
 test("a numeric fetch deadline extends Bun's socket idle deadline", async () => {
   const server = Bun.serve({
@@ -27,4 +34,4 @@ test("a numeric fetch deadline extends Bun's socket idle deadline", async () => 
   } finally {
     server.stop(true)
   }
-}, 15_000)
+})

--- a/sdk-and-cli-spec.md
+++ b/sdk-and-cli-spec.md
@@ -1,0 +1,50 @@
+# SDK and CLI (draft 1)
+
+Two pieces, one dependency between them: the server's routes become a declared `HttpApi`, and everything else derives from that declaration. The CLI is then a thin front door, and the voyager stops hand-maintaining a copy of the wire types.
+
+## Phase 1: the API becomes a declaration
+
+`apps/server` currently builds routes as layer-shaped `HttpRouter` handlers, and the contract lives in prose. Rewrite it as an `HttpApi` (all in-package with effect, no new dependency):
+
+- `HttpApiEndpoint` per route, with Schema for path params, query, success, and errors. The eight endpoints from the server spec, minus the stream (below).
+- `HttpApiGroup` for the agents group, `HttpApi` for the whole surface.
+- `HttpApiBuilder` implements it, calling the same `Agents` service and the same pure projections. The projections do not change; only the plumbing above them does.
+- Errors keep the problem+json shape through `HttpApiSchema` annotations, so the wire contract stays what the voyager already renders.
+
+What falls out of that declaration for free: `HttpApiClient` (a typed client), `OpenApi.fromApi` (a spec derived from the implementation, so it cannot drift), and a `/docs` page via `HttpApiScalar`.
+
+The SSE stream stays on `HttpRouter`. `HttpApi` is request-and-response shaped, and forcing a stream through it buys nothing. The client hand-writes the small `stream()` helper over `EventSource`, exactly as it does today.
+
+## Phase 2: one client
+
+`HttpApiClient.make(Api, { baseUrl })` is the client, published as `@clavia/tardigrade/client` through a MEMBERS entry in `tools/publish.ts`. It replaces `apps/voyager/src/api.ts` entirely: the hand-copied `AgentSummary`, `TurnView`, and `EventRow` types die, and the server's Schemas become the one definition all three consumers read.
+
+Effect and Schema enter the browser bundle. That is accepted, with one obligation: measure the built bundle in the same PR and record the number, so a later regression has a baseline to fail against. If the number ever stops being acceptable, the escape hatch is generating a zero-dependency client from our own OpenAPI document, which the declaration already produces.
+
+The bearer token and the base URL stay client construction options. `problem+json` failures surface as typed errors the UI renders verbatim.
+
+## Phase 3: the CLI
+
+`apps/cli`, published as the `tdg` bin on the same npm package, so one install gives the library, the server, the UI, and the command.
+
+    tdg dev                      boot the API and serve the voyager's build at one URL
+    tdg run "<brief>"            deliver, drive to quiescence, print the terminal
+    tdg send <agent> "<brief>"   deliver and print the turn handle
+    tdg ls                       the runs a store holds
+    tdg events <agent>           the log, for piping
+
+`run` is reserved for running an agent, which is why the dev command is `tdg dev` rather than `tdg run dev`.
+
+Every command is a few lines over the client. `tdg dev` boots one process: the server owns the log, the driver, and the HTTP surface, and serves the voyager's built assets at `/`. One URL, one port, one thing to kill. Inside the repo, Vite still runs separately for hot reload.
+
+Configuration resolves in one place and is the server's existing environment surface (`PORT`, `TARDIGRADE_DB`, `TARDIGRADE_TOKEN`, the `MODEL_*` fields), with flags overriding env. With no model configured the server still boots and turns fail with the message the server already gives, so the first run is honest rather than broken.
+
+The CLI is also the write surface. The voyager is read-only by decision, so `tdg send` and `tdg run` are how an agent gets created outside a script.
+
+## Sequencing
+
+The voyager PR lands first, since phase 2 deletes the file that PR is still editing. Then phase 1 and 2 as one PR (the declaration and the client that derives from it, with the voyager migrated in the same change, because the old client dies with it). Then phase 3.
+
+## Out of scope
+
+Generated clients for other languages (the OpenAPI document makes that a downstream job), auth beyond the existing bearer token, and any command that mutates a running agent beyond delivering a message.

--- a/tools/gate.ts
+++ b/tools/gate.ts
@@ -13,7 +13,7 @@ const packages = ["core", "code", "agent", "host", "client"]
 const platformPkg = (name: string) => `${root}platform/${name}`
 const platforms = ["model", "bun"]
 const appPkg = (name: string) => `${root}apps/${name}`
-const apps = ["server", "voyager"]
+const apps = ["cli", "server", "voyager"]
 // Apps that ship a bundle. A typecheck proves the sources agree; only a build proves the bundler
 // can resolve and emit them.
 const bundled = ["voyager"]

--- a/tools/publish.ts
+++ b/tools/publish.ts
@@ -30,8 +30,26 @@ const sources = [
   { dir: "packages/host", namespace: "host" },
   { dir: "packages/client", namespace: "client" },
   { dir: "platform/bun", namespace: "bun" },
-  { dir: "platform/model", namespace: "model" }
+  { dir: "platform/model", namespace: "model" },
+  { dir: "apps/server", namespace: "server" },
+  { dir: "apps/cli", namespace: "cli" }
 ] as const
+
+// The command the package installs, and the module it points at. One install gives the library, the
+// server, the UI, and the command (sdk-and-cli-spec.md, "Phase 3").
+const BIN_NAME = "tdg"
+
+const BIN_ENTRY = "./src/cli/main.ts"
+
+// Where the UI's build is staged, and where it comes from. `tdg dev` resolves this directory
+// relative to its own module, so a published command finds the build with no configuration. The
+// name is not the workspace directory's, so the candidate this command tries inside the repository
+// cannot match it (apps/cli/src/assets.ts, INSTALLED_ASSETS).
+const STAGED_ASSETS = "ui"
+
+const VOYAGER_SOURCE = "apps/voyager/dist"
+
+const VOYAGER_BUILD = ["bun", "run", "--cwd", "apps/voyager", "build"]
 
 const npmMin = { maj: 11, min: 5, patch: 1 } as const
 
@@ -147,9 +165,13 @@ const stage = join(destination, "package")
 
 try {
   await mkdir(stage, { recursive: true })
+  // The UI is built here rather than assumed: the tarball carries the assets `tdg dev` serves, and
+  // a stale build shipped as a fresh one is worse than the wait.
+  await run(VOYAGER_BUILD, root)
   await Promise.all([
     cp(join(root, "LICENSE"), join(stage, "LICENSE")),
     cp(join(root, "README.md"), join(stage, "README.md")),
+    cp(join(root, VOYAGER_SOURCE), join(stage, STAGED_ASSETS), { recursive: true }),
     ...packages.map(async (source) => {
       await cp(join(root, source.dir, "src"), join(stage, "src", source.namespace), {
         recursive: true,
@@ -179,9 +201,10 @@ try {
         : repository,
     bugs: publicSource.pkg.bugs,
     publishConfig: publicSource.pkg.publishConfig,
-    files: ["src"],
+    files: ["src", STAGED_ASSETS],
     engines: publicSource.pkg.engines,
     type: "module",
+    bin: { [BIN_NAME]: BIN_ENTRY },
     exports: {
       ".": "./src/agent/index.ts",
       "./package.json": "./package.json",
@@ -192,6 +215,8 @@ try {
       "./client": "./src/client/index.ts",
       "./client/*": "./src/client/*.ts",
       "./bun/*": "./src/bun/*.ts",
+      "./server/*": "./src/server/*.ts",
+      "./cli/*": "./src/cli/*.ts",
       "./model": "./src/model/model.ts",
       "./model/*": "./src/model/*.ts",
       "./*": "./src/agent/*.ts"


### PR DESCRIPTION
The voyager is read-only by decision, so creating and briefing an agent meant raw curl. tdg is the front door: five commands over the derived client, plus one command that boots the API and serves the explorer at a single URL.

    tdg dev                      boot the API and serve the voyager's build, local and ungated
    tdg run "<brief>"            deliver, drive to quiescence, print the terminal
    tdg send <agent> "<brief>"   deliver and print the turn handle
    tdg ls                       the runs a store holds
    tdg events <agent>           the log, one line per event

- built on effect/unstable/cli, so the command tree is a declaration: help, examples, the did-you-mean on a wrong subcommand, and shell completions all derive from the same values the parser runs, and no usage string is written by hand
- every command takes --json and prints the client's values verbatim; a ProblemError renders as its title, status, and detail with a non-zero exit and no stack trace
- run and send mint a message id per invocation, so a retried command is absorbed by the log's own dedup rather than duplicated
- tdg dev is local: it binds loopback and runs ungated, since a bearer cannot ride a browser navigation and a shared secret is not what protects a dev box. A server meant to be reachable is the one run directly with TARDIGRADE_TOKEN, which the server how-to covers. --token stays on the remote commands, which may point at a gated server elsewhere
- the model stays the operator's: no provider, endpoint, or key ships, and a server with the MODEL_* variables unset still boots and answers reads while a turn fails naming what is missing
- publishing gains the cli and the server as members, a tdg bin, and the voyager build staged into the tarball; verified by installing the packed tarball and running the binary
- boot-based tests across the repo now carry explicit budgets, which removes a flake that appeared when suites booting real servers competed under a parallel gate
- bun run gate green across 25 tasks, three consecutive runs

Also carries a fix a review found in the client that shipped with #135. Its tests stubbed the network by assigning globalThis.fetch, which never worked: the transport reads its fetch from a reference whose default resolves once per process, so in a shared process those tests silently reached whatever owned port 4111. Verified both ways, 7 failures before and none after.

- ClientOptions gains fetch, so a caller states how requests reach the network: a test stub, a proxy, or a runtime whose fetch is not the global one
- packages/client becomes private like every other internal workspace, since tools/publish.ts folds it into the single tarball and the flag as it stood would have let a workspace-wide publish push a package the project does not otherwise own
