### PR TITLE
docs: drop documentation section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,16 +2,6 @@
 
 [docs/README.md](docs/README.md) describes what this repository is and how the framework works. [CONTRIBUTING.md](CONTRIBUTING.md) covers setup, the gate, and pull requests.
 
-## Documentation
-
-`docs/` is the source of truth for repository behavior. It describes the repository as it is now.
-
-Do not write or revise a page in `docs/` unless the change asks for it. A page is read by a person who is deciding something, so it is worth a deliberate pass rather than a paragraph appended beside every change. When a change makes a page wrong, say so in the pull request and leave the page alone.
-
-State each fact in one place. If `docs/` contains a fact, link to it from this file, a README, or a comment.
-
-Keep the docs conceptual. Use diagrams, invariants, and links to explain concepts. Write what a thing is and why it has its shape. Do not include file maps or descriptions of documents.
-
 ## Design
 
 No silent hardcoding. When the framework applies a policy value, such as a cap, a threshold, a timeout, or a limit, the consumer must be able to see it and set it. Export the default, accept an override at the call site or on the surface that applies it, and make the effect visible in the output when the policy changes what the model sees. A constant a consumer can read but cannot change is a leaky abstraction; be explicit instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,9 @@
 
 ## Documentation
 
-`docs/` is the source of truth for repository behavior. It describes the repository as it is now. When behavior changes, update the docs in the same change.
+`docs/` is the source of truth for repository behavior. It describes the repository as it is now.
+
+Do not write or revise a page in `docs/` unless the change asks for it. A page is read by a person who is deciding something, so it is worth a deliberate pass rather than a paragraph appended beside every change. When a change makes a page wrong, say so in the pull request and leave the page alone.
 
 State each fact in one place. If `docs/` contains a fact, link to it from this file, a README, or a comment.
 


### PR DESCRIPTION
The Documentation section told every change to update docs/ alongside it, which turns a page into a place paragraphs accumulate rather than something written on purpose. Drop the section: docs/ pages get written when someone sets out to write them.

- remove the Documentation section from AGENTS.md
- the Style section still covers how a page reads when one is written, including the greenfield rule and the docs linter