### PR TITLE
refactor(api)!: name actors and threads

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "MIT",
   "author": "Clavia, Inc.",
-  "description": "The tdg command: run an agent, watch its log, and serve the API and the UI at one URL.",
+  "description": "The tdg command: run a thread, watch its log, and serve the API and the UI at one URL.",
   "homepage": "https://github.com/clavia-labs/tardigrade#readme",
   "repository": {
     "type": "git",

--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { Cause, Console, Effect, Exit, Layer, Option } from "effect"
 import { CliError, Command } from "effect/unstable/cli"
 import { BunServices } from "@effect/platform-bun"
-import { ProblemError, type Accepted, type AgentSummary, type Client, type EventRow, type TurnView } from "@clavia/tardigrade-client"
+import { ProblemError, RESERVED_ACTOR, type Accepted, type ThreadSummary, type Client, type EventRow, type TurnView } from "@clavia/tardigrade-client"
 
 import { problemLine, tdg } from "./commands"
 import { Cli, type CliServices } from "./services"
@@ -10,7 +10,7 @@ import { Cli, type CliServices } from "./services"
 // The command tree, driven the way a shell drives it: real arguments through the real parser, over
 // a client this file wrote. Nothing here spawns a process, and nothing here reaches a network.
 
-const agents: ReadonlyArray<AgentSummary> = [
+const threads: ReadonlyArray<ThreadSummary> = [
   { id: "root", events: 2, lastAt: 0, status: "settled" }
 ]
 
@@ -20,8 +20,8 @@ const events: ReadonlyArray<EventRow> = [
 ]
 
 interface Recorded {
-  readonly delivered: Array<{ agent: string; id: string; text: string }>
-  readonly asked: Array<{ agent: string; options: unknown }>
+  readonly delivered: Array<{ thread: string; id: string; text: string }>
+  readonly asked: Array<{ thread: string; options: unknown }>
 }
 
 const refuse = () => Promise.reject(new Error("this command should not have called that"))
@@ -31,7 +31,7 @@ const refuse = () => Promise.reject(new Error("this command should not have call
 const clientOf = (
   recorded: Recorded,
   answers: {
-    readonly list?: ReadonlyArray<AgentSummary>
+    readonly list?: ReadonlyArray<ThreadSummary>
     readonly events?: ReadonlyArray<EventRow>
     readonly turns?: ReadonlyArray<TurnView>
     readonly fail?: ProblemError
@@ -40,20 +40,21 @@ const clientOf = (
   let read = 0
   return {
     baseUrl: "http://localhost:0",
+    actor: RESERVED_ACTOR,
     list: () => (answers.fail === undefined ? Promise.resolve(answers.list ?? []) : Promise.reject(answers.fail)),
-    events: (agent, options) => {
-      recorded.asked.push({ agent, options })
+    events: (thread, options) => {
+      recorded.asked.push({ thread, options })
       return answers.fail === undefined ? Promise.resolve(answers.events ?? []) : Promise.reject(answers.fail)
     },
-    turn: (_agent, _turn) => {
+    turn: (_thread, _turn) => {
       const views = answers.turns ?? []
       const view = views[Math.min(read++, views.length - 1)]
       return view === undefined ? refuse() : Promise.resolve(view)
     },
-    deliver: (agent, message) => {
-      recorded.delivered.push({ agent, id: message.id, text: message.text })
+    deliver: (thread, message) => {
+      recorded.delivered.push({ thread, id: message.id, text: message.text })
       return answers.fail === undefined
-        ? Promise.resolve({ agent, turn: message.id } satisfies Accepted)
+        ? Promise.resolve({ actor: RESERVED_ACTOR, thread, turn: message.id } satisfies Accepted)
         : Promise.reject(answers.fail)
     },
     tree: refuse,
@@ -143,7 +144,7 @@ describe("parsing", () => {
   test("a missing argument fails", async () => {
     const ran = await drive(["events"])
     expect(ran.failed).toBe(true)
-    expect(failureText(ran).toLowerCase()).toContain("agent")
+    expect(failureText(ran).toLowerCase()).toContain("thread")
   })
 
   test("an unknown flag fails", async () => {
@@ -160,16 +161,16 @@ describe("parsing", () => {
 
 describe("ls", () => {
   test("the human rendering is a table", async () => {
-    const ran = await drive(["ls"], { answers: { list: agents } })
+    const ran = await drive(["ls"], { answers: { list: threads } })
     expect(ran.failed).toBe(false)
     const lines = (ran.lines[0] ?? "").split("\n")
-    expect(lines[0]).toContain("AGENT")
+    expect(lines[0]).toContain("THREAD")
     expect(lines[1]).toContain("root")
   })
 
   test("--json prints the client's value verbatim", async () => {
-    const ran = await drive(["ls", "--json"], { answers: { list: agents } })
-    expect(JSON.parse(ran.lines[0] ?? "")).toEqual(agents)
+    const ran = await drive(["ls", "--json"], { answers: { list: threads } })
+    expect(JSON.parse(ran.lines[0] ?? "")).toEqual(threads)
   })
 })
 
@@ -192,7 +193,7 @@ describe("events", () => {
       { answers: { events } }
     )
     expect(ran.recorded.asked[0]).toEqual({
-      agent: "root",
+      thread: "root",
       options: { after: 3, limit: 5, types: ["MessageReceived", "TurnCompleted"] }
     })
   })
@@ -202,7 +203,7 @@ describe("send", () => {
   test("the turn handle is printed and nothing is waited on", async () => {
     const ran = await drive(["send", "root", "do the thing"])
     expect(ran.lines[0]).toBe("root minted-1")
-    expect(ran.recorded.delivered).toEqual([{ agent: "root", id: "minted-1", text: "do the thing" }])
+    expect(ran.recorded.delivered).toEqual([{ thread: "root", id: "minted-1", text: "do the thing" }])
   })
 
   test("a stated id is the id, so a retry is absorbed", async () => {
@@ -212,14 +213,14 @@ describe("send", () => {
 
   test("--json prints the handle verbatim", async () => {
     const ran = await drive(["send", "root", "again", "--json", "--id", "m1"])
-    expect(JSON.parse(ran.lines[0] ?? "")).toEqual({ agent: "root", turn: "m1" })
+    expect(JSON.parse(ran.lines[0] ?? "")).toEqual({ actor: RESERVED_ACTOR, thread: "root", turn: "m1" })
   })
 })
 
 describe("run", () => {
   test("a pending turn is polled until it settles, and the output is printed", async () => {
     const ran = await drive(
-      ["run", "summarize", "--agent", "root", "--id", "m1", "--poll", "1"],
+      ["run", "summarize", "--thread", "root", "--id", "m1", "--poll", "1"],
       {
         answers: {
           turns: [
@@ -233,15 +234,15 @@ describe("run", () => {
     expect(ran.lines[0]).toBe("root m1 completed\nthe summary")
   })
 
-  test("an agent nobody named is minted, so a run births its own agent", async () => {
+  test("a thread nobody named is minted, so a run births its own thread", async () => {
     const ran = await drive(["run", "hello", "--poll", "1"], {
       answers: { turns: [{ turn: "minted-2", status: "completed", output: "hi" }] }
     })
-    expect(ran.recorded.delivered).toEqual([{ agent: "minted-1", id: "minted-2", text: "hello" }])
+    expect(ran.recorded.delivered).toEqual([{ thread: "minted-1", id: "minted-2", text: "hello" }])
   })
 
   test("a failed turn prints its error and exits non-zero", async () => {
-    const ran = await drive(["run", "hello", "--agent", "root", "--id", "m1", "--poll", "1"], {
+    const ran = await drive(["run", "hello", "--thread", "root", "--id", "m1", "--poll", "1"], {
       answers: { turns: [{ turn: "m1", status: "failed", error: "no model is configured" }] }
     })
     expect(ran.lines[0]).toBe("root m1 failed\nno model is configured")
@@ -249,7 +250,7 @@ describe("run", () => {
   })
 
   test("a turn that never settles gives up rather than hanging", async () => {
-    const ran = await drive(["run", "hello", "--agent", "root", "--id", "m1", "--poll", "1", "--timeout", "0"], {
+    const ran = await drive(["run", "hello", "--thread", "root", "--id", "m1", "--poll", "1", "--timeout", "0"], {
       answers: { turns: [{ turn: "m1", status: "pending" }] }
     })
     expect(ran.failed).toBe(true)
@@ -259,14 +260,14 @@ describe("run", () => {
 
 describe("failures", () => {
   const problem = new ProblemError({
-    type: "https://tardigrade.dev/problems/unknown-agent",
-    title: "Unknown Agent",
+    type: "https://tardigrade.dev/problems/unknown-thread",
+    title: "Unknown Thread",
     status: 404,
-    detail: "No agent named \"ghost\" has ever existed."
+    detail: "No thread named \"ghost\" has ever existed."
   })
 
   test("a problem document prints its title, status, and detail", () => {
-    expect(problemLine(problem)).toBe("Unknown Agent (404): No agent named \"ghost\" has ever existed.")
+    expect(problemLine(problem)).toBe("Unknown Thread (404): No thread named \"ghost\" has ever existed.")
   })
 
   // A call that never reached a response has no status line to quote.
@@ -277,6 +278,6 @@ describe("failures", () => {
   test("a failed call exits non-zero carrying the server's words", async () => {
     const ran = await drive(["events", "ghost"], { answers: { fail: problem } })
     expect(ran.failed).toBe(true)
-    expect(failureText(ran)).toContain("Unknown Agent (404)")
+    expect(failureText(ran)).toContain("Unknown Thread (404)")
   })
 })

--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -58,7 +58,7 @@ const clientOf = (
         : Promise.reject(answers.fail)
     },
     tree: refuse,
-    turns: refuse,
+    projection: refuse,
     resume: refuse,
     health: refuse,
     follow: () => () => {}

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -4,7 +4,7 @@ import { NO_ANSWER, ProblemError, type Client, type TurnView } from "@clavia/tar
 
 import { resolveRemote, resolveServer } from "./config"
 import { dev } from "./dev"
-import { agentsTable, DEFAULT_DETAIL_WIDTH, eventsTable, jsonOf, turnLines } from "./render"
+import { threadsTable, DEFAULT_DETAIL_WIDTH, eventsTable, jsonOf, turnLines } from "./render"
 import { Cli } from "./services"
 
 // The command tree. Every command is a declaration: its flags, its arguments, and its description
@@ -23,7 +23,7 @@ export const DEFAULT_POLL_MILLIS = 200
 export const DEFAULT_TIMEOUT_MILLIS = 300_000
 
 // The turn status a run is asked for. Everything else, `failed` and `parked` alike, leaves the
-// command with a non-zero exit: a script that ran an agent and got no answer should not read as
+// command with a non-zero exit: a script that ran a turn and got no answer should not read as
 // success (commands.test.ts, "a failed turn prints its error and exits non-zero").
 export const SETTLED: TurnView["status"] = "completed"
 
@@ -88,7 +88,7 @@ const stated = (option: Option.Option<string>): string | undefined => Option.get
 
 const settle = (
   client: Client,
-  agent: string,
+  thread: string,
   turn: string,
   pollMillis: number,
   timeoutMillis: number
@@ -96,12 +96,12 @@ const settle = (
   Effect.gen(function*() {
     const started = yield* Clock.currentTimeMillis
     for (;;) {
-      const view = yield* call(() => client.turn(agent, turn))
+      const view = yield* call(() => client.turn(thread, turn))
       if (view.status !== "pending") return view
       if ((yield* Clock.currentTimeMillis) - started >= timeoutMillis) {
         return yield* Effect.fail(
           userErrorOf(
-            `turn ${turn} on agent ${agent} was still pending after ${timeoutMillis}ms. It is still running: read it with \`tdg events ${agent}\`.`
+            `turn ${turn} on thread ${thread} was still pending after ${timeoutMillis}ms. It is still running: read it with \`tdg events ${thread}\`.`
           )
         )
       }
@@ -148,9 +148,9 @@ export const devCommand = Command.make("dev", {
     )
 
 export const runCommand = Command.make("run", {
-  brief: Argument.string("brief").pipe(Argument.withDescription("What to ask the agent to do")),
-  agent: Flag.string("agent").pipe(
-    Flag.withDescription("The agent to deliver to. A fresh id is minted per invocation, which births a new agent."),
+  brief: Argument.string("brief").pipe(Argument.withDescription("What to ask the actor to do")),
+  thread: Flag.string("thread").pipe(
+    Flag.withDescription("The thread to deliver to. A fresh id is minted per invocation, which births a new thread."),
     Flag.optional
   ),
   id: messageId,
@@ -167,27 +167,27 @@ export const runCommand = Command.make("run", {
   Effect.gen(function*() {
     const cli = yield* Cli
     const client = yield* clientOf(flags)
-    const agent = stated(flags.agent) ?? cli.mintId()
+    const thread = stated(flags.thread) ?? cli.mintId()
     const id = stated(flags.id) ?? cli.mintId()
-    const accepted = yield* call(() => client.deliver(agent, { id, text: flags.brief }))
-    const view = yield* settle(client, accepted.agent, accepted.turn, flags.poll, flags.timeout)
-    yield* Console.log(flags.json ? jsonOf(view) : turnLines(accepted.agent, view))
+    const accepted = yield* call(() => client.deliver(thread, { id, text: flags.brief }))
+    const view = yield* settle(client, accepted.thread, accepted.turn, flags.poll, flags.timeout)
+    yield* Console.log(flags.json ? jsonOf(view) : turnLines(accepted.thread, view))
     if (view.status !== SETTLED) {
-      return yield* Effect.fail(userErrorOf(`turn ${view.turn} on agent ${accepted.agent} is ${view.status}`))
+      return yield* Effect.fail(userErrorOf(`turn ${view.turn} on thread ${accepted.thread} is ${view.status}`))
     }
   })).pipe(
     Command.withDescription(
-      "Deliver a brief, wait for the turn to settle, and print what it answered. Exits non-zero unless the turn completed."
+      "Start a thread, wait for its turn to settle, and print what it answered. Exits non-zero unless the turn completed."
     ),
     Command.withExamples([
-      { command: "tdg run \"summarize the log\"", description: "Brief a new agent and wait for its answer" },
-      { command: "tdg run \"and again\" --agent surveyor", description: "Brief an agent that already exists" }
+      { command: "tdg run \"summarize the log\"", description: "Brief a new thread and wait for its answer" },
+      { command: "tdg run \"and again\" --thread surveyor", description: "Brief a thread that already exists" }
     ])
   )
 
 export const sendCommand = Command.make("send", {
-  agent: Argument.string("agent").pipe(Argument.withDescription("The agent to deliver to")),
-  brief: Argument.string("brief").pipe(Argument.withDescription("What to ask the agent to do")),
+  thread: Argument.string("thread").pipe(Argument.withDescription("The thread to deliver to")),
+  brief: Argument.string("brief").pipe(Argument.withDescription("What to ask the actor to do")),
   id: messageId,
   ...remote
 }, (flags) =>
@@ -195,8 +195,8 @@ export const sendCommand = Command.make("send", {
     const cli = yield* Cli
     const client = yield* clientOf(flags)
     const id = stated(flags.id) ?? cli.mintId()
-    const accepted = yield* call(() => client.deliver(flags.agent, { id, text: flags.brief }))
-    yield* Console.log(flags.json ? jsonOf(accepted) : `${accepted.agent} ${accepted.turn}`)
+    const accepted = yield* call(() => client.deliver(flags.thread, { id, text: flags.brief }))
+    yield* Console.log(flags.json ? jsonOf(accepted) : `${accepted.thread} ${accepted.turn}`)
   })).pipe(
     Command.withDescription(
       "Deliver a brief and print the turn handle without waiting. The turn settles on the server's own loop."
@@ -206,15 +206,15 @@ export const sendCommand = Command.make("send", {
 export const lsCommand = Command.make("ls", remote, (flags) =>
   Effect.gen(function*() {
     const client = yield* clientOf(flags)
-    const agents = yield* call(() => client.list())
-    yield* Console.log(flags.json ? jsonOf(agents) : agentsTable(agents))
+    const threads = yield* call(() => client.list())
+    yield* Console.log(flags.json ? jsonOf(threads) : threadsTable(threads))
   })).pipe(
-    Command.withDescription("List every agent a store holds, parent before child. A spawned child is an agent like any other, so a run that spawned nine lists ten rows."),
+    Command.withDescription("List every thread a store holds, parent before child. A spawned child is a thread like any other, so a run that spawned nine lists ten rows."),
     Command.withAlias("list")
   )
 
 export const eventsCommand = Command.make("events", {
-  agent: Argument.string("agent").pipe(Argument.withDescription("The agent whose log to read")),
+  thread: Argument.string("thread").pipe(Argument.withDescription("The thread whose log to read")),
   after: Flag.integer("after").pipe(
     Flag.withDescription("Start past this sequence number. The server numbers events from 1."),
     Flag.optional
@@ -237,7 +237,7 @@ export const eventsCommand = Command.make("events", {
     const client = yield* clientOf(flags)
     const types = stated(flags.types)?.split(",").map((type) => type.trim()).filter((type) => type.length > 0)
     const rows = yield* call(() =>
-      client.events(flags.agent, {
+      client.events(flags.thread, {
         after: Option.getOrUndefined(flags.after),
         limit: Option.getOrUndefined(flags.limit),
         types
@@ -245,7 +245,7 @@ export const eventsCommand = Command.make("events", {
     )
     yield* Console.log(flags.json ? jsonOf(rows) : eventsTable(rows, flags.width))
   })).pipe(
-    Command.withDescription("Print an agent's log, one line per event.")
+    Command.withDescription("Print a thread's log, one line per event.")
   )
 
 // The root. It has no handler, so `tdg` with no subcommand renders the help the declaration

--- a/apps/cli/src/dev.test.ts
+++ b/apps/cli/src/dev.test.ts
@@ -62,7 +62,7 @@ const booted = <A>(
       dev({
         config: resolveServer({ port: 0, db: ":memory:" }, env),
         assets: buildDirectory(),
-        agents: { infer: layerScripted },
+        threads: { infer: layerScripted },
         disableLogger: true,
         disableListenLog: true
       })
@@ -96,10 +96,10 @@ describe("tdg dev", () => {
       const asset = await fetch(`${baseUrl}/assets/app-abc123.js`)
       // A path the router does not own, asked for by something that renders HTML, is the UI's own
       // route: a deep link into the explorer is not a 404.
-      const deep = await fetch(`${baseUrl}/agents/root`, { headers: { accept: "text/html" } })
+      const deep = await fetch(`${baseUrl}/v1/actors/agent/threads/root`, { headers: { accept: "text/html" } })
       // The same path asked for as JSON is still the API's answer, so a script sees the problem
       // document rather than a page.
-      const ghost = await fetch(`${baseUrl}/agents/ghost/events`, { headers: { accept: "application/json" } })
+      const ghost = await fetch(`${baseUrl}/v1/actors/agent/threads/ghost/events`, { headers: { accept: "application/json" } })
       return {
         health: { status: health.status, body: await health.json() },
         index: { status: index.status, body: await index.text(), type: index.headers.get("content-type") },
@@ -126,7 +126,7 @@ describe("tdg dev", () => {
   // the token set (docs/how-to/server.md).
   test("the API answers without a token, on loopback", async () => {
     const seen = await booted(async (baseUrl, hostname) => {
-      const listed = await fetch(`${baseUrl}/agents`)
+      const listed = await fetch(`${baseUrl}/v1/actors/agent/threads`)
       const index = await fetch(`${baseUrl}/`, { headers: { accept: "text/html" } })
       return {
         hostname,
@@ -141,7 +141,7 @@ describe("tdg dev", () => {
 
   test("run drives a brief to a completed turn with no model credentials", async () => {
     const seen = await booted(async (baseUrl) => {
-      const ran = await drive(baseUrl, ["run", "survey the log", "--agent", "root", "--id", "m1", "--poll", "10"])
+      const ran = await drive(baseUrl, ["run", "survey the log", "--thread", "root", "--id", "m1", "--poll", "10"])
       const listed = await drive(baseUrl, ["ls", "--json"])
       const logged = await drive(baseUrl, ["events", "root", "--types", "MessageReceived"])
       const ghost = await drive(baseUrl, ["events", "ghost"])

--- a/apps/cli/src/dev.ts
+++ b/apps/cli/src/dev.ts
@@ -2,7 +2,7 @@ import { Effect, Layer } from "effect"
 import { HttpRouter, HttpStaticServer } from "effect/unstable/http"
 import { BunHttpServer } from "@effect/platform-bun"
 import { layerConfig, type ServerConfigValue } from "@clavia/tardigrade-server/config"
-import { layerAgents, type AgentsOptions } from "@clavia/tardigrade-server/host"
+import { layerThreads, type ThreadsOptions } from "@clavia/tardigrade-server/host"
 import { layerApp } from "@clavia/tardigrade-server/http"
 
 import { resolveAssets } from "./assets"
@@ -48,19 +48,19 @@ export interface DevOptions {
   // Where the built UI lives. Absent, the two layouts a build can arrive in are tried in order
   // (assets.ts, ASSET_CANDIDATES).
   readonly assets?: string | undefined
-  // The model seam, which a test binds to a scripted mind (apps/server/src/host.ts, AgentsOptions).
-  readonly agents?: AgentsOptions | undefined
+  // The model seam, which a test binds to a scripted mind (apps/server/src/host.ts, ThreadsOptions).
+  readonly threads?: ThreadsOptions | undefined
   readonly disableLogger?: boolean | undefined
   readonly disableListenLog?: boolean | undefined
 }
 
 // dev is the whole command: resolve the build, open the store, listen on loopback. It answers a
 // Layer rather than a running process, so the caller owns the scope and the process that stops
-// listening stops writing (apps/server/src/host.ts, layerAgents).
+// listening stops writing (apps/server/src/host.ts, layerThreads).
 export const dev = (options: DevOptions) => {
   const root = resolveAssets(options.assets)
   const config = layerConfig(options.config)
-  const agents = Layer.provide(layerAgents(options.agents ?? {}), config)
+  const threads = Layer.provide(layerThreads(options.threads ?? {}), config)
   // provideMerge rather than provide: the listening server stays visible in the layer's own
   // services, which is what lets a caller read the address it was given when it asked for port 0
   // (dev.test.ts).
@@ -69,6 +69,6 @@ export const dev = (options: DevOptions) => {
       disableLogger: options.disableLogger ?? false,
       disableListenLog: options.disableListenLog ?? false
     }),
-    [BunHttpServer.layer({ port: options.config.port, hostname: DEV_HOST }), config, agents]
+    [BunHttpServer.layer({ port: options.config.port, hostname: DEV_HOST }), config, threads]
   )
 }

--- a/apps/cli/src/render.test.ts
+++ b/apps/cli/src/render.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test"
-import type { AgentSummary, EventRow } from "@clavia/tardigrade-client"
+import type { ThreadSummary, EventRow } from "@clavia/tardigrade-client"
 
-import { agentsTable, ABSENT, DEFAULT_DETAIL_WIDTH, ELLIPSIS, eventsTable, table, turnLines } from "./render"
+import { threadsTable, ABSENT, DEFAULT_DETAIL_WIDTH, ELLIPSIS, eventsTable, table, turnLines } from "./render"
 
 // The human rendering. A table is plain aligned text, so these assert on columns rather than on
 // escape sequences, and a value the projection did not carry reads as absent rather than as empty.
 
-const agents: ReadonlyArray<AgentSummary> = [
+const threads: ReadonlyArray<ThreadSummary> = [
   { id: "root", events: 12, lastAt: 0, status: "settled" },
   { id: "root.1", parent: "root", events: 3, status: "running" }
 ]
@@ -18,10 +18,10 @@ describe("table", () => {
   })
 })
 
-describe("agentsTable", () => {
+describe("threadsTable", () => {
   test("a run is one row, and an absent field reads as absent", () => {
-    const lines = agentsTable(agents).split("\n")
-    expect(lines[0]).toContain("AGENT")
+    const lines = threadsTable(threads).split("\n")
+    expect(lines[0]).toContain("THREAD")
     expect(lines[1]).toContain("root")
     expect(lines[1]).toContain("settled")
     expect(lines[1]).toContain("1970-01-01T00:00:00.000Z")
@@ -30,7 +30,7 @@ describe("agentsTable", () => {
   })
 
   test("an empty store says so", () => {
-    expect(agentsTable([])).toBe("no agents")
+    expect(threadsTable([])).toBe("no threads")
   })
 })
 

--- a/apps/cli/src/render.ts
+++ b/apps/cli/src/render.ts
@@ -1,4 +1,4 @@
-import type { AgentSummary, EventRow, TurnView } from "@clavia/tardigrade-client"
+import type { ThreadSummary, EventRow, TurnView } from "@clavia/tardigrade-client"
 
 // What a command puts on stdout. Two renderings of the same value: aligned text for a person and
 // the client's own value for a pipe (`--json`), which is why every function here takes what the
@@ -38,19 +38,19 @@ const truncate = (value: string, width: number): string =>
 const timeOf = (at: number | undefined): string =>
   at === undefined ? ABSENT : new Date(at).toISOString()
 
-// Every agent a store holds, parent before child. `events` is the count of events in the log, which is the size of the
+// Every thread a store holds, parent before child. `events` is the count of events in the log, which is the size of the
 // thing every other read projects from, and `last` is when the log last grew.
-export const agentsTable = (agents: ReadonlyArray<AgentSummary>): string =>
-  agents.length === 0
-    ? "no agents"
+export const threadsTable = (threads: ReadonlyArray<ThreadSummary>): string =>
+  threads.length === 0
+    ? "no threads"
     : table(
-      ["AGENT", "STATUS", "EVENTS", "LAST", "PARENT"],
-      agents.map((agent) => [
-        agent.id,
-        agent.status,
-        String(agent.events),
-        timeOf(agent.lastAt),
-        agent.parent ?? ABSENT
+      ["THREAD", "STATUS", "EVENTS", "LAST", "PARENT"],
+      threads.map((thread) => [
+        thread.id,
+        thread.status,
+        String(thread.events),
+        timeOf(thread.lastAt),
+        thread.parent ?? ABSENT
       ])
     )
 
@@ -75,8 +75,8 @@ export const eventsTable = (rows: ReadonlyArray<EventRow>, width = DEFAULT_DETAI
 
 // A turn's boundary as a person reads it: the status word, then whichever of output or error the
 // projection carried.
-export const turnLines = (agent: string, view: TurnView): string => {
-  const head = `${agent} ${view.turn} ${view.status}`
+export const turnLines = (thread: string, view: TurnView): string => {
+  const head = `${thread} ${view.turn} ${view.status}`
   if (view.output !== undefined) return `${head}\n${view.output}`
   if (view.error !== undefined) return `${head}\n${view.error}`
   return head

--- a/apps/server/src/actor.test.ts
+++ b/apps/server/src/actor.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test"
+import { Schema } from "effect"
+import type { Event } from "@clavia/tardigrade-core/event"
+import { replyId } from "@clavia/tardigrade-core/message"
+import { projection, projectionsOf, RESERVED_PROJECTIONS } from "@clavia/tardigrade-client/contract"
+
+import { agentProjections } from "./actor"
+
+// The actor's own declaration: what it says a thread can be asked beyond its log, and what the
+// platform refuses to mount. The projections are pure functions of an event array, so the fixtures
+// are event arrays, trimmed to the fields the reading looks at.
+
+let clock = 0
+const at = () => ++clock
+
+const inbound = (id: string, text = "do the thing"): Event =>
+  ({ type: "MessageReceived", id, text, at: at() }) as Event
+
+const completed = (turn: string, output: string): Event =>
+  ({ type: "TurnCompleted", turn, output, at: at() }) as Event
+
+const failed = (turn: string, error: string): Event =>
+  ({ type: "TurnFailed", turn, error, at: at() }) as Event
+
+const requested = (turn: string, callId: string): Event =>
+  ({ type: "BudgetRequested", turn, callId, reason: "more calls", amount: 5, at: at() }) as Event
+
+const reply = (id: string, text = "done"): Event =>
+  ({ type: "MessageReceived", id: replyId(id), text, outcome: "completed", at: at() }) as Event
+
+const turns = agentProjections.turns
+
+describe("the turns projection", () => {
+  test("one entry per inbound message, with its boundary", () => {
+    const log = [
+      inbound("m1"),
+      completed("m1", "42"),
+      inbound("m2"),
+      failed("m2", "boom"),
+      inbound("m3")
+    ]
+    expect(turns.run(log, {})).toEqual([
+      { turn: "m1", status: "completed", output: "42" },
+      { turn: "m2", status: "failed", error: "boom" },
+      { turn: "m3", status: "pending" }
+    ])
+  })
+
+  test("a reply message is not a turn", () => {
+    const log = [inbound("m1"), reply("t1.0"), completed("m1", "42")]
+    expect(turns.run(log, {}).map((view) => view.turn)).toEqual(["m1"])
+  })
+
+  test("an unanswered budget ask is parked", () => {
+    const log = [inbound("m1"), requested("m1", "c1")]
+    expect(turns.run(log, {})).toEqual([{ turn: "m1", status: "parked" }])
+  })
+
+  // `at` is the projection's own declared parameter, so time travel is a query this actor accepts
+  // rather than a mode the platform holds (contract.ts, projection).
+  test("a prefix takes a turn back to pending", () => {
+    const log = [inbound("m1"), completed("m1", "42")]
+    expect(turns.run(log, {})[0]!.status).toBe("completed")
+    expect(turns.run(log, { at: 1 })).toEqual([{ turn: "m1", status: "pending" }])
+    expect(turns.run(log, { at: 0 })).toEqual([])
+  })
+})
+
+describe("declaring projections", () => {
+  // The log is not a projection of itself, so the two names that read it are refused where the
+  // declaration is written rather than where a request arrives (contract.ts, RESERVED_PROJECTIONS).
+  test("a projection may not claim a reserved name", () => {
+    for (const reserved of RESERVED_PROJECTIONS) {
+      expect(() =>
+        projectionsOf({
+          [reserved]: projection({
+            params: {},
+            result: Schema.Array(Schema.String),
+            run: () => []
+          })
+        })
+      ).toThrow(`a projection may not be named ${JSON.stringify(reserved)}`)
+    }
+  })
+
+  test("a name the log does not own is declared without complaint", () => {
+    const declared = projectionsOf({
+      streams: projection({ params: {}, result: Schema.Array(Schema.String), run: () => [] })
+    })
+    expect(Object.keys(declared)).toEqual(["streams"])
+  })
+
+  test("the reserved names are the log's own two routes", () => {
+    expect([...RESERVED_PROJECTIONS].sort()).toEqual(["events", "stream"])
+  })
+})

--- a/apps/server/src/actor.ts
+++ b/apps/server/src/actor.ts
@@ -1,0 +1,78 @@
+import { Schema } from "effect"
+import type { Event } from "@clavia/tardigrade-core/event"
+import {
+  agentOf,
+  agentsPackage,
+  budget,
+  codeModeFor,
+  compaction,
+  reply,
+  workspacePackage
+} from "@clavia/tardigrade"
+import { boundaryOf } from "@clavia/tardigrade/boundary"
+import { projection, projectionsOf, Seq, TurnView } from "@clavia/tardigrade-client/contract"
+
+import { inboundOf } from "./projections"
+
+// The actor this build serves: the reactors it runs, and the projections it declares over the logs
+// they write. Both halves belong together, because a projection is only meaningful to whoever knows
+// what the events mean, and that is the assembly that emitted them. The platform holds the log and
+// mounts what is declared here by name (packages/client/src/contract.ts, apiOf).
+
+// The assembly, one for every lane: code mode with the spawn and workspace packages in scope, plus
+// the three policy capabilities. v1 runs this one assembly and forking is the customization path
+// (apps-server-spec.md, "Explicitly out of scope for v1").
+export const assemblyOf = () =>
+  agentOf([
+    codeModeFor({ packages: [agentsPackage(), workspacePackage()] }),
+    reply,
+    budget,
+    compaction
+  ])
+
+// TurnStatus is this actor's turn vocabulary. `parked` is the budget ask nobody can answer over
+// HTTP (apps-server-spec.md, "Explicitly out of scope": budget escalation).
+export type TurnStatus = "pending" | "completed" | "failed" | "parked"
+
+export interface TurnViewShape {
+  readonly turn: string
+  readonly status: TurnStatus
+  readonly output?: string
+  readonly error?: string
+}
+
+// turnsOf projects one turn per inbound message, in the order the messages arrived. `at` cuts the
+// log to a prefix first: any prefix of a log is a valid state, so time travel is this one argument
+// and never a stored mode (apps-server-spec.md, "Principles"). A prefix taken before a turn's
+// terminal reads that turn pending again (projections.test.ts, "a prefix takes a turn back to
+// pending"), and a prefix taken before a message drops its turn from the list entirely.
+const turnsOf = (events: ReadonlyArray<Event>, at?: number): ReadonlyArray<TurnViewShape> => {
+  const prefix = events.slice(0, at ?? events.length)
+  return inboundOf(prefix).map((turn): TurnViewShape => {
+    const boundary = boundaryOf(prefix, turn)
+    if (boundary === undefined) return { turn, status: "pending" }
+    if (boundary.kind === "completed") return { turn, status: "completed", output: boundary.output }
+    if (boundary.kind === "failed") return { turn, status: "failed", error: boundary.error }
+    // A park is neither an output nor an error: the turn is alive and waiting on an answer the API
+    // has no door for, so the status carries the whole of what a client can act on.
+    return { turn, status: "parked" }
+  })
+}
+
+// What this actor answers about a thread beyond its log. A turn is not a fact the platform knows:
+// it is this assembly's reading of MessageReceived and the terminals its reactors write, so the
+// platform mounts the reading rather than holding it (api.test.ts, "a declared projection serves
+// what the actor computes").
+export const agentProjections = projectionsOf({
+  turns: projection({
+    params: { at: Schema.optionalKey(Seq) },
+    result: Schema.Array(TurnView),
+    run: (events, params) => turnsOf(events, params.at)
+  })
+})
+
+// turnViewsOf is the same reading, for the one route that reads a turn by id rather than over the
+// whole log (api.ts, "turn"). It goes through the declaration so the projection and the lookup can
+// never drift.
+export const turnViewsOf = (events: ReadonlyArray<Event>): ReadonlyArray<TurnViewShape> =>
+  agentProjections.turns.run(events, {})

--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -8,10 +8,11 @@ import type { Action } from "@clavia/tardigrade/events"
 
 import { openStreams } from "./api"
 import { layerConfig, readConfig } from "./config"
-import { RESERVED_ACTOR, type EventRow } from "@clavia/tardigrade-client/contract"
+import { PROBLEM_TYPE_BASE, RESERVED_ACTOR, type EventRow } from "@clavia/tardigrade-client/contract"
 import { layerThreads } from "./host"
 import { PROBLEM_CONTENT_TYPE, serve } from "./http"
-import type { ThreadSummary, ThreadNode, TurnView } from "./projections"
+import type { TurnViewShape as TurnView } from "./actor"
+import type { ThreadSummary, ThreadNode } from "./projections"
 
 // Every case here boots a real server on an ephemeral port, so it competes with every other task in
 // a parallel gate run. Bun's default per-test budget is tuned for a pure function and times out
@@ -311,7 +312,63 @@ describe("the event stream", () => {
   })
 })
 
-describe("turns", () => {
+// The projections the actor declares are mounted by name under a thread, and this build's actor
+// declares `turns` (actor.ts, agentProjections). The cases below are about the mounting: that a
+// declared name serves what the actor computes, that its own query reaches `run`, and that any
+// other name says what does exist.
+describe("projections", () => {
+  test("a declared projection serves what the actor computes", async () => {
+    const read = await serving(async (base) => {
+      await birth(base, "alpha", { id: "m1", text: "hello" })
+      const response = await fetch(`${base}/v1/actors/agent/threads/alpha/turns`)
+      return { status: response.status, body: await response.json() as ReadonlyArray<TurnView> }
+    })
+    expect(read.status).toBe(200)
+    expect(read.body).toEqual([{ turn: "m1", status: "completed", output: "ok: hello" }])
+  })
+
+  test("a name the actor never declared says what does exist", async () => {
+    const answers = await serving(async (base) => {
+      await birth(base, "alpha", { id: "m1", text: "hello" })
+      const read = async (path: string) => {
+        const response = await fetch(`${base}${path}`)
+        return {
+          status: response.status,
+          type: response.headers.get("content-type"),
+          body: await response.json() as Record<string, unknown>
+        }
+      }
+      return { ghost: await read("/v1/actors/agent/threads/alpha/facts"), actor: await read("/v1/actors/ghost/threads/alpha/facts") }
+    })
+    expect(answers.ghost.status).toBe(404)
+    expect(answers.ghost.type).toContain(PROBLEM_CONTENT_TYPE)
+    expect(answers.ghost.body).toMatchObject({
+      type: `${PROBLEM_TYPE_BASE}unknown-projection`,
+      title: "Unknown Projection"
+    })
+    // The detail lists what the actor does declare, so a caller who guessed a name learns the ones
+    // that exist rather than only that this one does not.
+    expect(String(answers.ghost.body["detail"])).toContain('"turns"')
+    // The actor is answered before the projection: a name nobody deployed is not a place where
+    // asking what it declares means anything.
+    expect(answers.actor.body).toMatchObject({ title: "Unknown Actor" })
+  })
+
+  // `events` is the log read back, and the log is not a projection of itself, so a reserved name
+  // keeps serving the platform's own route rather than reaching the projection mount. `stream` is
+  // the same rule for the tail, proven where the tail is exercised ("the event stream", below;
+  // contract.ts, RESERVED_PROJECTIONS).
+  test("a reserved name still serves the log", async () => {
+    const answers = await serving(async (base) => {
+      await birth(base, "alpha", { id: "m1", text: "hello" })
+      const events = await fetch(`${base}/v1/actors/agent/threads/alpha/events`)
+      return { status: events.status, type: events.headers.get("content-type") }
+    })
+    expect(answers.status).toBe(200)
+    // Not a problem document, which is what reaching the projection mount would have produced.
+    expect(answers.type).toContain("application/json")
+  })
+
   test("`at` reads the log's prefix, which takes a completed turn back to pending", async () => {
     const read = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })

--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -8,10 +8,10 @@ import type { Action } from "@clavia/tardigrade/events"
 
 import { openStreams } from "./api"
 import { layerConfig, readConfig } from "./config"
-import type { EventRow } from "@clavia/tardigrade-client/contract"
-import { layerAgents } from "./host"
+import { RESERVED_ACTOR, type EventRow } from "@clavia/tardigrade-client/contract"
+import { layerThreads } from "./host"
 import { PROBLEM_CONTENT_TYPE, serve } from "./http"
-import type { AgentSummary, AgentNode, TurnView } from "./projections"
+import type { ThreadSummary, ThreadNode, TurnView } from "./projections"
 
 // Every case here boots a real server on an ephemeral port, so it competes with every other task in
 // a parallel gate run. Bun's default per-test budget is tuned for a pure function and times out
@@ -23,7 +23,7 @@ setDefaultTimeout(BOOT_MS)
 
 // The API over a real Bun server on an ephemeral port, over a real durable host on a volatile
 // database, with the model seam bound to a scripted mind: every assertion here is about what a
-// client sees on the wire, and the only thing that is not real is the model (host.ts, AgentsOptions).
+// client sees on the wire, and the only thing that is not real is the model (host.ts, ThreadsOptions).
 
 const briefOf = (trajectory: ReadonlyArray<Event>): string => {
   for (let i = trajectory.length - 1; i >= 0; i--) {
@@ -63,7 +63,7 @@ const config = layerConfig(readConfig({ TARDIGRADE_DB: ":memory:" }))
 const app = Layer.provideMerge(serve({ disableLogger: true, disableListenLog: true }), [
   BunHttpServer.layer({ port: 0 }),
   config,
-  Layer.provide(layerAgents({ infer: layerScripted }), config)
+  Layer.provide(layerThreads({ infer: layerScripted }), config)
 ])
 
 // Boots the process and hands the body its base URL. The body is plain fetch, because a client of
@@ -99,25 +99,25 @@ const post = (base: string, path: string, body?: unknown) =>
   })
 
 const birth = async (base: string, id: string, message: { id: string; text: string }) => {
-  const response = await post(base, `/agents/${id}/messages`, message)
+  const response = await post(base, `/v1/actors/agent/threads/${id}/events`, message)
   expect(response.status).toBe(202)
-  expect(await response.json()).toEqual({ agent: id, turn: message.id })
+  expect(await response.json()).toEqual({ actor: RESERVED_ACTOR, thread: id, turn: message.id })
   return until(`turn ${message.id} of ${id}`, async () => {
-    const view = (await (await fetch(`${base}/agents/${id}/turns/${message.id}`)).json()) as TurnView
+    const view = (await (await fetch(`${base}/v1/actors/agent/threads/${id}/turns/${message.id}`)).json()) as TurnView
     return view.status === "pending" ? undefined : view
   })
 }
 
 describe("messages", () => {
-  test("a message births an agent and the server drives its turn to completed", async () => {
+  test("a message births a thread and the server drives its turn to completed", async () => {
     const view = await serving((base) => birth(base, "alpha", { id: "m1", text: "hello" }))
     expect(view).toEqual({ turn: "m1", status: "completed", output: "ok: hello" })
   })
 
   test("a body with no id or no text is refused", async () => {
     const problems = await serving(async (base) => {
-      const missingText = await post(base, "/agents/alpha/messages", { id: "m1" })
-      const missingId = await post(base, "/agents/alpha/messages", { text: "hello" })
+      const missingText = await post(base, "/v1/actors/agent/threads/alpha/events", { id: "m1" })
+      const missingId = await post(base, "/v1/actors/agent/threads/alpha/events", { text: "hello" })
       return [
         { status: missingText.status, type: missingText.headers.get("content-type"), body: await missingText.json() },
         { status: missingId.status, type: missingId.headers.get("content-type"), body: await missingId.json() }
@@ -137,12 +137,12 @@ describe("messages", () => {
   test("a redelivered message id answers the same and writes nothing", async () => {
     const counts = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
-      const before = ((await (await fetch(`${base}/agents/alpha/events`)).json()) as ReadonlyArray<EventRow>).length
-      const again = await post(base, "/agents/alpha/messages", { id: "m1", text: "hello" })
+      const before = ((await (await fetch(`${base}/v1/actors/agent/threads/alpha/events`)).json()) as ReadonlyArray<EventRow>).length
+      const again = await post(base, "/v1/actors/agent/threads/alpha/events", { id: "m1", text: "hello" })
       expect(again.status).toBe(202)
-      expect(await again.json()).toEqual({ agent: "alpha", turn: "m1" })
+      expect(await again.json()).toEqual({ actor: RESERVED_ACTOR, thread: "alpha", turn: "m1" })
       await sleep(50)
-      const after = ((await (await fetch(`${base}/agents/alpha/events`)).json()) as ReadonlyArray<EventRow>).length
+      const after = ((await (await fetch(`${base}/v1/actors/agent/threads/alpha/events`)).json()) as ReadonlyArray<EventRow>).length
       return [before, after]
     })
     expect(counts[1]).toBe(counts[0]!)
@@ -150,10 +150,10 @@ describe("messages", () => {
 })
 
 describe("the listing", () => {
-  test("an agent that has settled lists as settled", async () => {
+  test("a thread that has settled lists as settled", async () => {
     const listed = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
-      return (await (await fetch(`${base}/agents`)).json()) as ReadonlyArray<AgentSummary>
+      return (await (await fetch(`${base}/v1/actors/agent/threads`)).json()) as ReadonlyArray<ThreadSummary>
     })
     expect(listed).toHaveLength(1)
     expect(listed[0]).toMatchObject({ id: "alpha", status: "settled" })
@@ -167,13 +167,13 @@ describe("events", () => {
     const read = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
       const json = async (path: string) => (await (await fetch(`${base}${path}`)).json()) as ReadonlyArray<EventRow>
-      const all = await json("/agents/alpha/events")
+      const all = await json("/v1/actors/agent/threads/alpha/events")
       return {
         all,
-        page: await json("/agents/alpha/events?after=1&limit=2"),
-        completed: await json("/agents/alpha/events?types=TurnCompleted"),
-        both: await json(`/agents/alpha/events?after=1&types=MessageReceived,TurnCompleted`),
-        empty: await json("/agents/alpha/events?types=NothingLikeThis")
+        page: await json("/v1/actors/agent/threads/alpha/events?after=1&limit=2"),
+        completed: await json("/v1/actors/agent/threads/alpha/events?types=TurnCompleted"),
+        both: await json(`/v1/actors/agent/threads/alpha/events?after=1&types=MessageReceived,TurnCompleted`),
+        empty: await json("/v1/actors/agent/threads/alpha/events?types=NothingLikeThis")
       }
     })
     expect(read.all.map((row) => row.seq)).toEqual(read.all.map((_, i) => i + 1))
@@ -185,19 +185,60 @@ describe("events", () => {
     const completed = read.all.find((row) => row.event.type === "TurnCompleted")!
     expect(read.completed[0]!.seq).toBe(completed.seq)
     expect(read.both.every((row) => row.seq > 1)).toBe(true)
-    // An existing agent's filtered empty page is a page, not a 404.
+    // An existing thread's filtered empty page is a page, not a 404.
     expect(read.empty).toEqual([])
   })
 
   test("a log that never existed is the only 404", async () => {
     const answers = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
-      const missing = await fetch(`${base}/agents/ghost/events`)
+      const missing = await fetch(`${base}/v1/actors/agent/threads/ghost/events`)
       return { status: missing.status, type: missing.headers.get("content-type"), body: await missing.json() }
     })
     expect(answers.status).toBe(404)
     expect(answers.type).toContain(PROBLEM_CONTENT_TYPE)
-    expect(answers.body).toMatchObject({ status: 404, title: "Unknown Agent" })
+    expect(answers.body).toMatchObject({ status: 404, title: "Unknown Thread" })
+  })
+})
+
+describe("the actor level", () => {
+  // The actor is a path parameter so the declaration states the shape a deploy will vary, and this
+  // build answers for one name (contract.ts, RESERVED_ACTOR). A name it does not serve is code
+  // nobody deployed here, which is a different fact from a log nobody has written, so it carries a
+  // different problem type even though both are 404 (api.ts, actorOf).
+  test("an actor nobody deployed is its own 404", async () => {
+    const answers = await serving(async (base) => {
+      await birth(base, "alpha", { id: "m1", text: "hello" })
+      const read = async (path: string) => {
+        const response = await fetch(`${base}${path}`)
+        return { status: response.status, body: await response.json() as Record<string, unknown> }
+      }
+      return {
+        served: await read(`/v1/actors/${RESERVED_ACTOR}/threads`),
+        ghost: await read("/v1/actors/ghost/threads"),
+        ghostThread: await read("/v1/actors/ghost/threads/alpha/events")
+      }
+    })
+    expect(answers.served.status).toBe(200)
+    expect(answers.ghost.status).toBe(404)
+    expect(answers.ghost.body).toMatchObject({ title: "Unknown Actor" })
+    // The actor is answered before the thread, so a real thread under a name nobody deployed still
+    // reports the actor rather than the log.
+    expect(answers.ghostThread.status).toBe(404)
+    expect(answers.ghostThread.body).toMatchObject({ title: "Unknown Actor" })
+  })
+
+  // The tail decodes its own request because it is not a declared endpoint (contract.ts, the SSE
+  // note), so it carries its own copy of the same guard.
+  test("the tail refuses an actor nobody deployed", async () => {
+    const answers = await serving(async (base) => {
+      await birth(base, "alpha", { id: "m1", text: "hello" })
+      const response = await fetch(`${base}/v1/actors/ghost/threads/alpha/events/stream`)
+      return { status: response.status, type: response.headers.get("content-type"), body: await response.json() }
+    })
+    expect(answers.status).toBe(404)
+    expect(answers.type).toContain(PROBLEM_CONTENT_TYPE)
+    expect(answers.body).toMatchObject({ title: "Unknown Actor" })
   })
 })
 
@@ -219,9 +260,9 @@ describe("the event stream", () => {
   test("a reconnect replays from Last-Event-ID and then runs live, once each", async () => {
     const read = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
-      const before = (await (await fetch(`${base}/agents/alpha/events`)).json()) as ReadonlyArray<EventRow>
+      const before = (await (await fetch(`${base}/v1/actors/agent/threads/alpha/events`)).json()) as ReadonlyArray<EventRow>
       const abort = new AbortController()
-      const response = await fetch(`${base}/agents/alpha/events/stream?after=0`, {
+      const response = await fetch(`${base}/v1/actors/agent/threads/alpha/events/stream?after=0`, {
         // The header wins over the query, which is the whole of what a resuming EventSource can
         // state: it replays the URL it was opened with and carries the id in the header.
         headers: { "last-event-id": "2" },
@@ -246,7 +287,7 @@ describe("the event stream", () => {
       expect(openStreams()).toBe(1)
 
       // Then a message delivered while the stream is open arrives on it.
-      await post(base, "/agents/alpha/messages", { id: "m2", text: "again" })
+      await post(base, "/v1/actors/agent/threads/alpha/events", { id: "m2", text: "again" })
       await until("the live frames", async () => (framesOf(text).length > replayed.length ? true : undefined))
       const live = framesOf(text)
 
@@ -275,7 +316,7 @@ describe("turns", () => {
     const read = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
       const json = async (path: string) => (await (await fetch(`${base}${path}`)).json()) as ReadonlyArray<TurnView>
-      return { now: await json("/agents/alpha/turns"), atOne: await json("/agents/alpha/turns?at=1") }
+      return { now: await json("/v1/actors/agent/threads/alpha/turns"), atOne: await json("/v1/actors/agent/threads/alpha/turns?at=1") }
     })
     expect(read.now).toEqual([{ turn: "m1", status: "completed", output: "ok: hello" }])
     // One event stands before the cut: the message that asked for the turn, and nothing that
@@ -286,7 +327,7 @@ describe("turns", () => {
   test("a turn nobody was asked to serve is a 404", async () => {
     const answer = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
-      const missing = await fetch(`${base}/agents/alpha/turns/m9`)
+      const missing = await fetch(`${base}/v1/actors/agent/threads/alpha/turns/m9`)
       return { status: missing.status, body: await missing.json() }
     })
     expect(answer.status).toBe(404)
@@ -296,7 +337,7 @@ describe("turns", () => {
   test("a turn that did not fail refuses to resume", async () => {
     const answer = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
-      const refused = await post(base, "/agents/alpha/turns/m1/resume")
+      const refused = await post(base, "/v1/actors/agent/threads/alpha/turns/m1/resume")
       return { status: refused.status, type: refused.headers.get("content-type"), body: await refused.json() }
     })
     expect(answer.status).toBe(409)
@@ -307,7 +348,7 @@ describe("turns", () => {
 })
 
 describe("the tree", () => {
-  test("a spawned child hangs under the agent whose code briefed it", async () => {
+  test("a spawned child hangs under the thread whose code briefed it", async () => {
     const read = await serving(async (base) => {
       await birth(base, "root", { id: "m1", text: "spawn call-1" })
       // The root's turn can complete while the child's lane is still settling, so the tree read
@@ -317,9 +358,9 @@ describe("the tree", () => {
         return health.status === "resting" ? health : undefined
       })
       return {
-        tree: (await (await fetch(`${base}/agents/root/tree`)).json()) as AgentNode,
-        listed: (await (await fetch(`${base}/agents`)).json()) as ReadonlyArray<AgentSummary>,
-        ghost: (await fetch(`${base}/agents/ghost/tree`)).status
+        tree: (await (await fetch(`${base}/v1/actors/agent/threads/root/tree`)).json()) as ThreadNode,
+        listed: (await (await fetch(`${base}/v1/actors/agent/threads`)).json()) as ReadonlyArray<ThreadSummary>,
+        ghost: (await fetch(`${base}/v1/actors/agent/threads/ghost/tree`)).status
       }
     })
     expect(read.tree.id).toBe("root")
@@ -327,7 +368,7 @@ describe("the tree", () => {
     const child = read.tree.children[0]!
     expect(child.parent).toBe("root")
     expect(child.children).toEqual([])
-    // The child is an agent like any other: it lists, with the same parent the tree gave it.
+    // The child is a thread like any other: it lists, with the same parent the tree gave it.
     expect(read.listed.map((summary) => summary.id).sort()).toEqual(["root", child.id].sort())
     expect(read.listed.find((summary) => summary.id === child.id)!.parent).toBe("root")
     expect(read.ghost).toBe(404)

--- a/apps/server/src/api.ts
+++ b/apps/server/src/api.ts
@@ -6,24 +6,26 @@ import type { Event } from "@clavia/tardigrade-core/event"
 import {
   Api,
   invalidRequest,
+  RESERVED_ACTOR,
   ResumeRefused,
   unacceptableField,
-  UnknownAgent,
+  UnknownActor,
+  UnknownThread,
   UnknownTurn,
-  type AgentNode
+  type ThreadNode
 } from "@clavia/tardigrade-client/contract"
-import { Agents } from "./host"
+import { Threads } from "./host"
 import { problemResponse } from "./problem"
-import { treeOf, turnsOf, type AgentSummary } from "./projections"
+import { treeOf, turnsOf, type ThreadSummary } from "./projections"
 
-// The agent endpoints. A route is a lookup on the Agents service plus one projection, because the
+// The thread endpoints. A route is a lookup on the Threads service plus one projection, because the
 // read side is a pure function of a log (projections.ts) and the write side is one delivery
 // (host.ts). What each route accepts and answers is declared in contract.ts; this module is the
 // implementation of that declaration. Nothing here holds state between requests: the SSE tail keeps
 // a cursor for the connection it serves and nothing else, so two processes reading the same log
 // answer the same way.
 
-// The page size of GET /agents/:id/events when the caller states no `limit`
+// The page size of GET /v1/actors/:actor/threads/:id/events when the caller states no `limit`
 // (docs/how-to/server.md, "Endpoints").
 export const DEFAULT_EVENT_LIMIT = 200
 
@@ -55,22 +57,32 @@ const integerOf = (raw: string | undefined): number | undefined => {
   return /^\d+$/.test(trimmed) ? Number(trimmed) : undefined
 }
 
-const unknownAgentDetail = (id: string) => `No agent named ${JSON.stringify(id)} has ever existed.`
+const unknownThreadDetail = (id: string) => `No thread named ${JSON.stringify(id)} has ever existed.`
 
-// logOf reads an agent's events, failing the route when the log is empty. An agent exists once its
+const unknownActorDetail = (actor: string) =>
+  `This server serves one actor, ${JSON.stringify(RESERVED_ACTOR)}, and nothing named ${JSON.stringify(actor)}.`
+
+// actorOf is the guard every declared route runs first. The actor level is a path parameter so the
+// declaration states the shape a deploy will vary (contract.ts, RESERVED_ACTOR), and this build
+// serves exactly the reserved name: any other is code nobody deployed here, which is its own 404
+// rather than an empty listing (api.test.ts, "an actor nobody deployed is its own 404").
+const actorOf = (actor: string): Effect.Effect<string, ReturnType<typeof UnknownActor.of>> =>
+  actor === RESERVED_ACTOR ? Effect.succeed(actor) : Effect.fail(UnknownActor.of(unknownActorDetail(actor)))
+
+// logOf reads a thread's events, failing the route when the log is empty. A thread exists once its
 // log has an event (docs/how-to/server.md, "Creation is delivery"), so an empty log is the only
-// unknown agent there is.
+// unknown thread there is.
 const logOf = (read: (id: string) => Effect.Effect<ReadonlyArray<Event>>, id: string) =>
   Effect.flatMap(read(id), (log) =>
-    log.length === 0 ? Effect.fail(UnknownAgent.of(unknownAgentDetail(id))) : Effect.succeed(log))
+    log.length === 0 ? Effect.fail(UnknownThread.of(unknownThreadDetail(id))) : Effect.succeed(log))
 
-// flatten lists a forest depth-first, parent before child. GET /agents is this listing rather than
+// flatten lists a forest depth-first, parent before child. The threads listing is this rather than
 // the raw lane list because `parent` is a fact of the forest and only treeOf can see it
 // (projections.ts, summaryOf).
-const flatten = (nodes: ReadonlyArray<AgentNode>): ReadonlyArray<AgentSummary> =>
+const flatten = (nodes: ReadonlyArray<ThreadNode>): ReadonlyArray<ThreadSummary> =>
   nodes.flatMap(({ children, ...summary }) => [summary, ...flatten(children)])
 
-const findNode = (nodes: ReadonlyArray<AgentNode>, id: string): AgentNode | undefined => {
+const findNode = (nodes: ReadonlyArray<ThreadNode>, id: string): ThreadNode | undefined => {
   for (const node of nodes) {
     if (node.id === id) return node
     const found = findNode(node.children, id)
@@ -153,12 +165,18 @@ export const layerStream = (options: ApiOptions = {}) => {
   const heartbeat = options.heartbeat ?? DEFAULT_SSE_HEARTBEAT
   return HttpRouter.add(
     "GET",
-    "/agents/:id/events/stream",
+    "/v1/actors/:actor/threads/:id/events/stream",
     Effect.gen(function*() {
-      const id = paramOf(yield* HttpRouter.params, "id")
-      const agents = yield* Agents
-      const log = yield* agents.events(id)
-      if (log.length === 0) return problemResponse(UnknownAgent.of(unknownAgentDetail(id)))
+      const params = yield* HttpRouter.params
+      const actor = paramOf(params, "actor")
+      // The tail answers the same actor guard the declared routes do. It is spelled out rather than
+      // shared with them because this route decodes its own request: it is not a declared endpoint
+      // (contract.ts, the SSE note; api.test.ts, "the tail refuses an actor nobody deployed").
+      if (actor !== RESERVED_ACTOR) return problemResponse(UnknownActor.of(unknownActorDetail(actor)))
+      const id = paramOf(params, "id")
+      const threads = yield* Threads
+      const log = yield* threads.events(id)
+      if (log.length === 0) return problemResponse(UnknownThread.of(unknownThreadDetail(id)))
       const query = yield* HttpServerRequest.ParsedSearchParams
       const rawAfter = singleOf(query["after"])
       const after = integerOf(rawAfter)
@@ -170,7 +188,7 @@ export const layerStream = (options: ApiOptions = {}) => {
       // first connection began.
       const request = yield* HttpServerRequest.HttpServerRequest
       const from = integerOf(request.headers["last-event-id"]) ?? after ?? 0
-      return HttpServerResponse.stream(tail(agents.events, id, from, poll, heartbeat), {
+      return HttpServerResponse.stream(tail(threads.events, id, from, poll, heartbeat), {
         contentType: "text/event-stream",
         headers: { "cache-control": "no-cache" }
       })
@@ -178,31 +196,35 @@ export const layerStream = (options: ApiOptions = {}) => {
   )
 }
 
-// layerAgentsGroup implements every declared agent endpoint over the Agents service and the
+// layerThreadsGroup implements every declared thread endpoint over the Threads service and the
 // projections. It carries no gate of its own: the bearer middleware is global to the router, so a
 // route is inside it by being part of the same application (http.ts, layerAuth; http.test.ts, "a
 // token closes the API and leaves healthz open").
-export const layerAgentsGroup = (options: ApiOptions = {}) => {
+export const layerThreadsGroup = (options: ApiOptions = {}) => {
   const limit = options.limit ?? DEFAULT_EVENT_LIMIT
-  return HttpApiBuilder.group(Api, "agents", (handlers) =>
+  return HttpApiBuilder.group(Api, "threads", (handlers) =>
     handlers
       // The body is the declared payload, decoded before this runs: a body that is not one is
       // refused by the declaration and rendered as a problem document (contract.ts,
       // layerRequestProblems), so the handler only ever sees a message.
       .handle("deliver", ({ params, payload }) =>
         Effect.gen(function*() {
-          const agents = yield* Agents
-          return yield* agents.deliver(params.id, payload)
+          const actor = yield* actorOf(params.actor)
+          const threads = yield* Threads
+          const accepted = yield* threads.deliver(params.id, payload)
+          return { actor, ...accepted }
         }))
-      .handle("list", () =>
+      .handle("list", ({ params }) =>
         Effect.gen(function*() {
-          const agents = yield* Agents
-          return flatten(treeOf(logsOf(yield* agents.list())))
+          yield* actorOf(params.actor)
+          const threads = yield* Threads
+          return flatten(treeOf(logsOf(yield* threads.list())))
         }))
       .handle("events", ({ params, query }) =>
         Effect.gen(function*() {
-          const agents = yield* Agents
-          const log = yield* logOf(agents.events, params.id)
+          yield* actorOf(params.actor)
+          const threads = yield* Threads
+          const log = yield* logOf(threads.events, params.id)
           const { after, limit: page } = query
           // The comma list is the one rule the query Schema does not state: every value it could
           // hold is a valid event type, including ones this build has never seen.
@@ -214,8 +236,9 @@ export const layerAgentsGroup = (options: ApiOptions = {}) => {
         }))
       .handle("turns", ({ params, query }) =>
         Effect.gen(function*() {
-          const agents = yield* Agents
-          const log = yield* logOf(agents.events, params.id)
+          yield* actorOf(params.actor)
+          const threads = yield* Threads
+          const log = yield* logOf(threads.events, params.id)
           const { at } = query
           // `at` is a seq, and a seq is a 1-based position, so `at` events stand before the cut and
           // the prefix length is the seq itself (projections.ts, turnsOf).
@@ -223,13 +246,14 @@ export const layerAgentsGroup = (options: ApiOptions = {}) => {
         }))
       .handle("turn", ({ params }) =>
         Effect.gen(function*() {
-          const agents = yield* Agents
-          const log = yield* logOf(agents.events, params.id)
+          yield* actorOf(params.actor)
+          const threads = yield* Threads
+          const log = yield* logOf(threads.events, params.id)
           const view = turnsOf(log).find((candidate) => candidate.turn === params.turn)
           if (view === undefined) {
             return yield* Effect.fail(
               UnknownTurn.of(
-                `Agent ${JSON.stringify(params.id)} was never asked to serve a turn named ${
+                `Thread ${JSON.stringify(params.id)} was never asked to serve a turn named ${
                   JSON.stringify(params.turn)
                 }.`
               )
@@ -239,20 +263,22 @@ export const layerAgentsGroup = (options: ApiOptions = {}) => {
         }))
       .handle("resume", ({ params }) =>
         Effect.gen(function*() {
-          const agents = yield* Agents
-          return yield* agents.resume(params.id, params.turn).pipe(
-            Effect.as({ agent: params.id, turn: params.turn }),
+          const actor = yield* actorOf(params.actor)
+          const threads = yield* Threads
+          return yield* threads.resume(params.id, params.turn).pipe(
+            Effect.as({ actor, thread: params.id, turn: params.turn }),
             Effect.catch((refused) => Effect.fail(ResumeRefused.of(refused.detail)))
           )
         }))
       .handle("tree", ({ params }) =>
         Effect.gen(function*() {
-          const agents = yield* Agents
+          yield* actorOf(params.actor)
+          const threads = yield* Threads
           // The forest is built over every log because parentage is a claim in the PARENT's log; a
           // subtree cannot be derived from the subtree's own events (projections.ts, treeOf).
-          const node = findNode(treeOf(logsOf(yield* agents.list())), params.id)
+          const node = findNode(treeOf(logsOf(yield* threads.list())), params.id)
           if (node === undefined) {
-            return yield* Effect.fail(UnknownAgent.of(unknownAgentDetail(params.id)))
+            return yield* Effect.fail(UnknownThread.of(unknownThreadDetail(params.id)))
           }
           return node
         })))

--- a/apps/server/src/api.ts
+++ b/apps/server/src/api.ts
@@ -1,22 +1,26 @@
 import { Duration, Effect, Stream } from "effect"
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
-import { HttpApiBuilder } from "effect/unstable/httpapi"
+import { HttpApiBuilder, type HttpApiEndpoint } from "effect/unstable/httpapi"
 import type { Event } from "@clavia/tardigrade-core/event"
 
 import {
   Api,
+  apiOf,
   invalidRequest,
   RESERVED_ACTOR,
   ResumeRefused,
   unacceptableField,
   UnknownActor,
+  UnknownProjection,
   UnknownThread,
   UnknownTurn,
+  type ProjectionDeclaration,
   type ThreadNode
 } from "@clavia/tardigrade-client/contract"
+import { agentProjections, turnViewsOf } from "./actor"
 import { Threads } from "./host"
 import { problemResponse } from "./problem"
-import { treeOf, turnsOf, type ThreadSummary } from "./projections"
+import { treeOf, type ThreadSummary } from "./projections"
 
 // The thread endpoints. A route is a lookup on the Threads service plus one projection, because the
 // read side is a pure function of a log (projections.ts) and the write side is one delivery
@@ -234,22 +238,12 @@ export const layerThreadsGroup = (options: ApiOptions = {}) => {
             .filter((row) => row.seq > (after ?? 0) && (types === undefined || types.includes(row.event.type)))
             .slice(0, page ?? limit)
         }))
-      .handle("turns", ({ params, query }) =>
-        Effect.gen(function*() {
-          yield* actorOf(params.actor)
-          const threads = yield* Threads
-          const log = yield* logOf(threads.events, params.id)
-          const { at } = query
-          // `at` is a seq, and a seq is a 1-based position, so `at` events stand before the cut and
-          // the prefix length is the seq itself (projections.ts, turnsOf).
-          return turnsOf(log, at)
-        }))
       .handle("turn", ({ params }) =>
         Effect.gen(function*() {
           yield* actorOf(params.actor)
           const threads = yield* Threads
           const log = yield* logOf(threads.events, params.id)
-          const view = turnsOf(log).find((candidate) => candidate.turn === params.turn)
+          const view = turnViewsOf(log).find((candidate) => candidate.turn === params.turn)
           if (view === undefined) {
             return yield* Effect.fail(
               UnknownTurn.of(
@@ -282,4 +276,72 @@ export const layerThreadsGroup = (options: ApiOptions = {}) => {
           }
           return node
         })))
+}
+
+// ServerApi is the surface this process serves: the platform's log routes plus the projections the
+// actor it mounts declares (actor.ts, agentProjections). The OpenAPI document and the reference
+// page are derived from this value, so a projection appears in both by being declared.
+export const ServerApi = apiOf(agentProjections)
+
+// layerProjectionsGroup implements every declared projection the same way, because there is only
+// one way: read the thread's log, hand it to `run` with the decoded query, and answer what comes
+// back. Nothing about a projection's meaning reaches this module; the actor holds all of it.
+// readOf is the whole of what serving a projection is: refuse an actor this build does not serve,
+// read the thread's log, and hand it to `run` with the decoded query. Nothing about what a
+// projection means reaches this module; the actor holds all of it (actor.ts, agentProjections).
+const readOf = (declaration: ProjectionDeclaration) =>
+(request: {
+  readonly params: { readonly actor: string; readonly id: string }
+  readonly query: never
+}) =>
+  Effect.gen(function*() {
+    yield* actorOf(request.params.actor)
+    const threads = yield* Threads
+    const log = yield* logOf(threads.events, request.params.id)
+    return declaration.run(log, request.query)
+  })
+
+export const layerProjectionsGroup = () =>
+  HttpApiBuilder.group(ServerApi, "projections", (handlers) => {
+    // Every declared name gets the same handler, built from the same record the endpoints were
+    // generated from, so the two cannot disagree about which names exist. The type is the group's
+    // own endpoint map with every key required: `handleAll` accepts a partial record, and a partial
+    // one would leave the group short a handler at run time (api.test.ts, "a declared projection
+    // serves what the actor computes").
+    type Endpoints = (typeof handlers)["~EndpointsByIdentifier"]
+    type Complete = {
+      readonly [Name in keyof Endpoints]: HttpApiEndpoint.Handler<
+        Endpoints[Name],
+        HttpApiEndpoint.MiddlewareError<Endpoints[Name]>,
+        Threads
+      >
+    }
+    const served = Object.fromEntries(
+      Object.entries(agentProjections).map(([name, declaration]) => [name, readOf(declaration)])
+    ) as unknown as Complete
+    return handlers.handleAll(served)
+  })
+
+// The name a request asked for, when the actor never declared it. The declared names are literal
+// paths, and a literal segment beats a parameter in this router, so this route is reached only by a
+// name that matched nothing (api.test.ts, "a name the actor never declared says what does exist").
+// `events` and `stream` never reach here either, for the same reason: they are the log's own routes.
+export const layerUnknownProjection = () => {
+  const declared = Object.keys(agentProjections)
+  const detail = declared.length === 0
+    ? "This actor declares no projections."
+    : `This actor declares ${declared.map((name) => JSON.stringify(name)).join(", ")}.`
+  return HttpRouter.add(
+    "GET",
+    "/v1/actors/:actor/threads/:id/:name",
+    Effect.gen(function*() {
+      const params = yield* HttpRouter.params
+      const actor = paramOf(params, "actor")
+      if (actor !== RESERVED_ACTOR) return problemResponse(UnknownActor.of(unknownActorDetail(actor)))
+      const name = paramOf(params, "name")
+      return problemResponse(
+        UnknownProjection.of(`No projection named ${JSON.stringify(name)} is mounted here. ${detail}`)
+      )
+    })
+  )
 }

--- a/apps/server/src/contract.test.ts
+++ b/apps/server/src/contract.test.ts
@@ -6,17 +6,17 @@ import { BunHttpServer } from "@effect/platform-bun"
 
 import { layerConfig, readConfig } from "./config"
 import { Api, DOCS_PATH, OPENAPI_PATH } from "@clavia/tardigrade-client/contract"
-import { Agents, ResumeRefused } from "./host"
+import { Threads, ResumeRefused } from "./host"
 import { layerGaugeResting, PROBLEM_CONTENT_TYPE, serve } from "./http"
 
 // The declaration, from the outside. These assertions are about what the declaration produces: the
 // document a client generates from, and the failure shape that document promises. The routes
 // themselves are exercised against a real host in api.test.ts.
 
-// An Agents that owns nothing, so every read is the empty log a 404 is made of and every resume is
+// An Threads that owns nothing, so every read is the empty log a 404 is made of and every resume is
 // refused.
-const layerAgentsEmpty = Layer.succeed(Agents)({
-  deliver: (id, message) => Effect.succeed({ agent: id, turn: message.id }),
+const layerThreadsEmpty = Layer.succeed(Threads)({
+  deliver: (id, message) => Effect.succeed({ thread: id, turn: message.id }),
   events: () => Effect.succeed([]),
   list: () => Effect.succeed([]),
   resume: (id, turn) => Effect.fail(new ResumeRefused({ id, turn, detail: "cannot resume a turn that did not fail" })),
@@ -36,7 +36,7 @@ const serving = <A, E>(
         BunHttpServer.layerTest,
         layerConfig({ ...readConfig({}), token: options.token }),
         layerGaugeResting,
-        layerAgentsEmpty
+        layerThreadsEmpty
       ])
     ),
     Effect.scoped,
@@ -54,13 +54,13 @@ setDefaultTimeout(BOOT_MS)
 // Every route the server answers, as method and OpenAPI path. The stream is absent because it is
 // not a declared endpoint (api.ts, layerStream).
 const ROUTES: ReadonlyArray<readonly [string, string]> = [
-  ["post", "/agents/{id}/messages"],
-  ["get", "/agents"],
-  ["get", "/agents/{id}/events"],
-  ["get", "/agents/{id}/turns"],
-  ["get", "/agents/{id}/turns/{turn}"],
-  ["post", "/agents/{id}/turns/{turn}/resume"],
-  ["get", "/agents/{id}/tree"],
+  ["post", "/v1/actors/{actor}/threads/{id}/events"],
+  ["get", "/v1/actors/{actor}/threads"],
+  ["get", "/v1/actors/{actor}/threads/{id}/events"],
+  ["get", "/v1/actors/{actor}/threads/{id}/turns"],
+  ["get", "/v1/actors/{actor}/threads/{id}/turns/{turn}"],
+  ["post", "/v1/actors/{actor}/threads/{id}/turns/{turn}/resume"],
+  ["get", "/v1/actors/{actor}/threads/{id}/tree"],
   ["get", "/healthz"]
 ]
 
@@ -81,7 +81,7 @@ describe("the OpenAPI document", () => {
         readonly content?: Record<string, unknown>
       }> }>>
     }
-    const responses = spec.paths["/agents/{id}/events"]!["get"]!.responses
+    const responses = spec.paths["/v1/actors/{actor}/threads/{id}/events"]!["get"]!.responses
     expect(Object.keys(responses).sort()).toEqual(["200", "400", "404"])
     expect(Object.keys(responses["404"]!.content!)).toEqual([PROBLEM_CONTENT_TYPE])
   })
@@ -112,7 +112,7 @@ describe("the OpenAPI document", () => {
       Effect.gen(function*() {
         const document = yield* client.get(OPENAPI_PATH)
         const page = yield* client.get(DOCS_PATH)
-        const gated = yield* client.get("/agents")
+        const gated = yield* client.get("/v1/actors/agent/threads")
         return [document.status, page.status, gated.status]
       }))
     expect(statuses).toEqual([200, 200, 401])
@@ -125,11 +125,11 @@ describe("problem documents", () => {
   test("carry type, title, status, and detail", async () => {
     const failures = await serving({}, (client) =>
       Effect.gen(function*() {
-        const unknownAgent = yield* client.get("/agents/ghost/events")
-        const refused = yield* client.post("/agents/ghost/turns/t1/resume")
-        const unknownTurn = yield* client.get("/agents/ghost/turns?at=1")
+        const unknownThread = yield* client.get("/v1/actors/agent/threads/ghost/events")
+        const refused = yield* client.post("/v1/actors/agent/threads/ghost/turns/t1/resume")
+        const unknownTurn = yield* client.get("/v1/actors/agent/threads/ghost/turns?at=1")
         return [
-          { status: unknownAgent.status, type: unknownAgent.headers["content-type"], body: yield* unknownAgent.json },
+          { status: unknownThread.status, type: unknownThread.headers["content-type"], body: yield* unknownThread.json },
           { status: refused.status, type: refused.headers["content-type"], body: yield* refused.json },
           { status: unknownTurn.status, type: unknownTurn.headers["content-type"], body: yield* unknownTurn.json }
         ]
@@ -147,7 +147,7 @@ describe("problem documents", () => {
     expect(failures.map((failure) => failure.status)).toEqual([404, 409, 404])
     // An endpoint declaring two failures encodes the one the value names, so the 404 does not
     // render as the 400 beside it (contract.ts, problemKind).
-    expect(failures[2]!.body).toMatchObject({ title: "Unknown Agent" })
+    expect(failures[2]!.body).toMatchObject({ title: "Unknown Thread" })
   })
 
   // A Schema in the declaration refusing input is a failure like any other, so it answers in the
@@ -158,12 +158,12 @@ describe("problem documents", () => {
       Effect.gen(function*() {
         const post = (path: string, body: unknown) =>
           client.post(path, { body: HttpBody.jsonUnsafe(body) })
-        const repeated = yield* client.get("/agents/ghost/turns?at=1&at=2")
-        const notANumber = yield* client.get("/agents/ghost/events?after=soon")
-        const negative = yield* client.get("/agents/ghost/events?limit=-1")
-        const missingField = yield* post("/agents/ghost/messages", { id: "m1" })
-        const emptyId = yield* post("/agents/ghost/messages", { id: "", text: "hello" })
-        const notAnObject = yield* post("/agents/ghost/messages", "hello")
+        const repeated = yield* client.get("/v1/actors/agent/threads/ghost/turns?at=1&at=2")
+        const notANumber = yield* client.get("/v1/actors/agent/threads/ghost/events?after=soon")
+        const negative = yield* client.get("/v1/actors/agent/threads/ghost/events?limit=-1")
+        const missingField = yield* post("/v1/actors/agent/threads/ghost/events", { id: "m1" })
+        const emptyId = yield* post("/v1/actors/agent/threads/ghost/events", { id: "", text: "hello" })
+        const notAnObject = yield* post("/v1/actors/agent/threads/ghost/events", "hello")
         return yield* Effect.forEach(
           [repeated, notANumber, negative, missingField, emptyId, notAnObject],
           (response) =>

--- a/apps/server/src/contract.test.ts
+++ b/apps/server/src/contract.test.ts
@@ -5,7 +5,8 @@ import { OpenApi } from "effect/unstable/httpapi"
 import { BunHttpServer } from "@effect/platform-bun"
 
 import { layerConfig, readConfig } from "./config"
-import { Api, DOCS_PATH, OPENAPI_PATH } from "@clavia/tardigrade-client/contract"
+import { DOCS_PATH, OPENAPI_PATH } from "@clavia/tardigrade-client/contract"
+import { ServerApi } from "./api"
 import { Threads, ResumeRefused } from "./host"
 import { layerGaugeResting, PROBLEM_CONTENT_TYPE, serve } from "./http"
 
@@ -52,7 +53,9 @@ const BOOT_MS = 20_000
 setDefaultTimeout(BOOT_MS)
 
 // Every route the server answers, as method and OpenAPI path. The stream is absent because it is
-// not a declared endpoint (api.ts, layerStream).
+// not a declared endpoint (api.ts, layerStream). The first three are the log, which is the whole of
+// what the platform declares; `turns` is there because the actor this build mounts declares it
+// (actor.ts, agentProjections), and it appears in the document by being declared.
 const ROUTES: ReadonlyArray<readonly [string, string]> = [
   ["post", "/v1/actors/{actor}/threads/{id}/events"],
   ["get", "/v1/actors/{actor}/threads"],
@@ -71,12 +74,12 @@ const operationsOf = (spec: { readonly paths: Record<string, Record<string, unkn
 
 describe("the OpenAPI document", () => {
   test("lists every endpoint the declaration holds", () => {
-    const listed = operationsOf(OpenApi.fromApi(Api) as never)
+    const listed = operationsOf(OpenApi.fromApi(ServerApi) as never)
     expect(listed.sort()).toEqual(ROUTES.map(([method, path]) => `${method} ${path}`).sort())
   })
 
   test("describes a failure as problem+json", () => {
-    const spec = OpenApi.fromApi(Api) as never as {
+    const spec = OpenApi.fromApi(ServerApi) as never as {
       readonly paths: Record<string, Record<string, { readonly responses: Record<string, {
         readonly content?: Record<string, unknown>
       }> }>>

--- a/apps/server/src/contract.ts
+++ b/apps/server/src/contract.ts
@@ -15,6 +15,7 @@ import {
   type Problem
 } from "@clavia/tardigrade-client/contract"
 
+import type * as Actor from "./actor"
 import type * as Projections from "./projections"
 
 // This server's side of the contract. The declaration itself is a package
@@ -69,7 +70,7 @@ const asserts = <_ extends true>(): void => {}
 asserts<Same<Projections.ThreadStatus, typeof ThreadStatus.Type>>()
 asserts<Same<Projections.ThreadSummary, typeof ThreadSummary.Type>>()
 asserts<Same<Projections.ThreadNode, typeof ThreadNode.Type>>()
-asserts<Same<Projections.TurnStatus, typeof TurnStatus.Type>>()
-asserts<Same<Projections.TurnView, typeof TurnView.Type>>()
+asserts<Same<Actor.TurnStatus, typeof TurnStatus.Type>>()
+asserts<Same<Actor.TurnViewShape, typeof TurnView.Type>>()
 asserts<Extends<typeof UnknownThread.schema.Type, Problem>>()
 asserts<Extends<typeof InvalidRequest.schema.Type, Problem>>()

--- a/apps/server/src/contract.ts
+++ b/apps/server/src/contract.ts
@@ -1,9 +1,9 @@
 import { Effect, Layer, type SchemaIssue } from "effect"
 import { HttpApiMiddleware } from "effect/unstable/httpapi"
 import {
-  AgentNode,
-  AgentStatus,
-  AgentSummary,
+  ThreadNode,
+  ThreadStatus,
+  ThreadSummary,
   InvalidRequest,
   invalidRequest,
   missingField,
@@ -11,7 +11,7 @@ import {
   TurnStatus,
   TurnView,
   unacceptableField,
-  UnknownAgent,
+  UnknownThread,
   type Problem
 } from "@clavia/tardigrade-client/contract"
 
@@ -66,10 +66,10 @@ type Extends<A, B> = [A] extends [B] ? true : never
 
 const asserts = <_ extends true>(): void => {}
 
-asserts<Same<Projections.AgentStatus, typeof AgentStatus.Type>>()
-asserts<Same<Projections.AgentSummary, typeof AgentSummary.Type>>()
-asserts<Same<Projections.AgentNode, typeof AgentNode.Type>>()
+asserts<Same<Projections.ThreadStatus, typeof ThreadStatus.Type>>()
+asserts<Same<Projections.ThreadSummary, typeof ThreadSummary.Type>>()
+asserts<Same<Projections.ThreadNode, typeof ThreadNode.Type>>()
 asserts<Same<Projections.TurnStatus, typeof TurnStatus.Type>>()
 asserts<Same<Projections.TurnView, typeof TurnView.Type>>()
-asserts<Extends<typeof UnknownAgent.schema.Type, Problem>>()
+asserts<Extends<typeof UnknownThread.schema.Type, Problem>>()
 asserts<Extends<typeof InvalidRequest.schema.Type, Problem>>()

--- a/apps/server/src/host.test.ts
+++ b/apps/server/src/host.test.ts
@@ -5,7 +5,7 @@ import { Infer, type InferRequest } from "@clavia/tardigrade"
 import type { Action } from "@clavia/tardigrade/events"
 
 import { layerConfig, readConfig } from "./config"
-import { Agents, layerAgents, ResumeRefused } from "./host"
+import { Threads, layerThreads, ResumeRefused } from "./host"
 import { DriverGauge } from "./http"
 
 // Every case here opens a real store on disk and drives a real host, so it competes with every
@@ -39,43 +39,43 @@ const layerScripted: Layer.Layer<Infer> = Layer.succeed(Infer)({
 // The database is ":memory:", so each test opens its own store and closes it with the scope.
 const config = layerConfig(readConfig({ TARDIGRADE_DB: ":memory:" }))
 
-// The body runs with both services the layer provides: the agents it drives, and the gauge
+// The body runs with both services the layer provides: the threads it drives, and the gauge
 // /healthz reads over the same driver (http.ts, DriverGauge).
 const running = <A, E>(
-  body: (agents: Context.Service.Shape<typeof Agents>) => Effect.Effect<A, E, DriverGauge>
+  body: (threads: Context.Service.Shape<typeof Threads>) => Effect.Effect<A, E, DriverGauge>
 ): Promise<A> =>
   Effect.gen(function*() {
-    const agents = yield* Agents
-    return yield* body(agents)
+    const threads = yield* Threads
+    return yield* body(threads)
   }).pipe(
-    Effect.provide(Layer.provide(layerAgents({ infer: layerScripted }), config)),
+    Effect.provide(Layer.provide(layerThreads({ infer: layerScripted }), config)),
     Effect.scoped,
     Effect.runPromise
   ) as Promise<A>
 
-describe("the agents service", () => {
+describe("the threads service", () => {
   test("a delivered brief drives to a completed turn", async () => {
-    const types = await running((agents) =>
+    const types = await running((threads) =>
       Effect.gen(function*() {
-        const accepted = yield* agents.deliver("alpha", { id: "m1", text: "hello" })
-        expect(accepted).toEqual({ agent: "alpha", turn: "m1" })
-        yield* agents.settled
+        const accepted = yield* threads.deliver("alpha", { id: "m1", text: "hello" })
+        expect(accepted).toEqual({ thread: "alpha", turn: "m1" })
+        yield* threads.settled
         const gauge = yield* DriverGauge
         expect(yield* gauge.dirty).toBe(0)
         expect(yield* gauge.resting).toBe(true)
-        return (yield* agents.events("alpha")).map((e) => e.type)
+        return (yield* threads.events("alpha")).map((e) => e.type)
       })
     )
     expect(types).toContain("TurnCompleted")
   })
 
-  test("list names every agent lane with its log", async () => {
-    const listed = await running((agents) =>
+  test("list names every thread lane with its log", async () => {
+    const listed = await running((threads) =>
       Effect.gen(function*() {
-        yield* agents.deliver("alpha", { id: "m1", text: "hello" })
-        yield* agents.deliver("beta", { id: "m2", text: "hello" })
-        yield* agents.settled
-        return yield* agents.list()
+        yield* threads.deliver("alpha", { id: "m1", text: "hello" })
+        yield* threads.deliver("beta", { id: "m2", text: "hello" })
+        yield* threads.settled
+        return yield* threads.list()
       })
     )
     expect(listed.map((entry) => entry.id)).toEqual(["alpha", "beta"])
@@ -83,11 +83,11 @@ describe("the agents service", () => {
   })
 
   test("a turn that did not fail refuses to resume", async () => {
-    const refused = await running((agents) =>
+    const refused = await running((threads) =>
       Effect.gen(function*() {
-        yield* agents.deliver("alpha", { id: "m1", text: "hello" })
-        yield* agents.settled
-        return yield* Effect.flip(agents.resume("alpha", "m1"))
+        yield* threads.deliver("alpha", { id: "m1", text: "hello" })
+        yield* threads.settled
+        return yield* Effect.flip(threads.resume("alpha", "m1"))
       })
     )
     expect(refused).toBeInstanceOf(ResumeRefused)
@@ -96,14 +96,14 @@ describe("the agents service", () => {
   })
 
   test("redelivering one message id is absorbed", async () => {
-    const counts = await running((agents) =>
+    const counts = await running((threads) =>
       Effect.gen(function*() {
-        yield* agents.deliver("alpha", { id: "m1", text: "hello" })
-        yield* agents.settled
-        const before = (yield* agents.events("alpha")).length
-        yield* agents.deliver("alpha", { id: "m1", text: "hello" })
-        yield* agents.settled
-        return [before, (yield* agents.events("alpha")).length]
+        yield* threads.deliver("alpha", { id: "m1", text: "hello" })
+        yield* threads.settled
+        const before = (yield* threads.events("alpha")).length
+        yield* threads.deliver("alpha", { id: "m1", text: "hello" })
+        yield* threads.settled
+        return [before, (yield* threads.events("alpha")).length]
       })
     )
     expect(counts[1]).toBe(counts[0]!)

--- a/apps/server/src/host.ts
+++ b/apps/server/src/host.ts
@@ -21,11 +21,14 @@ import { ServerConfig, type ServerConfigValue } from "./config"
 import { DriverGauge } from "./http"
 
 // The durable host, the assembly it runs, and the loop that drives it, behind one service. The
-// routes speak agent ids; the lane a host knows lives here and nowhere else, so a route can never
+// routes speak thread ids; the lane a host knows lives here and nowhere else, so a route can never
 // name a lane and the store can never see an id.
 
 // LANE_PREFIX is the id-to-lane map (apps-server-spec.md, "Resources"). A lane outside it belongs
-// to something other than an agent and never appears in a listing.
+// to something other than a thread and never appears in a listing. The prefix stays `ag.` while the
+// API's noun is the thread, because the lane is where the agent assembly runs, and that assembly
+// mints its own child lanes under the same prefix (packages/agent/src/spawn.ts, `sibling`). Renaming
+// it would rename addresses a spawn already wrote into a durable log.
 export const LANE_PREFIX = "ag."
 
 export const laneOf = (id: string): string => `${LANE_PREFIX}${id}`
@@ -54,12 +57,12 @@ export class ResumeRefused extends Data.TaggedError("ResumeRefused")<{
 }> {}
 
 // The operations the HTTP surface has: deliver a message, read a log, list what exists, resume a
-// failed turn. Every one speaks an agent id. Reads return raw events because the projections are
+// failed turn. Every one speaks a thread id. Reads return raw events because the projections are
 // pure functions of a log (projections.ts); a route joins the two.
-export class Agents extends Context.Service<
-  Agents,
+export class Threads extends Context.Service<
+  Threads,
   {
-    readonly deliver: (id: string, message: Inbound) => Effect.Effect<{ agent: string; turn: string }>
+    readonly deliver: (id: string, message: Inbound) => Effect.Effect<{ thread: string; turn: string }>
     readonly events: (id: string) => Effect.Effect<ReadonlyArray<Event>>
     readonly list: () => Effect.Effect<ReadonlyArray<{ readonly id: string; readonly events: ReadonlyArray<Event> }>>
     readonly resume: (id: string, turn: string) => Effect.Effect<void, ResumeRefused>
@@ -68,7 +71,7 @@ export class Agents extends Context.Service<
     // a shutdown do (host.test.ts).
     readonly settled: Effect.Effect<void>
   }
->()("tardigrade/server/Agents") {}
+>()("tardigrade/server/Threads") {}
 
 // The assembly this server runs, one for every lane: code mode with the spawn and workspace
 // packages in scope, plus the three policy capabilities. v1 runs this one assembly and forking is
@@ -95,7 +98,7 @@ const layerInferFrom = (config: ServerConfigValue): Layer.Layer<Infer> => {
   return infer({ baseUrl, apiKey, model: id, ...(provider === undefined ? {} : { provider }) })
 }
 
-export interface AgentsOptions {
+export interface ThreadsOptions {
   // The model seam. Absent, the binding is derived from ServerConfig; present, it replaces that
   // derivation whole, which is how a test runs a scripted mind with no credentials
   // (host.test.ts). It is the one seam because Infer is the one place a turn leaves the process.
@@ -104,7 +107,7 @@ export interface AgentsOptions {
 
 // make builds the host, recovers what a death interrupted, and returns the service pair. The
 // close is a scope finalizer, so the process that stops listening also stops writing.
-const make = (options: AgentsOptions) =>
+const make = (options: ThreadsOptions) =>
   Effect.gen(function*() {
     const config = yield* ServerConfig
     const assembly = assemblyOf()
@@ -168,7 +171,7 @@ const make = (options: AgentsOptions) =>
 
     const read = (id: string) => Effect.promise(() => host.read(laneOf(id)))
 
-    const service: Context.Service.Shape<typeof Agents> = {
+    const service: Context.Service.Shape<typeof Threads> = {
       deliver: (id, message) =>
         Effect.gen(function*() {
           const at = yield* Clock.currentTimeMillis
@@ -185,7 +188,7 @@ const make = (options: AgentsOptions) =>
             )
           )
           request()
-          return { agent: id, turn: message.id }
+          return { thread: id, turn: message.id }
         }),
       events: read,
       list: () =>
@@ -221,10 +224,10 @@ const make = (options: AgentsOptions) =>
       dirty: Effect.sync(() => (driving === undefined ? 0 : follow ? 2 : 1))
     }
 
-    return Context.make(Agents, service).pipe(Context.add(DriverGauge, gauge))
+    return Context.make(Threads, service).pipe(Context.add(DriverGauge, gauge))
   })
 
-// layerAgents is the host, the assembly, and the driver: the Agents the routes consume and the
+// layerThreads is the host, the assembly, and the driver: the Threads the routes consume and the
 // DriverGauge /healthz reads, built once and closed with the scope.
-export const layerAgents = (options: AgentsOptions = {}): Layer.Layer<Agents | DriverGauge, never, ServerConfig> =>
+export const layerThreads = (options: ThreadsOptions = {}): Layer.Layer<Threads | DriverGauge, never, ServerConfig> =>
   Layer.effectContext(make(options))

--- a/apps/server/src/host.ts
+++ b/apps/server/src/host.ts
@@ -1,22 +1,12 @@
 import { Clock, Context, Data, Effect, Layer } from "effect"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { messageReceived } from "@clavia/tardigrade-core/message"
-import {
-  agentOf,
-  agentsPackage,
-  budget,
-  codeModeFor,
-  compaction,
-  Infer,
-  reply,
-  resumeTurn,
-  workspacePackage,
-  type RlmR
-} from "@clavia/tardigrade"
+import { Infer, resumeTurn, type RlmR } from "@clavia/tardigrade"
 import type { Action } from "@clavia/tardigrade/events"
 import { createBunHost, type BunHost } from "@clavia/tardigrade-bun/host"
 import { infer } from "@clavia/tardigrade-model/model"
 
+import { assemblyOf } from "./actor"
 import { ServerConfig, type ServerConfigValue } from "./config"
 import { DriverGauge } from "./http"
 
@@ -72,17 +62,6 @@ export class Threads extends Context.Service<
     readonly settled: Effect.Effect<void>
   }
 >()("tardigrade/server/Threads") {}
-
-// The assembly this server runs, one for every lane: code mode with the spawn and workspace
-// packages in scope, plus the three policy capabilities. v1 runs this one assembly and forking is
-// the customization path (apps-server-spec.md, "Explicitly out of scope for v1").
-const assemblyOf = () =>
-  agentOf([
-    codeModeFor({ packages: [agentsPackage(), workspacePackage()] }),
-    reply,
-    budget,
-    compaction
-  ])
 
 // The model binding the configured coordinates name. Absent coordinates are not an endpoint this
 // server invents: every attempt fails with what is missing, so the process still boots, still

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -4,7 +4,7 @@ import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { BunHttpServer } from "@effect/platform-bun"
 
 import { DEFAULT_DB, DEFAULT_PORT, layerConfig, readConfig, type ServerConfigValue } from "./config"
-import { Agents } from "./host"
+import { Threads } from "./host"
 import { ALLOWED_HEADERS, layerGaugeResting, serve, PROBLEM_CONTENT_TYPE, DriverGauge, type Health } from "./http"
 
 // Every case here boots a real server on an ephemeral port, so it competes with every other task in
@@ -18,10 +18,10 @@ setDefaultTimeout(BOOT_MS)
 // The HTTP surface against a real Bun server on an ephemeral port, so the assertions are about
 // wire behavior rather than about the shape of a layer.
 
-// The conventions these tests are about hold over any host, so the agent routes get one that owns
+// The conventions these tests are about hold over any host, so the thread routes get one that owns
 // nothing. The routes themselves are exercised against a real host in api.test.ts.
-const layerAgentsEmpty = Layer.succeed(Agents)({
-  deliver: (id, message) => Effect.succeed({ agent: id, turn: message.id }),
+const layerThreadsEmpty = Layer.succeed(Threads)({
+  deliver: (id, message) => Effect.succeed({ thread: id, turn: message.id }),
   events: () => Effect.succeed([]),
   list: () => Effect.succeed([]),
   resume: () => Effect.void,
@@ -50,7 +50,7 @@ const serving = <A, E>(
         BunHttpServer.layerTest,
         layerConfig(options.config ?? configOf()),
         options.gauge ?? layerGaugeResting,
-        layerAgentsEmpty
+        layerThreadsEmpty
       ])
     ),
     Effect.scoped,
@@ -132,7 +132,7 @@ describe("auth", () => {
 
     const anonymous = await serving({ config }, (client) =>
       Effect.gen(function*() {
-        const response = yield* client.get("/agents")
+        const response = yield* client.get("/v1/actors/agent/threads")
         return { status: response.status, contentType: response.headers["content-type"], body: yield* response.json }
       }))
     expect(anonymous.status).toBe(401)
@@ -140,11 +140,11 @@ describe("auth", () => {
     expect(anonymous.body).toMatchObject({ status: 401, title: "Unauthorized" })
 
     const wrong = await serving({ config }, (client) =>
-      client.execute(HttpClientRequest.bearerToken(HttpClientRequest.get("/agents"), "guess")))
+      client.execute(HttpClientRequest.bearerToken(HttpClientRequest.get("/v1/actors/agent/threads"), "guess")))
     expect(wrong.status).toBe(403)
 
     const right = await serving({ config }, (client) =>
-      client.execute(HttpClientRequest.bearerToken(HttpClientRequest.get("/agents"), "secret")))
+      client.execute(HttpClientRequest.bearerToken(HttpClientRequest.get("/v1/actors/agent/threads"), "secret")))
     expect(right.status).toBe(200)
 
     const health = await serving({ config }, (client) => client.get("/healthz"))
@@ -161,7 +161,7 @@ describe("cors", () => {
     const allowed = await serving({}, (client) =>
       Effect.map(
         client.execute(
-          HttpClientRequest.setHeaders(HttpClientRequest.options("/agents"), {
+          HttpClientRequest.setHeaders(HttpClientRequest.options("/v1/actors/agent/threads"), {
             origin: "http://localhost:5173",
             "access-control-request-method": "GET",
             "access-control-request-headers": ALLOWED_HEADERS.join(",")

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -2,7 +2,7 @@ import { Context, Effect, Layer } from "effect"
 import { Headers, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiScalar } from "effect/unstable/httpapi"
 
-import { layerThreadsGroup, layerStream, type ApiOptions } from "./api"
+import { layerProjectionsGroup, layerThreadsGroup, layerStream, layerUnknownProjection, ServerApi, type ApiOptions } from "./api"
 import { ServerConfig } from "./config"
 import { Api, DOCS_PATH, OPENAPI_PATH, type Health } from "@clavia/tardigrade-client/contract"
 import { layerRequestProblems } from "./contract"
@@ -160,14 +160,19 @@ export const layerCors = HttpRouter.cors({
 export const layerApp = (options: ApiOptions = {}) =>
   Layer.mergeAll(
     Layer.provide(
-      Layer.provide(HttpApiBuilder.layer(Api, { openapiPath: OPENAPI_PATH }), [
+      Layer.provide(HttpApiBuilder.layer(ServerApi, { openapiPath: OPENAPI_PATH }), [
         layerThreadsGroup(options),
+        layerProjectionsGroup(),
         layerHealthGroup
       ]),
       layerRequestProblems
     ),
-    HttpApiScalar.layer(Api, { path: DOCS_PATH }),
+    HttpApiScalar.layer(ServerApi, { path: DOCS_PATH }),
     layerStream(options),
+    // After the declared routes and before the catch-all: a literal segment beats a parameter in
+    // this router, so a projection the actor declared is served and every other name under a thread
+    // is told what does exist (api.ts, layerUnknownProjection).
+    layerUnknownProjection(),
     layerNotFound,
     layerCors,
     layerAuth

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -2,7 +2,7 @@ import { Context, Effect, Layer } from "effect"
 import { Headers, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiScalar } from "effect/unstable/httpapi"
 
-import { layerAgentsGroup, layerStream, type ApiOptions } from "./api"
+import { layerThreadsGroup, layerStream, type ApiOptions } from "./api"
 import { ServerConfig } from "./config"
 import { Api, DOCS_PATH, OPENAPI_PATH, type Health } from "@clavia/tardigrade-client/contract"
 import { layerRequestProblems } from "./contract"
@@ -161,7 +161,7 @@ export const layerApp = (options: ApiOptions = {}) =>
   Layer.mergeAll(
     Layer.provide(
       Layer.provide(HttpApiBuilder.layer(Api, { openapiPath: OPENAPI_PATH }), [
-        layerAgentsGroup(options),
+        layerThreadsGroup(options),
         layerHealthGroup
       ]),
       layerRequestProblems

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -3,7 +3,7 @@ import { BunHttpServer, BunRuntime } from "@effect/platform-bun"
 import { assertSupportedBun } from "@clavia/tardigrade-core/runtime"
 
 import { layerFromEnv, readConfig } from "./config"
-import { layerAgents } from "./host"
+import { layerThreads } from "./host"
 import { serve } from "./http"
 
 // The entry point: environment to configuration to a listening Bun process. It holds no logic of
@@ -19,9 +19,9 @@ const config = readConfig(process.env)
 const configLayer = layerFromEnv(process.env)
 
 // The host is built from the same configuration the routes read, and closed with the scope the
-// server runs in, so the process that stops listening stops writing (host.ts, layerAgents).
-const agents = Layer.provide(layerAgents(), configLayer)
+// server runs in, so the process that stops listening stops writing (host.ts, layerThreads).
+const threads = Layer.provide(layerThreads(), configLayer)
 
-const main = Layer.provide(serve(), [BunHttpServer.layer({ port: config.port }), configLayer, agents])
+const main = Layer.provide(serve(), [BunHttpServer.layer({ port: config.port }), configLayer, threads])
 
 BunRuntime.runMain(Layer.launch(main))

--- a/apps/server/src/projections.test.ts
+++ b/apps/server/src/projections.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { replyId } from "@clavia/tardigrade-core/message"
 
-import { statusOf, summaryOf, treeOf, turnsOf } from "./projections"
+import { statusOf, summaryOf, treeOf } from "./projections"
 
 // The projections are functions of an event array, so the fixtures are event arrays: the shapes
 // below are the ones an assembled thread writes (packages/agent/src/index.test.ts and
@@ -31,9 +31,6 @@ const completed = (turn: string, output: string): Event =>
 
 const failed = (turn: string, error: string): Event =>
   ({ type: "TurnFailed", turn, error, at: at() }) as Event
-
-const requested = (turn: string, callId: string): Event =>
-  ({ type: "BudgetRequested", turn, callId, reason: "more calls", amount: 5, at: at() }) as Event
 
 const reply = (id: string, text = "done"): Event =>
   ({ type: "MessageReceived", id: replyId(id), text, outcome: "completed", at: at() }) as Event
@@ -147,39 +144,5 @@ describe("treeOf", () => {
     const late = [inbound("b")]
     const logs = new Map<string, ReadonlyArray<Event>>([["late", late], ["early", early]])
     expect(treeOf(logs).map((node) => node.id)).toEqual(["early", "late"])
-  })
-})
-
-describe("turnsOf", () => {
-  test("one entry per inbound message, with its boundary", () => {
-    const log = [
-      inbound("m1"),
-      completed("m1", "42"),
-      inbound("m2"),
-      failed("m2", "boom"),
-      inbound("m3")
-    ]
-    expect(turnsOf(log)).toEqual([
-      { turn: "m1", status: "completed", output: "42" },
-      { turn: "m2", status: "failed", error: "boom" },
-      { turn: "m3", status: "pending" }
-    ])
-  })
-
-  test("a reply message is not a turn", () => {
-    const log = [inbound("m1"), reply("t1.0"), completed("m1", "42")]
-    expect(turnsOf(log).map((view) => view.turn)).toEqual(["m1"])
-  })
-
-  test("an unanswered budget ask is parked", () => {
-    const log = [inbound("m1"), requested("m1", "c1")]
-    expect(turnsOf(log)).toEqual([{ turn: "m1", status: "parked" }])
-  })
-
-  test("a prefix takes a turn back to pending", () => {
-    const log = [inbound("m1"), completed("m1", "42")]
-    expect(turnsOf(log)[0]!.status).toBe("completed")
-    expect(turnsOf(log, 1)).toEqual([{ turn: "m1", status: "pending" }])
-    expect(turnsOf(log, 0)).toEqual([])
   })
 })

--- a/apps/server/src/projections.test.ts
+++ b/apps/server/src/projections.test.ts
@@ -5,7 +5,7 @@ import { replyId } from "@clavia/tardigrade-core/message"
 import { statusOf, summaryOf, treeOf, turnsOf } from "./projections"
 
 // The projections are functions of an event array, so the fixtures are event arrays: the shapes
-// below are the ones an assembled agent writes (packages/agent/src/index.test.ts and
+// below are the ones an assembled thread writes (packages/agent/src/index.test.ts and
 // packages/code/src/events.ts), trimmed to the fields a projection reads.
 
 let clock = 0
@@ -17,7 +17,7 @@ const inbound = (id: string, text = "do the thing"): Event =>
 const dispatched = (execId: string): Event =>
   ({ type: "CodeDispatched", execId, code: "return 1", at: at() }) as Event
 
-const called = (callId: string, name = "agents"): Event =>
+const called = (callId: string, name = "threads"): Event =>
   ({ type: "PackageCalled", callId, name, arguments: {}, at: at() }) as Event
 
 const blocked = (callId: string, awaiting: string): Event =>
@@ -135,7 +135,7 @@ describe("treeOf", () => {
     expect("parent" in root).toBe(false)
   })
 
-  test("a package call to a non-agent claims nothing", () => {
+  test("a package call to a non-thread claims nothing", () => {
     const logs = new Map<string, ReadonlyArray<Event>>([
       ["root", [inbound("m1"), dispatched("t1"), called("t1.0", "workspace")]]
     ])

--- a/apps/server/src/projections.ts
+++ b/apps/server/src/projections.ts
@@ -3,20 +3,20 @@ import { REPLY_SUFFIX } from "@clavia/tardigrade-core/message"
 import { canProgress, factsOf } from "@clavia/tardigrade-code/projections"
 import { boundaryOf } from "@clavia/tardigrade/boundary"
 
-// The read side of the API. Every endpoint that answers a question about an agent answers it here,
-// as a pure function of that agent's events (apps-server-spec.md, "Principles": every read is a
+// The read side of the API. Every endpoint that answers a question about a thread answers it here,
+// as a pure function of that thread's events (apps-server-spec.md, "Principles": every read is a
 // projection of the log). Nothing in this module touches a store, a host, or a clock, so a route is
 // a lookup plus one of these calls, and a test is an array of events.
 //
 // The projections read the framework's own projections wherever one already answers the question:
 // the lane's owed work comes from the code lane (@clavia/tardigrade-code/projections), and a turn's
-// outcome comes from the agent's boundary (@clavia/tardigrade/boundary). The vocabulary the wire
+// outcome comes from the thread's boundary (@clavia/tardigrade/boundary). The vocabulary the wire
 // speaks is the only thing added here.
 
-// AgentStatus is the summary vocabulary of GET /agents. Four answers, in the order they are
-// decided: an agent whose work cannot move is blocked, an agent that owes a transition is running,
-// an agent whose last turn died owing nothing is failed, and anything else has settled.
-export type AgentStatus = "settled" | "running" | "blocked" | "failed"
+// ThreadStatus is the summary vocabulary of GET /v1/actors/:actor/threads. Four answers, in the order they are
+// decided: a thread whose work cannot move is blocked, a thread that owes a transition is running,
+// a thread whose last turn died owing nothing is failed, and anything else has settled.
+export type ThreadStatus = "settled" | "running" | "blocked" | "failed"
 
 const numberAt = (event: Event): number | undefined => {
   const at = (event as { at?: unknown }).at
@@ -26,7 +26,7 @@ const numberAt = (event: Event): number | undefined => {
 const idOf = (event: Event): string => String((event as { id?: unknown }).id ?? "")
 
 // inboundOf returns the ids of the turns a log was asked to serve, in log order. A reply is an
-// inbound event and never an inbound turn: it answers an id this agent sent out, under that id's
+// inbound event and never an inbound turn: it answers an id this thread sent out, under that id's
 // own `<id>.reply` name (@clavia/tardigrade-core/message, REPLY_SUFFIX), so listing it would report
 // a child's answer as a turn of the parent (projections.test.ts, "a reply message is not a turn").
 const inboundOf = (events: ReadonlyArray<Event>): ReadonlyArray<string> => {
@@ -42,9 +42,9 @@ const inboundOf = (events: ReadonlyArray<Event>): ReadonlyArray<string> => {
   return ids
 }
 
-// statusOf reports what the agent is doing, decided in one order because the states overlap in the
+// statusOf reports what the thread is doing, decided in one order because the states overlap in the
 // log: a blocked lane also has a turn without a terminal, and a failed turn is only failed once
-// nothing is owed (apps-server-spec.md, "GET /agents").
+// nothing is owed (apps-server-spec.md, "GET /v1/actors/:actor/threads").
 //
 // The first two answers are the code lane's own head-of-queue reading, not a second derivation of
 // it: `workOwed` is this head plus `canProgress`, so blocked is exactly the case that leaves
@@ -54,7 +54,7 @@ const inboundOf = (events: ReadonlyArray<Event>): ReadonlyArray<string> => {
 //
 // A turn with no terminal and no owed execution is running as well: the model owes the next
 // transition, and no code has been dispatched yet (projections.test.ts, "a fresh turn is running").
-export const statusOf = (events: ReadonlyArray<Event>): AgentStatus => {
+export const statusOf = (events: ReadonlyArray<Event>): ThreadStatus => {
   const head = factsOf(events).find((facts) => !facts.settled)
   if (head !== undefined) return canProgress(head) ? "running" : "blocked"
   const turns = inboundOf(events)
@@ -65,21 +65,21 @@ export const statusOf = (events: ReadonlyArray<Event>): AgentStatus => {
   return boundary.kind === "failed" ? "failed" : "settled"
 }
 
-// AgentSummary is one row of GET /agents: what an agent is, without its events. `parent` is absent
-// for a root, and `lastAt` for an agent whose events carry no timestamp.
-export interface AgentSummary {
+// ThreadSummary is one row of GET /v1/actors/:actor/threads: what a thread is, without its events. `parent` is absent
+// for a root, and `lastAt` for a thread whose events carry no timestamp.
+export interface ThreadSummary {
   readonly id: string
   readonly parent?: string
   readonly events: number
   readonly lastAt?: number
-  readonly status: AgentStatus
+  readonly status: ThreadStatus
 }
 
 // summaryOf projects one log into its row. `parent` is a parameter because a child's own log holds
 // no evidence of its parent: the claim is a `PackageCalled` in the PARENT's log, so parentage is a
 // fact of the forest and only `treeOf` can see it (projections.test.ts, "a summary carries the
 // parent the caller supplies").
-export const summaryOf = (id: string, events: ReadonlyArray<Event>, parent?: string): AgentSummary => {
+export const summaryOf = (id: string, events: ReadonlyArray<Event>, parent?: string): ThreadSummary => {
   let lastAt: number | undefined
   for (const event of events) {
     const at = numberAt(event)
@@ -94,13 +94,13 @@ export const summaryOf = (id: string, events: ReadonlyArray<Event>, parent?: str
   }
 }
 
-// AgentNode is a summary with the agents it spawned, the shape GET /agents/:id/tree serves.
-export interface AgentNode extends AgentSummary {
-  readonly children: ReadonlyArray<AgentNode>
+// ThreadNode is a summary with the threads it spawned, the shape GET /v1/actors/:actor/threads/:id/tree serves.
+export interface ThreadNode extends ThreadSummary {
+  readonly children: ReadonlyArray<ThreadNode>
 }
 
 // firstAt is the log's own start, the order the forest is listed in. A log with no timestamp sorts
-// last rather than first, so an untimed agent never displaces a real one.
+// last rather than first, so an untimed thread never displaces a real one.
 const firstAt = (events: ReadonlyArray<Event>): number => {
   for (const event of events) {
     const at = numberAt(event)
@@ -113,11 +113,11 @@ const firstAt = (events: ReadonlyArray<Event>): number => {
 // `callId` is Y's id: a spawn names its child by the call's own id and places it at `ag.<callId>`
 // (packages/agent/src/spawn.ts, `sibling`), so the recorded call IS the claim, and no id parsing is
 // needed to find it. Ids the map does not hold are calls to other packages and claim nothing
-// (projections.test.ts, "a package call to a non-agent claims nothing").
+// (projections.test.ts, "a package call to a non-thread claims nothing").
 //
-// Roots are the agents no log claims, sorted by first event time; children sort the same way, so
+// Roots are the threads no log claims, sorted by first event time; children sort the same way, so
 // two runs of the same forest render identically (projections.test.ts, "three levels, two roots").
-export const treeOf = (logs: ReadonlyMap<string, ReadonlyArray<Event>>): ReadonlyArray<AgentNode> => {
+export const treeOf = (logs: ReadonlyMap<string, ReadonlyArray<Event>>): ReadonlyArray<ThreadNode> => {
   const parents = new Map<string, string>()
   for (const [id, events] of logs) {
     for (const event of events) {
@@ -138,7 +138,7 @@ export const treeOf = (logs: ReadonlyMap<string, ReadonlyArray<Event>>): Readonl
   // A claim cycle is not reachable through minted call ids, but the map is an argument, so the walk
   // carries the guard rather than trusting its caller.
   const walked = new Set<string>()
-  const node = (id: string, parent?: string): AgentNode => {
+  const node = (id: string, parent?: string): ThreadNode => {
     walked.add(id)
     const events = logs.get(id) ?? []
     const children = (childrenOf.get(id) ?? []).filter((child) => !walked.has(child)).sort(order)
@@ -147,7 +147,7 @@ export const treeOf = (logs: ReadonlyMap<string, ReadonlyArray<Event>>): Readonl
   return [...logs.keys()].filter((id) => !parents.has(id)).sort(order).map((id) => node(id))
 }
 
-// TurnStatus is the turn vocabulary of GET /agents/:id/turns. `parked` is the budget ask nobody can
+// TurnStatus is the turn vocabulary of GET /v1/actors/:actor/threads/:id/turns. `parked` is the budget ask nobody can
 // answer over HTTP (apps-server-spec.md, "Explicitly out of scope": budget escalation).
 export type TurnStatus = "pending" | "completed" | "failed" | "parked"
 

--- a/apps/server/src/projections.ts
+++ b/apps/server/src/projections.ts
@@ -29,7 +29,7 @@ const idOf = (event: Event): string => String((event as { id?: unknown }).id ?? 
 // inbound event and never an inbound turn: it answers an id this thread sent out, under that id's
 // own `<id>.reply` name (@clavia/tardigrade-core/message, REPLY_SUFFIX), so listing it would report
 // a child's answer as a turn of the parent (projections.test.ts, "a reply message is not a turn").
-const inboundOf = (events: ReadonlyArray<Event>): ReadonlyArray<string> => {
+export const inboundOf = (events: ReadonlyArray<Event>): ReadonlyArray<string> => {
   const ids: string[] = []
   const seen = new Set<string>()
   for (const event of events) {
@@ -145,33 +145,4 @@ export const treeOf = (logs: ReadonlyMap<string, ReadonlyArray<Event>>): Readonl
     return { ...summaryOf(id, events, parent), children: children.map((child) => node(child, id)) }
   }
   return [...logs.keys()].filter((id) => !parents.has(id)).sort(order).map((id) => node(id))
-}
-
-// TurnStatus is the turn vocabulary of GET /v1/actors/:actor/threads/:id/turns. `parked` is the budget ask nobody can
-// answer over HTTP (apps-server-spec.md, "Explicitly out of scope": budget escalation).
-export type TurnStatus = "pending" | "completed" | "failed" | "parked"
-
-export interface TurnView {
-  readonly turn: string
-  readonly status: TurnStatus
-  readonly output?: string
-  readonly error?: string
-}
-
-// turnsOf projects one turn per inbound message, in the order the messages arrived. `at` cuts the
-// log to a prefix first: any prefix of a log is a valid state, so time travel is this one argument
-// and never a stored mode (apps-server-spec.md, "Principles"). A prefix taken before a turn's
-// terminal reads that turn pending again (projections.test.ts, "a prefix takes a turn back to
-// pending"), and a prefix taken before a message drops its turn from the list entirely.
-export const turnsOf = (events: ReadonlyArray<Event>, at?: number): ReadonlyArray<TurnView> => {
-  const prefix = events.slice(0, at ?? events.length)
-  return inboundOf(prefix).map((turn): TurnView => {
-    const boundary = boundaryOf(prefix, turn)
-    if (boundary === undefined) return { turn, status: "pending" }
-    if (boundary.kind === "completed") return { turn, status: "completed", output: boundary.output }
-    if (boundary.kind === "failed") return { turn, status: "failed", error: boundary.error }
-    // A park is neither an output nor an error: the turn is alive and waiting on an answer the API
-    // has no door for, so the status carries the whole of what a client can act on.
-    return { turn, status: "parked" }
-  })
 }

--- a/apps/voyager/dev/fixture.ts
+++ b/apps/voyager/dev/fixture.ts
@@ -4,7 +4,7 @@ import { Infer, type InferRequest } from "@clavia/tardigrade"
 import type { Action } from "@clavia/tardigrade/events"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { layerConfig, readConfig } from "@clavia/tardigrade-server/config"
-import { layerAgents } from "@clavia/tardigrade-server/host"
+import { layerThreads } from "@clavia/tardigrade-server/host"
 import { serve } from "@clavia/tardigrade-server/http"
 
 // The development server: the real apps/server process, on a volatile database, with the model seam
@@ -12,7 +12,7 @@ import { serve } from "@clavia/tardigrade-server/http"
 // (apps/server/src/api.test.ts), so the UI develops against real projections, a real driver, and a
 // real SSE tail, and needs no model credentials.
 //
-// Every agent this fixture serves is invented by the script below. Nothing here is imported by the
+// Every thread this fixture serves is invented by the script below. Nothing here is imported by the
 // app; the app only ever speaks HTTP.
 
 // Where the fixture listens, matching the client's DEFAULT_BASE_URL (packages/client/src/client.ts).
@@ -65,31 +65,31 @@ const layerScripted: Layer.Layer<Infer> = Layer.succeed(Infer)({
 // loop wants: the forest on screen is the forest this session made.
 const config = layerConfig(readConfig({ TARDIGRADE_DB: ":memory:", PORT: String(FIXTURE_PORT) }))
 
-const agents = Layer.provide(layerAgents({ infer: layerScripted }), config)
+const threads = Layer.provide(layerThreads({ infer: layerScripted }), config)
 
 const app = Layer.provideMerge(serve({ disableLogger: true }), [
   BunHttpServer.layer({ port: FIXTURE_PORT }),
   config,
-  agents
+  threads
 ])
 
 // The briefs the fixture delivers at boot, so the UI has a forest before anyone types anything. The
 // server dedups by message id, so re-running a brief costs nothing (apps/server/src/host.ts).
-export const FIXTURE_BRIEFS: ReadonlyArray<{ readonly agent: string; readonly id: string; readonly text: string }> = [
-  { agent: "root", id: "m1", text: `${SPAWN_BRIEF}survey` },
-  { agent: "root", id: "m2", text: "summarize the survey" },
-  { agent: "deriver", id: "m3", text: "derive the shape of the log" }
+export const FIXTURE_BRIEFS: ReadonlyArray<{ readonly thread: string; readonly id: string; readonly text: string }> = [
+  { thread: "root", id: "m1", text: `${SPAWN_BRIEF}survey` },
+  { thread: "root", id: "m2", text: "summarize the survey" },
+  { thread: "deriver", id: "m3", text: "derive the shape of the log" }
 ]
 
-const post = (agent: string, body: unknown) =>
-  fetch(`http://127.0.0.1:${FIXTURE_PORT}/agents/${encodeURIComponent(agent)}/messages`, {
+const post = (thread: string, body: unknown) =>
+  fetch(`http://127.0.0.1:${FIXTURE_PORT}/v1/actors/agent/threads/${encodeURIComponent(thread)}/events`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body)
   })
 
 const seed = Effect.promise(async () => {
-  for (const { agent, ...message } of FIXTURE_BRIEFS) await post(agent, message)
+  for (const { thread, ...message } of FIXTURE_BRIEFS) await post(thread, message)
   console.log(`fixture: seeded ${FIXTURE_BRIEFS.length} briefs on http://127.0.0.1:${FIXTURE_PORT}`)
 })
 

--- a/apps/voyager/src/App.tsx
+++ b/apps/voyager/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type ReactElement } from "react"
 
-import { Agent } from "./Agent"
-import { NO_ANSWER, ProblemError, type AgentSummary } from "@clavia/tardigrade-client"
+import { Thread } from "./Thread"
+import { NO_ANSWER, ProblemError, type ThreadSummary } from "@clavia/tardigrade-client"
 
 import { client } from "./client"
 import { useRoute } from "./nav"
@@ -10,7 +10,7 @@ import { Rail } from "./Rail"
 import { EMPTY_ROSTER, rosterOf, type Roster } from "./roster"
 
 // The app: one screen, two panes. The rail lists the run's roots and the center pane reads the
-// selected agent's log (mock.html). The reader chooses on the left and reads on the right, and
+// selected thread's log (mock.html). The reader chooses on the left and reads on the right, and
 // there is nowhere else to go: voyager reads a run and never writes to it.
 
 interface Reading {
@@ -19,12 +19,12 @@ interface Reading {
   readonly at: number
 }
 
-// useRoster polls GET /agents once for the whole screen: the rail's rows and the header's status
+// useRoster polls GET /v1/actors/:actor/threads once for the whole screen: the rail's rows and the header's status
 // chip are the same listing read twice rather than two calls. The last good reading survives a
 // failure, so a server restart holds the rail rather than blanking it.
 const useRoster = (intervalMs: number) => {
   const [reading, setReading] = useState<Reading>({ roster: EMPTY_ROSTER, at: Date.now() })
-  const [summaries, setSummaries] = useState<ReadonlyArray<AgentSummary>>([])
+  const [summaries, setSummaries] = useState<ReadonlyArray<ThreadSummary>>([])
   const [problem, setProblem] = useState<ProblemError | undefined>(undefined)
 
   useEffect(() => {
@@ -55,15 +55,15 @@ const useRoster = (intervalMs: number) => {
 export const App = (): ReactElement => {
   const route = useRoute()
   const { problem, reading, summaries } = useRoster(ROSTER_POLL_MS)
-  const status = summaries.find((summary) => summary.id === route.agent)?.status
+  const status = summaries.find((summary) => summary.id === route.thread)?.status
   return (
     <div style={{ height: "100%", display: "flex", overflow: "hidden" }}>
-      <Rail roster={reading.roster} now={reading.at} problem={problem} selected={route.agent} />
+      <Rail roster={reading.roster} now={reading.at} problem={problem} selected={route.thread} />
       <main style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        {route.agent === undefined ? (
+        {route.thread === undefined ? (
           <div className="mono pane-empty">select a run</div>
         ) : (
-          <Agent id={route.agent} status={status} />
+          <Thread id={route.thread} status={status} />
         )}
       </main>
     </div>

--- a/apps/voyager/src/Rail.tsx
+++ b/apps/voyager/src/Rail.tsx
@@ -8,7 +8,7 @@ import { agoOf, countsOf, matches, type Roster, type RootRow } from "./roster"
 
 // The rail: the run's roots and nothing else (mock.html, the aside). A root is a run, and the tree
 // under it is the run's own business, so the rail lists the six things a reader chooses between
-// rather than the twenty-four agents behind them.
+// rather than the twenty-four threads behind them.
 
 // Where the collapsed state is kept. It is the reader's shape of the screen, not the run's, so it
 // lives in the browser and never on the wire (src/theme.ts, THEME_KEY).
@@ -30,7 +30,7 @@ const Row = ({
 }): ReactElement => {
   // Choosing a run clears the window: the edges are fractions of the log a reader was looking at,
   // and they name nothing in the log they are moving to (src/nav.ts, Route).
-  const open = () => navigate({ agent: row.id, from: undefined, to: undefined })
+  const open = () => navigate({ thread: row.id, from: undefined, to: undefined })
   return (
     <div
       role="button"

--- a/apps/voyager/src/Thread.tsx
+++ b/apps/voyager/src/Thread.tsx
@@ -1,7 +1,7 @@
 import { Moon, Sun } from "@phosphor-icons/react"
 import { Fragment, useEffect, useRef, useState, type ReactElement } from "react"
 
-import { NO_ANSWER, ProblemError, type AgentStatus, type EventRow } from "@clavia/tardigrade-client"
+import { NO_ANSWER, ProblemError, type ThreadStatus, type EventRow } from "@clavia/tardigrade-client"
 
 import { client } from "./client"
 import { fieldsOf, merged, momentsOf, stampOf, type Moment } from "./narrative"
@@ -11,8 +11,8 @@ import { useTheme } from "./theme"
 import { axisOf, defaultWindowOf, FULL_WINDOW, shared, shownIn, type Window } from "./window"
 import { WindowBrush } from "./WindowBrush"
 
-// The center pane: one agent's log as a flat chronological list under its own header and the window
-// brush (mock.html, the main element). The pane holds cursors only: which agent, which range the
+// The center pane: one thread's log as a flat chronological list under its own header and the window
+// brush (mock.html, the main element). The pane holds cursors only: which thread, which range the
 // window holds, which row is open. Every fact on it is the server's, read through src/client.ts.
 
 const errorOf = (error: unknown): ProblemError =>
@@ -180,8 +180,8 @@ const Problem = ({ problem }: { readonly problem: ProblemError }): ReactElement 
   </div>
 )
 
-const Head = ({ id, status }: { readonly id: string; readonly status: AgentStatus | undefined }): ReactElement => (
-  <div className="agent-head">
+const Head = ({ id, status }: { readonly id: string; readonly status: ThreadStatus | undefined }): ReactElement => (
+  <div className="thread-head">
     <span className="mono" style={{ fontSize: "var(--text-dense)", fontWeight: 500 }}>{id}</span>
     {status === undefined ? null : (
       <span className={`chip chip-${status}${status === "running" ? " breathe" : ""}`}>{status}</span>
@@ -191,7 +191,7 @@ const Head = ({ id, status }: { readonly id: string; readonly status: AgentStatu
   </div>
 )
 
-export const Agent = ({ id, status }: { readonly id: string; readonly status: AgentStatus | undefined }): ReactElement => {
+export const Thread = ({ id, status }: { readonly id: string; readonly status: ThreadStatus | undefined }): ReactElement => {
   const route = useRoute()
   // The window's own edges. The URL carries them so a view is shareable, and the pane holds them so
   // a drag renders from one place: `navigate` publishes the URL synchronously, and a control that
@@ -204,7 +204,7 @@ export const Agent = ({ id, status }: { readonly id: string; readonly status: Ag
   // Whether the reader is at the log's end. Auto-scroll follows a live log only from there; a reader
   // who has scrolled up is reading, and the log must not pull the page away from them.
   const atEnd = useRef(true)
-  // Whether this agent's log has been given its opening window. The default is read once, from the
+  // Whether this thread's log has been given its opening window. The default is read once, from the
   // first full reading; recomputing it as events arrive would move the window under the reader.
   const seeded = useRef(false)
 
@@ -250,7 +250,7 @@ export const Agent = ({ id, status }: { readonly id: string; readonly status: Ag
     navigate({ from: link.from, to: link.to }, { replace: true })
   }
 
-  // An agent the server has never heard of has no log to read, so the pane is its header and the
+  // A thread the server has never heard of has no log to read, so the pane is its header and the
   // problem document verbatim (apps/server/src/problem.ts).
   if (problem !== undefined && problem.status === 404) {
     return (

--- a/apps/voyager/src/client.ts
+++ b/apps/voyager/src/client.ts
@@ -2,7 +2,7 @@ import { DEFAULT_BASE_URL, makeClient, type Client } from "@clavia/tardigrade-cl
 
 // Where the app reads the server. The calls and the wire types are the client package's, derived
 // from the server's own declaration (packages/client/src/contract.ts), so the app holds no second
-// idea of what an agent is. What is decided here is only what a browser decides: which server this
+// idea of what a thread is. What is decided here is only what a browser decides: which server this
 // tab talks to, and which token it holds.
 
 // Where the server listens when VITE_API_URL is absent, which is the client's own default

--- a/apps/voyager/src/narrative.ts
+++ b/apps/voyager/src/narrative.ts
@@ -84,7 +84,7 @@ const line = (parts: ReadonlyArray<string | undefined>, chars: number): string =
 export const summaryOf = (event: Event, chars: number = SUMMARY_CHARS): string => {
   switch (event.type) {
     case "MessageReceived": {
-      // A reply is an inbound message answering an id this agent sent out, and it reads as the
+      // A reply is an inbound message answering an id this thread sent out, and it reads as the
       // answer it is (packages/core/src/message.ts, replyEvent).
       const outcome = str(event.outcome)
       const from = str(event.from)

--- a/apps/voyager/src/nav.ts
+++ b/apps/voyager/src/nav.ts
@@ -1,6 +1,6 @@
 import { useCallback, useSyncExternalStore } from "react"
 
-// The URL is the app's only navigation state. `?agent=` chooses the screen and `?from=` and `?to=`
+// The URL is the app's only navigation state. `?thread=` chooses the screen and `?from=` and `?to=`
 // carry the window's two edges, so a view is shareable and survives a refresh (voyager-spec.md,
 // "Conventions"). There is no routing library: three params and pushState are the whole of it.
 
@@ -11,7 +11,7 @@ import { useCallback, useSyncExternalStore } from "react"
 // A fraction is what the handle is dragged to, so the URL states the position the reader chose
 // rather than a seq the app would have to derive from it.
 export interface Route {
-  readonly agent: string | undefined
+  readonly thread: string | undefined
   readonly from: number | undefined
   readonly to: number | undefined
 }
@@ -24,9 +24,9 @@ const fraction = (raw: string | null): number | undefined => {
 
 const parse = (search: string): Route => {
   const params = new URLSearchParams(search)
-  const agent = params.get("agent")
+  const thread = params.get("thread")
   return {
-    agent: agent === null || agent.length === 0 ? undefined : agent,
+    thread: thread === null || thread.length === 0 ? undefined : thread,
     from: fraction(params.get("from")),
     to: fraction(params.get("to"))
   }
@@ -35,14 +35,14 @@ const parse = (search: string): Route => {
 export const routeOf = (search: string): Route => parse(search)
 
 // navigate writes the route into the URL and tells the subscribers. History gets one entry per
-// agent change and none per drag step: moving a handle should not fill the back button.
+// thread change and none per drag step: moving a handle should not fill the back button.
 export const navigate = (next: Partial<Route>, options: { readonly replace?: boolean } = {}): void => {
   const params = new URLSearchParams(location.search)
   const write = (name: string, value: string | number | undefined) => {
     if (value === undefined) params.delete(name)
     else params.set(name, String(value))
   }
-  if ("agent" in next) write("agent", next.agent)
+  if ("thread" in next) write("thread", next.thread)
   if ("from" in next) write("from", next.from)
   if ("to" in next) write("to", next.to)
   const search = params.toString()

--- a/apps/voyager/src/policy.ts
+++ b/apps/voyager/src/policy.ts
@@ -14,7 +14,7 @@ export const COLLAPSED_RAIL_WIDTH = 48
 // for the whole set, because a second size would be a second style.
 export const ICON_SIZE = 15
 
-// How often the rail re-reads GET /agents for the roster: the roots and their counts. The server
+// How often the rail re-reads GET /v1/actors/:actor/threads for the roster: the roots and their counts. The server
 // publishes no change feed for the listing, so the rail polls, and this is both the delay between a
 // run changing and the rail saying so and the resolution of the age column.
 export const ROSTER_POLL_MS = 2000

--- a/apps/voyager/src/roster.test.ts
+++ b/apps/voyager/src/roster.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test"
 
-import type { AgentSummary } from "@clavia/tardigrade-client"
+import type { ThreadSummary } from "@clavia/tardigrade-client"
 import { agoOf, countsOf, matches, rosterOf } from "./roster"
 
-// The rail's decisions: which agents are rows, how big each root's family is, what a row's counts
+// The rail's decisions: which threads are rows, how big each root's family is, what a row's counts
 // say, and how an age reads. All pure, so none of them needs a server or a DOM.
 
-const summary = (id: string, parent?: string, events = 1): AgentSummary => ({
+const summary = (id: string, parent?: string, events = 1): ThreadSummary => ({
   id,
   ...(parent === undefined ? {} : { parent }),
   events,
@@ -26,7 +26,7 @@ describe("rosterOf", () => {
     expect(rosterOf(listing).roots.map((row) => row.id)).toEqual(["root", "alone"])
   })
 
-  test("a root's family is every agent under it, at any depth", () => {
+  test("a root's family is every thread under it, at any depth", () => {
     const roots = rosterOf(listing).roots
     expect(roots[0]?.family).toBe(3)
     expect(roots[1]?.family).toBe(0)
@@ -49,12 +49,12 @@ describe("rosterOf", () => {
 describe("countsOf", () => {
   const row = { id: "root", status: "settled" as const, events: 34, lastAt: undefined }
 
-  test("a root that spawned nothing says nothing about agents", () => {
+  test("a root that spawned nothing says nothing about threads", () => {
     expect(countsOf({ ...row, family: 0 })).toBe("34 ev")
   })
 
   test("a root with a family states its size", () => {
-    expect(countsOf({ ...row, family: 9 })).toBe("34 ev · 9 agents")
+    expect(countsOf({ ...row, family: 9 })).toBe("34 ev · 9 threads")
   })
 })
 

--- a/apps/voyager/src/roster.ts
+++ b/apps/voyager/src/roster.ts
@@ -1,16 +1,16 @@
-import type { AgentStatus, AgentSummary } from "@clavia/tardigrade-client"
+import type { ThreadStatus, ThreadSummary } from "@clavia/tardigrade-client"
 
-// The rail's projections. GET /agents answers with every agent and its parent, and the rail shows
+// The rail's projections. GET /v1/actors/:actor/threads answers with every thread and its parent, and the rail shows
 // roots alone, so these functions turn one flat listing into the rows the rail renders. They are
 // pure, so the screen holds no arithmetic of its own.
 
 // RootRow is one rail row: the root's own facts plus the size of the family it started.
 export interface RootRow {
   readonly id: string
-  readonly status: AgentStatus
+  readonly status: ThreadStatus
   readonly events: number
   readonly lastAt: number | undefined
-  // The agents this root spawned, at any depth, not counting the root. Zero for a root that ran
+  // The threads this root spawned, at any depth, not counting the root. Zero for a root that ran
   // alone, and the rail then omits the segment.
   readonly family: number
 }
@@ -24,7 +24,7 @@ export interface Roster {
 
 export const EMPTY_ROSTER: Roster = { roots: [] }
 
-// rootOf walks an agent's parents to the root of its family. Parentage is the server's fact: only
+// rootOf walks a thread's parents to the root of its family. Parentage is the server's fact: only
 // the forest can see it, and a summary states it (apps/server/src/projections.ts, treeOf). The
 // guard stops a claim cycle, which minted call ids cannot produce but an argument can.
 const rootOf = (id: string, parents: ReadonlyMap<string, string | undefined>): string => {
@@ -38,9 +38,9 @@ const rootOf = (id: string, parents: ReadonlyMap<string, string | undefined>): s
   }
 }
 
-// rosterOf projects the listing into the rail. The roots keep the order GET /agents published, which
+// rosterOf projects the listing into the rail. The roots keep the order GET /v1/actors/:actor/threads published, which
 // is first event time, so two polls of one run render identically.
-export const rosterOf = (summaries: ReadonlyArray<AgentSummary>): Roster => {
+export const rosterOf = (summaries: ReadonlyArray<ThreadSummary>): Roster => {
   const parents = new Map(summaries.map((summary) => [summary.id, summary.parent]))
   const family = new Map<string, number>()
   for (const summary of summaries) {
@@ -78,6 +78,6 @@ export const agoOf = (at: number, now: number): string => {
 }
 
 // countsOf is a rail row's second line, after the chip: how many events the root holds and how big
-// its family is. A root that spawned nothing says nothing about agents (mock.html, the rail row).
+// its family is. A root that spawned nothing says nothing about threads (mock.html, the rail row).
 export const countsOf = (row: RootRow): string =>
-  row.family === 0 ? `${row.events} ev` : `${row.events} ev · ${row.family} agents`
+  row.family === 0 ? `${row.events} ev` : `${row.events} ev · ${row.family} threads`

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -166,7 +166,7 @@ textarea {
   font-variant-numeric: tabular-nums;
 }
 
-/* A working agent breathes and nothing else moves at rest (voyager-design-system.md, principle 4). */
+/* A working thread breathes and nothing else moves at rest (voyager-design-system.md, principle 4). */
 @keyframes breathe {
   0%,
   100% {
@@ -214,7 +214,7 @@ textarea {
 }
 
 /* One class per word of the status vocabulary the server publishes (apps/server/src/projections.ts,
-   AgentStatus). The app renames nothing on the way in. */
+   ThreadStatus). The app renames nothing on the way in. */
 .chip-running {
   background: var(--run-wash);
   color: var(--run);
@@ -354,8 +354,8 @@ textarea {
   color: var(--faint);
 }
 
-/* The pane's header: who this agent is, what it is doing, and the theme toggle at the right edge. */
-.agent-head {
+/* The pane's header: who this thread is, what it is doing, and the theme toggle at the right edge. */
+.thread-head {
   display: flex;
   align-items: center;
   gap: var(--space-2);

--- a/docs/how-to/cli.md
+++ b/docs/how-to/cli.md
@@ -20,12 +20,14 @@ bun run --cwd apps/cli start -- --help
 | Command | What it does |
 | --- | --- |
 | `tdg dev` | Boot the API and serve the built UI at one URL. One process, one port, one thing to stop. |
-| `tdg run "<brief>"` | Deliver a brief, wait for the turn to settle, and print what it answered. |
-| `tdg send <agent> "<brief>"` | Deliver a brief and print the turn handle without waiting. |
-| `tdg ls` | Every agent a store holds, parent before child, as a table. |
-| `tdg events <agent>` | The log, one line per event. |
+| `tdg run "<brief>"` | Start a thread, wait for its turn to settle, and print what it answered. |
+| `tdg send <thread> "<brief>"` | Deliver a brief and print the turn handle without waiting. |
+| `tdg ls` | Every thread a store holds, parent before child, as a table. |
+| `tdg events <thread>` | The log, one line per event. |
 
 `tdg --help` prints the tree and `tdg <command> --help` prints one command. A command nobody declared exits non-zero and says which command it looked like.
+
+Every command names a thread, never an actor. A v1 server serves one actor and reserves the name `agent` for it, so the client fills that level in and a command states only the thread it reads or writes ([the server's vocabulary](server.md)).
 
 ## Configuration resolves in one place
 
@@ -59,7 +61,7 @@ The server boots without model coordinates and every turn it drives fails with t
 
 `tdg send` returns as soon as the server has accepted the message, because a delivery answers `202` and the turn settles on the server's own loop. `tdg run` waits: it delivers, then reads the turn every `DEFAULT_POLL_MILLIS` until it leaves `pending`, and gives up after `DEFAULT_TIMEOUT_MILLIS` while saying that the turn is still running (`apps/cli/src/commands.ts`). `--poll` and `--timeout` set both. The exit code is zero only when the turn completed.
 
-Both commands mint a message id per invocation unless `--id` states one. The id is the dedup key end to end and becomes the turn id, so an invocation retried with the same `--id` is absorbed by the server rather than started twice, and an invocation retried without one starts a second turn. `tdg run` also mints the agent when `--agent` states none, which births a new agent, since an agent exists once its log has an event.
+Both commands mint a message id per invocation unless `--id` states one. The id is the dedup key end to end and becomes the turn id, so an invocation retried with the same `--id` is absorbed by the server rather than started twice, and an invocation retried without one starts a second turn. `tdg run` also mints the thread when `--thread` states none, which births a new thread, since a thread exists once its log has an event.
 
 ## Output for people, and for pipes
 

--- a/docs/how-to/server.md
+++ b/docs/how-to/server.md
@@ -2,6 +2,21 @@
 
 The server is the self-hostable deployable: one Bun process that holds a durable SQLite log, runs the default agent assembly over it, and exposes HTTP. The assembly is code mode with the spawn and workspace packages in scope, plus reply, budget, and compaction. Everything the API answers is derived from the log, so the process keeps no state a restart could lose.
 
+## What the API names
+
+The API has four levels, and a route names the first three.
+
+| Level | What it is |
+| --- | --- |
+| Actor | The deployed code, addressed by name. This build compiles one assembly in and serves it as `agent` (`RESERVED_ACTOR`); every other name is a `404 unknown-actor`. |
+| Thread | One log, resumable forever. It is the resource every read projects from, and it exists once its log has an event. |
+| Turn | One inbound message and the work it caused, named by the message id. |
+| Event | One fact, recorded once, numbered by its position in the log. |
+
+The platform's guarantee stops at the thread: a durable log, one writer, and a settle loop. Whether the reactors over that log constitute an agent is the assembly's business, which is why the actor is the level a deploy will vary and the thread is the level a route reads.
+
+Every versioned route lives under `/v1`. `/healthz`, `/openapi.json`, and `/docs` describe the process rather than its resources, so they stay unversioned.
+
 ## Run it
 
 ```bash
@@ -24,24 +39,24 @@ Configuration is the environment and nothing else. Every default is an exported 
 
 ## Running without a model
 
-The process boots without model coordinates. It listens, answers `/healthz`, accepts messages, and every turn it drives fails with `no model is configured: set MODEL_BASE_URL, MODEL_API_KEY, and MODEL_ID`. The failure is an event in the log like any other, so `GET /agents/:id/turns/:turn` reports the turn as `failed` and carries that sentence as its error. Set the three variables and `POST /agents/:id/turns/:turn/resume` runs the same turn again from where it stopped. A server that refused to start without a model would hide the log an operator can already read.
+The process boots without model coordinates. It listens, answers `/healthz`, accepts messages, and every turn it drives fails with `no model is configured: set MODEL_BASE_URL, MODEL_API_KEY, and MODEL_ID`. The failure is an event in the log like any other, so `GET /v1/actors/agent/threads/:id/turns/:turn` reports the turn as `failed` and carries that sentence as its error. Set the three variables and `POST /v1/actors/agent/threads/:id/turns/:turn/resume` runs the same turn again from where it stopped. A server that refused to start without a model would hide the log an operator can already read.
 
 ## Endpoints
 
 | Endpoint | Contract |
 | --- | --- |
-| `POST /agents/:id/messages` | Deliver one message, `{ id, text, input?, data? }`. Answers `202 { agent, turn }`, or `400` when the body states no `id` or no `text`. |
-| `GET /agents` | Every agent, parent before child, as a summary: id, parent, event count, last event time, and status (`settled`, `running`, `blocked`, `failed`). |
-| `GET /agents/:id/events` | The log as `{ seq, event }` rows. `after` starts the page past a sequence number, `limit` caps it (default 200, `DEFAULT_EVENT_LIMIT`), `types` filters by a comma list. |
-| `GET /agents/:id/events/stream` | The same log as `text/event-stream`, replayed from the cursor and then followed live. The tail re-reads every 50 milliseconds (`DEFAULT_SSE_POLL`) and writes a comment frame after 15 seconds of silence (`DEFAULT_SSE_HEARTBEAT`). |
-| `GET /agents/:id/turns` | Every turn boundary as `{ turn, status, output?, error? }`, where status is `pending`, `completed`, `failed`, or `parked`. `at` evaluates the projection over a prefix of the log. |
-| `GET /agents/:id/turns/:turn` | One turn's boundary, the same shape. This is the poll target for whether a run finished. |
-| `POST /agents/:id/turns/:turn/resume` | Resume a failed turn. `202` with the turn handle, `409` when the turn did not fail or belongs to a spent epoch, carrying the library's own reason. |
+| `POST /v1/actors/agent/threads/:id/events` | Deliver one message, `{ id, text, input?, data? }`. Answers `202 { actor, thread, turn }`, or `400` when the body states no `id` or no `text`. |
+| `GET /v1/actors/agent/threads` | Every thread, parent before child, as a summary: id, parent, event count, last event time, and status (`settled`, `running`, `blocked`, `failed`). |
+| `GET /v1/actors/agent/threads/:id/events` | The log as `{ seq, event }` rows. `after` starts the page past a sequence number, `limit` caps it (default 200, `DEFAULT_EVENT_LIMIT`), `types` filters by a comma list. |
+| `GET /v1/actors/agent/threads/:id/events/stream` | The same log as `text/event-stream`, replayed from the cursor and then followed live. The tail re-reads every 50 milliseconds (`DEFAULT_SSE_POLL`) and writes a comment frame after 15 seconds of silence (`DEFAULT_SSE_HEARTBEAT`). |
+| `GET /v1/actors/agent/threads/:id/turns` | Every turn boundary as `{ turn, status, output?, error? }`, where status is `pending`, `completed`, `failed`, or `parked`. `at` evaluates the projection over a prefix of the log. |
+| `GET /v1/actors/agent/threads/:id/turns/:turn` | One turn's boundary, the same shape. This is the poll target for whether a run finished. |
+| `POST /v1/actors/agent/threads/:id/turns/:turn/resume` | Resume a failed turn. `202` with the turn handle, `409` when the turn did not fail or belongs to a spent epoch, carrying the library's own reason. |
 | `GET /healthz` | `200` while the host answers, carrying `status` (`resting` or `driving`) and `dirty`, the count of drive passes owed. Open even when a token is set, so a supervisor can tell an outage from a misconfiguration. |
 | `GET /openapi.json` | The OpenAPI document, derived from the same declaration the routes are built from (`OPENAPI_PATH`). Open even when a token is set. |
 | `GET /docs` | That document rendered as a reference page (`DOCS_PATH`). Open even when a token is set. |
 
-Every failure is `application/problem+json`: `{ type, title, status, detail }`, where `type` is a URI under `https://tardigrade.dev/problems/` that a client matches on. A `404` on a read means the agent has never existed; an existing agent whose filter matches nothing answers `200 []`. A request that does not match what the endpoint accepts is `400 invalid-request`, whose `detail` names the part that was refused and the fields at fault, as in ``The request body is not what this endpoint accepts. `text` is missing.``
+Every failure is `application/problem+json`: `{ type, title, status, detail }`, where `type` is a URI under `https://tardigrade.dev/problems/` that a client matches on. A `404` is one of two facts and the `type` says which: `unknown-actor` names code this build does not serve, and `unknown-thread` names a log that has never been written. The actor is answered first, so a real thread under an actor nobody deployed reports `unknown-actor`. An existing thread whose filter matches nothing answers `200 []`. A request that does not match what the endpoint accepts is `400 invalid-request`, whose `detail` names the part that was refused and the fields at fault, as in ``The request body is not what this endpoint accepts. `text` is missing.``
 
 ## The routes are one declaration
 
@@ -61,9 +76,9 @@ The client carries Schema into whatever loads it, a browser included. That is th
 
 ## Creation is delivery
 
-There is no create endpoint, no registration, and no lifecycle. An agent exists once its log has an event, so `POST /agents/:id/messages` with an id nobody has used births that agent and starts its first turn. The same rule reads backwards: the only unknown agent is one with an empty log, which is what a `404` on any read reports.
+There is no create endpoint, no registration, and no lifecycle. A thread exists once its log has an event, so `POST /v1/actors/agent/threads/:id/events` with an id nobody has used births that thread and starts its first turn. The same rule reads backwards: the only unknown thread is one with an empty log, which is what a `404 unknown-thread` on any read reports.
 
-Children born by spawn get derived ids (`<execId>.<n>`) and appear in `GET /agents` and `GET /agents/:id/tree` like any other agent. Parentage is a claim in the parent's log, which is why the tree is derived across every log rather than from the subtree alone.
+Children born by spawn get derived ids (`<execId>.<n>`) and appear in `GET /v1/actors/agent/threads` and `GET /v1/actors/agent/threads/:id/tree` like any other thread. Parentage is a claim in the parent's log, which is why the tree is derived across every log rather than from the subtree alone.
 
 ## Redelivery is absorbed
 
@@ -75,7 +90,7 @@ Each log event is one SSE event, and its `id:` field is the sequence number. A d
 
 ## Time travel is a query
 
-Any prefix of a log is a valid state, so reading the past is a parameter rather than a mode. `GET /agents/:id/turns?at=<seq>` evaluates the turn projection over the first `<seq>` events, which is what the agent's outcome looked like at that point. Nothing is stored to make this work: the projection is a pure function of the events it is handed.
+Any prefix of a log is a valid state, so reading the past is a parameter rather than a mode. `GET /v1/actors/agent/threads/:id/turns?at=<seq>` evaluates the turn projection over the first `<seq>` events, which is what the thread's outcome looked like at that point. Nothing is stored to make this work: the projection is a pure function of the events it is handed.
 
 ## Out of scope
 
@@ -83,7 +98,7 @@ The server runs one assembly, chosen in code, and forking is the customization p
 
 - **Inbound sources.** Provider webhooks becoming messages arrive with the `Package.source` spec that defines them.
 - **Connections and credential storage.** The door's values arrive with that same spec.
-- **Per-agent assembly configuration.** Capabilities and packages as a wire format reopen every composition question, so the assembly stays a code decision in `apps/server/src/host.ts`.
+- **Per-thread assembly configuration.** Capabilities and packages as a wire format reopen every composition question, so the assembly stays a code decision in `apps/server/src/host.ts`.
 - **Budget answers over HTTP.** A parked turn reports `parked`; answering the ask needs the synchronous call doors the in-process host refuses, and waits on a consumer shape that needs them.
 
 Multi-tenancy, quotas, and users are outside the frame entirely: one store, one operator.

--- a/docs/how-to/server.md
+++ b/docs/how-to/server.md
@@ -10,10 +10,10 @@ The API has four levels, and a route names the first three.
 | --- | --- |
 | Actor | The deployed code, addressed by name. This build compiles one assembly in and serves it as `agent` (`RESERVED_ACTOR`); every other name is a `404 unknown-actor`. |
 | Thread | One log, resumable forever. It is the resource every read projects from, and it exists once its log has an event. |
-| Turn | One inbound message and the work it caused, named by the message id. |
+| Turn | One inbound message and the work it caused, named by the message id. It is the actor's reading of its own log rather than a fact the platform holds. |
 | Event | One fact, recorded once, numbered by its position in the log. |
 
-The platform's guarantee stops at the thread: a durable log, one writer, and a settle loop. Whether the reactors over that log constitute an agent is the assembly's business, which is why the actor is the level a deploy will vary and the thread is the level a route reads.
+The platform's guarantee stops at the thread: a durable log, one writer, and a settle loop. Turns are the actor's own reading of that log, served as a declared projection. Whether the reactors over that log constitute an agent is the assembly's business, which is why the actor is the level a deploy will vary and the thread is the level a route reads.
 
 Every versioned route lives under `/v1`. `/healthz`, `/openapi.json`, and `/docs` describe the process rather than its resources, so they stay unversioned.
 
@@ -43,20 +43,45 @@ The process boots without model coordinates. It listens, answers `/healthz`, acc
 
 ## Endpoints
 
+The first three are the log, which is the whole of what the platform guarantees. `turns` is a projection this build's actor declares, and it appears here by being declared. The last three are the assembly's surface, each pending its own change.
+
 | Endpoint | Contract |
 | --- | --- |
 | `POST /v1/actors/agent/threads/:id/events` | Deliver one message, `{ id, text, input?, data? }`. Answers `202 { actor, thread, turn }`, or `400` when the body states no `id` or no `text`. |
 | `GET /v1/actors/agent/threads` | Every thread, parent before child, as a summary: id, parent, event count, last event time, and status (`settled`, `running`, `blocked`, `failed`). |
 | `GET /v1/actors/agent/threads/:id/events` | The log as `{ seq, event }` rows. `after` starts the page past a sequence number, `limit` caps it (default 200, `DEFAULT_EVENT_LIMIT`), `types` filters by a comma list. |
 | `GET /v1/actors/agent/threads/:id/events/stream` | The same log as `text/event-stream`, replayed from the cursor and then followed live. The tail re-reads every 50 milliseconds (`DEFAULT_SSE_POLL`) and writes a comment frame after 15 seconds of silence (`DEFAULT_SSE_HEARTBEAT`). |
-| `GET /v1/actors/agent/threads/:id/turns` | Every turn boundary as `{ turn, status, output?, error? }`, where status is `pending`, `completed`, `failed`, or `parked`. `at` evaluates the projection over a prefix of the log. |
+| `GET /v1/actors/agent/threads/:id/turns` | The actor's `turns` projection: every turn boundary as `{ turn, status, output?, error? }`, where status is `pending`, `completed`, `failed`, or `parked`. `at` is the projection's own parameter, and evaluates it over a prefix of the log. |
+| `GET /v1/actors/agent/threads/:id/{name}` | Any other name is `404 unknown-projection`, whose detail lists the names the actor does declare. |
 | `GET /v1/actors/agent/threads/:id/turns/:turn` | One turn's boundary, the same shape. This is the poll target for whether a run finished. |
 | `POST /v1/actors/agent/threads/:id/turns/:turn/resume` | Resume a failed turn. `202` with the turn handle, `409` when the turn did not fail or belongs to a spent epoch, carrying the library's own reason. |
 | `GET /healthz` | `200` while the host answers, carrying `status` (`resting` or `driving`) and `dirty`, the count of drive passes owed. Open even when a token is set, so a supervisor can tell an outage from a misconfiguration. |
 | `GET /openapi.json` | The OpenAPI document, derived from the same declaration the routes are built from (`OPENAPI_PATH`). Open even when a token is set. |
 | `GET /docs` | That document rendered as a reference page (`DOCS_PATH`). Open even when a token is set. |
 
-Every failure is `application/problem+json`: `{ type, title, status, detail }`, where `type` is a URI under `https://tardigrade.dev/problems/` that a client matches on. A `404` is one of two facts and the `type` says which: `unknown-actor` names code this build does not serve, and `unknown-thread` names a log that has never been written. The actor is answered first, so a real thread under an actor nobody deployed reports `unknown-actor`. An existing thread whose filter matches nothing answers `200 []`. A request that does not match what the endpoint accepts is `400 invalid-request`, whose `detail` names the part that was refused and the fields at fault, as in ``The request body is not what this endpoint accepts. `text` is missing.``
+Every failure is `application/problem+json`: `{ type, title, status, detail }`, where `type` is a URI under `https://tardigrade.dev/problems/` that a client matches on. A `404` is one of three facts and the `type` says which: `unknown-actor` names code this build does not serve, `unknown-thread` names a log that has never been written, and `unknown-projection` names a reading its actor never declared. The actor is answered first, so a real thread under an actor nobody deployed reports `unknown-actor`. An existing thread whose filter matches nothing answers `200 []`. A request that does not match what the endpoint accepts is `400 invalid-request`, whose `detail` names the part that was refused and the fields at fault, as in ``The request body is not what this endpoint accepts. `text` is missing.``
+
+## The log is the platform, and the rest is the actor's
+
+Listing threads, appending an event, reading the log back, and following it are what the platform guarantees, and they are the same for every actor. Everything else a thread can be asked is a projection: a pure function of that thread's events, declared by the actor whose reactors wrote them, and mounted by the platform at `GET /v1/actors/{actor}/threads/{id}/{name}`.
+
+A declaration is a record, and it lives beside the reactors in `apps/server/src/actor.ts`:
+
+```ts
+export const agentProjections = projectionsOf({
+  turns: projection({
+    params: { at: Schema.optionalKey(Seq) },
+    result: Schema.Array(TurnView),
+    run: (events, params) => turnsOf(events, params.at)
+  })
+})
+```
+
+`params` is the query the URL carries, `result` is what the answer looks like on the wire, and `run` computes it. The endpoints, the OpenAPI document, and the derived client are generated from that record, so a projection has a typed call and a documented schema by being declared and nothing else.
+
+`run` is a projection in the framework's sense: pure over the event set, recomputed per request, never stored. A prefix of a log is a valid argument, which is why time travel is a parameter the actor accepts rather than a mode the platform holds.
+
+`events` and `stream` are reserved. The log is not a projection of itself: one is the log read back and the other is the same log followed, and both are the platform's own guarantee. A declaration that claims either name fails at construction rather than at a request, the way `agentOf` refuses a duplicate tool.
 
 ## The routes are one declaration
 

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, test } from "bun:test"
+import { Schema } from "effect"
 
 import { makeClient, UNEXPECTED_RESPONSE_TITLE } from "./client"
-import { PROBLEM_CONTENT_TYPE, PROBLEM_TYPE_BASE } from "./contract"
+import { PROBLEM_CONTENT_TYPE, PROBLEM_TYPE_BASE, projection, projectionsOf } from "./contract"
 import { ProblemError } from "./problem"
 
 // The client against a stand-in for the network. What is asserted here is what the client decides
@@ -119,5 +120,48 @@ describe("a failed call", () => {
     const failure = await makeClient({ baseUrl: "http://localhost:4111" , fetch: stub }).list().catch((error: unknown) => error) as ProblemError
     expect(failure.title).toBe(UNEXPECTED_RESPONSE_TITLE)
     expect(failure.status).toBe(502)
+  })
+})
+
+// The platform's API is the log, and everything else a thread can be asked is a projection its
+// actor declares. A client states the same declaration the server mounts, and gets a call typed by
+// it (contract.ts, apiOf; apps/server/src/actor.ts).
+describe("a declared projection", () => {
+  const projections = projectionsOf({
+    turns: projection({
+      params: { at: Schema.optionalKey(Schema.Int) },
+      result: Schema.Array(Schema.Struct({ turn: Schema.String, status: Schema.String })),
+      run: () => []
+    })
+  })
+
+  test("serves at the name it was declared under, and carries its own query", async () => {
+    const client = makeClient({ baseUrl: "http://localhost:4111", fetch: stub, projections })
+    await client.projection("root", "turns", { at: 3 })
+    expect(lastUrl().pathname).toBe("/v1/actors/agent/threads/root/turns")
+    expect(lastUrl().searchParams.get("at")).toBe("3")
+  })
+
+  test("an absent query is an absent param rather than a stated default", async () => {
+    const client = makeClient({ baseUrl: "http://localhost:4111", fetch: stub, projections })
+    await client.projection("root", "turns")
+    expect(lastUrl().searchParams.has("at")).toBe(false)
+  })
+
+  // The declaration's own types reach the call: the name is one it declares, the query is what that
+  // projection accepts, and the answer is what it promises. A name it does not declare, or a query
+  // field it does not accept, does not compile.
+  test("types the answer from the declaration", async () => {
+    answer = () =>
+      new Response(JSON.stringify([{ turn: "m1", status: "completed" }]), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      })
+    const client = makeClient({ baseUrl: "http://localhost:4111", fetch: stub, projections })
+    const views: ReadonlyArray<{ readonly turn: string; readonly status: string }> = await client.projection(
+      "root",
+      "turns"
+    )
+    expect(views).toEqual([{ turn: "m1", status: "completed" }])
   })
 })

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -45,12 +45,12 @@ describe("the address a call goes to", () => {
   test("sends every request through the stated fetch", async () => {
     await makeClient({ baseUrl: "http://localhost:4111", fetch: stub }).list()
     expect(calls).toHaveLength(1)
-    expect(lastUrl().pathname).toBe("/agents")
+    expect(lastUrl().pathname).toBe("/v1/actors/agent/threads")
   })
 
-  test("an agent id is encoded into the path", async () => {
+  test("a thread id is encoded into the path", async () => {
     await makeClient({ baseUrl: "http://localhost:4111" , fetch: stub }).events("ag/one two")
-    expect(lastUrl().pathname).toBe("/agents/ag%2Fone%20two/events")
+    expect(lastUrl().pathname).toBe("/v1/actors/agent/threads/ag%2Fone%20two/events")
   })
 
   test("a stated option is a query param and an absent one is absent", async () => {
@@ -63,7 +63,7 @@ describe("the address a call goes to", () => {
 
   test("a base with a trailing slash does not double it", async () => {
     await makeClient({ baseUrl: "http://127.0.0.1:4111/" , fetch: stub }).list()
-    expect(calls[0]!.url).toBe("http://127.0.0.1:4111/agents")
+    expect(calls[0]!.url).toBe("http://127.0.0.1:4111/v1/actors/agent/threads")
   })
 })
 
@@ -84,10 +84,10 @@ describe("the token", () => {
 describe("a failed call", () => {
   test("a declared problem+json failure keeps all four fields", async () => {
     const document = {
-      type: `${PROBLEM_TYPE_BASE}unknown-agent`,
-      title: "Unknown Agent",
+      type: `${PROBLEM_TYPE_BASE}unknown-thread`,
+      title: "Unknown Thread",
       status: 404,
-      detail: 'No agent named "ghost" has ever existed.'
+      detail: 'No thread named "ghost" has ever existed.'
     }
     answer = problemAnswer(404, document)
     const failure = await makeClient({ baseUrl: "http://localhost:4111" , fetch: stub }).events("ghost").catch((error: unknown) => error)

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -4,9 +4,10 @@ import { HttpApiClient } from "effect/unstable/httpapi"
 
 import {
   Api,
+  RESERVED_ACTOR,
   type Accepted,
-  type AgentNode,
-  type AgentSummary,
+  type ThreadNode,
+  type ThreadSummary,
   type EventRow,
   type Health,
   type Inbound,
@@ -41,6 +42,9 @@ export interface ClientOptions {
   // The bearer token, sent as an `authorization` header on every request (apps/server/src/http.ts,
   // layerAuth). The tail cannot carry it (stream.ts).
   readonly token?: string | undefined
+  // Which actor's threads this client addresses. The default is the one name a v1 server reserves
+  // for the assembly it compiled in (contract.ts, RESERVED_ACTOR).
+  readonly actor?: string | undefined
   // How the tail opens a connection. The default is `globalThis.EventSource`.
   readonly eventSource?: OpenEventSource | undefined
   // How a request reaches the network. The default is the platform's own fetch, read through
@@ -59,21 +63,23 @@ export interface EventsOptions {
   readonly types?: ReadonlyArray<string> | undefined
 }
 
-// What a caller states to follow a log: the tail's options, less the two the client already holds.
-export type FollowOptions = Omit<StreamOptions, "baseUrl" | "agent" | "eventSource">
+// What a caller states to follow a log: the tail's options, less the ones the client already holds.
+export type FollowOptions = Omit<StreamOptions, "baseUrl" | "thread" | "actor" | "eventSource">
 
 export interface Client {
   readonly baseUrl: string
-  readonly list: () => Promise<ReadonlyArray<AgentSummary>>
-  readonly tree: (agent: string) => Promise<AgentNode>
-  readonly events: (agent: string, options?: EventsOptions) => Promise<ReadonlyArray<EventRow>>
-  readonly turns: (agent: string, at?: number) => Promise<ReadonlyArray<TurnView>>
-  readonly turn: (agent: string, turn: string) => Promise<TurnView>
-  readonly deliver: (agent: string, message: Inbound) => Promise<Accepted>
-  readonly resume: (agent: string, turn: string) => Promise<Accepted>
+  // The actor every call addresses, resolved once at construction (ClientOptions, actor).
+  readonly actor: string
+  readonly list: () => Promise<ReadonlyArray<ThreadSummary>>
+  readonly tree: (thread: string) => Promise<ThreadNode>
+  readonly events: (thread: string, options?: EventsOptions) => Promise<ReadonlyArray<EventRow>>
+  readonly turns: (thread: string, at?: number) => Promise<ReadonlyArray<TurnView>>
+  readonly turn: (thread: string, turn: string) => Promise<TurnView>
+  readonly deliver: (thread: string, message: Inbound) => Promise<Accepted>
+  readonly resume: (thread: string, turn: string) => Promise<Accepted>
   readonly health: () => Promise<Health>
-  // Follows one agent's log and answers with the unsubscribe.
-  readonly follow: (agent: string, options: FollowOptions) => (() => void)
+  // Follows one thread's log and answers with the unsubscribe.
+  readonly follow: (thread: string, options: FollowOptions) => (() => void)
 }
 
 const messageOf = (failure: unknown): string =>
@@ -142,21 +148,29 @@ export const makeClient = (options: ClientOptions = {}): Client => {
         : Effect.provideService(FetchHttpClient.Fetch, options.fetch)
     )
   )
+  // The actor this client addresses. One name today, because the server compiles one assembly in
+  // and reserves that name for it (contract.ts, RESERVED_ACTOR); it is an option rather than a
+  // literal at each call so a deploy that serves more than one is a client option, not a rewrite.
+  const actor = options.actor ?? RESERVED_ACTOR
   return {
     baseUrl,
-    list: () => run(api.agents.list({})),
-    tree: (agent) => run(api.agents.tree({ params: { id: agent } })),
-    events: (agent, events = {}) => run(api.agents.events({ params: { id: agent }, query: eventsQuery(events) })),
-    turns: (agent, at) => run(api.agents.turns({ params: { id: agent }, query: at === undefined ? {} : { at } })),
-    turn: (agent, turn) => run(api.agents.turn({ params: { id: agent, turn } })),
-    deliver: (agent, message) => run(api.agents.deliver({ params: { id: agent }, payload: message })),
-    resume: (agent, turn) => run(api.agents.resume({ params: { id: agent, turn } })),
+    actor,
+    list: () => run(api.threads.list({ params: { actor } })),
+    tree: (thread) => run(api.threads.tree({ params: { actor, id: thread } })),
+    events: (thread, events = {}) =>
+      run(api.threads.events({ params: { actor, id: thread }, query: eventsQuery(events) })),
+    turns: (thread, at) =>
+      run(api.threads.turns({ params: { actor, id: thread }, query: at === undefined ? {} : { at } })),
+    turn: (thread, turn) => run(api.threads.turn({ params: { actor, id: thread, turn } })),
+    deliver: (thread, message) => run(api.threads.deliver({ params: { actor, id: thread }, payload: message })),
+    resume: (thread, turn) => run(api.threads.resume({ params: { actor, id: thread, turn } })),
     health: () => run(api.health.healthz({})),
-    follow: (agent, follow) =>
+    follow: (thread, follow) =>
       stream({
         ...follow,
         baseUrl,
-        agent,
+        thread,
+        actor,
         ...(options.eventSource === undefined ? {} : { eventSource: options.eventSource })
       })
   }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,9 +1,9 @@
-import { Effect } from "effect"
+import { Effect, type Schema } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientError, HttpClientRequest } from "effect/unstable/http"
-import { HttpApiClient } from "effect/unstable/httpapi"
+import { HttpApiClient, type HttpApi } from "effect/unstable/httpapi"
 
 import {
-  Api,
+  apiOf,
   RESERVED_ACTOR,
   type Accepted,
   type ThreadNode,
@@ -11,6 +11,7 @@ import {
   type EventRow,
   type Health,
   type Inbound,
+  type Projections,
   type TurnView
 } from "./contract"
 import { isProblem, NO_ANSWER, problemOf, ProblemError } from "./problem"
@@ -36,7 +37,20 @@ export const UNEXPECTED_RESPONSE_TITLE = "Unexpected Response"
 
 export const UNREADABLE_EXCHANGE_TITLE = "Unreadable Exchange"
 
-export interface ClientOptions {
+// One derived projection call, as much of its shape as the lookup below needs. The declaration's
+// own types are what a caller sees (Client.projection); this is the untyped middle.
+// The client HttpApiClient derives for one actor's API: the log's methods, the actor's projections
+// keyed by name, and the health probe.
+type GroupsOf<Api> = Api extends HttpApi.HttpApi<string, infer Groups> ? Groups : never
+
+type DerivedApi<P extends Projections> = HttpApiClient.Client<GroupsOf<ReturnType<typeof apiOf<P>>>>
+
+type ProjectionCall = (request: {
+  readonly params: { readonly actor: string; readonly id: string }
+  readonly query: unknown
+}) => Effect.Effect<unknown, unknown>
+
+export interface ClientOptions<P extends Projections = {}> {
   // The server's address. A path on it is kept, so a server mounted under a prefix works.
   readonly baseUrl?: string | undefined
   // The bearer token, sent as an `authorization` header on every request (apps/server/src/http.ts,
@@ -53,6 +67,10 @@ export interface ClientOptions {
   // does not work, because the reference resolves its default once per process
   // (client.test.ts, "sends every request through the stated fetch").
   readonly fetch?: typeof globalThis.fetch | undefined
+  // The projections the actor this client addresses declares. The platform's API is the log, so a
+  // client that reads the log alone states none; one that calls a projection states the same
+  // declaration the server mounts (contract.ts, apiOf).
+  readonly projections?: P | undefined
 }
 
 export interface EventsOptions {
@@ -66,18 +84,34 @@ export interface EventsOptions {
 // What a caller states to follow a log: the tail's options, less the ones the client already holds.
 export type FollowOptions = Omit<StreamOptions, "baseUrl" | "thread" | "actor" | "eventSource">
 
-export interface Client {
+// The query one projection accepts, and what it answers: both read from the actor's own
+// declaration, so a caller states what that projection states and gets back what it promises
+// (contract.ts, projection).
+export type ProjectionQuery<P extends Projections, Name extends keyof P> = SchemaStructType<P[Name]["params"]>
+
+export type ProjectionResult<P extends Projections, Name extends keyof P> = P[Name]["result"]["Type"]
+
+type SchemaStructType<Fields> = Fields extends Schema.Struct.Fields ? Schema.Struct<Fields>["Type"] : never
+
+export interface Client<P extends Projections = {}> {
   readonly baseUrl: string
   // The actor every call addresses, resolved once at construction (ClientOptions, actor).
   readonly actor: string
   readonly list: () => Promise<ReadonlyArray<ThreadSummary>>
   readonly tree: (thread: string) => Promise<ThreadNode>
   readonly events: (thread: string, options?: EventsOptions) => Promise<ReadonlyArray<EventRow>>
-  readonly turns: (thread: string, at?: number) => Promise<ReadonlyArray<TurnView>>
   readonly turn: (thread: string, turn: string) => Promise<TurnView>
   readonly deliver: (thread: string, message: Inbound) => Promise<Accepted>
   readonly resume: (thread: string, turn: string) => Promise<Accepted>
   readonly health: () => Promise<Health>
+  // Reads one projection the actor declared. The name is one this client was built with, and the
+  // query and the answer are that declaration's own types (client.test.ts, "a declared projection
+  // serves and types").
+  readonly projection: <const Name extends keyof P & string>(
+    thread: string,
+    name: Name,
+    query?: ProjectionQuery<P, Name>
+  ) => Promise<ProjectionResult<P, Name>>
   // Follows one thread's log and answers with the unsubscribe.
   readonly follow: (thread: string, options: FollowOptions) => (() => void)
 }
@@ -132,11 +166,15 @@ const eventsQuery = (options: EventsOptions) => {
 
 // makeClient builds the client once. The derivation reads the declaration and compiles an encoder
 // and a decoder per endpoint, so it happens at construction rather than per call.
-export const makeClient = (options: ClientOptions = {}): Client => {
+export const makeClient = <const P extends Projections = {}>(options: ClientOptions<P> = {}): Client<P> => {
   const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL
   const token = options.token
+  // The derivation's own requirement is `HttpClient`, which the layer below provides, plus whatever
+  // the API's middleware asks a client for. RequestProblems asks for nothing, so nothing is left to
+  // provide; the compiler proves that for a stated declaration and cannot for a generic one, which
+  // is what the annotation states here rather than at every call site.
   const api = Effect.runSync(
-    HttpApiClient.make(Api, {
+    (HttpApiClient.make(apiOf(options.projections ?? ({} as P)), {
       baseUrl,
       ...(token === undefined
         ? {}
@@ -146,7 +184,7 @@ export const makeClient = (options: ClientOptions = {}): Client => {
       options.fetch === undefined
         ? (self) => self
         : Effect.provideService(FetchHttpClient.Fetch, options.fetch)
-    )
+    ) as Effect.Effect<DerivedApi<P>>)
   )
   // The actor this client addresses. One name today, because the server compiles one assembly in
   // and reserves that name for it (contract.ts, RESERVED_ACTOR); it is an option rather than a
@@ -159,12 +197,18 @@ export const makeClient = (options: ClientOptions = {}): Client => {
     tree: (thread) => run(api.threads.tree({ params: { actor, id: thread } })),
     events: (thread, events = {}) =>
       run(api.threads.events({ params: { actor, id: thread }, query: eventsQuery(events) })),
-    turns: (thread, at) =>
-      run(api.threads.turns({ params: { actor, id: thread }, query: at === undefined ? {} : { at } })),
     turn: (thread, turn) => run(api.threads.turn({ params: { actor, id: thread, turn } })),
     deliver: (thread, message) => run(api.threads.deliver({ params: { actor, id: thread }, payload: message })),
     resume: (thread, turn) => run(api.threads.resume({ params: { actor, id: thread, turn } })),
     health: () => run(api.health.healthz({})),
+    // The derivation keys the projections group by name, and the name a caller passes is one of
+    // those keys, so the lookup cannot miss. The types are recovered on the way out because an
+    // index into a mapped record of endpoint methods is not one the compiler can narrow per call.
+    projection: (thread, name, query) =>
+      run((api.projections as Record<string, ProjectionCall>)[name]!({
+        params: { actor, id: thread },
+        query: query ?? {}
+      })) as never,
     follow: (thread, follow) =>
       stream({
         ...follow,

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -12,6 +12,24 @@ import { Event } from "@clavia/tardigrade-core/event"
 // The SSE route is absent on purpose. HttpApi is request-and-response shaped, and the tail is a
 // connection with a cursor, so it stays an HttpRouter route beside this app
 // (apps/server/src/api.ts, layerStream) and a hand-written helper follows it (stream.ts).
+//
+// The vocabulary is four levels, and every route names the first three. An actor is the deployed
+// code, addressed by name. A thread is one log under an actor, resumable forever. A turn is one
+// inbound message and the work it caused. An event is one fact. The resource a route reads is the
+// thread; the actor above it is what a deploy will vary.
+
+// Where every versioned route lives. The unversioned paths are the three that describe the process
+// rather than its resources: /healthz, OPENAPI_PATH, and DOCS_PATH (apps/server/src/http.ts,
+// UNAUTHENTICATED_PATHS). The endpoint paths below are written out in full rather than built from
+// this, because a declaration a reader can grep for is worth more than a spared repetition; this
+// constant is what a hand-written helper follows the declaration with (stream.ts, streamUrl).
+export const V1_PREFIX = "/v1"
+
+// The one actor this build serves. The server compiles one assembly into the binary, so the actor
+// level is declared as a path parameter and answered for exactly this name: the shape is honest
+// about what a deploy will vary, and no URL has to be taught twice when it does
+// (apps/server/src/api.ts, actorOf).
+export const RESERVED_ACTOR = "agent"
 
 // Where the derived OpenAPI document is served, and where the reference page renders it. Both are
 // open even when a token is set (apps/server/src/http.ts, UNAUTHENTICATED_PATHS), because a
@@ -64,9 +82,15 @@ const problemKind = <const Kind extends string, const Title extends string, cons
 // problem document").
 export const InvalidRequest = problemKind("invalid-request", "Invalid Request", 400)
 
-// An agent exists once its log has an event, so an empty log is the only unknown agent there is
+// A thread exists once its log has an event, so an empty log is the only unknown thread there is
 // (apps/server/src/api.test.ts, "a log that never existed is the only 404").
-export const UnknownAgent = problemKind("unknown-agent", "Unknown Agent", 404)
+export const UnknownThread = problemKind("unknown-thread", "Unknown Thread", 404)
+
+// An actor is deployed code, and this build has one compiled in, so every name but the reserved one
+// is an actor this server does not serve (apps/server/src/api.test.ts, "an actor nobody deployed is
+// its own 404"). It is a separate failure from an unknown thread because the two say different
+// things to a caller: one names code that is not here, the other a log that has never been written.
+export const UnknownActor = problemKind("unknown-actor", "Unknown Actor", 404)
 
 export const UnknownTurn = problemKind("unknown-turn", "Unknown Turn", 404)
 
@@ -97,31 +121,31 @@ export const missingField = (field: string): string => `\`${field}\` is missing.
 
 export const unacceptableField = (field: string): string => `\`${field}\` is not a value it accepts.`
 
-export const AgentStatus = Schema.Literals(["settled", "running", "blocked", "failed"])
+export const ThreadStatus = Schema.Literals(["settled", "running", "blocked", "failed"])
 
-export type AgentStatus = typeof AgentStatus.Type
+export type ThreadStatus = typeof ThreadStatus.Type
 
-// One row of GET /agents: what an agent is, without its events. `parent` is absent for a root, and
-// `lastAt` for an agent whose events carry no timestamp.
-export const AgentSummary = Schema.Struct({
+// One row of GET /v1/actors/:actor/threads: what a thread is, without its events. `parent` is absent for a root, and
+// `lastAt` for a thread whose events carry no timestamp.
+export const ThreadSummary = Schema.Struct({
   id: Schema.String,
   parent: Schema.optionalKey(Schema.String),
   events: Schema.Number,
   lastAt: Schema.optionalKey(Schema.Number),
-  status: AgentStatus
-}).annotate({ identifier: "AgentSummary" })
+  status: ThreadStatus
+}).annotate({ identifier: "ThreadSummary" })
 
-export type AgentSummary = typeof AgentSummary.Type
+export type ThreadSummary = typeof ThreadSummary.Type
 
-export interface AgentNode extends AgentSummary {
-  readonly children: ReadonlyArray<AgentNode>
+export interface ThreadNode extends ThreadSummary {
+  readonly children: ReadonlyArray<ThreadNode>
 }
 
-// A summary with the agents it spawned, the shape GET /agents/:id/tree serves.
-export const AgentNode = Schema.Struct({
-  ...AgentSummary.fields,
-  children: Schema.Array(Schema.suspend((): Schema.Codec<AgentNode> => AgentNode))
-}).annotate({ identifier: "AgentNode" })
+// A summary with the threads it spawned, the shape GET /v1/actors/:actor/threads/:id/tree serves.
+export const ThreadNode = Schema.Struct({
+  ...ThreadSummary.fields,
+  children: Schema.Array(Schema.suspend((): Schema.Codec<ThreadNode> => ThreadNode))
+}).annotate({ identifier: "ThreadNode" })
 
 export const TurnStatus = Schema.Literals(["pending", "completed", "failed", "parked"])
 
@@ -136,7 +160,7 @@ export const TurnView = Schema.Struct({
 
 export type TurnView = typeof TurnView.Type
 
-// One row of GET /agents/:id/events. `seq` is the event's 1-based position in the whole log,
+// One row of GET /v1/actors/:actor/threads/:id/events. `seq` is the event's 1-based position in the whole log,
 // assigned before any filter runs, so a `types` filter narrows the rows without renumbering them
 // and `after` still means the same place (apps/server/src/api.test.ts, "after and limit page the
 // log, and types filters without renumbering it").
@@ -148,9 +172,12 @@ export const EventRow = Schema.Struct({
 export type EventRow = typeof EventRow.Type
 
 // The turn handle a delivery and a resume both answer with. 202 either way: the host dedups by
-// message id, so a retrying client gets the same answer and never learns it retried.
+// message id, so a retrying client gets the same answer and never learns it retried. All three
+// levels the request named are echoed, so a caller holds the whole address of the work it started
+// without reassembling it from the URL.
 export const Accepted = Schema.Struct({
-  agent: Schema.String,
+  actor: Schema.String,
+  thread: Schema.String,
   turn: Schema.String
 }).annotate({ identifier: "Accepted" }).pipe(HttpApiSchema.status(202))
 
@@ -186,45 +213,55 @@ const Seq = Schema.Int.pipe(
 
 const SeqQuery = Schema.optionalKey(Seq)
 
-const AgentParams = { id: Schema.String }
+// The actor level, on every route that reads or writes a thread. It is a parameter rather than the
+// literal `agent` so the declaration states the shape a deploy will vary, and every route can refuse
+// a name this build does not serve in the same way (apps/server/src/api.ts, actorOf).
+const ActorParams = { actor: Schema.String }
 
-const TurnParams = { id: Schema.String, turn: Schema.String }
+const ThreadParams = { actor: Schema.String, id: Schema.String }
 
-export const agentsGroup = HttpApiGroup.make("agents").add(
-  HttpApiEndpoint.post("deliver", "/agents/:id/messages", {
-    params: AgentParams,
+const TurnParams = { actor: Schema.String, id: Schema.String, turn: Schema.String }
+
+export const threadsGroup = HttpApiGroup.make("threads").add(
+  // Delivery is an append: a message is an event, and the log is where it lands, so the write side
+  // of a thread is the same noun as its read side (docs/how-to/server.md, "Creation is delivery").
+  HttpApiEndpoint.post("deliver", "/v1/actors/:actor/threads/:id/events", {
+    params: ThreadParams,
     payload: Inbound,
-    success: Accepted
+    success: Accepted,
+    error: [UnknownActor.schema]
   }),
-  HttpApiEndpoint.get("list", "/agents", {
-    success: Schema.Array(AgentSummary)
+  HttpApiEndpoint.get("list", "/v1/actors/:actor/threads", {
+    params: ActorParams,
+    success: Schema.Array(ThreadSummary),
+    error: [UnknownActor.schema]
   }),
-  HttpApiEndpoint.get("events", "/agents/:id/events", {
-    params: AgentParams,
+  HttpApiEndpoint.get("events", "/v1/actors/:actor/threads/:id/events", {
+    params: ThreadParams,
     query: { after: SeqQuery, limit: SeqQuery, types: Schema.optionalKey(Schema.String) },
     success: Schema.Array(EventRow),
-    error: [UnknownAgent.schema]
+    error: [UnknownActor.schema, UnknownThread.schema]
   }),
-  HttpApiEndpoint.get("turns", "/agents/:id/turns", {
-    params: AgentParams,
+  HttpApiEndpoint.get("turns", "/v1/actors/:actor/threads/:id/turns", {
+    params: ThreadParams,
     query: { at: SeqQuery },
     success: Schema.Array(TurnView),
-    error: [UnknownAgent.schema]
+    error: [UnknownActor.schema, UnknownThread.schema]
   }),
-  HttpApiEndpoint.get("turn", "/agents/:id/turns/:turn", {
+  HttpApiEndpoint.get("turn", "/v1/actors/:actor/threads/:id/turns/:turn", {
     params: TurnParams,
     success: TurnView,
-    error: [UnknownAgent.schema, UnknownTurn.schema]
+    error: [UnknownActor.schema, UnknownThread.schema, UnknownTurn.schema]
   }),
-  HttpApiEndpoint.post("resume", "/agents/:id/turns/:turn/resume", {
+  HttpApiEndpoint.post("resume", "/v1/actors/:actor/threads/:id/turns/:turn/resume", {
     params: TurnParams,
     success: Accepted,
-    error: [ResumeRefused.schema]
+    error: [UnknownActor.schema, ResumeRefused.schema]
   }),
-  HttpApiEndpoint.get("tree", "/agents/:id/tree", {
-    params: AgentParams,
-    success: AgentNode,
-    error: [UnknownAgent.schema]
+  HttpApiEndpoint.get("tree", "/v1/actors/:actor/threads/:id/tree", {
+    params: ThreadParams,
+    success: ThreadNode,
+    error: [UnknownActor.schema, UnknownThread.schema]
   })
 )
 
@@ -242,11 +279,11 @@ export class RequestProblems extends HttpApiMiddleware.Service<RequestProblems>(
   { error: InvalidRequest.schema }
 ) {}
 
-export const Api = HttpApi.make("tardigrade").add(agentsGroup, healthGroup).middleware(RequestProblems)
+export const Api = HttpApi.make("tardigrade").add(threadsGroup, healthGroup).middleware(RequestProblems)
   .annotateMerge(
     OpenApi.annotations({
       title: "Tardigrade",
       description:
-        "The agent server: every read is a projection of a durable log, and every failure is an RFC 9457 problem document."
+        "Actors, threads, turns, and events: every read is a projection of a durable log, and every failure is an RFC 9457 problem document."
     })
   )

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -94,6 +94,11 @@ export const UnknownActor = problemKind("unknown-actor", "Unknown Actor", 404)
 
 export const UnknownTurn = problemKind("unknown-turn", "Unknown Turn", 404)
 
+// A name the actor never declared. The platform mounts what an actor declares and nothing else, so
+// this is the answer for any other name under a thread, and its detail lists the names that do
+// exist (apps/server/src/api.ts, layerProjections).
+export const UnknownProjection = problemKind("unknown-projection", "Unknown Projection", 404)
+
 // The library's guard is the API's 409: a turn resumes only from a failed active epoch, and its
 // refusal carries the reason a caller acts on (apps/server/src/host.ts, ResumeRefused).
 export const ResumeRefused = problemKind("resume-refused", "Resume Refused", 409)
@@ -207,7 +212,7 @@ export type Inbound = typeof Inbound.Type
 // carries it as text and the declaration is what turns it into a number: a value that is not one is
 // refused here rather than read as page one (apps/server/src/contract.test.ts, "a refused request
 // is a problem document").
-const Seq = Schema.Int.pipe(
+export const Seq = Schema.Int.pipe(
   Schema.check(Schema.makeFilter((value: number) => value >= 0, { title: "at or above zero" }))
 )
 
@@ -222,6 +227,9 @@ const ThreadParams = { actor: Schema.String, id: Schema.String }
 
 const TurnParams = { actor: Schema.String, id: Schema.String, turn: Schema.String }
 
+// The log, which is the whole of what the platform guarantees: list the threads an actor holds,
+// append an event, read the events back. A tail follows beside this group (stream.ts). Everything
+// else a thread can be asked is a projection its actor declares, mounted by name below.
 export const threadsGroup = HttpApiGroup.make("threads").add(
   // Delivery is an append: a message is an event, and the log is where it lands, so the write side
   // of a thread is the same noun as its read side (docs/how-to/server.md, "Creation is delivery").
@@ -242,22 +250,22 @@ export const threadsGroup = HttpApiGroup.make("threads").add(
     success: Schema.Array(EventRow),
     error: [UnknownActor.schema, UnknownThread.schema]
   }),
-  HttpApiEndpoint.get("turns", "/v1/actors/:actor/threads/:id/turns", {
-    params: ThreadParams,
-    query: { at: SeqQuery },
-    success: Schema.Array(TurnView),
-    error: [UnknownActor.schema, UnknownThread.schema]
-  }),
+  // The assembly's surface, pending its own change: one turn's boundary, read by id rather than
+  // over the whole log, so its path is not the `{name}` a projection mounts at.
   HttpApiEndpoint.get("turn", "/v1/actors/:actor/threads/:id/turns/:turn", {
     params: TurnParams,
     success: TurnView,
     error: [UnknownActor.schema, UnknownThread.schema, UnknownTurn.schema]
   }),
+  // The assembly's surface, pending its own change: a resume is a guard over an appended
+  // TurnResumed, so folding it in means deciding how a reactor records a refusal.
   HttpApiEndpoint.post("resume", "/v1/actors/:actor/threads/:id/turns/:turn/resume", {
     params: TurnParams,
     success: Accepted,
     error: [UnknownActor.schema, ResumeRefused.schema]
   }),
+  // The assembly's surface, pending its own change: the tree reads the whole family rather than one
+  // thread's events, and its parentage rule comes from PackageCalled claims in a parent's log.
   HttpApiEndpoint.get("tree", "/v1/actors/:actor/threads/:id/tree", {
     params: ThreadParams,
     success: ThreadNode,
@@ -269,6 +277,91 @@ export const healthGroup = HttpApiGroup.make("health").add(
   HttpApiEndpoint.get("healthz", "/healthz", { success: Health })
 )
 
+// A projection is a pure read of one thread's events, declared by the actor whose reactors wrote
+// them. The platform holds the log and mounts what the actor declares; what the events mean is the
+// actor's own knowledge, so the declaration lives beside its reactors (apps/server/src/actor.ts).
+//
+// `run` is a projection in the framework's sense: pure over the event set, recomputed per request,
+// never stored. Nothing here performs IO, and a prefix of a log is a valid argument.
+export interface ProjectionDeclaration {
+  readonly params: Schema.Struct.Fields
+  readonly result: Schema.Top
+  // `never` is the widest parameter a constraint can ask for: it accepts a `run` typed against its
+  // own decoded query, which is what `projection` below infers for an author.
+  readonly run: (events: ReadonlyArray<Event>, params: never) => unknown
+}
+
+export type Projections = Record<string, ProjectionDeclaration>
+
+// projection is how an actor writes one, and exists so `run` is inferred rather than annotated: the
+// query it receives is `params` decoded, and what it answers is `result`'s type.
+export const projection = <Params extends Schema.Struct.Fields, Result extends Schema.Top>(
+  declaration: {
+    readonly params: Params
+    readonly result: Result
+    readonly run: (events: ReadonlyArray<Event>, params: Schema.Struct<Params>["Type"]) => Result["Type"]
+  }
+): typeof declaration => declaration
+
+// The two names a projection may not claim. The log is not a projection of itself: `events` is the
+// log read back and `stream` is the same log followed, and both are the platform's own guarantee
+// rather than anything an actor derives (projectionsOf refuses either, the way agentOf refuses a
+// duplicate tool).
+export const RESERVED_PROJECTIONS: ReadonlyArray<string> = ["events", "stream"]
+
+// projectionsOf is the constructor an actor declares through. It refuses a reserved name where the
+// declaration is written rather than where a request arrives, so a build that would shadow the log
+// never starts (apps/server/src/actor.test.ts, "a projection may not claim a reserved name").
+export const projectionsOf = <const P extends Projections>(projections: P): P => {
+  for (const name of Object.keys(projections)) {
+    if (RESERVED_PROJECTIONS.includes(name)) {
+      throw new Error(
+        `a projection may not be named ${JSON.stringify(name)}: ${
+          RESERVED_PROJECTIONS.map((reserved) => JSON.stringify(reserved)).join(" and ")
+        } are the log itself`
+      )
+    }
+  }
+  return projections
+}
+
+// One endpoint from one declaration. The schemas are type parameters of this function rather than
+// fields reached through one declaration parameter, because inference through an indexed access
+// widens `success` to `Schema.Top` and the derived client then answers `unknown`.
+const projectionEndpoint = <
+  const Name extends string,
+  Params extends Schema.Struct.Fields,
+  Result extends Schema.Top
+>(name: Name, params: Params, result: Result) =>
+  HttpApiEndpoint.get(name, `/v1/actors/:actor/threads/:id/${name}` as const, {
+    params: ThreadParams,
+    query: params,
+    success: result,
+    error: [UnknownActor.schema, UnknownThread.schema]
+  })
+
+export type ProjectionEndpoint<Name extends string, D extends ProjectionDeclaration> = ReturnType<
+  typeof projectionEndpoint<Name, D["params"], D["result"]>
+>
+
+export type ProjectionEndpoints<P extends Projections> = {
+  readonly [Name in keyof P & string]: ProjectionEndpoint<Name, P[Name]>
+}[keyof P & string]
+
+// The endpoints a declaration mounts. The assertion is about arity, not shape: the element type is
+// derived from the same record the values are built from, and a loop over `Object.entries` cannot
+// carry a key's literal type, which is what `add` needs to key the group by name. An actor that
+// declares nothing yields a group with no endpoints, which is what it should.
+const projectionEndpointsOf = <const P extends Projections>(
+  projections: P
+): readonly [ProjectionEndpoints<P>, ...ReadonlyArray<ProjectionEndpoints<P>>] =>
+  Object.entries(projections).map(([name, declaration]) =>
+    projectionEndpoint(name, declaration.params, declaration.result)
+  ) as never
+
+export const projectionsGroupOf = <const P extends Projections>(projections: P) =>
+  HttpApiGroup.make("projections").add(...projectionEndpointsOf(projections))
+
 // RequestProblems is the declaration's own guarantee: whatever a Schema in it refuses, the caller
 // reads as a problem document. It is API-wide middleware rather than an error on each endpoint
 // because the refusal happens before a handler runs, in framework code every endpoint shares, and
@@ -279,11 +372,22 @@ export class RequestProblems extends HttpApiMiddleware.Service<RequestProblems>(
   { error: InvalidRequest.schema }
 ) {}
 
-export const Api = HttpApi.make("tardigrade").add(threadsGroup, healthGroup).middleware(RequestProblems)
-  .annotateMerge(
-    OpenApi.annotations({
-      title: "Tardigrade",
-      description:
-        "Actors, threads, turns, and events: every read is a projection of a durable log, and every failure is an RFC 9457 problem document."
-    })
-  )
+// apiOf is the whole surface for one actor: the log, the projections that actor declares, and the
+// health probe. It is a function rather than a constant because the projections are not the
+// platform's to know: a server builds the API it serves from the actor it mounts
+// (apps/server/src/api.ts, ServerApi).
+export const apiOf = <const P extends Projections>(projections: P) =>
+  HttpApi.make("tardigrade").add(threadsGroup, projectionsGroupOf(projections), healthGroup)
+    .middleware(RequestProblems)
+    .annotateMerge(
+      OpenApi.annotations({
+        title: "Tardigrade",
+        description:
+          "Actors, threads, turns, and events: the platform holds the log, and every other read is a projection its actor declares. Every failure is an RFC 9457 problem document."
+      })
+    )
+
+// The platform's own API, with no actor mounted. It is what a consumer that reads the log alone
+// derives from (client.ts, makeClient), and the group identifiers it carries are the ones every
+// build shares, so a handler written against it serves an API with projections too.
+export const Api = apiOf({})

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -13,13 +13,17 @@ export {
   type FollowOptions
 } from "./client"
 export { isProblem, NO_ANSWER, problemOf, ProblemError } from "./problem"
+// The vocabulary's top level, and where the versioned routes live. A consumer that builds a URL by
+// hand, or names the actor it addresses, reads them from here rather than spelling either again
+// (contract.ts).
+export { RESERVED_ACTOR, V1_PREFIX } from "./contract"
 export { CLOSED, stream, streamUrl, type EventSourceLike, type Frame, type OpenEventSource, type StreamOptions } from "./stream"
 
 export type {
   Accepted,
-  AgentNode,
-  AgentStatus,
-  AgentSummary,
+  ThreadNode,
+  ThreadStatus,
+  ThreadSummary,
   EventRow,
   Health,
   Inbound,

--- a/packages/client/src/problem.test.ts
+++ b/packages/client/src/problem.test.ts
@@ -8,17 +8,17 @@ import { isProblem, problemOf, ProblemError } from "./problem"
 describe("problemOf", () => {
   test("a problem document surfaces all four fields", () => {
     const error = problemOf(404, {
-      type: `${PROBLEM_TYPE_BASE}unknown-agent`,
-      title: "Unknown Agent",
+      type: `${PROBLEM_TYPE_BASE}unknown-thread`,
+      title: "Unknown Thread",
       status: 404,
-      detail: 'No agent named "ghost" has ever existed.'
+      detail: 'No thread named "ghost" has ever existed.'
     }, "Not Found")
     expect(error).toBeInstanceOf(ProblemError)
-    expect(error.type).toBe(`${PROBLEM_TYPE_BASE}unknown-agent`)
-    expect(error.title).toBe("Unknown Agent")
+    expect(error.type).toBe(`${PROBLEM_TYPE_BASE}unknown-thread`)
+    expect(error.title).toBe("Unknown Thread")
     expect(error.status).toBe(404)
-    expect(error.detail).toBe('No agent named "ghost" has ever existed.')
-    expect(error.message).toBe('Unknown Agent: No agent named "ghost" has ever existed.')
+    expect(error.detail).toBe('No thread named "ghost" has ever existed.')
+    expect(error.message).toBe('Unknown Thread: No thread named "ghost" has ever existed.')
   })
 
   test("the document's own status wins over the response's", () => {

--- a/packages/client/src/stream.test.ts
+++ b/packages/client/src/stream.test.ts
@@ -40,7 +40,7 @@ const following = (options: { readonly after?: number } = {}) => {
   let source: FakeSource | undefined
   const unsubscribe = stream({
     baseUrl: "http://localhost:4111",
-    agent: "root",
+    thread: "root",
     ...(options.after === undefined ? {} : { after: options.after }),
     onEvent: (row) => rows.push(row),
     onError: (error) => failures.push(error),
@@ -53,13 +53,13 @@ const following = (options: { readonly after?: number } = {}) => {
 }
 
 describe("streamUrl", () => {
-  test("the first connection carries after, and an agent id is encoded", () => {
+  test("the first connection carries after, and a thread id is encoded", () => {
     expect(streamUrl("http://localhost:4111/", "ag/one", 40))
-      .toBe("http://localhost:4111/agents/ag%2Fone/events/stream?after=40")
+      .toBe("http://localhost:4111/v1/actors/agent/threads/ag%2Fone/events/stream?after=40")
   })
 
   test("no after means the whole log", () => {
-    expect(streamUrl("http://localhost:4111", "root")).toBe("http://localhost:4111/agents/root/events/stream")
+    expect(streamUrl("http://localhost:4111", "root")).toBe("http://localhost:4111/v1/actors/agent/threads/root/events/stream")
   })
 })
 

--- a/packages/client/src/stream.ts
+++ b/packages/client/src/stream.ts
@@ -1,6 +1,6 @@
 import type { Event } from "@clavia/tardigrade-core/event"
 
-import type { EventRow } from "./contract"
+import { RESERVED_ACTOR, V1_PREFIX, type EventRow } from "./contract"
 import { NO_ANSWER, ProblemError } from "./problem"
 
 // The log tail. The stream is not a declared endpoint, because HttpApi is request-and-response
@@ -46,7 +46,10 @@ const globalEventSource: OpenEventSource = (url) => {
 
 export interface StreamOptions {
   readonly baseUrl: string
-  readonly agent: string
+  readonly thread: string
+  // Which actor holds the thread. The default is the name a v1 server reserves (contract.ts,
+  // RESERVED_ACTOR); the derived client always states it (client.ts, follow).
+  readonly actor?: string | undefined
   // Where the first connection starts. A reconnect ignores it: the source replays the same URL with
   // a Last-Event-ID header, and the server prefers that header, so a resume lands where the dropped
   // connection stopped rather than back at `after` (apps/server/src/api.ts, layerStream).
@@ -58,15 +61,24 @@ export interface StreamOptions {
 
 const trimSlash = (url: string): string => (url.endsWith("/") ? url.slice(0, -1) : url)
 
-// streamUrl is the address one tail is opened at. The agent id is encoded because it is a minted
-// call id and is not guaranteed to be path-safe (stream.test.ts, "the first connection carries
-// after").
-export const streamUrl = (baseUrl: string, agent: string, after?: number): string => {
+// streamUrl is the address one tail is opened at. It follows the declaration by hand because the
+// tail is not a declared endpoint (contract.ts, the SSE note), so the prefix and the actor level
+// come from the declaration's own constants rather than a second spelling of them. Both ids are
+// encoded because a thread id is a minted call id and is not guaranteed to be path-safe
+// (stream.test.ts, "the first connection carries after").
+export const streamUrl = (
+  baseUrl: string,
+  thread: string,
+  after?: number,
+  actor: string = RESERVED_ACTOR
+): string => {
   const suffix = after === undefined ? "" : `?after=${after}`
-  return `${trimSlash(baseUrl)}/agents/${encodeURIComponent(agent)}/events/stream${suffix}`
+  return `${trimSlash(baseUrl)}${V1_PREFIX}/actors/${encodeURIComponent(actor)}/threads/${
+    encodeURIComponent(thread)
+  }/events/stream${suffix}`
 }
 
-// stream follows one agent's log and returns the unsubscribe. Reconnection belongs to the
+// stream follows one thread's log and returns the unsubscribe. Reconnection belongs to the
 // EventSource, and so does the Last-Event-ID it carries; this function adds only the frame decoding
 // and the seq, so a source that drops and resumes keeps feeding the same handler and no event is
 // numbered twice (stream.test.ts, "a resumed connection keeps feeding the same handler").
@@ -77,7 +89,7 @@ export const streamUrl = (baseUrl: string, agent: string, after?: number): strin
 // an ordinary `events` poll as the fallback.
 export const stream = (options: StreamOptions): (() => void) => {
   const open = options.eventSource ?? globalEventSource
-  const source = open(streamUrl(options.baseUrl, options.agent, options.after))
+  const source = open(streamUrl(options.baseUrl, options.thread, options.after, options.actor))
   source.onmessage = (frame) => {
     const seq = Number(frame.lastEventId)
     if (!Number.isFinite(seq)) return
@@ -95,7 +107,7 @@ export const stream = (options: StreamOptions): (() => void) => {
         new ProblemError({
           title: "Stream Closed",
           status: NO_ANSWER,
-          detail: `The event stream for ${options.agent} ended and will not reconnect.`
+          detail: `The event stream for ${options.thread} ended and will not reconnect.`
         })
       )
     }


### PR DESCRIPTION
## Surface

    GET    /v1/actors/{actor}/threads
    POST   /v1/actors/{actor}/threads/{id}/events
    GET    /v1/actors/{actor}/threads/{id}/events
    GET    /v1/actors/{actor}/threads/{id}/events/stream
    GET    /v1/actors/{actor}/threads/{id}/{projection}
    GET    /v1/actors/{actor}/threads/{id}/turns/{turn}
    POST   /v1/actors/{actor}/threads/{id}/turns/{turn}/resume
    GET    /v1/actors/{actor}/threads/{id}/tree
    GET    /healthz  /openapi.json  /docs

## Changes

Breaking:

- `/agents/*` becomes `/v1/actors/{actor}/threads/*`; `agent` is the reserved actor name
- `POST .../messages` becomes `POST .../events`
- `AgentSummary`/`AgentNode`/`AgentStatus` become `Thread*`; `Accepted` carries `{ actor, thread, turn }`
- `unknown-actor` and `unknown-thread` are separate 404s

New:

- a projection is declared by the actor with params, a result schema, and a pure `run`; one record gives it a route, an OpenAPI entry, and a typed client call
- `turns` is now the agent actor's declared projection, at the URL it already had
- `events` and `stream` are reserved names, refused when a declaration is built
- an undeclared name answers `404 unknown-projection` listing what exists

Left hand-written, each commented as the assembly's surface: `tree` (reads a family, parentage from `PackageCalled` claims), `resume` (a guard over an appended `TurnResumed`), `turns/{turn}` (a second path segment a projection cannot mount).

Gate green across 25 tasks. Checked by hand against the voyager fixture and `tdg dev`.
