### PR TITLE
docs: lead with running it

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ $$\lbrace\mathrm{transitions}\rbrace = f(\mathrm{log})$$
 Use Bun 1.4 or later.
 
 ```bash
+bunx @clavia/tardigrade setup
+bunx @clavia/tardigrade dev
+```
+
+`setup` asks for a provider, a model id, and a key. `dev` serves the API and the explorer on one port, over a SQLite log beside you. Start a thread from another shell:
+
+```bash
+tdg run "read this repo and tell me what it does"
+```
+
+## Build one
+
+```bash
 bun add @clavia/tardigrade
 ```
 


### PR DESCRIPTION
The readme opened with an install and a code snippet. A first-time reader now gets a running server and a UI in two commands.

```bash
bunx @clavia/tardigrade setup
bunx @clavia/tardigrade dev
tdg run "read this repo and tell me what it does"
```

- new Quickstart section, above the composition example
- the composition example keeps its place under Build one, for readers who came for the framework
