### PR TITLE
refactor(api)!: drop the turn routes

### DIFF
--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -5,7 +5,7 @@ import { BunServices } from "@effect/platform-bun"
 import { ProblemError, RESERVED_ACTOR, type Accepted, type ThreadSummary, type Client, type EventRow, type TurnView } from "@clavia/tardigrade-client"
 
 import { problemLine, tdg } from "./commands"
-import { Cli, type CliServices } from "./services"
+import { Cli, type CliProjections, type CliServices } from "./services"
 
 // The command tree, driven the way a shell drives it: real arguments through the real parser, over
 // a client this file wrote. Nothing here spawns a process, and nothing here reaches a network.
@@ -20,7 +20,7 @@ const events: ReadonlyArray<EventRow> = [
 ]
 
 interface Recorded {
-  readonly delivered: Array<{ thread: string; id: string; text: string }>
+  readonly appended: Array<{ thread: string; id: string; text: string }>
   readonly asked: Array<{ thread: string; options: unknown }>
 }
 
@@ -36,7 +36,7 @@ const clientOf = (
     readonly turns?: ReadonlyArray<TurnView>
     readonly fail?: ProblemError
   }
-): Client => {
+): Client<CliProjections> => {
   let read = 0
   return {
     baseUrl: "http://localhost:0",
@@ -46,19 +46,26 @@ const clientOf = (
       recorded.asked.push({ thread, options })
       return answers.fail === undefined ? Promise.resolve(answers.events ?? []) : Promise.reject(answers.fail)
     },
-    turn: (_thread, _turn) => {
+    // The single turn lookup is a query on the actor's declared projection, so the stand-in answers
+    // it the way the server does: the entries that match, narrowed by `turn` when one is stated.
+    projection: ((_thread: string, _name: string, query?: { readonly turn?: string }) => {
       const views = answers.turns ?? []
       const view = views[Math.min(read++, views.length - 1)]
-      return view === undefined ? refuse() : Promise.resolve(view)
-    },
-    deliver: (thread, message) => {
-      recorded.delivered.push({ thread, id: message.id, text: message.text })
+      if (view === undefined) return refuse()
+      const wanted = query?.turn
+      return Promise.resolve(wanted === undefined || view.turn === wanted ? [view] : [])
+    }) as Client<CliProjections>["projection"],
+    append: (thread, event) => {
+      recorded.appended.push({
+        thread,
+        id: String(event["id"] ?? ""),
+        text: String(event["text"] ?? "")
+      })
       return answers.fail === undefined
-        ? Promise.resolve({ actor: RESERVED_ACTOR, thread, turn: message.id } satisfies Accepted)
+        ? Promise.resolve({ actor: RESERVED_ACTOR, thread } satisfies Accepted)
         : Promise.reject(answers.fail)
     },
     tree: refuse,
-    projection: refuse,
     resume: refuse,
     health: refuse,
     follow: () => () => {}
@@ -84,7 +91,7 @@ const drive = async (
   } = {}
 ): Promise<Ran> => {
   const lines: Array<string> = []
-  const recorded: Recorded = { delivered: [], asked: [] }
+  const recorded: Recorded = { appended: [], asked: [] }
   const minted = [...(options.ids ?? ["minted-1", "minted-2", "minted-3"])]
   const services: CliServices = {
     env: options.env ?? {},
@@ -203,12 +210,12 @@ describe("send", () => {
   test("the turn handle is printed and nothing is waited on", async () => {
     const ran = await drive(["send", "root", "do the thing"])
     expect(ran.lines[0]).toBe("root minted-1")
-    expect(ran.recorded.delivered).toEqual([{ thread: "root", id: "minted-1", text: "do the thing" }])
+    expect(ran.recorded.appended).toEqual([{ thread: "root", id: "minted-1", text: "do the thing" }])
   })
 
   test("a stated id is the id, so a retry is absorbed", async () => {
     const ran = await drive(["send", "root", "again", "--id", "m1"])
-    expect(ran.recorded.delivered[0]?.id).toBe("m1")
+    expect(ran.recorded.appended[0]?.id).toBe("m1")
   })
 
   test("--json prints the handle verbatim", async () => {
@@ -224,8 +231,8 @@ describe("run", () => {
       {
         answers: {
           turns: [
-            { turn: "m1", status: "pending" },
-            { turn: "m1", status: "completed", output: "the summary" }
+            { turn: "m1", status: "pending", epoch: 0 },
+            { turn: "m1", status: "completed", epoch: 0, output: "the summary" }
           ]
         }
       }
@@ -236,14 +243,14 @@ describe("run", () => {
 
   test("a thread nobody named is minted, so a run births its own thread", async () => {
     const ran = await drive(["run", "hello", "--poll", "1"], {
-      answers: { turns: [{ turn: "minted-2", status: "completed", output: "hi" }] }
+      answers: { turns: [{ turn: "minted-2", status: "completed", epoch: 0, output: "hi" }] }
     })
-    expect(ran.recorded.delivered).toEqual([{ thread: "minted-1", id: "minted-2", text: "hello" }])
+    expect(ran.recorded.appended).toEqual([{ thread: "minted-1", id: "minted-2", text: "hello" }])
   })
 
   test("a failed turn prints its error and exits non-zero", async () => {
     const ran = await drive(["run", "hello", "--thread", "root", "--id", "m1", "--poll", "1"], {
-      answers: { turns: [{ turn: "m1", status: "failed", error: "no model is configured" }] }
+      answers: { turns: [{ turn: "m1", status: "failed", epoch: 0, error: "no model is configured" }] }
     })
     expect(ran.lines[0]).toBe("root m1 failed\nno model is configured")
     expect(ran.failed).toBe(true)
@@ -251,7 +258,7 @@ describe("run", () => {
 
   test("a turn that never settles gives up rather than hanging", async () => {
     const ran = await drive(["run", "hello", "--thread", "root", "--id", "m1", "--poll", "1", "--timeout", "0"], {
-      answers: { turns: [{ turn: "m1", status: "pending" }] }
+      answers: { turns: [{ turn: "m1", status: "pending", epoch: 0 }] }
     })
     expect(ran.failed).toBe(true)
     expect(failureText(ran)).toContain("still pending")

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -5,7 +5,7 @@ import { NO_ANSWER, ProblemError, type Client, type TurnView } from "@clavia/tar
 import { resolveRemote, resolveServer } from "./config"
 import { dev } from "./dev"
 import { threadsTable, DEFAULT_DETAIL_WIDTH, eventsTable, jsonOf, turnLines } from "./render"
-import { Cli } from "./services"
+import { Cli, type CliProjections } from "./services"
 
 // The command tree. Every command is a declaration: its flags, its arguments, and its description
 // are values, so the help a person reads and the completions a shell installs are generated from
@@ -87,7 +87,7 @@ const clientOf = (flags: {
 const stated = (option: Option.Option<string>): string | undefined => Option.getOrUndefined(option)
 
 const settle = (
-  client: Client,
+  client: Client<CliProjections>,
   thread: string,
   turn: string,
   pollMillis: number,
@@ -96,8 +96,12 @@ const settle = (
   Effect.gen(function*() {
     const started = yield* Clock.currentTimeMillis
     for (;;) {
-      const view = yield* call(() => client.turn(thread, turn))
-      if (view.status !== "pending") return view
+      // The single lookup is a query on the actor's declared projection rather than a route of its
+      // own: `turn` narrows it to one entry, and a turn nobody was asked to serve matches nothing
+      // (apps/server/src/actor.ts, agentProjections).
+      const views = yield* call(() => client.projection(thread, "turns", { turn }))
+      const view = views.find((candidate) => candidate.turn === turn)
+      if (view !== undefined && view.status !== "pending") return view
       if ((yield* Clock.currentTimeMillis) - started >= timeoutMillis) {
         return yield* Effect.fail(
           userErrorOf(
@@ -169,8 +173,8 @@ export const runCommand = Command.make("run", {
     const client = yield* clientOf(flags)
     const thread = stated(flags.thread) ?? cli.mintId()
     const id = stated(flags.id) ?? cli.mintId()
-    const accepted = yield* call(() => client.deliver(thread, { id, text: flags.brief }))
-    const view = yield* settle(client, accepted.thread, accepted.turn, flags.poll, flags.timeout)
+    const accepted = yield* call(() => client.append(thread, { type: "MessageReceived", id, text: flags.brief }))
+    const view = yield* settle(client, accepted.thread, id, flags.poll, flags.timeout)
     yield* Console.log(flags.json ? jsonOf(view) : turnLines(accepted.thread, view))
     if (view.status !== SETTLED) {
       return yield* Effect.fail(userErrorOf(`turn ${view.turn} on thread ${accepted.thread} is ${view.status}`))
@@ -195,8 +199,10 @@ export const sendCommand = Command.make("send", {
     const cli = yield* Cli
     const client = yield* clientOf(flags)
     const id = stated(flags.id) ?? cli.mintId()
-    const accepted = yield* call(() => client.deliver(flags.thread, { id, text: flags.brief }))
-    yield* Console.log(flags.json ? jsonOf(accepted) : `${accepted.thread} ${accepted.turn}`)
+    const accepted = yield* call(() => client.append(flags.thread, { type: "MessageReceived", id, text: flags.brief }))
+    // The turn is the id this invocation minted: the platform echoes the two levels it knows and
+    // nothing turn-shaped, because a turn is the actor's reading of the log (contract.ts, Accepted).
+    yield* Console.log(flags.json ? jsonOf({ ...accepted, turn: id }) : `${accepted.thread} ${id}`)
   })).pipe(
     Command.withDescription(
       "Deliver a brief and print the turn handle without waiting. The turn settles on the server's own loop."

--- a/apps/cli/src/render.test.ts
+++ b/apps/cli/src/render.test.ts
@@ -69,14 +69,14 @@ describe("eventsTable", () => {
 
 describe("turnLines", () => {
   test("a completed turn prints its output under its handle", () => {
-    expect(turnLines("root", { turn: "m1", status: "completed", output: "ok" })).toBe("root m1 completed\nok")
+    expect(turnLines("root", { turn: "m1", status: "completed", epoch: 0, output: "ok" })).toBe("root m1 completed\nok")
   })
 
   test("a failed turn prints its error", () => {
-    expect(turnLines("root", { turn: "m1", status: "failed", error: "no model" })).toBe("root m1 failed\nno model")
+    expect(turnLines("root", { turn: "m1", status: "failed", epoch: 0, error: "no model" })).toBe("root m1 failed\nno model")
   })
 
   test("a pending turn is its handle alone", () => {
-    expect(turnLines("root", { turn: "m1", status: "pending" })).toBe("root m1 pending")
+    expect(turnLines("root", { turn: "m1", status: "pending", epoch: 0 })).toBe("root m1 pending")
   })
 })

--- a/apps/cli/src/services.ts
+++ b/apps/cli/src/services.ts
@@ -1,5 +1,6 @@
 import { Context, Layer } from "effect"
 import { makeClient, type Client, type ClientOptions } from "@clavia/tardigrade-client"
+import { agentProjections } from "@clavia/tardigrade-server/actor"
 
 import type { Env } from "./config"
 
@@ -8,9 +9,14 @@ import type { Env } from "./config"
 // drives a real command tree against a client it wrote, with an environment it stated, and no
 // process to spawn (commands.test.ts).
 
+// The projections the command line reads. They are the served actor's own declaration, imported
+// rather than restated, so `tdg` asks for exactly what the server mounts and gets it typed
+// (apps/server/src/actor.ts, agentProjections).
+export type CliProjections = typeof agentProjections
+
 export interface CliServices {
   readonly env: Env
-  readonly openClient: (options: ClientOptions) => Client
+  readonly openClient: (options: ClientOptions<CliProjections>) => Client<CliProjections>
   // Where the invocation's message id comes from. A retried invocation carrying the same id is
   // absorbed by the server rather than started twice (docs/how-to/server.md, "Redelivery is
   // absorbed"), so the id is minted once per delivery and is stated in the help.
@@ -21,6 +27,6 @@ export class Cli extends Context.Service<Cli, CliServices>()("tardigrade/cli/Cli
 
 export const layerCli: Layer.Layer<Cli> = Layer.succeed(Cli)({
   env: process.env,
-  openClient: makeClient,
+  openClient: (options) => makeClient({ ...options, projections: agentProjections }),
   mintId: () => crypto.randomUUID()
 })

--- a/apps/server/src/actor.test.ts
+++ b/apps/server/src/actor.test.ts
@@ -40,9 +40,9 @@ describe("the turns projection", () => {
       inbound("m3")
     ]
     expect(turns.run(log, {})).toEqual([
-      { turn: "m1", status: "completed", output: "42" },
-      { turn: "m2", status: "failed", error: "boom" },
-      { turn: "m3", status: "pending" }
+      { turn: "m1", status: "completed", epoch: 0, output: "42" },
+      { turn: "m2", status: "failed", epoch: 0, error: "boom" },
+      { turn: "m3", status: "pending", epoch: 0 }
     ])
   })
 
@@ -53,7 +53,7 @@ describe("the turns projection", () => {
 
   test("an unanswered budget ask is parked", () => {
     const log = [inbound("m1"), requested("m1", "c1")]
-    expect(turns.run(log, {})).toEqual([{ turn: "m1", status: "parked" }])
+    expect(turns.run(log, {})).toEqual([{ turn: "m1", status: "parked", epoch: 0 }])
   })
 
   // `at` is the projection's own declared parameter, so time travel is a query this actor accepts
@@ -61,8 +61,38 @@ describe("the turns projection", () => {
   test("a prefix takes a turn back to pending", () => {
     const log = [inbound("m1"), completed("m1", "42")]
     expect(turns.run(log, {})[0]!.status).toBe("completed")
-    expect(turns.run(log, { at: 1 })).toEqual([{ turn: "m1", status: "pending" }])
+    expect(turns.run(log, { at: 1 })).toEqual([{ turn: "m1", status: "pending", epoch: 0 }])
     expect(turns.run(log, { at: 0 })).toEqual([])
+  })
+})
+
+// The single lookup is a query on this projection rather than a route of its own, which is what
+// lets the platform keep no turn-shaped handler at all (apps/server/src/api.ts).
+describe("reading one turn", () => {
+  test("`turn` narrows the answer to that entry", () => {
+    const log = [inbound("m1"), completed("m1", "42"), inbound("m2"), failed("m2", "boom")]
+    expect(turns.run(log, { turn: "m2" })).toEqual([{ turn: "m2", status: "failed", epoch: 0, error: "boom" }])
+  })
+
+  test("a turn nobody was asked to serve matches nothing", () => {
+    const log = [inbound("m1"), completed("m1", "42")]
+    expect(turns.run(log, { turn: "m9" })).toEqual([])
+  })
+
+  test("`turn` and `at` narrow together", () => {
+    const log = [inbound("m1"), completed("m1", "42")]
+    expect(turns.run(log, { turn: "m1", at: 1 })).toEqual([{ turn: "m1", status: "pending", epoch: 0 }])
+  })
+
+  // The epoch is on the wire because resuming stamps the next one, and a resumed turn reads the
+  // epoch its active attempt belongs to (packages/agent/src/resume.ts, resumeTurn).
+  test("a resumed turn reads the epoch its active attempt belongs to", () => {
+    const log = [
+      inbound("m1"),
+      failed("m1", "boom"),
+      { type: "TurnResumed", turn: "m1", failedEpoch: 0, epoch: 1, at: at() } as Event
+    ]
+    expect(turns.run(log, { turn: "m1" })).toEqual([{ turn: "m1", status: "pending", epoch: 1 }])
   })
 })
 

--- a/apps/server/src/actor.ts
+++ b/apps/server/src/actor.ts
@@ -9,6 +9,7 @@ import {
   reply,
   workspacePackage
 } from "@clavia/tardigrade"
+import { turnEpochOf } from "@clavia/tardigrade-code/turns"
 import { boundaryOf } from "@clavia/tardigrade/boundary"
 import { projection, projectionsOf, Seq, TurnView } from "@clavia/tardigrade-client/contract"
 
@@ -37,6 +38,9 @@ export type TurnStatus = "pending" | "completed" | "failed" | "parked"
 export interface TurnViewShape {
   readonly turn: string
   readonly status: TurnStatus
+  // The execution epoch the active attempt belongs to, zero until an operator has resumed the turn.
+  // It is on the wire because resuming stamps the next one (packages/agent/src/resume.ts).
+  readonly epoch: number
   readonly output?: string
   readonly error?: string
 }
@@ -44,19 +48,31 @@ export interface TurnViewShape {
 // turnsOf projects one turn per inbound message, in the order the messages arrived. `at` cuts the
 // log to a prefix first: any prefix of a log is a valid state, so time travel is this one argument
 // and never a stored mode (apps-server-spec.md, "Principles"). A prefix taken before a turn's
-// terminal reads that turn pending again (projections.test.ts, "a prefix takes a turn back to
-// pending"), and a prefix taken before a message drops its turn from the list entirely.
-const turnsOf = (events: ReadonlyArray<Event>, at?: number): ReadonlyArray<TurnViewShape> => {
-  const prefix = events.slice(0, at ?? events.length)
-  return inboundOf(prefix).map((turn): TurnViewShape => {
-    const boundary = boundaryOf(prefix, turn)
-    if (boundary === undefined) return { turn, status: "pending" }
-    if (boundary.kind === "completed") return { turn, status: "completed", output: boundary.output }
-    if (boundary.kind === "failed") return { turn, status: "failed", error: boundary.error }
-    // A park is neither an output nor an error: the turn is alive and waiting on an answer the API
-    // has no door for, so the status carries the whole of what a client can act on.
-    return { turn, status: "parked" }
-  })
+// terminal reads that turn pending again (actor.test.ts, "a prefix takes a turn back to pending"),
+// and a prefix taken before a message drops its turn from the list entirely.
+//
+// `turn` narrows the answer to one entry, which is what makes the single lookup a query on this
+// projection rather than a route of its own: a turn nobody was asked to serve simply matches
+// nothing, so the answer is an empty array and not a failure (actor.test.ts, "a turn nobody was
+// asked to serve matches nothing").
+const turnsOf = (
+  events: ReadonlyArray<Event>,
+  params: { readonly at?: number; readonly turn?: string }
+): ReadonlyArray<TurnViewShape> => {
+  const prefix = events.slice(0, params.at ?? events.length)
+  const wanted = params.turn
+  return inboundOf(prefix)
+    .filter((turn) => wanted === undefined || turn === wanted)
+    .map((turn): TurnViewShape => {
+      const epoch = turnEpochOf(prefix, turn)
+      const boundary = boundaryOf(prefix, turn)
+      if (boundary === undefined) return { turn, status: "pending", epoch }
+      if (boundary.kind === "completed") return { turn, status: "completed", epoch, output: boundary.output }
+      if (boundary.kind === "failed") return { turn, status: "failed", epoch, error: boundary.error }
+      // A park is neither an output nor an error: the turn is alive and waiting on an answer the API
+      // has no door for, so the status carries the whole of what a client can act on.
+      return { turn, status: "parked", epoch }
+    })
 }
 
 // What this actor answers about a thread beyond its log. A turn is not a fact the platform knows:
@@ -65,14 +81,8 @@ const turnsOf = (events: ReadonlyArray<Event>, at?: number): ReadonlyArray<TurnV
 // what the actor computes").
 export const agentProjections = projectionsOf({
   turns: projection({
-    params: { at: Schema.optionalKey(Seq) },
+    params: { at: Schema.optionalKey(Seq), turn: Schema.optionalKey(Schema.String) },
     result: Schema.Array(TurnView),
-    run: (events, params) => turnsOf(events, params.at)
+    run: turnsOf
   })
 })
-
-// turnViewsOf is the same reading, for the one route that reads a turn by id rather than over the
-// whole log (api.ts, "turn"). It goes through the declaration so the projection and the lookup can
-// never drift.
-export const turnViewsOf = (events: ReadonlyArray<Event>): ReadonlyArray<TurnViewShape> =>
-  agentProjections.turns.run(events, {})

--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -99,49 +99,68 @@ const post = (base: string, path: string, body?: unknown) =>
     ...(body === undefined ? {} : { body: JSON.stringify(body) })
   })
 
+// turnOf reads one turn through the actor's declared projection, narrowed by its `turn` query.
+// There is no route that reads a turn by id: the single lookup is this query (actor.ts,
+// agentProjections).
+const turnOf = async (base: string, thread: string, turn: string): Promise<TurnView | undefined> => {
+  const views = (await (await fetch(
+    `${base}/v1/actors/agent/threads/${thread}/turns?turn=${encodeURIComponent(turn)}`
+  )).json()) as ReadonlyArray<TurnView>
+  return views[0]
+}
+
 const birth = async (base: string, id: string, message: { id: string; text: string }) => {
-  const response = await post(base, `/v1/actors/agent/threads/${id}/events`, message)
+  const response = await post(base, `/v1/actors/agent/threads/${id}/events`, {
+    type: "MessageReceived",
+    ...message
+  })
   expect(response.status).toBe(202)
-  expect(await response.json()).toEqual({ actor: RESERVED_ACTOR, thread: id, turn: message.id })
+  expect(await response.json()).toEqual({ actor: RESERVED_ACTOR, thread: id })
   return until(`turn ${message.id} of ${id}`, async () => {
-    const view = (await (await fetch(`${base}/v1/actors/agent/threads/${id}/turns/${message.id}`)).json()) as TurnView
-    return view.status === "pending" ? undefined : view
+    const view = await turnOf(base, id, message.id)
+    return view === undefined || view.status === "pending" ? undefined : view
   })
 }
 
-describe("messages", () => {
-  test("a message births a thread and the server drives its turn to completed", async () => {
+describe("appending", () => {
+  test("an appended message births a thread and the server drives its turn to completed", async () => {
     const view = await serving((base) => birth(base, "alpha", { id: "m1", text: "hello" }))
-    expect(view).toEqual({ turn: "m1", status: "completed", output: "ok: hello" })
+    expect(view).toEqual({ turn: "m1", status: "completed", epoch: 0, output: "ok: hello" })
   })
 
-  test("a body with no id or no text is refused", async () => {
+  // `type` is the only field the platform requires, because an event is one fact and what its
+  // other fields mean is the actor's knowledge (contract.ts, Append).
+  test("a body with no type is refused", async () => {
     const problems = await serving(async (base) => {
-      const missingText = await post(base, "/v1/actors/agent/threads/alpha/events", { id: "m1" })
-      const missingId = await post(base, "/v1/actors/agent/threads/alpha/events", { text: "hello" })
+      const noType = await post(base, "/v1/actors/agent/threads/alpha/events", { id: "m1", text: "hello" })
+      const emptyType = await post(base, "/v1/actors/agent/threads/alpha/events", { type: "" })
       return [
-        { status: missingText.status, type: missingText.headers.get("content-type"), body: await missingText.json() },
-        { status: missingId.status, type: missingId.headers.get("content-type"), body: await missingId.json() }
+        { status: noType.status, type: noType.headers.get("content-type"), body: await noType.json() },
+        { status: emptyType.status, type: emptyType.headers.get("content-type"), body: await emptyType.json() }
       ]
     })
-    // The declaration refuses the body, and the refusal is a problem document naming the field
-    // that is missing (contract.ts, layerRequestProblems).
     for (const refused of problems) {
       expect(refused.status).toBe(400)
       expect(refused.type).toContain(PROBLEM_CONTENT_TYPE)
       expect(refused.body).toMatchObject({ status: 400, title: "Invalid Request" })
     }
-    expect((problems[0]!.body as { detail: string }).detail).toContain("`text` is missing")
-    expect((problems[1]!.body as { detail: string }).detail).toContain("`id` is missing")
+    expect((problems[0]!.body as { detail: string }).detail).toContain("`type` is missing")
+    expect((problems[1]!.body as { detail: string }).detail).toContain("`type` is not a value it accepts")
   })
 
+  // Duplicate suppression is the actor's, keyed by its own `keyOf` (packages/core/src/message.ts,
+  // messageKeys), so the platform appends and the assembly decides what a repeat means.
   test("a redelivered message id answers the same and writes nothing", async () => {
     const counts = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
       const before = ((await (await fetch(`${base}/v1/actors/agent/threads/alpha/events`)).json()) as ReadonlyArray<EventRow>).length
-      const again = await post(base, "/v1/actors/agent/threads/alpha/events", { id: "m1", text: "hello" })
+      const again = await post(base, "/v1/actors/agent/threads/alpha/events", {
+        type: "MessageReceived",
+        id: "m1",
+        text: "hello"
+      })
       expect(again.status).toBe(202)
-      expect(await again.json()).toEqual({ actor: RESERVED_ACTOR, thread: "alpha", turn: "m1" })
+      expect(await again.json()).toEqual({ actor: RESERVED_ACTOR, thread: "alpha" })
       await sleep(50)
       const after = ((await (await fetch(`${base}/v1/actors/agent/threads/alpha/events`)).json()) as ReadonlyArray<EventRow>).length
       return [before, after]
@@ -288,7 +307,7 @@ describe("the event stream", () => {
       expect(openStreams()).toBe(1)
 
       // Then a message delivered while the stream is open arrives on it.
-      await post(base, "/v1/actors/agent/threads/alpha/events", { id: "m2", text: "again" })
+      await post(base, "/v1/actors/agent/threads/alpha/events", { type: "MessageReceived", id: "m2", text: "again" })
       await until("the live frames", async () => (framesOf(text).length > replayed.length ? true : undefined))
       const live = framesOf(text)
 
@@ -324,7 +343,7 @@ describe("projections", () => {
       return { status: response.status, body: await response.json() as ReadonlyArray<TurnView> }
     })
     expect(read.status).toBe(200)
-    expect(read.body).toEqual([{ turn: "m1", status: "completed", output: "ok: hello" }])
+    expect(read.body).toEqual([{ turn: "m1", status: "completed", epoch: 0, output: "ok: hello" }])
   })
 
   test("a name the actor never declared says what does exist", async () => {
@@ -375,32 +394,27 @@ describe("projections", () => {
       const json = async (path: string) => (await (await fetch(`${base}${path}`)).json()) as ReadonlyArray<TurnView>
       return { now: await json("/v1/actors/agent/threads/alpha/turns"), atOne: await json("/v1/actors/agent/threads/alpha/turns?at=1") }
     })
-    expect(read.now).toEqual([{ turn: "m1", status: "completed", output: "ok: hello" }])
+    expect(read.now).toEqual([{ turn: "m1", status: "completed", epoch: 0, output: "ok: hello" }])
     // One event stands before the cut: the message that asked for the turn, and nothing that
     // answered it.
-    expect(read.atOne).toEqual([{ turn: "m1", status: "pending" }])
+    expect(read.atOne).toEqual([{ turn: "m1", status: "pending", epoch: 0 }])
   })
 
-  test("a turn nobody was asked to serve is a 404", async () => {
-    const answer = await serving(async (base) => {
+  // The single lookup is the same projection with its `turn` query, which is why the platform keeps
+  // no turn-shaped route at all (actor.ts, agentProjections).
+  test("`turn` narrows the projection to one entry, and an unknown turn is an empty array", async () => {
+    const read = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
-      const missing = await fetch(`${base}/v1/actors/agent/threads/alpha/turns/m9`)
-      return { status: missing.status, body: await missing.json() }
+      const json = async (path: string) => (await (await fetch(`${base}${path}`)).json()) as ReadonlyArray<TurnView>
+      return {
+        one: await json("/v1/actors/agent/threads/alpha/turns?turn=m1"),
+        ghost: await json("/v1/actors/agent/threads/alpha/turns?turn=m9")
+      }
     })
-    expect(answer.status).toBe(404)
-    expect(answer.body).toMatchObject({ status: 404, title: "Unknown Turn" })
-  })
-
-  test("a turn that did not fail refuses to resume", async () => {
-    const answer = await serving(async (base) => {
-      await birth(base, "alpha", { id: "m1", text: "hello" })
-      const refused = await post(base, "/v1/actors/agent/threads/alpha/turns/m1/resume")
-      return { status: refused.status, type: refused.headers.get("content-type"), body: await refused.json() }
-    })
-    expect(answer.status).toBe(409)
-    expect(answer.type).toContain(PROBLEM_CONTENT_TYPE)
-    expect(answer.body).toMatchObject({ status: 409, title: "Resume Refused" })
-    expect(String((answer.body as { detail?: unknown }).detail)).toContain("cannot resume")
+    expect(read.one).toEqual([{ turn: "m1", status: "completed", epoch: 0, output: "ok: hello" }])
+    // A turn nobody was asked to serve matches nothing. It is not a failure: asking a projection
+    // about an id it has never seen is a question with an empty answer.
+    expect(read.ghost).toEqual([])
   })
 })
 

--- a/apps/server/src/api.ts
+++ b/apps/server/src/api.ts
@@ -8,16 +8,14 @@ import {
   apiOf,
   invalidRequest,
   RESERVED_ACTOR,
-  ResumeRefused,
   unacceptableField,
   UnknownActor,
   UnknownProjection,
   UnknownThread,
-  UnknownTurn,
   type ProjectionDeclaration,
   type ThreadNode
 } from "@clavia/tardigrade-client/contract"
-import { agentProjections, turnViewsOf } from "./actor"
+import { agentProjections } from "./actor"
 import { Threads } from "./host"
 import { problemResponse } from "./problem"
 import { treeOf, type ThreadSummary } from "./projections"
@@ -210,13 +208,13 @@ export const layerThreadsGroup = (options: ApiOptions = {}) => {
     handlers
       // The body is the declared payload, decoded before this runs: a body that is not one is
       // refused by the declaration and rendered as a problem document (contract.ts,
-      // layerRequestProblems), so the handler only ever sees a message.
-      .handle("deliver", ({ params, payload }) =>
+      // layerRequestProblems), so the handler only ever sees an event.
+      .handle("append", ({ params, payload }) =>
         Effect.gen(function*() {
           const actor = yield* actorOf(params.actor)
           const threads = yield* Threads
-          const accepted = yield* threads.deliver(params.id, payload)
-          return { actor, ...accepted }
+          yield* threads.append(params.id, payload)
+          return { actor, thread: params.id }
         }))
       .handle("list", ({ params }) =>
         Effect.gen(function*() {
@@ -237,32 +235,6 @@ export const layerThreadsGroup = (options: ApiOptions = {}) => {
             .map((event, index) => ({ seq: index + 1, event }))
             .filter((row) => row.seq > (after ?? 0) && (types === undefined || types.includes(row.event.type)))
             .slice(0, page ?? limit)
-        }))
-      .handle("turn", ({ params }) =>
-        Effect.gen(function*() {
-          yield* actorOf(params.actor)
-          const threads = yield* Threads
-          const log = yield* logOf(threads.events, params.id)
-          const view = turnViewsOf(log).find((candidate) => candidate.turn === params.turn)
-          if (view === undefined) {
-            return yield* Effect.fail(
-              UnknownTurn.of(
-                `Thread ${JSON.stringify(params.id)} was never asked to serve a turn named ${
-                  JSON.stringify(params.turn)
-                }.`
-              )
-            )
-          }
-          return view
-        }))
-      .handle("resume", ({ params }) =>
-        Effect.gen(function*() {
-          const actor = yield* actorOf(params.actor)
-          const threads = yield* Threads
-          return yield* threads.resume(params.id, params.turn).pipe(
-            Effect.as({ actor, thread: params.id, turn: params.turn }),
-            Effect.catch((refused) => Effect.fail(ResumeRefused.of(refused.detail)))
-          )
         }))
       .handle("tree", ({ params }) =>
         Effect.gen(function*() {

--- a/apps/server/src/contract.test.ts
+++ b/apps/server/src/contract.test.ts
@@ -7,20 +7,18 @@ import { BunHttpServer } from "@effect/platform-bun"
 import { layerConfig, readConfig } from "./config"
 import { DOCS_PATH, OPENAPI_PATH } from "@clavia/tardigrade-client/contract"
 import { ServerApi } from "./api"
-import { Threads, ResumeRefused } from "./host"
+import { Threads } from "./host"
 import { layerGaugeResting, PROBLEM_CONTENT_TYPE, serve } from "./http"
 
 // The declaration, from the outside. These assertions are about what the declaration produces: the
 // document a client generates from, and the failure shape that document promises. The routes
 // themselves are exercised against a real host in api.test.ts.
 
-// An Threads that owns nothing, so every read is the empty log a 404 is made of and every resume is
-// refused.
+// A Threads that owns nothing, so every read is the empty log a 404 is made of.
 const layerThreadsEmpty = Layer.succeed(Threads)({
-  deliver: (id, message) => Effect.succeed({ thread: id, turn: message.id }),
+  append: () => Effect.void,
   events: () => Effect.succeed([]),
   list: () => Effect.succeed([]),
-  resume: (id, turn) => Effect.fail(new ResumeRefused({ id, turn, detail: "cannot resume a turn that did not fail" })),
   settled: Effect.void
 })
 
@@ -61,8 +59,6 @@ const ROUTES: ReadonlyArray<readonly [string, string]> = [
   ["get", "/v1/actors/{actor}/threads"],
   ["get", "/v1/actors/{actor}/threads/{id}/events"],
   ["get", "/v1/actors/{actor}/threads/{id}/turns"],
-  ["get", "/v1/actors/{actor}/threads/{id}/turns/{turn}"],
-  ["post", "/v1/actors/{actor}/threads/{id}/turns/{turn}/resume"],
   ["get", "/v1/actors/{actor}/threads/{id}/tree"],
   ["get", "/healthz"]
 ]
@@ -129,11 +125,15 @@ describe("problem documents", () => {
     const failures = await serving({}, (client) =>
       Effect.gen(function*() {
         const unknownThread = yield* client.get("/v1/actors/agent/threads/ghost/events")
-        const refused = yield* client.post("/v1/actors/agent/threads/ghost/turns/t1/resume")
+        const unknownProjection = yield* client.get("/v1/actors/agent/threads/ghost/facts")
         const unknownTurn = yield* client.get("/v1/actors/agent/threads/ghost/turns?at=1")
         return [
           { status: unknownThread.status, type: unknownThread.headers["content-type"], body: yield* unknownThread.json },
-          { status: refused.status, type: refused.headers["content-type"], body: yield* refused.json },
+          {
+            status: unknownProjection.status,
+            type: unknownProjection.headers["content-type"],
+            body: yield* unknownProjection.json
+          },
           { status: unknownTurn.status, type: unknownTurn.headers["content-type"], body: yield* unknownTurn.json }
         ]
       }))
@@ -147,7 +147,7 @@ describe("problem documents", () => {
       expect(String(body["title"]).length).toBeGreaterThan(0)
       expect(String(body["detail"]).length).toBeGreaterThan(0)
     }
-    expect(failures.map((failure) => failure.status)).toEqual([404, 409, 404])
+    expect(failures.map((failure) => failure.status)).toEqual([404, 404, 404])
     // An endpoint declaring two failures encodes the one the value names, so the 404 does not
     // render as the 400 beside it (contract.ts, problemKind).
     expect(failures[2]!.body).toMatchObject({ title: "Unknown Thread" })
@@ -165,10 +165,10 @@ describe("problem documents", () => {
         const notANumber = yield* client.get("/v1/actors/agent/threads/ghost/events?after=soon")
         const negative = yield* client.get("/v1/actors/agent/threads/ghost/events?limit=-1")
         const missingField = yield* post("/v1/actors/agent/threads/ghost/events", { id: "m1" })
-        const emptyId = yield* post("/v1/actors/agent/threads/ghost/events", { id: "", text: "hello" })
+        const emptyType = yield* post("/v1/actors/agent/threads/ghost/events", { type: "", id: "m1" })
         const notAnObject = yield* post("/v1/actors/agent/threads/ghost/events", "hello")
         return yield* Effect.forEach(
-          [repeated, notANumber, negative, missingField, emptyId, notAnObject],
+          [repeated, notANumber, negative, missingField, emptyType, notAnObject],
           (response) =>
             Effect.map(response.json, (body) => ({
               status: response.status,
@@ -192,8 +192,8 @@ describe("problem documents", () => {
     expect(details[0]).toBe("The query is not what this endpoint accepts. `at` is not a value it accepts.")
     expect(details[1]).toContain("`after` is not a value it accepts")
     expect(details[2]).toContain("`limit` is not a value it accepts")
-    expect(details[3]).toBe("The request body is not what this endpoint accepts. `text` is missing.")
-    expect(details[4]).toContain("`id` is not a value it accepts")
+    expect(details[3]).toBe("The request body is not what this endpoint accepts. `type` is missing.")
+    expect(details[4]).toContain("`type` is not a value it accepts")
     // A body that is not an object at all names no field, so the sentence stops at the part.
     expect(details[5]).toBe("The request body is not what this endpoint accepts.")
   })

--- a/apps/server/src/host.test.ts
+++ b/apps/server/src/host.test.ts
@@ -5,7 +5,7 @@ import { Infer, type InferRequest } from "@clavia/tardigrade"
 import type { Action } from "@clavia/tardigrade/events"
 
 import { layerConfig, readConfig } from "./config"
-import { Threads, layerThreads, ResumeRefused } from "./host"
+import { Threads, layerThreads } from "./host"
 import { DriverGauge } from "./http"
 
 // Every case here opens a real store on disk and drives a real host, so it competes with every
@@ -53,12 +53,15 @@ const running = <A, E>(
     Effect.runPromise
   ) as Promise<A>
 
+// One brief, as the event it is. The platform requires only `type`; `id` and `text` are the
+// assembly's fields, and `id` is the key its own `keyOf` dedups on (packages/core/src/message.ts).
+const brief = (id: string, text = "hello") => ({ type: "MessageReceived", id, text })
+
 describe("the threads service", () => {
-  test("a delivered brief drives to a completed turn", async () => {
+  test("an appended brief drives to a completed turn", async () => {
     const types = await running((threads) =>
       Effect.gen(function*() {
-        const accepted = yield* threads.deliver("alpha", { id: "m1", text: "hello" })
-        expect(accepted).toEqual({ thread: "alpha", turn: "m1" })
+        yield* threads.append("alpha", brief("m1"))
         yield* threads.settled
         const gauge = yield* DriverGauge
         expect(yield* gauge.dirty).toBe(0)
@@ -72,8 +75,8 @@ describe("the threads service", () => {
   test("list names every thread lane with its log", async () => {
     const listed = await running((threads) =>
       Effect.gen(function*() {
-        yield* threads.deliver("alpha", { id: "m1", text: "hello" })
-        yield* threads.deliver("beta", { id: "m2", text: "hello" })
+        yield* threads.append("alpha", brief("m1"))
+        yield* threads.append("beta", brief("m2"))
         yield* threads.settled
         return yield* threads.list()
       })
@@ -82,26 +85,28 @@ describe("the threads service", () => {
     expect(listed.every((entry) => entry.events.some((e) => e.type === "TurnCompleted"))).toBe(true)
   })
 
-  test("a turn that did not fail refuses to resume", async () => {
-    const refused = await running((threads) =>
+  // The service appends whatever fact it is handed and reads none of its fields: what an event
+  // means is the actor's knowledge (actor.ts, agentProjections). An append that carries its own
+  // `at` keeps it, so a replayed fact keeps the time it happened.
+  test("an appended event keeps the time it states", async () => {
+    const stamps = await running((threads) =>
       Effect.gen(function*() {
-        yield* threads.deliver("alpha", { id: "m1", text: "hello" })
+        yield* threads.append("alpha", { type: "MessageReceived", id: "m1", text: "hello", at: 4242 })
         yield* threads.settled
-        return yield* Effect.flip(threads.resume("alpha", "m1"))
+        const log = yield* threads.events("alpha")
+        return log.filter((event) => event.type === "MessageReceived").map((event) => event["at"])
       })
     )
-    expect(refused).toBeInstanceOf(ResumeRefused)
-    expect(refused.turn).toBe("m1")
-    expect(refused.detail).toContain("cannot resume")
+    expect(stamps).toEqual([4242])
   })
 
   test("redelivering one message id is absorbed", async () => {
     const counts = await running((threads) =>
       Effect.gen(function*() {
-        yield* threads.deliver("alpha", { id: "m1", text: "hello" })
+        yield* threads.append("alpha", brief("m1"))
         yield* threads.settled
         const before = (yield* threads.events("alpha")).length
-        yield* threads.deliver("alpha", { id: "m1", text: "hello" })
+        yield* threads.append("alpha", brief("m1"))
         yield* threads.settled
         return [before, (yield* threads.events("alpha")).length]
       })

--- a/apps/server/src/host.ts
+++ b/apps/server/src/host.ts
@@ -1,7 +1,6 @@
-import { Clock, Context, Data, Effect, Layer } from "effect"
+import { Clock, Context, Effect, Layer } from "effect"
 import type { Event } from "@clavia/tardigrade-core/event"
-import { messageReceived } from "@clavia/tardigrade-core/message"
-import { Infer, resumeTurn, type RlmR } from "@clavia/tardigrade"
+import { Infer, type RlmR } from "@clavia/tardigrade"
 import type { Action } from "@clavia/tardigrade/events"
 import { createBunHost, type BunHost } from "@clavia/tardigrade-bun/host"
 import { infer } from "@clavia/tardigrade-model/model"
@@ -27,35 +26,15 @@ export const laneOf = (id: string): string => `${LANE_PREFIX}${id}`
 export const idOf = (lane: string): string | undefined =>
   lane.startsWith(LANE_PREFIX) ? lane.slice(LANE_PREFIX.length) : undefined
 
-// Inbound is one delivered message: the canonical inbound's fields a client may state
-// (packages/core/src/message.ts, MessageReceived). `id` is the dedup key end to end and becomes
-// the turn id.
-export interface Inbound {
-  readonly id: string
-  readonly text: string
-  readonly input?: unknown
-  readonly data?: unknown
-}
-
-// ResumeRefused is the library's guard, typed: a turn resumes only from a failed active epoch
-// (packages/agent/src/resume.ts). `detail` is the library's own message, which the route renders
-// as the 409's detail (host.test.ts, "a turn that did not fail refuses to resume").
-export class ResumeRefused extends Data.TaggedError("ResumeRefused")<{
-  readonly id: string
-  readonly turn: string
-  readonly detail: string
-}> {}
-
-// The operations the HTTP surface has: deliver a message, read a log, list what exists, resume a
-// failed turn. Every one speaks a thread id. Reads return raw events because the projections are
-// pure functions of a log (projections.ts); a route joins the two.
+// The operations the HTTP surface has: append an event, read a log, list what exists. Every one
+// speaks a thread id and none of them reads an event's fields, because what an event means is the
+// actor's knowledge and this service holds the log (actor.ts, agentProjections).
 export class Threads extends Context.Service<
   Threads,
   {
-    readonly deliver: (id: string, message: Inbound) => Effect.Effect<{ thread: string; turn: string }>
+    readonly append: (id: string, event: Event) => Effect.Effect<void>
     readonly events: (id: string) => Effect.Effect<ReadonlyArray<Event>>
     readonly list: () => Effect.Effect<ReadonlyArray<{ readonly id: string; readonly events: ReadonlyArray<Event> }>>
-    readonly resume: (id: string, turn: string) => Effect.Effect<void, ResumeRefused>
     // settled resolves once the drive in flight, and the follow-up it coalesced, has finished. A
     // client never waits on it (a delivery answers 202 and the client polls the turn); a test and
     // a shutdown do (host.test.ts).
@@ -151,23 +130,15 @@ const make = (options: ThreadsOptions) =>
     const read = (id: string) => Effect.promise(() => host.read(laneOf(id)))
 
     const service: Context.Service.Shape<typeof Threads> = {
-      deliver: (id, message) =>
+      // An append stamps `at` only when the caller stated none, so a replayed event keeps the time
+      // it happened. Everything else about the fact is passed through: duplicate suppression is the
+      // assembly's own key function, which the host was built with (actor.ts, assemblyOf).
+      append: (id, event) =>
         Effect.gen(function*() {
           const at = yield* Clock.currentTimeMillis
-          yield* Effect.promise(() =>
-            host.deliver(
-              host.self(laneOf(id)),
-              messageReceived({
-                id: message.id,
-                text: message.text,
-                ...(message.input === undefined ? {} : { input: message.input }),
-                ...(message.data === undefined ? {} : { data: message.data }),
-                at
-              })
-            )
-          )
+          const stamped = event.at === undefined ? { ...event, at } : event
+          yield* Effect.promise(() => host.deliver(host.self(laneOf(id)), stamped))
           request()
-          return { thread: id, turn: message.id }
         }),
       events: read,
       list: () =>
@@ -179,19 +150,6 @@ const make = (options: ThreadsOptions) =>
           })
           return yield* Effect.forEach(ids, (id) => Effect.map(read(id), (events) => ({ id, events })))
         }),
-      // resumeTurn drives through this loop rather than the host, so a resume is serialized with
-      // every other drive (packages/agent/src/resume.ts, TurnDriver).
-      resume: (id, turn) =>
-        Effect.tryPromise({
-          try: () =>
-            resumeTurn(
-              { read: host.read, deliver: host.deliver, drive: request, self: host.self },
-              laneOf(id),
-              turn
-            ),
-          catch: (e) =>
-            new ResumeRefused({ id, turn, detail: e instanceof Error ? e.message : String(e) })
-        }).pipe(Effect.asVoid),
       settled
     }
 

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -21,10 +21,9 @@ setDefaultTimeout(BOOT_MS)
 // The conventions these tests are about hold over any host, so the thread routes get one that owns
 // nothing. The routes themselves are exercised against a real host in api.test.ts.
 const layerThreadsEmpty = Layer.succeed(Threads)({
-  deliver: (id, message) => Effect.succeed({ thread: id, turn: message.id }),
+  append: () => Effect.void,
   events: () => Effect.succeed([]),
   list: () => Effect.succeed([]),
-  resume: () => Effect.void,
   settled: Effect.void
 })
 

--- a/apps/voyager/dev/fixture.ts
+++ b/apps/voyager/dev/fixture.ts
@@ -89,7 +89,7 @@ const post = (thread: string, body: unknown) =>
   })
 
 const seed = Effect.promise(async () => {
-  for (const { thread, ...message } of FIXTURE_BRIEFS) await post(thread, message)
+  for (const { thread, ...message } of FIXTURE_BRIEFS) await post(thread, { type: "MessageReceived", ...message })
   console.log(`fixture: seeded ${FIXTURE_BRIEFS.length} briefs on http://127.0.0.1:${FIXTURE_PORT}`)
 })
 

--- a/docs/how-to/cli.md
+++ b/docs/how-to/cli.md
@@ -59,9 +59,9 @@ The server boots without model coordinates and every turn it drives fails with t
 
 ## Waiting, and what a retry costs
 
-`tdg send` returns as soon as the server has accepted the message, because a delivery answers `202` and the turn settles on the server's own loop. `tdg run` waits: it delivers, then reads the turn every `DEFAULT_POLL_MILLIS` until it leaves `pending`, and gives up after `DEFAULT_TIMEOUT_MILLIS` while saying that the turn is still running (`apps/cli/src/commands.ts`). `--poll` and `--timeout` set both. The exit code is zero only when the turn completed.
+`tdg send` returns as soon as the server has accepted the event, because an append answers `202` and the turn settles on the server's own loop. `tdg run` waits: it appends, then reads the actor's `turns` projection with `?turn=` every `DEFAULT_POLL_MILLIS` until that turn leaves `pending`, and gives up after `DEFAULT_TIMEOUT_MILLIS` while saying that the turn is still running (`apps/cli/src/commands.ts`). `--poll` and `--timeout` set both. The exit code is zero only when the turn completed.
 
-Both commands mint a message id per invocation unless `--id` states one. The id is the dedup key end to end and becomes the turn id, so an invocation retried with the same `--id` is absorbed by the server rather than started twice, and an invocation retried without one starts a second turn. `tdg run` also mints the thread when `--thread` states none, which births a new thread, since a thread exists once its log has an event.
+Both commands mint a message id per invocation unless `--id` states one. The id is the dedup key end to end and becomes the turn id, so an invocation retried with the same `--id` is absorbed rather than started twice, and an invocation retried without one starts a second turn. `tdg run` also mints the thread when `--thread` states none, which births a new thread, since a thread exists once its log has an event.
 
 ## Output for people, and for pipes
 

--- a/docs/how-to/server.md
+++ b/docs/how-to/server.md
@@ -39,22 +39,20 @@ Configuration is the environment and nothing else. Every default is an exported 
 
 ## Running without a model
 
-The process boots without model coordinates. It listens, answers `/healthz`, accepts messages, and every turn it drives fails with `no model is configured: set MODEL_BASE_URL, MODEL_API_KEY, and MODEL_ID`. The failure is an event in the log like any other, so `GET /v1/actors/agent/threads/:id/turns/:turn` reports the turn as `failed` and carries that sentence as its error. Set the three variables and `POST /v1/actors/agent/threads/:id/turns/:turn/resume` runs the same turn again from where it stopped. A server that refused to start without a model would hide the log an operator can already read.
+The process boots without model coordinates. It listens, answers `/healthz`, accepts messages, and every turn it drives fails with `no model is configured: set MODEL_BASE_URL, MODEL_API_KEY, and MODEL_ID`. The failure is an event in the log like any other, so `GET /v1/actors/agent/threads/:id/turns?turn=<id>` reports the turn as `failed` and carries that sentence as its error. Set the three variables and `client.resume(thread, turn)` appends the `TurnResumed` that runs the same turn again from where it stopped. A server that refused to start without a model would hide the log an operator can already read.
 
 ## Endpoints
 
-The first three are the log, which is the whole of what the platform guarantees. `turns` is a projection this build's actor declares, and it appears here by being declared. The last three are the assembly's surface, each pending its own change.
+The first three are the log, which is the whole of what the platform guarantees. `turns` is a projection this build's actor declares, and it appears here by being declared. `tree` is the last of the assembly's surface, pending its own change.
 
 | Endpoint | Contract |
 | --- | --- |
-| `POST /v1/actors/agent/threads/:id/events` | Deliver one message, `{ id, text, input?, data? }`. Answers `202 { actor, thread, turn }`, or `400` when the body states no `id` or no `text`. |
+| `POST /v1/actors/agent/threads/:id/events` | Append one event, `{ type, ... }`. A brief is `{ type: "MessageReceived", id, text }`. Answers `202 { actor, thread }`, or `400` when the body states no `type`. |
 | `GET /v1/actors/agent/threads` | Every thread, parent before child, as a summary: id, parent, event count, last event time, and status (`settled`, `running`, `blocked`, `failed`). |
 | `GET /v1/actors/agent/threads/:id/events` | The log as `{ seq, event }` rows. `after` starts the page past a sequence number, `limit` caps it (default 200, `DEFAULT_EVENT_LIMIT`), `types` filters by a comma list. |
 | `GET /v1/actors/agent/threads/:id/events/stream` | The same log as `text/event-stream`, replayed from the cursor and then followed live. The tail re-reads every 50 milliseconds (`DEFAULT_SSE_POLL`) and writes a comment frame after 15 seconds of silence (`DEFAULT_SSE_HEARTBEAT`). |
-| `GET /v1/actors/agent/threads/:id/turns` | The actor's `turns` projection: every turn boundary as `{ turn, status, output?, error? }`, where status is `pending`, `completed`, `failed`, or `parked`. `at` is the projection's own parameter, and evaluates it over a prefix of the log. |
+| `GET /v1/actors/agent/threads/:id/turns` | The actor's `turns` projection: every turn boundary as `{ turn, status, epoch, output?, error? }`, where status is `pending`, `completed`, `failed`, or `parked`. Its two declared parameters narrow it: `at` evaluates it over a prefix of the log, and `turn` answers with that one entry, or an empty array when nothing matches. |
 | `GET /v1/actors/agent/threads/:id/{name}` | Any other name is `404 unknown-projection`, whose detail lists the names the actor does declare. |
-| `GET /v1/actors/agent/threads/:id/turns/:turn` | One turn's boundary, the same shape. This is the poll target for whether a run finished. |
-| `POST /v1/actors/agent/threads/:id/turns/:turn/resume` | Resume a failed turn. `202` with the turn handle, `409` when the turn did not fail or belongs to a spent epoch, carrying the library's own reason. |
 | `GET /healthz` | `200` while the host answers, carrying `status` (`resting` or `driving`) and `dirty`, the count of drive passes owed. Open even when a token is set, so a supervisor can tell an outage from a misconfiguration. |
 | `GET /openapi.json` | The OpenAPI document, derived from the same declaration the routes are built from (`OPENAPI_PATH`). Open even when a token is set. |
 | `GET /docs` | That document rendered as a reference page (`DOCS_PATH`). Open even when a token is set. |
@@ -107,7 +105,13 @@ Children born by spawn get derived ids (`<execId>.<n>`) and appear in `GET /v1/a
 
 ## Redelivery is absorbed
 
-The message `id` is the dedup key end to end and becomes the turn id. Posting the same id twice answers `202` both times and starts one turn: the host absorbs the second delivery, and the client never learns it retried. An at-least-once caller, a webhook relay, or a shell script in a retry loop needs no care beyond keeping the id stable.
+Duplicate suppression is the actor's, not the platform's: the assembly the server mounts states a key per event type, and the host absorbs a second append that carries a key it already holds. For a `MessageReceived` that key is the `id`, which is also the turn id, so posting the same id twice answers `202` both times and starts one turn. An at-least-once caller, a webhook relay, or a shell script in a retry loop needs no care beyond keeping the id stable.
+
+## Resuming is an append
+
+There is no resume endpoint. A resume is a `TurnResumed` event, which the actor's reactors already interpret, so it goes through `POST /v1/actors/agent/threads/:id/events` like every other fact. The ergonomics live in the client rather than the platform: `client.resume(thread, turn)` reads the turns projection, refuses a turn whose active epoch is not `failed`, and otherwise appends the event stamped with the next epoch.
+
+That check is advisory. A turn that fails between the read and the append still gets its `TurnResumed`, and a `TurnResumed` for a turn that is not failed derives nothing, so a race costs an inert event rather than a wrong outcome. A duplicate costs nothing either, because the assembly keys the event by turn and epoch.
 
 ## Streams resume where they dropped
 
@@ -115,7 +119,7 @@ Each log event is one SSE event, and its `id:` field is the sequence number. A d
 
 ## Time travel is a query
 
-Any prefix of a log is a valid state, so reading the past is a parameter rather than a mode. `GET /v1/actors/agent/threads/:id/turns?at=<seq>` evaluates the turn projection over the first `<seq>` events, which is what the thread's outcome looked like at that point. Nothing is stored to make this work: the projection is a pure function of the events it is handed.
+Any prefix of a log is a valid state, so reading the past is a parameter rather than a mode. `GET /v1/actors/agent/threads/:id/turns?at=<seq>` evaluates the turns projection over the first `<seq>` events, which is what the thread's outcome looked like at that point. Nothing is stored to make this work: a projection is a pure function of the events it is handed, and `at` is a parameter the actor declares rather than a mode the platform holds.
 
 ## Out of scope
 

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -12,9 +12,19 @@ import { ProblemError } from "./problem"
 interface Call {
   readonly url: string
   readonly headers: Record<string, string>
+  readonly body: string | undefined
 }
 
 const calls: Array<Call> = []
+
+// The transport encodes a JSON payload before it reaches fetch, so the recorded body is bytes as
+// often as it is a string.
+const bodyOf = (body: unknown): string | undefined => {
+  if (typeof body === "string") return body
+  if (body instanceof Uint8Array) return new TextDecoder().decode(body)
+  if (body instanceof ArrayBuffer) return new TextDecoder().decode(new Uint8Array(body))
+  return undefined
+}
 
 const emptyList = () => new Response("[]", { status: 200, headers: { "content-type": "application/json" } })
 
@@ -25,7 +35,11 @@ let answer: () => Response = emptyList
 // never be consulted and these calls would reach whatever owns the port.
 const stub = ((input: string | URL | Request, init?: RequestInit) => {
   const headers = new Headers(init?.headers ?? {})
-  calls.push({ url: String(input), headers: Object.fromEntries(headers.entries()) })
+  calls.push({
+    url: String(input),
+    headers: Object.fromEntries(headers.entries()),
+    body: bodyOf(init?.body)
+  })
   return Promise.resolve(answer())
 }) as typeof globalThis.fetch
 
@@ -163,5 +177,102 @@ describe("a declared projection", () => {
       "turns"
     )
     expect(views).toEqual([{ turn: "m1", status: "completed" }])
+  })
+})
+
+// A resume is an appended TurnResumed and nothing else. The platform has no resume route, so the
+// guard and the epoch arithmetic are the SDK's, and both read the actor's turns projection.
+describe("resuming a turn", () => {
+  // A resume is two exchanges: the projection it reads, then the append it makes. The stand-in
+  // answers by method, because both go to the same server.
+  const accepting = (view: unknown) => {
+    let read = false
+    return () => {
+      if (read) {
+        return new Response(JSON.stringify({ actor: "agent", thread: "root" }), {
+          status: 202,
+          headers: { "content-type": "application/json" }
+        })
+      }
+      read = true
+      return new Response(JSON.stringify(view === undefined ? [] : [view]), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      })
+    }
+  }
+
+  const projections = projectionsOf({
+    turns: projection({
+      params: { at: Schema.optionalKey(Schema.Int), turn: Schema.optionalKey(Schema.String) },
+      result: Schema.Array(
+        Schema.Struct({
+          turn: Schema.String,
+          status: Schema.Literals(["pending", "completed", "failed", "parked"]),
+          epoch: Schema.Number,
+          output: Schema.optionalKey(Schema.String),
+          error: Schema.optionalKey(Schema.String)
+        })
+      ),
+      run: () => []
+    })
+  })
+
+  const client = () => makeClient({ baseUrl: "http://localhost:4111", fetch: stub, projections })
+
+  test("a failed turn appends the TurnResumed its reactors interpret", async () => {
+    answer = accepting({ turn: "m1", status: "failed", epoch: 0, error: "boom" })
+    const accepted = await client().resume("root", "m1")
+    expect(accepted).toEqual({ actor: "agent", thread: "root" })
+    // Two calls: the projection it read, then the append it made.
+    expect(calls).toHaveLength(2)
+    const read = new URL(calls[0]!.url)
+    expect(read.pathname).toBe("/v1/actors/agent/threads/root/turns")
+    expect(read.searchParams.get("turn")).toBe("m1")
+    const appended = new URL(calls[1]!.url)
+    expect(appended.pathname).toBe("/v1/actors/agent/threads/root/events")
+    expect(JSON.parse(calls[1]!.body ?? "")).toEqual({
+      type: "TurnResumed",
+      turn: "m1",
+      failedEpoch: 0,
+      epoch: 1
+    })
+  })
+
+  // The epoch is read rather than assumed, so resuming an already-resumed turn starts the next one
+  // rather than restating the last (packages/agent/src/resume.ts, resumeTurn).
+  test("the appended epoch is the one after the turn's active attempt", async () => {
+    answer = accepting({ turn: "m1", status: "failed", epoch: 2, error: "boom" })
+    await client().resume("root", "m1")
+    expect(JSON.parse(calls[1]!.body ?? "")).toMatchObject({ failedEpoch: 2, epoch: 3 })
+  })
+
+  test("a turn that did not fail is refused, and nothing is appended", async () => {
+    answer = accepting({ turn: "m1", status: "completed", epoch: 0, output: "done" })
+    const failure = await client().resume("root", "m1").then(() => undefined, (error: unknown) => error)
+    expect(failure).toBeInstanceOf(ProblemError)
+    expect((failure as ProblemError).title).toBe("Resume Refused")
+    expect((failure as ProblemError).status).toBe(409)
+    expect((failure as ProblemError).detail).toContain("its active epoch is completed")
+    expect(calls).toHaveLength(1)
+  })
+
+  test("a turn nobody was asked to serve is refused too", async () => {
+    answer = accepting(undefined)
+    const failure = await client().resume("root", "m9").then(() => undefined, (error: unknown) => error)
+    expect(failure).toBeInstanceOf(ProblemError)
+    expect((failure as ProblemError).detail).toContain('No turn named "m9"')
+    expect(calls).toHaveLength(1)
+  })
+
+  // `resume` is on every client, and the declaration it needs is not, so a client that reads the
+  // log alone says why rather than failing on an undefined call.
+  test("a client built with no turns projection says so", async () => {
+    const failure = await makeClient({ baseUrl: "http://localhost:4111", fetch: stub })
+      .resume("root", "m1")
+      .then(() => undefined, (error: unknown) => error)
+    expect(failure).toBeInstanceOf(ProblemError)
+    expect((failure as ProblemError).detail).toContain("without a `turns` projection")
+    expect(calls).toHaveLength(0)
   })
 })

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -5,12 +5,13 @@ import { HttpApiClient, type HttpApi } from "effect/unstable/httpapi"
 import {
   apiOf,
   RESERVED_ACTOR,
+  ResumeRefused,
   type Accepted,
+  type Append,
   type ThreadNode,
   type ThreadSummary,
   type EventRow,
   type Health,
-  type Inbound,
   type Projections,
   type TurnView
 } from "./contract"
@@ -100,8 +101,12 @@ export interface Client<P extends Projections = {}> {
   readonly list: () => Promise<ReadonlyArray<ThreadSummary>>
   readonly tree: (thread: string) => Promise<ThreadNode>
   readonly events: (thread: string, options?: EventsOptions) => Promise<ReadonlyArray<EventRow>>
-  readonly turn: (thread: string, turn: string) => Promise<TurnView>
-  readonly deliver: (thread: string, message: Inbound) => Promise<Accepted>
+  // Appends one event to a thread's log. A brief is `{ type: "MessageReceived", id, text }`; the
+  // platform requires nothing but `type` (contract.ts, Append).
+  readonly append: (thread: string, event: Append) => Promise<Accepted>
+  // Resumes a failed turn by appending the TurnResumed its reactors already interpret. It is the
+  // SDK's convenience rather than a route: the platform has no resume, because a resume is an
+  // append like any other (resume, below).
   readonly resume: (thread: string, turn: string) => Promise<Accepted>
   readonly health: () => Promise<Health>
   // Reads one projection the actor declared. The name is one this client was built with, and the
@@ -190,6 +195,25 @@ export const makeClient = <const P extends Projections = {}>(options: ClientOpti
   // and reserves that name for it (contract.ts, RESERVED_ACTOR); it is an option rather than a
   // literal at each call so a deploy that serves more than one is a client option, not a rewrite.
   const actor = options.actor ?? RESERVED_ACTOR
+  const append = (thread: string, event: Append): Promise<Accepted> =>
+    run(api.threads.append({ params: { actor, id: thread }, payload: event }))
+
+  // turnsOf reads the `turns` projection through the derivation, which is where the resume
+  // convenience gets the epoch it has to stamp. It is spelled by name rather than through
+  // `projection` because `resume` is on every client while the declaration is not: a client built
+  // for an actor that declares no `turns` says so instead of failing on an undefined call.
+  const turnsOf = async (thread: string, turn: string): Promise<ReadonlyArray<TurnView>> => {
+    const call = (api.projections as Record<string, ProjectionCall | undefined>)["turns"]
+    if (call === undefined) {
+      throw new ProblemError({
+        ...ResumeRefused.of(
+          "This client was built without a `turns` projection, so it cannot tell whether a turn failed."
+        )
+      })
+    }
+    return await run(call({ params: { actor, id: thread }, query: { turn } })) as ReadonlyArray<TurnView>
+  }
+
   return {
     baseUrl,
     actor,
@@ -197,9 +221,38 @@ export const makeClient = <const P extends Projections = {}>(options: ClientOpti
     tree: (thread) => run(api.threads.tree({ params: { actor, id: thread } })),
     events: (thread, events = {}) =>
       run(api.threads.events({ params: { actor, id: thread }, query: eventsQuery(events) })),
-    turn: (thread, turn) => run(api.threads.turn({ params: { actor, id: thread, turn } })),
-    deliver: (thread, message) => run(api.threads.deliver({ params: { actor, id: thread }, payload: message })),
-    resume: (thread, turn) => run(api.threads.resume({ params: { actor, id: thread, turn } })),
+    append,
+    // A resume is an append, so the platform has no route for it and no guard over it. The check
+    // below is advisory: it reads the turns projection to refuse the obvious mistake early and to
+    // learn the epoch to stamp. A turn that fails between the read and the append still gets a
+    // TurnResumed, and a TurnResumed for a turn that is not failed derives nothing, so a race costs
+    // an inert event rather than a wrong outcome. A duplicate costs nothing either: the assembly
+    // keys TurnResumed by turn and epoch, so a second one absorbs (packages/agent/src/events.ts,
+    // agentKeys).
+    resume: async (thread, turn) => {
+      const views = await turnsOf(thread, turn)
+      const view = views.find((candidate) => candidate.turn === turn)
+      if (view === undefined) {
+        throw new ProblemError({
+          ...ResumeRefused.of(`No turn named ${JSON.stringify(turn)} has been served on this thread.`)
+        })
+      }
+      if (view.status !== "failed") {
+        throw new ProblemError({
+          ...ResumeRefused.of(
+            `turn ${JSON.stringify(turn)} cannot resume because its active epoch is ${view.status}`
+          )
+        })
+      }
+      // The next execution epoch, stamped the way the library stamps it
+      // (packages/agent/src/resume.ts, resumeTurn).
+      return append(thread, {
+        type: "TurnResumed",
+        turn,
+        failedEpoch: view.epoch,
+        epoch: view.epoch + 1
+      })
+    },
     health: () => run(api.health.healthz({})),
     // The derivation keys the projections group by name, and the name a caller passes is one of
     // those keys, so the lookup cannot miss. The types are recovered on the way out because an

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -92,15 +92,14 @@ export const UnknownThread = problemKind("unknown-thread", "Unknown Thread", 404
 // things to a caller: one names code that is not here, the other a log that has never been written.
 export const UnknownActor = problemKind("unknown-actor", "Unknown Actor", 404)
 
-export const UnknownTurn = problemKind("unknown-turn", "Unknown Turn", 404)
-
 // A name the actor never declared. The platform mounts what an actor declares and nothing else, so
 // this is the answer for any other name under a thread, and its detail lists the names that do
 // exist (apps/server/src/api.ts, layerProjections).
 export const UnknownProjection = problemKind("unknown-projection", "Unknown Projection", 404)
 
-// The library's guard is the API's 409: a turn resumes only from a failed active epoch, and its
-// refusal carries the reason a caller acts on (apps/server/src/host.ts, ResumeRefused).
+// A resume refused before it was sent. The platform has no resume route: a resume is an appended
+// TurnResumed like any other event, and the guard that a turn's active epoch must be failed is the
+// SDK's convenience rather than the server's rule (client.ts, resume).
 export const ResumeRefused = problemKind("resume-refused", "Resume Refused", 409)
 
 // The parts of a request a declaration can refuse, named the way the framework names them
@@ -156,9 +155,14 @@ export const TurnStatus = Schema.Literals(["pending", "completed", "failed", "pa
 
 export type TurnStatus = typeof TurnStatus.Type
 
+// `epoch` is the execution epoch the turn's active attempt belongs to, zero until an operator has
+// resumed it. It is on the wire because resuming stamps the next one, and a caller that cannot read
+// the current epoch cannot name the next (client.ts, resume; packages/code/src/turns.ts,
+// turnEpochOf).
 export const TurnView = Schema.Struct({
   turn: Schema.String,
   status: TurnStatus,
+  epoch: Schema.Number,
   output: Schema.optionalKey(Schema.String),
   error: Schema.optionalKey(Schema.String)
 }).annotate({ identifier: "TurnView" })
@@ -176,14 +180,13 @@ export const EventRow = Schema.Struct({
 
 export type EventRow = typeof EventRow.Type
 
-// The turn handle a delivery and a resume both answer with. 202 either way: the host dedups by
-// message id, so a retrying client gets the same answer and never learns it retried. All three
-// levels the request named are echoed, so a caller holds the whole address of the work it started
-// without reassembling it from the URL.
+// What an append answers: the two levels the request named. 202 because the event is committed and
+// the settle loop takes it from there, and because the actor's own key absorbs a duplicate, so a
+// retrying caller gets this same answer and never learns it retried. Nothing turn-shaped is echoed:
+// a turn is the actor's reading of the log, and the caller already holds whatever id it sent.
 export const Accepted = Schema.Struct({
   actor: Schema.String,
-  thread: Schema.String,
-  turn: Schema.String
+  thread: Schema.String
 }).annotate({ identifier: "Accepted" }).pipe(HttpApiSchema.status(202))
 
 export type Accepted = typeof Accepted.Type
@@ -195,18 +198,20 @@ export const Health = Schema.Struct({
 
 export type Health = typeof Health.Type
 
-// The message a client delivers. `id` is the dedup key end to end and becomes the turn id, so it is
-// stated rather than defaulted: inventing one would turn a retry into a second turn
-// (docs/how-to/server.md, "Redelivery is absorbed"). `input` and `data` are the canonical inbound's
-// optional fields (packages/core/src/message.ts, MessageReceived).
-export const Inbound = Schema.Struct({
-  id: Schema.NonEmptyString,
-  text: Schema.String,
-  input: Schema.optionalKey(Schema.Unknown),
-  data: Schema.optionalKey(Schema.Unknown)
-}).annotate({ identifier: "Inbound" })
+// One event to append. `type` is the only field the platform requires, because an event is one fact
+// and what its other fields mean is the actor's own knowledge: a brief is
+// `{ type: "MessageReceived", id, text }`, and a resume is a `TurnResumed`. The platform stamps `at`
+// when the caller states none and otherwise passes the fact through untouched.
+//
+// Duplicate suppression is the actor's too, keyed by its own `keyOf`: a MessageReceived dedups on
+// `id`, so a retried brief is absorbed rather than started twice (packages/core/src/message.ts,
+// messageKeys; docs/how-to/server.md, "Redelivery is absorbed").
+export const Append = Schema.StructWithRest(
+  Schema.Struct({ type: Schema.NonEmptyString }),
+  [Schema.Record(Schema.String, Schema.Unknown)]
+).annotate({ identifier: "Append" })
 
-export type Inbound = typeof Inbound.Type
+export type Append = typeof Append.Type
 
 // A sequence number names a position in a log, so it is a whole number at or above zero. The query
 // carries it as text and the declaration is what turns it into a number: a value that is not one is
@@ -225,17 +230,15 @@ const ActorParams = { actor: Schema.String }
 
 const ThreadParams = { actor: Schema.String, id: Schema.String }
 
-const TurnParams = { actor: Schema.String, id: Schema.String, turn: Schema.String }
-
 // The log, which is the whole of what the platform guarantees: list the threads an actor holds,
 // append an event, read the events back. A tail follows beside this group (stream.ts). Everything
 // else a thread can be asked is a projection its actor declares, mounted by name below.
 export const threadsGroup = HttpApiGroup.make("threads").add(
   // Delivery is an append: a message is an event, and the log is where it lands, so the write side
   // of a thread is the same noun as its read side (docs/how-to/server.md, "Creation is delivery").
-  HttpApiEndpoint.post("deliver", "/v1/actors/:actor/threads/:id/events", {
+  HttpApiEndpoint.post("append", "/v1/actors/:actor/threads/:id/events", {
     params: ThreadParams,
-    payload: Inbound,
+    payload: Append,
     success: Accepted,
     error: [UnknownActor.schema]
   }),
@@ -249,20 +252,6 @@ export const threadsGroup = HttpApiGroup.make("threads").add(
     query: { after: SeqQuery, limit: SeqQuery, types: Schema.optionalKey(Schema.String) },
     success: Schema.Array(EventRow),
     error: [UnknownActor.schema, UnknownThread.schema]
-  }),
-  // The assembly's surface, pending its own change: one turn's boundary, read by id rather than
-  // over the whole log, so its path is not the `{name}` a projection mounts at.
-  HttpApiEndpoint.get("turn", "/v1/actors/:actor/threads/:id/turns/:turn", {
-    params: TurnParams,
-    success: TurnView,
-    error: [UnknownActor.schema, UnknownThread.schema, UnknownTurn.schema]
-  }),
-  // The assembly's surface, pending its own change: a resume is a guard over an appended
-  // TurnResumed, so folding it in means deciding how a reactor records a refusal.
-  HttpApiEndpoint.post("resume", "/v1/actors/:actor/threads/:id/turns/:turn/resume", {
-    params: TurnParams,
-    success: Accepted,
-    error: [UnknownActor.schema, ResumeRefused.schema]
   }),
   // The assembly's surface, pending its own change: the tree reads the whole family rather than one
   // thread's events, and its parentage rule comes from PackageCalled claims in a parent's log.

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -26,7 +26,7 @@ export type {
   ThreadSummary,
   EventRow,
   Health,
-  Inbound,
+  Append,
   Problem,
   TurnStatus,
   TurnView


### PR DESCRIPTION
Two routes the platform could not serve without knowing what a turn is.

Removed:

- `GET .../turns/{turn}` — the single lookup is now `?turn=` on the turns projection
- `POST .../turns/{turn}/resume` — a resume is an appended `TurnResumed`, so it goes through `POST .../events`. `client.resume` still reads the turns projection and refuses a turn that did not fail

Falls out of that:

- `POST .../events` takes any event now, not an inbound message. It requires `type` and stamps `at` when the caller states none
- `Accepted` drops `turn`; `TurnView` gains `epoch` so a client can stamp the next one

`tree` is the last route pending its own change: it reads a whole family, not one thread's events.
