### PR TITLE
docs: add npm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 # Tardigrade
 
+[![npm version](https://img.shields.io/npm/v/@clavia/tardigrade.svg)](https://www.npmjs.com/package/@clavia/tardigrade)
+
 A durable and modular agent harness built for self-improvement.
 
 ### A harness made for self-improvement


### PR DESCRIPTION
## Summary
- Add an npm version badge for `@clavia/tardigrade` to the README, linking to the package page.

## Test plan
- [x] Verified `@clavia/tardigrade` (packages/agent) is the published, non-private package
- [x] Rendered badge markdown points to the correct npm package