### PR TITLE
feat(actors): build and push

### DIFF
--- a/apps/cli/src/build.test.ts
+++ b/apps/cli/src/build.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+import { ACTOR_ARTIFACT_VERSION } from "tardie"
+
+import { ACTOR_MANIFEST_FILE, ACTOR_MODULE_FILE, buildActor } from "./build"
+
+let root = ""
+
+afterEach(async () => {
+  if (root.length > 0) await rm(root, { recursive: true, force: true })
+})
+
+const entry = async (source: string): Promise<string> => {
+  root = await mkdtemp(join(process.cwd(), ".tdg-build-test-"))
+  const path = join(root, "actor.ts")
+  await writeFile(path, source, "utf8")
+  return path
+}
+
+describe("buildActor", () => {
+  test("writes a named portable artifact", async () => {
+    const path = await entry(`
+      import { defineActor } from "tardie"
+      export default defineActor({
+        name: "researcher",
+        actor: { reactors: [], keyOf: () => "root" }
+      })
+    `)
+    const built = await buildActor(path, { cwd: root, out: "output" })
+    expect(built.directory).toBe(join(root, "output", "researcher"))
+    expect(await readFile(join(built.directory, ACTOR_MODULE_FILE), "utf8")).toContain("researcher")
+    expect(JSON.parse(await readFile(join(built.directory, ACTOR_MANIFEST_FILE), "utf8"))).toEqual(built.manifest)
+    expect(built.manifest.schema).toBe(ACTOR_ARTIFACT_VERSION)
+    expect(built.manifest.digest).toMatch(/^sha256:[a-f0-9]{64}$/)
+  })
+
+  test("refuses an unnamed module", async () => {
+    const path = await entry("export default { actor: { reactors: [], keyOf: () => 'root' } }")
+    await expect(buildActor(path, { cwd: root, out: "output" })).rejects.toThrow("name must match")
+  })
+})

--- a/apps/cli/src/build.ts
+++ b/apps/cli/src/build.ts
@@ -1,0 +1,107 @@
+import { createHash } from "node:crypto"
+import { mkdtemp, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises"
+import { dirname, join, resolve } from "node:path"
+import { pathToFileURL } from "node:url"
+
+import {
+  ACTOR_ARTIFACT_VERSION,
+  ACTOR_NAME_PATTERN,
+  type ActorArtifactManifest,
+  type ActorDefinition
+} from "tardie"
+
+export const DEFAULT_BUILD_DIRECTORY = ".tardigrade/build"
+export const ACTOR_MODULE_FILE = "actor.mjs"
+export const ACTOR_MANIFEST_FILE = "manifest.json"
+
+export interface BuildActorOptions {
+  readonly out?: string
+  readonly cwd?: string
+}
+
+export interface BuiltActor {
+  readonly directory: string
+  readonly manifest: ActorArtifactManifest
+}
+
+const definitionOf = async (modulePath: string): Promise<ActorDefinition<unknown>> => {
+  const loaded: unknown = await import(`${pathToFileURL(modulePath).href}?build=${crypto.randomUUID()}`)
+  const definition = (loaded as { readonly default?: unknown }).default
+  if (typeof definition !== "object" || definition === null) {
+    throw new Error("actor entry must default export defineActor({ name, actor })")
+  }
+  const candidate = definition as Partial<ActorDefinition<unknown>>
+  if (typeof candidate.name !== "string" || !ACTOR_NAME_PATTERN.test(candidate.name)) {
+    throw new Error(`actor entry name must match ${String(ACTOR_NAME_PATTERN)}`)
+  }
+  if (
+    typeof candidate.actor !== "object" ||
+    candidate.actor === null ||
+    !Array.isArray(candidate.actor.reactors) ||
+    typeof candidate.actor.keyOf !== "function"
+  ) {
+    throw new Error("actor entry must contain an Actor in its actor field")
+  }
+  return candidate as ActorDefinition<unknown>
+}
+
+export const buildActor = async (entry: string, options: BuildActorOptions = {}): Promise<BuiltActor> => {
+  const cwd = resolve(options.cwd ?? process.cwd())
+  const source = resolve(cwd, entry)
+  const out = resolve(cwd, options.out ?? DEFAULT_BUILD_DIRECTORY)
+  await mkdir(dirname(out), { recursive: true })
+  const temporary = await mkdtemp(join(dirname(out), ".tdg-build-"))
+  try {
+    const result = await Bun.build({
+      entrypoints: [source],
+      outdir: temporary,
+      naming: ACTOR_MODULE_FILE,
+      target: "bun",
+      format: "esm",
+      minify: false,
+      sourcemap: "none"
+    })
+    if (!result.success) {
+      const detail = result.logs.map((log) => log.message).join("\n")
+      throw new Error(detail.length > 0 ? detail : `could not build ${entry}`)
+    }
+    const modulePath = join(temporary, ACTOR_MODULE_FILE)
+    const definition = await definitionOf(modulePath)
+    const code = await readFile(modulePath)
+    const manifest: ActorArtifactManifest = {
+      schema: ACTOR_ARTIFACT_VERSION,
+      name: definition.name,
+      module: ACTOR_MODULE_FILE,
+      digest: `sha256:${createHash("sha256").update(code).digest("hex")}`
+    }
+    await writeFile(join(temporary, ACTOR_MANIFEST_FILE), `${JSON.stringify(manifest, null, 2)}\n`, "utf8")
+    await mkdir(out, { recursive: true })
+    const destination = join(out, definition.name)
+    const previous = `${destination}.previous`
+    await rm(previous, { recursive: true, force: true })
+    try {
+      await rename(destination, previous)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+    }
+    try {
+      await rename(temporary, destination)
+    } catch (error) {
+      try {
+        await rename(previous, destination)
+      } catch {}
+      throw error
+    }
+    await rm(previous, { recursive: true, force: true })
+    return { directory: destination, manifest }
+  } finally {
+    await rm(temporary, { recursive: true, force: true })
+  }
+}
+
+export const buildSummary = (built: BuiltActor): string =>
+  [
+    `built ${built.manifest.name}`,
+    `at    ${built.directory}`,
+    `hash  ${built.manifest.digest}`
+  ].join("\n")

--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -41,6 +41,7 @@ const clientOf = (
   return {
     baseUrl: "http://localhost:0",
     actor: RESERVED_ACTOR,
+    actors: () => Promise.resolve([{ name: RESERVED_ACTOR, builtIn: true }]),
     list: () => (answers.fail === undefined ? Promise.resolve(answers.list ?? []) : Promise.reject(answers.fail)),
     events: (thread, options) => {
       recorded.asked.push({ thread, options })
@@ -138,6 +139,8 @@ describe("parsing", () => {
   // is the first one a person runs, so it is the first one listed (commands.ts, tdg).
   test("the tree names setup, and its help says what it writes", async () => {
     expect((await drive([])).lines.join("\n")).toContain("setup")
+    expect((await drive([])).lines.join("\n")).toContain("build")
+    expect((await drive([])).lines.join("\n")).toContain("push")
     const help = (await drive(["setup", "--help"])).lines.join("\n")
     expect(help).toContain("~/.tardigrade/config.json")
     expect(help).toContain("0600")
@@ -150,10 +153,21 @@ describe("parsing", () => {
     expect(help).toContain("--limit")
     expect(help).toContain("--types")
     expect(help).toContain("--json")
+    expect(help).toContain("--actor")
     const devHelp = (await drive(["dev", "--no-open", "--help"])).lines.join("\n")
     expect(devHelp).toContain("--open")
     expect(devHelp).toContain("--no-open")
     expect(devHelp).toContain("--min-port")
+    const pushHelp = (await drive(["push", "--help"])).lines.join("\n")
+    expect(pushHelp).toContain("--target")
+    expect(pushHelp).toContain("local")
+    expect(pushHelp).toContain("hosted")
+  })
+
+  test("push requires an explicit target", async () => {
+    const ran = await drive(["push", "actor.ts"])
+    expect(ran.failed).toBe(true)
+    expect(failureText(ran)).toContain("target")
   })
 
   test("an unknown command fails", async () => {

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -1,11 +1,13 @@
 import { Clock, Console, Effect, Layer, Option } from "effect"
 import { Argument, CliError, Command, Flag } from "effect/unstable/cli"
-import { NO_ANSWER, ProblemError, type Client, type TurnView } from "@clavia/tardigrade-client"
+import { NO_ANSWER, ProblemError, RESERVED_ACTOR, type Client, type TurnView } from "@clavia/tardigrade-client"
 
 import { modelIsConfigured } from "@clavia/tardigrade-server/host"
 
+import { buildActor, buildSummary, DEFAULT_BUILD_DIRECTORY } from "./build"
 import { readFileConfig, resolveRemote, resolveServer } from "./config"
 import { availableDevPort, DEFAULT_MIN_PORT, DEV_URL_HOST, dev, openBrowser } from "./dev"
+import { DEFAULT_ACTOR_DIRECTORY, pushActor, pushSummary, PUSH_TARGETS } from "./push"
 import { homeOf, HOME_MISSING, setupJson, setupPrompt, setupSummary, writeSetup } from "./setup"
 import { threadsTable, DEFAULT_DETAIL_WIDTH, eventsTable, jsonOf, turnLines } from "./render"
 import { Cli, type CliProjections } from "./services"
@@ -71,6 +73,11 @@ const json = Flag.boolean("json").pipe(
   Flag.withDefault(false)
 )
 
+const actor = Flag.string("actor").pipe(
+  Flag.withDescription(`The actor to address. Defaults to ${RESERVED_ACTOR}.`),
+  Flag.withDefault(RESERVED_ACTOR)
+)
+
 const messageId = Flag.string("id").pipe(
   Flag.withDescription(
     "The message id, which is also the turn id and the dedup key. A fresh one is minted per invocation, so state it to make a retry absorbed rather than duplicated."
@@ -78,19 +85,20 @@ const messageId = Flag.string("id").pipe(
   Flag.optional
 )
 
-const remote = { url, token, json }
+const remote = { url, token, actor, json }
 
 // clientOf resolves where to call and opens the client, which is the one place the two sources meet
 // (config.ts, resolveRemote).
 const clientOf = (flags: {
   readonly url: Option.Option<string>
   readonly token: Option.Option<string>
+  readonly actor: string
 }) =>
   Effect.gen(function*() {
     const cli = yield* Cli
     const file = yield* readFileConfig(cli.env)
     const resolved = resolveRemote({ url: stated(flags.url), token: stated(flags.token) }, cli.env, file)
-    return cli.openClient({ baseUrl: resolved.baseUrl, token: resolved.token })
+    return cli.openClient({ baseUrl: resolved.baseUrl, token: resolved.token, actor: flags.actor })
   })
 
 const stated = (option: Option.Option<string>): string | undefined => Option.getOrUndefined(option)
@@ -151,6 +159,72 @@ export const setupCommand = Command.make("setup", { json }, (flags) =>
     ])
   )
 
+export const buildCommand = Command.make("build", {
+  entry: Argument.string("entry").pipe(Argument.withDescription("The actor source file to bundle")),
+  out: Flag.string("out").pipe(
+    Flag.withDescription(`The artifact root. Defaults to ${DEFAULT_BUILD_DIRECTORY}.`),
+    Flag.optional
+  ),
+  json
+}, (flags) =>
+  Effect.gen(function*() {
+    const out = stated(flags.out)
+    const built = yield* Effect.tryPromise({
+      try: () => buildActor(flags.entry, out === undefined ? {} : { out }),
+      catch: userErrorOf
+    })
+    yield* Console.log(flags.json ? jsonOf(built) : buildSummary(built))
+  })).pipe(
+    Command.withDescription("Bundle and validate one named actor as a portable artifact."),
+    Command.withExamples([
+      { command: "tdg build ./actors/researcher.ts", description: "Build one actor into the default artifact root" }
+    ])
+  )
+
+export const pushCommand = Command.make("push", {
+  entry: Argument.string("entry").pipe(Argument.withDescription("The actor source file to build and push")),
+  target: Flag.choice("target", PUSH_TARGETS).pipe(
+    Flag.withDescription("Where to push the actor. State local or hosted explicitly.")
+  ),
+  out: Flag.string("out").pipe(
+    Flag.withDescription(`The artifact root. Defaults to ${DEFAULT_BUILD_DIRECTORY}.`),
+    Flag.optional
+  ),
+  actors: Flag.string("actors").pipe(
+    Flag.withDescription(`The local actor root. Defaults to ${DEFAULT_ACTOR_DIRECTORY}.`),
+    Flag.optional
+  ),
+  url,
+  token,
+  json
+}, (flags) =>
+  Effect.gen(function*() {
+    const cli = yield* Cli
+    const file = yield* readFileConfig(cli.env)
+    const resolved = flags.target === "hosted"
+      ? resolveRemote({ url: stated(flags.url), token: stated(flags.token) }, cli.env, file)
+      : undefined
+    const out = stated(flags.out)
+    const actors = stated(flags.actors)
+    const pushed = yield* Effect.tryPromise({
+      try: () => pushActor(flags.entry, {
+        target: flags.target,
+        ...(out === undefined ? {} : { out }),
+        ...(actors === undefined ? {} : { actors }),
+        ...(resolved === undefined ? {} : { baseUrl: resolved.baseUrl }),
+        ...(resolved?.token === undefined ? {} : { token: resolved.token })
+      }),
+      catch: userErrorOf
+    })
+    yield* Console.log(flags.json ? jsonOf(pushed) : pushSummary(pushed))
+  })).pipe(
+    Command.withDescription("Build one named actor and push the same artifact to a local or hosted actor root."),
+    Command.withExamples([
+      { command: "tdg push ./actors/researcher.ts --target local", description: "Push an actor into the local actor root" },
+      { command: "tdg push ./actors/researcher.ts --target hosted --url https://api.example.com", description: "Push an actor to a hosted server" }
+    ])
+  )
+
 export const devCommand = Command.make("dev", {
   port: Flag.integer("port").pipe(
     Flag.withDescription("The port to listen on. Defaults to PORT, then the server's own default."),
@@ -162,6 +236,14 @@ export const devCommand = Command.make("dev", {
   ),
   db: Flag.string("db").pipe(
     Flag.withDescription("The SQLite file that holds every log. Defaults to TARDIGRADE_DB."),
+    Flag.optional
+  ),
+  actors: Flag.string("actors").pipe(
+    Flag.withDescription("The directory holding pushed actors. Defaults to TARDIGRADE_ACTORS."),
+    Flag.optional
+  ),
+  actorData: Flag.string("actor-data").pipe(
+    Flag.withDescription("The directory holding pushed actor databases. Defaults to TARDIGRADE_ACTOR_DATA."),
     Flag.optional
   ),
   ui: Flag.string("ui").pipe(
@@ -177,7 +259,12 @@ export const devCommand = Command.make("dev", {
     const cli = yield* Cli
     const file = yield* readFileConfig(cli.env)
     const config = yield* Effect.try({
-      try: () => resolveServer({ port: Option.getOrUndefined(flags.port), db: stated(flags.db) }, cli.env, file),
+      try: () => resolveServer({
+        port: Option.getOrUndefined(flags.port),
+        db: stated(flags.db),
+        actors: stated(flags.actors),
+        actorData: stated(flags.actorData)
+      }, cli.env, file),
       catch: userErrorOf
     })
     // A first boot with no model asks for one, because two commands to see anything is one too
@@ -195,7 +282,12 @@ export const devCommand = Command.make("dev", {
         yield* Console.log(setupSummary(path, answers))
         const written = yield* readFileConfig(cli.env)
         return yield* Effect.try({
-          try: () => resolveServer({ port: Option.getOrUndefined(flags.port), db: stated(flags.db) }, cli.env, written),
+          try: () => resolveServer({
+            port: Option.getOrUndefined(flags.port),
+            db: stated(flags.db),
+            actors: stated(flags.actors),
+            actorData: stated(flags.actorData)
+          }, cli.env, written),
           catch: userErrorOf
         })
       })
@@ -339,5 +431,5 @@ export const tdg = Command.make("tdg").pipe(
   Command.withDescription(
     "The tardigrade command. Every read is a projection of a durable log, and every failure is the server's own problem document."
   ),
-  Command.withSubcommands([setupCommand, devCommand, runCommand, sendCommand, lsCommand, eventsCommand])
+  Command.withSubcommands([setupCommand, buildCommand, pushCommand, devCommand, runCommand, sendCommand, lsCommand, eventsCommand])
 )

--- a/apps/cli/src/config.test.ts
+++ b/apps/cli/src/config.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { Effect } from "effect"
 import { BunFileSystem } from "@effect/platform-bun"
 import { DEFAULT_BASE_URL } from "@clavia/tardigrade-client"
-import { DEFAULT_DB, DEFAULT_PORT } from "@clavia/tardigrade-server/config"
+import { DEFAULT_ACTORS, DEFAULT_ACTOR_DATA, DEFAULT_DB, DEFAULT_PORT } from "@clavia/tardigrade-server/config"
 
 import { configPathIn, parseFileConfig, readFileConfig, resolve, resolveRemote, resolveServer } from "./config"
 
@@ -43,6 +43,8 @@ describe("resolveServer", () => {
     const config = resolveServer({}, {})
     expect(config.port).toBe(DEFAULT_PORT)
     expect(config.db).toBe(DEFAULT_DB)
+    expect(config.actors).toBe(DEFAULT_ACTORS)
+    expect(config.actorData).toBe(DEFAULT_ACTOR_DATA)
     expect(config.token).toBeUndefined()
   })
 

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -115,6 +115,8 @@ export const resolveRemote = (flags: RemoteFlags, env: Env, file: FileConfig = {
 export interface ServerFlags {
   readonly port?: number | undefined
   readonly db?: string | undefined
+  readonly actors?: string | undefined
+  readonly actorData?: string | undefined
 }
 
 // resolveServer answers what `tdg dev` boots on. It starts from the server's own reader, so a
@@ -135,6 +137,8 @@ export const resolveServer = (flags: ServerFlags, env: Env, file: FileConfig = {
     ...base,
     port: flags.port ?? base.port,
     db: text(flags.db) ?? base.db,
+    actors: text(flags.actors) ?? base.actors,
+    actorData: text(flags.actorData) ?? base.actorData,
     token: undefined,
     model: {
       baseUrl: resolve(undefined, base.model.baseUrl, model.baseUrl),

--- a/apps/cli/src/dev.test.ts
+++ b/apps/cli/src/dev.test.ts
@@ -61,7 +61,11 @@ const booted = <A>(
   }).pipe(
     Effect.provide(
       dev({
-        config: resolveServer({ port: 0, db: ":memory:" }, env),
+        config: resolveServer({
+          port: 0,
+          db: ":memory:",
+          actors: `/tmp/tardigrade-dev-test-${process.pid}`
+        }, env),
         assets: buildDirectory(),
         threads: { infer: layerScripted },
         disableLogger: true,

--- a/apps/cli/src/push.test.ts
+++ b/apps/cli/src/push.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+import { ACTOR_MANIFEST_FILE, ACTOR_MODULE_FILE } from "./build"
+import { PUSH_PATH, pushActor } from "./push"
+
+let root = ""
+
+afterEach(async () => {
+  if (root.length > 0) await rm(root, { recursive: true, force: true })
+})
+
+const entry = async (): Promise<string> => {
+  root = await mkdtemp(join(process.cwd(), ".tdg-push-test-"))
+  const path = join(root, "actor.ts")
+  await writeFile(path, `
+    import { defineActor } from "tardie"
+    export default defineActor({ name: "reviewer", actor: { reactors: [], keyOf: () => "root" } })
+  `, "utf8")
+  return path
+}
+
+describe("pushActor", () => {
+  test("installs the built bytes locally", async () => {
+    const path = await entry()
+    const pushed = await pushActor(path, { cwd: root, target: "local" })
+    const installed = join(root, ".tardigrade", "actors", "reviewer")
+    expect(pushed.location).toBe(installed)
+    expect(await readFile(join(installed, ACTOR_MODULE_FILE), "utf8"))
+      .toBe(await readFile(join(pushed.directory, ACTOR_MODULE_FILE), "utf8"))
+    expect(JSON.parse(await readFile(join(installed, ACTOR_MANIFEST_FILE), "utf8"))).toEqual(pushed.manifest)
+  })
+
+  test("sends the same artifact to a hosted server", async () => {
+    const path = await entry()
+    let request: Request | undefined
+    const fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      if (input instanceof Request) request = new Request(input, init)
+      else request = new Request(String(input), init)
+      return new Response(null, { status: 204 })
+    }) as typeof globalThis.fetch
+    const pushed = await pushActor(path, {
+      cwd: root,
+      target: "hosted",
+      baseUrl: "https://example.test/",
+      token: "secret",
+      fetch
+    })
+    expect(request?.url).toBe(`https://example.test${PUSH_PATH}`)
+    expect(request?.method).toBe("PUT")
+    expect(request?.headers.get("authorization")).toBe("Bearer secret")
+    const payload = JSON.parse(await request!.text())
+    expect(payload.manifest).toEqual(pushed.manifest)
+    expect(payload.module).toBe(await readFile(join(pushed.directory, ACTOR_MODULE_FILE), "utf8"))
+  })
+})

--- a/apps/cli/src/push.ts
+++ b/apps/cli/src/push.ts
@@ -1,0 +1,107 @@
+import { createHash } from "node:crypto"
+import { mkdir, readFile, rename, rm } from "node:fs/promises"
+import { join, resolve } from "node:path"
+
+import type { ActorArtifactManifest } from "tardie"
+
+import { ACTOR_MANIFEST_FILE, ACTOR_MODULE_FILE, buildActor, type BuildActorOptions, type BuiltActor } from "./build"
+
+export const DEFAULT_ACTOR_DIRECTORY = ".tardigrade/actors"
+export const PUSH_PATH = "/v1/actors"
+export const PUSH_TARGETS = ["local", "hosted"] as const
+
+export type PushTarget = typeof PUSH_TARGETS[number]
+
+export interface PushActorOptions extends BuildActorOptions {
+  readonly target: PushTarget
+  readonly actors?: string
+  readonly baseUrl?: string
+  readonly token?: string
+  readonly fetch?: typeof globalThis.fetch
+}
+
+export interface PushedActor extends BuiltActor {
+  readonly target: PushTarget
+  readonly location: string
+}
+
+interface ActorPayload {
+  readonly manifest: ActorArtifactManifest
+  readonly module: string
+}
+
+const payloadOf = async (built: BuiltActor): Promise<ActorPayload> => {
+  const module = await readFile(join(built.directory, ACTOR_MODULE_FILE), "utf8")
+  const digest = `sha256:${createHash("sha256").update(module).digest("hex")}`
+  if (digest !== built.manifest.digest) throw new Error(`actor artifact digest mismatch: expected ${built.manifest.digest}, got ${digest}`)
+  return { manifest: built.manifest, module }
+}
+
+const pushLocal = async (built: BuiltActor, options: PushActorOptions): Promise<PushedActor> => {
+  const cwd = resolve(options.cwd ?? process.cwd())
+  const actors = resolve(cwd, options.actors ?? DEFAULT_ACTOR_DIRECTORY)
+  await mkdir(actors, { recursive: true })
+  const destination = join(actors, built.manifest.name)
+  const temporary = `${destination}.incoming`
+  const previous = `${destination}.previous`
+  await rm(temporary, { recursive: true, force: true })
+  await rm(previous, { recursive: true, force: true })
+  await mkdir(temporary, { recursive: true })
+  const payload = await payloadOf(built)
+  await Bun.write(join(temporary, ACTOR_MODULE_FILE), payload.module)
+  await Bun.write(join(temporary, ACTOR_MANIFEST_FILE), `${JSON.stringify(payload.manifest, null, 2)}\n`)
+  try {
+    await rename(destination, previous)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+  }
+  try {
+    await rename(temporary, destination)
+  } catch (error) {
+    try {
+      await rename(previous, destination)
+    } catch {}
+    throw error
+  }
+  await rm(previous, { recursive: true, force: true })
+  return { ...built, target: "local", location: destination }
+}
+
+const responseMessage = async (response: Response): Promise<string> => {
+  const body = await response.text()
+  if (body.length === 0) return `${response.status} ${response.statusText}`.trim()
+  try {
+    const parsed = JSON.parse(body) as { readonly detail?: unknown; readonly title?: unknown }
+    if (typeof parsed.detail === "string") return parsed.detail
+    if (typeof parsed.title === "string") return parsed.title
+  } catch {}
+  return body
+}
+
+const pushHosted = async (built: BuiltActor, options: PushActorOptions): Promise<PushedActor> => {
+  if (options.baseUrl === undefined) throw new Error("hosted push requires --url or TARDIGRADE_URL")
+  const baseUrl = options.baseUrl.replace(/\/+$/u, "")
+  const response = await (options.fetch ?? globalThis.fetch)(`${baseUrl}${PUSH_PATH}`, {
+    method: "PUT",
+    headers: {
+      "content-type": "application/json",
+      ...(options.token === undefined ? {} : { authorization: `Bearer ${options.token}` })
+    },
+    body: JSON.stringify(await payloadOf(built))
+  })
+  if (!response.ok) throw new Error(`hosted push failed (${response.status}): ${await responseMessage(response)}`)
+  return { ...built, target: "hosted", location: `${baseUrl}/actors/${built.manifest.name}` }
+}
+
+export const pushActor = async (entry: string, options: PushActorOptions): Promise<PushedActor> => {
+  const built = await buildActor(entry, options)
+  return options.target === "local" ? pushLocal(built, options) : pushHosted(built, options)
+}
+
+export const pushSummary = (pushed: PushedActor): string =>
+  [
+    `pushed ${pushed.manifest.name}`,
+    `to     ${pushed.target}`,
+    `at     ${pushed.location}`,
+    `hash   ${pushed.manifest.digest}`
+  ].join("\n")

--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, setDefaultTimeout, test } from "bun:test"
+import { createHash } from "node:crypto"
+import { mkdtemp, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
 import { Effect, Layer } from "effect"
 import { HttpServer } from "effect/unstable/http"
 import { BunHttpServer } from "@effect/platform-bun"
@@ -59,7 +63,10 @@ const layerScripted: Layer.Layer<Infer> = Layer.succeed(Infer)({
   react: (request: InferRequest) => Effect.succeed(scripted(request))
 })
 
-const config = layerConfig(readConfig({ TARDIGRADE_DB: ":memory:" }))
+const config = layerConfig(readConfig({
+  TARDIGRADE_DB: ":memory:",
+  TARDIGRADE_ACTORS: `/tmp/tardigrade-api-test-${process.pid}`
+}))
 
 const app = Layer.provideMerge(serve({ disableLogger: true, disableListenLog: true }), [
   BunHttpServer.layer({ port: 0 }),
@@ -97,6 +104,13 @@ const post = (base: string, path: string, body?: unknown) =>
     method: "POST",
     headers: { "content-type": "application/json" },
     ...(body === undefined ? {} : { body: JSON.stringify(body) })
+  })
+
+const put = (base: string, path: string, body: unknown) =>
+  fetch(`${base}${path}`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
   })
 
 // turnOf reads one turn through the actor's declared projection, narrowed by its `turn` query.
@@ -166,6 +180,56 @@ describe("appending", () => {
       return [before, after]
     })
     expect(counts[1]).toBe(counts[0]!)
+  })
+})
+
+describe("actors", () => {
+  test("a pushed actor is discovered and serves its own log", async () => {
+    const root = await mkdtemp(join(tmpdir(), "tardigrade-actors-"))
+    const actorData = await mkdtemp(join(tmpdir(), "tardigrade-actor-data-"))
+    const isolatedConfig = layerConfig(readConfig({
+      TARDIGRADE_DB: ":memory:",
+      TARDIGRADE_ACTORS: root,
+      TARDIGRADE_ACTOR_DATA: actorData
+    }))
+    const isolatedApp = Layer.provideMerge(serve({ disableLogger: true, disableListenLog: true }), [
+      BunHttpServer.layer({ port: 0 }),
+      isolatedConfig,
+      Layer.provide(layerThreads({ infer: layerScripted }), isolatedConfig)
+    ])
+    const module = `export default { name: "reviewer", actor: { reactors: [], keyOf: () => undefined } }\n`
+    const digest = `sha256:${createHash("sha256").update(module).digest("hex")}`
+    try {
+      const result = await Effect.gen(function*() {
+        const server = yield* HttpServer.HttpServer
+        const address = server.address
+        const port = address._tag === "TcpAddress" ? address.port : 0
+        const base = `http://127.0.0.1:${port}`
+        return yield* Effect.promise(async () => {
+          const pushed = await put(base, "/v1/actors", {
+            manifest: { schema: 1, name: "reviewer", module: "actor.mjs", digest },
+            module
+          })
+          const summary = await pushed.json()
+          const accepted = await post(base, "/v1/actors/reviewer/threads/review/events", {
+            type: "MessageReceived",
+            id: "m1",
+            text: "inspect"
+          })
+          const actors = await (await fetch(`${base}/v1/actors`)).json()
+          const events = await (await fetch(`${base}/v1/actors/reviewer/threads/review/events`)).json()
+          return { pushStatus: pushed.status, summary, accepted: await accepted.json(), actors, events }
+        })
+      }).pipe(Effect.provide(isolatedApp), Effect.scoped, Effect.runPromise)
+      expect(result.pushStatus).toBe(200)
+      expect(result.summary).toEqual({ name: "reviewer", builtIn: false, digest })
+      expect(result.accepted).toEqual({ actor: "reviewer", thread: "review" })
+      expect(result.actors).toContainEqual({ name: "reviewer", builtIn: false, digest })
+      expect(result.events).toHaveLength(1)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+      await rm(actorData, { recursive: true, force: true })
+    }
   })
 })
 

--- a/apps/server/src/api.ts
+++ b/apps/server/src/api.ts
@@ -6,6 +6,7 @@ import type { Event } from "@clavia/tardigrade-core/event"
 import {
   Api,
   apiOf,
+  InvalidRequest,
   invalidRequest,
   RESERVED_ACTOR,
   unacceptableField,
@@ -16,7 +17,7 @@ import {
   type ThreadNode
 } from "@clavia/tardigrade-client/contract"
 import { agentProjections } from "./actor"
-import { Threads } from "./host"
+import { Threads, type ActorThreads } from "./host"
 import { problemResponse } from "./problem"
 import { treeOf, type ThreadSummary } from "./projections"
 
@@ -62,14 +63,19 @@ const integerOf = (raw: string | undefined): number | undefined => {
 const unknownThreadDetail = (id: string) => `No thread named ${JSON.stringify(id)} has ever existed.`
 
 const unknownActorDetail = (actor: string) =>
-  `This server serves one actor, ${JSON.stringify(RESERVED_ACTOR)}, and nothing named ${JSON.stringify(actor)}.`
+  `No actor named ${JSON.stringify(actor)} is available on this server.`
 
 // actorOf is the guard every declared route runs first. The actor level is a path parameter so the
 // declaration states the shape a deploy will vary (contract.ts, RESERVED_ACTOR), and this build
 // serves exactly the reserved name: any other is code nobody deployed here, which is its own 404
 // rather than an empty listing (api.test.ts, "an actor nobody deployed is its own 404").
-const actorOf = (actor: string): Effect.Effect<string, ReturnType<typeof UnknownActor.of>> =>
-  actor === RESERVED_ACTOR ? Effect.succeed(actor) : Effect.fail(UnknownActor.of(unknownActorDetail(actor)))
+const actorOf = (actor: string): Effect.Effect<ActorThreads, ReturnType<typeof UnknownActor.of>, Threads> =>
+  Effect.flatMap(Threads, (threads) => {
+    const selected = actor === RESERVED_ACTOR ? threads : threads.actor?.(actor)
+    return selected === undefined
+      ? Effect.fail(UnknownActor.of(unknownActorDetail(actor)))
+      : Effect.succeed(selected)
+  })
 
 // logOf reads a thread's events, failing the route when the log is empty. A thread exists once its
 // log has an event (docs/how-to/server.md, "Creation is delivery"), so an empty log is the only
@@ -174,9 +180,10 @@ export const layerStream = (options: ApiOptions = {}) => {
       // The tail answers the same actor guard the declared routes do. It is spelled out rather than
       // shared with them because this route decodes its own request: it is not a declared endpoint
       // (contract.ts, the SSE note; api.test.ts, "the tail refuses an actor nobody deployed").
-      if (actor !== RESERVED_ACTOR) return problemResponse(UnknownActor.of(unknownActorDetail(actor)))
       const id = paramOf(params, "id")
-      const threads = yield* Threads
+      const registry = yield* Threads
+      const threads = actor === RESERVED_ACTOR ? registry : registry.actor?.(actor)
+      if (threads === undefined) return problemResponse(UnknownActor.of(unknownActorDetail(actor)))
       const log = yield* threads.events(id)
       if (log.length === 0) return problemResponse(UnknownThread.of(unknownThreadDetail(id)))
       const query = yield* HttpServerRequest.ParsedSearchParams
@@ -211,21 +218,18 @@ export const layerThreadsGroup = (options: ApiOptions = {}) => {
       // layerRequestProblems), so the handler only ever sees an event.
       .handle("append", ({ params, payload }) =>
         Effect.gen(function*() {
-          const actor = yield* actorOf(params.actor)
-          const threads = yield* Threads
+          const threads = yield* actorOf(params.actor)
           yield* threads.append(params.id, payload)
-          return { actor, thread: params.id }
+          return { actor: params.actor, thread: params.id }
         }))
       .handle("list", ({ params }) =>
         Effect.gen(function*() {
-          yield* actorOf(params.actor)
-          const threads = yield* Threads
+          const threads = yield* actorOf(params.actor)
           return flatten(treeOf(logsOf(yield* threads.list())))
         }))
       .handle("events", ({ params, query }) =>
         Effect.gen(function*() {
-          yield* actorOf(params.actor)
-          const threads = yield* Threads
+          const threads = yield* actorOf(params.actor)
           const log = yield* logOf(threads.events, params.id)
           const { after, limit: page } = query
           // The comma list is the one rule the query Schema does not state: every value it could
@@ -238,8 +242,7 @@ export const layerThreadsGroup = (options: ApiOptions = {}) => {
         }))
       .handle("tree", ({ params }) =>
         Effect.gen(function*() {
-          yield* actorOf(params.actor)
-          const threads = yield* Threads
+          const threads = yield* actorOf(params.actor)
           // The forest is built over every log because parentage is a claim in the PARENT's log; a
           // subtree cannot be derived from the subtree's own events (projections.ts, treeOf).
           const node = findNode(treeOf(logsOf(yield* threads.list())), params.id)
@@ -267,8 +270,7 @@ const readOf = (declaration: ProjectionDeclaration) =>
   readonly query: never
 }) =>
   Effect.gen(function*() {
-    yield* actorOf(request.params.actor)
-    const threads = yield* Threads
+    const threads = yield* actorOf(request.params.actor)
     const log = yield* logOf(threads.events, request.params.id)
     return declaration.run(log, request.query)
   })
@@ -309,7 +311,10 @@ export const layerUnknownProjection = () => {
     Effect.gen(function*() {
       const params = yield* HttpRouter.params
       const actor = paramOf(params, "actor")
-      if (actor !== RESERVED_ACTOR) return problemResponse(UnknownActor.of(unknownActorDetail(actor)))
+      const registry = yield* Threads
+      if (actor !== RESERVED_ACTOR && registry.actor?.(actor) === undefined) {
+        return problemResponse(UnknownActor.of(unknownActorDetail(actor)))
+      }
       const name = paramOf(params, "name")
       return problemResponse(
         UnknownProjection.of(`No projection named ${JSON.stringify(name)} is mounted here. ${detail}`)
@@ -317,3 +322,19 @@ export const layerUnknownProjection = () => {
     })
   )
 }
+
+export const layerActorsGroup = () =>
+  HttpApiBuilder.group(ServerApi, "actors", (handlers) =>
+    handlers
+      .handle("actors", () =>
+        Effect.flatMap(Threads, (threads) => threads.actors ?? Effect.succeed([
+          { name: RESERVED_ACTOR, builtIn: true }
+        ])))
+      .handle("pushActor", ({ payload }) =>
+        Effect.gen(function*() {
+          const threads = yield* Threads
+          if (threads.push === undefined) {
+            return yield* Effect.fail(InvalidRequest.of("This server does not accept actor pushes."))
+          }
+          return yield* Effect.mapError(threads.push(payload), (error) => InvalidRequest.of(error.message))
+        })))

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -12,6 +12,10 @@ export const DEFAULT_PORT = 4242
 // Where the log lives when TARDIGRADE_DB is absent: a hidden directory under the working directory.
 export const DEFAULT_DB = ".tardigrade/agents.sqlite"
 
+export const DEFAULT_ACTORS = ".tardigrade/actors"
+
+export const DEFAULT_ACTOR_DATA = ".tardigrade/data"
+
 // The model binding's coordinates. Absent values are absent rather than guessed: the model layer
 // decides what it can do without them, and the server does not invent an endpoint.
 export interface ModelConfig {
@@ -24,6 +28,8 @@ export interface ModelConfig {
 export interface ServerConfigValue {
   readonly port: number
   readonly db: string
+  readonly actors: string
+  readonly actorData: string
   // Absent leaves the API open, which is why the process is meant to bind to localhost. Present
   // makes a bearer token required on every route except /healthz (http.ts).
   readonly token: string | undefined
@@ -59,6 +65,8 @@ const port = (env: Env): number => {
 export const readConfig = (env: Env): ServerConfigValue => ({
   port: port(env),
   db: text(env, "TARDIGRADE_DB") ?? DEFAULT_DB,
+  actors: text(env, "TARDIGRADE_ACTORS") ?? DEFAULT_ACTORS,
+  actorData: text(env, "TARDIGRADE_ACTOR_DATA") ?? DEFAULT_ACTOR_DATA,
   token: text(env, "TARDIGRADE_TOKEN"),
   model: {
     baseUrl: text(env, "MODEL_BASE_URL"),

--- a/apps/server/src/contract.test.ts
+++ b/apps/server/src/contract.test.ts
@@ -55,6 +55,8 @@ setDefaultTimeout(BOOT_MS)
 // what the platform declares; `turns` is there because the actor this build mounts declares it
 // (actor.ts, agentProjections), and it appears in the document by being declared.
 const ROUTES: ReadonlyArray<readonly [string, string]> = [
+  ["get", "/v1/actors"],
+  ["put", "/v1/actors"],
   ["post", "/v1/actors/{actor}/threads/{id}/events"],
   ["get", "/v1/actors/{actor}/threads"],
   ["get", "/v1/actors/{actor}/threads/{id}/events"],

--- a/apps/server/src/host.test.ts
+++ b/apps/server/src/host.test.ts
@@ -37,7 +37,10 @@ const layerScripted: Layer.Layer<Infer> = Layer.succeed(Infer)({
 })
 
 // The database is ":memory:", so each test opens its own store and closes it with the scope.
-const config = layerConfig(readConfig({ TARDIGRADE_DB: ":memory:" }))
+const config = layerConfig(readConfig({
+  TARDIGRADE_DB: ":memory:",
+  TARDIGRADE_ACTORS: `/tmp/tardigrade-host-test-${process.pid}`
+}))
 
 // The body runs with both services the layer provides: the threads it drives, and the gauge
 // /healthz reads over the same driver (http.ts, DriverGauge).

--- a/apps/server/src/host.ts
+++ b/apps/server/src/host.ts
@@ -1,11 +1,23 @@
 import { Clock, Context, Effect, Layer } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
 import { BunFileSystem, BunPath } from "@effect/platform-bun"
+import { createHash } from "node:crypto"
+import { mkdir, readFile, readdir, rename, rm, writeFile } from "node:fs/promises"
+import { join, resolve } from "node:path"
+import { pathToFileURL } from "node:url"
 import type { Event } from "@clavia/tardigrade-core/event"
-import { Infer } from "tardie"
+import type { Actor } from "@clavia/tardigrade-core/actor"
+import {
+  ACTOR_ARTIFACT_VERSION,
+  ACTOR_NAME_PATTERN,
+  Infer,
+  type ActorArtifactManifest,
+  type ActorDefinition
+} from "tardie"
 import type { Action } from "tardie/events"
 import { createBunHost, type BunHost } from "@clavia/tardigrade-bun/host"
 import { infer } from "@clavia/tardigrade-model/model"
+import { RESERVED_ACTOR, type ActorArtifact, type ActorSummary } from "@clavia/tardigrade-client/contract"
 
 import { assemblyOf, type ServerR } from "./actor"
 import { ServerConfig, type ServerConfigValue } from "./config"
@@ -28,19 +40,29 @@ export const laneOf = (id: string): string => `${LANE_PREFIX}${id}`
 export const idOf = (lane: string): string | undefined =>
   lane.startsWith(LANE_PREFIX) ? lane.slice(LANE_PREFIX.length) : undefined
 
+export interface ActorThreads {
+  readonly append: (id: string, event: Event) => Effect.Effect<void>
+  readonly events: (id: string) => Effect.Effect<ReadonlyArray<Event>>
+  readonly list: () => Effect.Effect<ReadonlyArray<{ readonly id: string; readonly events: ReadonlyArray<Event> }>>
+  readonly settled: Effect.Effect<void>
+}
+
 // The operations the HTTP surface has: append an event, read a log, list what exists. Every one
 // speaks a thread id and none of them reads an event's fields, because what an event means is the
 // actor's knowledge and this service holds the log (actor.ts, agentProjections).
 export class Threads extends Context.Service<
   Threads,
   {
-    readonly append: (id: string, event: Event) => Effect.Effect<void>
-    readonly events: (id: string) => Effect.Effect<ReadonlyArray<Event>>
-    readonly list: () => Effect.Effect<ReadonlyArray<{ readonly id: string; readonly events: ReadonlyArray<Event> }>>
+    readonly append: ActorThreads["append"]
+    readonly events: ActorThreads["events"]
+    readonly list: ActorThreads["list"]
     // settled resolves once the drive in flight, and the follow-up it coalesced, has finished. A
     // client never waits on it (a delivery answers 202 and the client polls the turn); a test and
     // a shutdown do (host.test.ts).
-    readonly settled: Effect.Effect<void>
+    readonly settled: ActorThreads["settled"]
+    readonly actors?: Effect.Effect<ReadonlyArray<ActorSummary>>
+    readonly actor?: (name: string) => ActorThreads | undefined
+    readonly push?: (artifact: ActorArtifact) => Effect.Effect<ActorSummary, Error>
   }
 >()("tardigrade/server/Threads") {}
 
@@ -82,104 +104,230 @@ export interface ThreadsOptions {
   readonly infer?: Layer.Layer<Infer>
 }
 
-// make builds the host, recovers what a death interrupted, and returns the service pair. The
-// close is a scope finalizer, so the process that stops listening also stops writing.
+interface ActorRuntime {
+  readonly summary: ActorSummary
+  readonly threads: ActorThreads
+  readonly resting: () => Promise<boolean>
+  readonly dirty: () => number
+  readonly close: () => Promise<void>
+}
+
+const digestOf = (module: string): string =>
+  `sha256:${createHash("sha256").update(module).digest("hex")}`
+
+const definitionOf = async (modulePath: string, expected: ActorArtifactManifest): Promise<ActorDefinition<ServerR>> => {
+  const loaded: unknown = await import(`${pathToFileURL(modulePath).href}?digest=${encodeURIComponent(expected.digest)}`)
+  const definition = (loaded as { readonly default?: unknown }).default
+  if (typeof definition !== "object" || definition === null) {
+    throw new Error("actor artifact must default export defineActor({ name, actor })")
+  }
+  const candidate = definition as Partial<ActorDefinition<ServerR>>
+  if (candidate.name !== expected.name || !ACTOR_NAME_PATTERN.test(expected.name)) {
+    throw new Error(`actor artifact name does not match ${JSON.stringify(expected.name)}`)
+  }
+  if (
+    typeof candidate.actor !== "object" ||
+    candidate.actor === null ||
+    !Array.isArray(candidate.actor.reactors) ||
+    typeof candidate.actor.keyOf !== "function"
+  ) {
+    throw new Error("actor artifact does not contain an Actor")
+  }
+  return candidate as ActorDefinition<ServerR>
+}
+
+const runtimeOf = async (
+  summary: ActorSummary,
+  actor: Actor<ServerR>,
+  log: string,
+  lane: ReturnType<typeof layerLane>
+): Promise<ActorRuntime> => {
+  const host: BunHost = await createBunHost<ServerR>({
+    log,
+    actorFor: (candidate) => (idOf(candidate) === undefined ? undefined : actor),
+    layersFor: () => lane,
+    keyOf: (event) => actor.keyOf?.(event)
+  })
+  let driving: Promise<void> | undefined
+  let follow = false
+  let failure: unknown = undefined
+  const pump = async (): Promise<void> => {
+    try {
+      do {
+        follow = false
+        await host.drive()
+      } while (follow)
+    } catch (error) {
+      failure = error
+    } finally {
+      driving = undefined
+      follow = false
+    }
+  }
+  const request = (): Promise<void> => {
+    if (driving !== undefined) {
+      follow = true
+      return driving
+    }
+    driving = pump()
+    return driving
+  }
+  const settled = Effect.suspend(() =>
+    Effect.promise(() => driving ?? Promise.resolve()).pipe(
+      Effect.flatMap(() => {
+        if (failure === undefined) return Effect.void
+        const held = failure
+        failure = undefined
+        return Effect.die(held)
+      })
+    )
+  )
+  await host.recover()
+  const read = (id: string) => Effect.promise(() => host.read(laneOf(id)))
+  const threads: ActorThreads = {
+    append: (id, event) =>
+      Effect.gen(function*() {
+        const at = yield* Clock.currentTimeMillis
+        const stamped = event.at === undefined ? { ...event, at } : event
+        yield* Effect.promise(() => host.deliver(host.self(laneOf(id)), stamped))
+        request()
+      }),
+    events: read,
+    list: () =>
+      Effect.gen(function*() {
+        const lanes = yield* Effect.promise(() => host.lanes())
+        const ids = lanes.flatMap((candidate) => {
+          const id = idOf(candidate)
+          return id === undefined ? [] : [id]
+        })
+        return yield* Effect.forEach(ids, (id) => Effect.map(read(id), (events) => ({ id, events })))
+      }),
+    settled
+  }
+  return {
+    summary,
+    threads,
+    resting: () => host.resting(),
+    dirty: () => (driving === undefined ? 0 : follow ? 2 : 1),
+    close: async () => {
+      await Effect.runPromise(settled)
+      await host.close()
+    }
+  }
+}
+
+const manifestOf = async (directory: string): Promise<{ readonly manifest: ActorArtifactManifest; readonly module: string }> => {
+  const raw = JSON.parse(await readFile(join(directory, "manifest.json"), "utf8")) as Partial<ActorArtifactManifest>
+  if (
+    raw.schema !== ACTOR_ARTIFACT_VERSION ||
+    typeof raw.name !== "string" ||
+    typeof raw.module !== "string" ||
+    typeof raw.digest !== "string"
+  ) {
+    throw new Error(`invalid actor manifest in ${directory}`)
+  }
+  const manifest = raw as ActorArtifactManifest
+  const module = await readFile(join(directory, manifest.module), "utf8")
+  const actual = digestOf(module)
+  if (actual !== manifest.digest) throw new Error(`actor artifact digest mismatch for ${manifest.name}`)
+  return { manifest, module }
+}
+
+// make builds one isolated host per actor and returns their shared HTTP-facing registry.
 const make = (options: ThreadsOptions) =>
   Effect.gen(function*() {
     const config = yield* ServerConfig
-    const assembly = assemblyOf()
     const lane = layerLane(config, options)
-    const host: BunHost = yield* Effect.acquireRelease(
-      Effect.promise(() =>
-        createBunHost<ServerR>({
-          log: config.db,
-          actorFor: (lane) => (idOf(lane) === undefined ? undefined : assembly),
-          layersFor: () => lane,
-          keyOf: (event) => assembly.keyOf?.(event)
+    const runtimes = new Map<string, ActorRuntime>()
+    const builtIn = assemblyOf()
+    const open = async (summary: ActorSummary, actor: Actor<ServerR>, log: string): Promise<ActorRuntime> => {
+      const runtime = await runtimeOf(summary, actor, log, lane)
+      runtimes.set(summary.name, runtime)
+      return runtime
+    }
+    yield* Effect.acquireRelease(
+      Effect.promise(async () => {
+        await open({ name: RESERVED_ACTOR, builtIn: true }, builtIn, config.db)
+        const root = resolve(config.actors)
+        const entries = await readdir(root, { withFileTypes: true }).catch((error: NodeJS.ErrnoException) => {
+          if (error.code === "ENOENT") return []
+          throw error
         })
-      ),
-      (open) => Effect.promise(() => open.close())
+        for (const entry of entries) {
+          if (!entry.isDirectory()) continue
+          const directory = join(root, entry.name)
+          const artifact = await manifestOf(directory)
+          if (artifact.manifest.name === RESERVED_ACTOR) throw new Error(`${RESERVED_ACTOR} is reserved for the built-in actor`)
+          const definition = await definitionOf(join(directory, artifact.manifest.module), artifact.manifest)
+          await open(
+            { name: definition.name, builtIn: false, digest: artifact.manifest.digest },
+            definition.actor,
+            join(resolve(config.actorData), `${definition.name}.sqlite`)
+          )
+        }
+        return runtimes
+      }),
+      (opened) => Effect.promise(() => Promise.all([...opened.values()].map((runtime) => runtime.close())).then(() => undefined))
     )
 
-    // The drive loop. Deliveries request a drive rather than run one: drives are serialized, so
-    // two lanes never settle at once, and coalesced, so a request arriving mid-drive schedules
-    // exactly one follow-up pass however many arrive. The follow-up runs inside the same promise,
-    // so a caller awaiting a requested drive also awaits the work its own delivery enabled.
-    let driving: Promise<void> | undefined
-    let follow = false
-    let failure: unknown = undefined
-    const pump = async (): Promise<void> => {
-      try {
-        do {
-          follow = false
-          await host.drive()
-        } while (follow)
-      } catch (e) {
-        failure = e
-      } finally {
-        driving = undefined
-        follow = false
-      }
-    }
-    const request = (): Promise<void> => {
-      if (driving !== undefined) {
-        follow = true
-        return driving
-      }
-      driving = pump()
-      return driving
-    }
-
-    // A drive that threw is a defect the loop cannot report to the delivery that caused it, so it
-    // is held and raised by the next `settled`: the process dies on it rather than driving on
-    // over a broken host.
-    const settled = Effect.suspend(() =>
-      Effect.promise(() => driving ?? Promise.resolve()).pipe(
-        Effect.flatMap(() => {
-          if (failure === undefined) return Effect.void
-          const held = failure
-          failure = undefined
-          return Effect.die(held)
-        })
-      )
-    )
-
-    yield* Effect.promise(() => host.recover())
-
-    const read = (id: string) => Effect.promise(() => host.read(laneOf(id)))
+    const selected = (name: string): ActorThreads | undefined => runtimes.get(name)?.threads
+    const primary = selected(RESERVED_ACTOR)!
+    const push = (artifact: ActorArtifact): Effect.Effect<ActorSummary, Error> =>
+      Effect.tryPromise({
+        try: async () => {
+          const manifest = artifact.manifest as ActorArtifactManifest
+          if (manifest.schema !== ACTOR_ARTIFACT_VERSION) throw new Error(`unsupported actor artifact schema ${manifest.schema}`)
+          if (!ACTOR_NAME_PATTERN.test(manifest.name)) throw new Error(`actor name must match ${String(ACTOR_NAME_PATTERN)}`)
+          if (manifest.name === RESERVED_ACTOR) throw new Error(`${RESERVED_ACTOR} is reserved for the built-in actor`)
+          if (manifest.module !== "actor.mjs") throw new Error(`actor module must be ${JSON.stringify("actor.mjs")}`)
+          const actual = digestOf(artifact.module)
+          if (actual !== manifest.digest) throw new Error(`actor artifact digest mismatch: expected ${manifest.digest}, got ${actual}`)
+          const root = resolve(config.actors)
+          const destination = join(root, manifest.name)
+          const temporary = `${destination}.incoming`
+          const previous = `${destination}.previous`
+          await mkdir(root, { recursive: true })
+          await rm(temporary, { recursive: true, force: true })
+          await rm(previous, { recursive: true, force: true })
+          await mkdir(temporary, { recursive: true })
+          await writeFile(join(temporary, manifest.module), artifact.module, "utf8")
+          await writeFile(join(temporary, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`, "utf8")
+          const definition = await definitionOf(join(temporary, manifest.module), manifest)
+          const current = runtimes.get(manifest.name)
+          if (current !== undefined) {
+            await current.close()
+            runtimes.delete(manifest.name)
+          }
+          const summary: ActorSummary = { name: manifest.name, builtIn: false, digest: manifest.digest }
+          try {
+            await open(summary, definition.actor, join(resolve(config.actorData), `${manifest.name}.sqlite`))
+            try {
+              await rename(destination, previous)
+            } catch (error) {
+              if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+            }
+            await rename(temporary, destination)
+            await rm(previous, { recursive: true, force: true })
+            return summary
+          } catch (error) {
+            await rm(temporary, { recursive: true, force: true })
+            throw error
+          }
+        },
+        catch: (error) => error instanceof Error ? error : new Error(String(error))
+      })
 
     const service: Context.Service.Shape<typeof Threads> = {
-      // An append stamps `at` only when the caller stated none, so a replayed event keeps the time
-      // it happened. Everything else about the fact is passed through: duplicate suppression is the
-      // assembly's own key function, which the host was built with (actor.ts, assemblyOf).
-      append: (id, event) =>
-        Effect.gen(function*() {
-          const at = yield* Clock.currentTimeMillis
-          const stamped = event.at === undefined ? { ...event, at } : event
-          yield* Effect.promise(() => host.deliver(host.self(laneOf(id)), stamped))
-          request()
-        }),
-      events: read,
-      list: () =>
-        Effect.gen(function*() {
-          const lanes = yield* Effect.promise(() => host.lanes())
-          const ids = lanes.flatMap((lane) => {
-            const id = idOf(lane)
-            return id === undefined ? [] : [id]
-          })
-          return yield* Effect.forEach(ids, (id) => Effect.map(read(id), (events) => ({ id, events })))
-        }),
-      settled
+      ...primary,
+      actors: Effect.sync(() => [...runtimes.values()].map((runtime) => runtime.summary)),
+      actor: selected,
+      push,
+      settled: Effect.forEach(runtimes.values(), (runtime) => runtime.threads.settled, { discard: true })
     }
-
-    // dirty counts the drive passes owed, not lanes: 0 resting, 1 while a drive runs, 2 when that
-    // drive has already coalesced a follow-up. The host's own dirty set is private to it, and the
-    // number a client reads is the one this loop acts on.
     const gauge: Context.Service.Shape<typeof DriverGauge> = {
-      resting: Effect.promise(() => host.resting()),
-      dirty: Effect.sync(() => (driving === undefined ? 0 : follow ? 2 : 1))
+      resting: Effect.promise(async () => (await Promise.all([...runtimes.values()].map((runtime) => runtime.resting()))).every(Boolean)),
+      dirty: Effect.sync(() => [...runtimes.values()].reduce((total, runtime) => total + runtime.dirty(), 0))
     }
-
     return Context.make(Threads, service).pipe(Context.add(DriverGauge, gauge))
   })
 

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -3,7 +3,7 @@ import { Effect, Layer } from "effect"
 import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { BunHttpServer } from "@effect/platform-bun"
 
-import { DEFAULT_DB, DEFAULT_PORT, layerConfig, readConfig, type ServerConfigValue } from "./config"
+import { DEFAULT_ACTORS, DEFAULT_ACTOR_DATA, DEFAULT_DB, DEFAULT_PORT, layerConfig, readConfig, type ServerConfigValue } from "./config"
 import { Threads } from "./host"
 import { ALLOWED_HEADERS, layerGaugeResting, serve, PROBLEM_CONTENT_TYPE, DriverGauge, type Health } from "./http"
 
@@ -61,6 +61,8 @@ describe("config", () => {
     const config = readConfig({})
     expect(config.port).toBe(DEFAULT_PORT)
     expect(config.db).toBe(DEFAULT_DB)
+    expect(config.actors).toBe(DEFAULT_ACTORS)
+    expect(config.actorData).toBe(DEFAULT_ACTOR_DATA)
     expect(config.token).toBeUndefined()
     expect(config.model).toEqual({
       baseUrl: undefined,
@@ -74,6 +76,8 @@ describe("config", () => {
     const config = readConfig({
       PORT: "8080",
       TARDIGRADE_DB: "/var/lib/agents.sqlite",
+      TARDIGRADE_ACTORS: "/var/lib/actors",
+      TARDIGRADE_ACTOR_DATA: "/var/lib/actor-data",
       TARDIGRADE_TOKEN: "secret",
       MODEL_BASE_URL: "https://api.example.com",
       MODEL_API_KEY: "key",
@@ -82,6 +86,8 @@ describe("config", () => {
     })
     expect(config.port).toBe(8080)
     expect(config.db).toBe("/var/lib/agents.sqlite")
+    expect(config.actors).toBe("/var/lib/actors")
+    expect(config.actorData).toBe("/var/lib/actor-data")
     expect(config.token).toBe("secret")
     expect(config.model.baseUrl).toBe("https://api.example.com")
     expect(config.model.provider).toBe("openai")

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -2,7 +2,7 @@ import { Context, Effect, Layer } from "effect"
 import { Headers, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiScalar } from "effect/unstable/httpapi"
 
-import { layerProjectionsGroup, layerThreadsGroup, layerStream, layerUnknownProjection, ServerApi, type ApiOptions } from "./api"
+import { layerActorsGroup, layerProjectionsGroup, layerThreadsGroup, layerStream, layerUnknownProjection, ServerApi, type ApiOptions } from "./api"
 import { ServerConfig } from "./config"
 import { Api, DOCS_PATH, OPENAPI_PATH, type Health } from "@clavia/tardigrade-client/contract"
 import { layerRequestProblems } from "./contract"
@@ -161,6 +161,7 @@ export const layerApp = (options: ApiOptions = {}) =>
   Layer.mergeAll(
     Layer.provide(
       Layer.provide(HttpApiBuilder.layer(ServerApi, { openapiPath: OPENAPI_PATH }), [
+        layerActorsGroup(),
         layerThreadsGroup(options),
         layerProjectionsGroup(),
         layerHealthGroup

--- a/apps/voyager/src/ActorRail.tsx
+++ b/apps/voyager/src/ActorRail.tsx
@@ -1,0 +1,45 @@
+import type { ActorSummary, ProblemError } from "@clavia/tardigrade-client"
+import type { ReactElement } from "react"
+
+import { navigate } from "./nav"
+import { ACTOR_RAIL_WIDTH } from "./policy"
+
+export const ActorRail = ({
+  actors,
+  problem,
+  selected
+}: {
+  readonly actors: ReadonlyArray<ActorSummary>
+  readonly problem: ProblemError | undefined
+  readonly selected: string | undefined
+}): ReactElement => (
+  <aside className="actor-rail" style={{ width: ACTOR_RAIL_WIDTH }}>
+    <div className="actor-head">
+      <div className="rail-wordmark">voyager</div>
+      <div className="mono actor-label">actors</div>
+    </div>
+    {problem === undefined ? null : (
+      <div className="problem actor-problem">
+        <div className="problem-title">{problem.title}</div>
+        {problem.detail === undefined ? null : <div className="problem-detail">{problem.detail}</div>}
+      </div>
+    )}
+    <div className="actor-list">
+      {actors.map((actor) => {
+        const chosen = actor.name === selected
+        return (
+          <button
+            type="button"
+            key={actor.name}
+            className={`actor-row${chosen ? " actor-row-selected" : ""}`}
+            aria-current={chosen ? "true" : undefined}
+            onClick={() => navigate({ actor: actor.name, thread: undefined, from: undefined, to: undefined })}
+          >
+            <span className="mono actor-name">{actor.name}</span>
+            {actor.builtIn ? <span className="mono actor-kind">built-in</span> : null}
+          </button>
+        )
+      })}
+    </div>
+  </aside>
+)

--- a/apps/voyager/src/App.tsx
+++ b/apps/voyager/src/App.tsx
@@ -1,15 +1,16 @@
 import { useEffect, useState, type ReactElement } from "react"
 
 import { Thread } from "./Thread"
-import { NO_ANSWER, ProblemError, type ThreadSummary } from "@clavia/tardigrade-client"
+import { NO_ANSWER, ProblemError, type ActorSummary, type ThreadSummary } from "@clavia/tardigrade-client"
 
-import { client } from "./client"
-import { useRoute } from "./nav"
+import { client, clientFor } from "./client"
+import { navigate, useRoute } from "./nav"
 import { ROSTER_POLL_MS } from "./policy"
 import { Quickstart } from "./Quickstart"
 import { Rail } from "./Rail"
 import { EMPTY_ROSTER, rosterOf, type Roster } from "./roster"
 import { ThemeToggle } from "./ThemeToggle"
+import { ActorRail } from "./ActorRail"
 
 // The app: one screen, two panes. The rail lists the run's roots and the center pane reads the
 // selected thread's log (mock.html). The reader chooses on the left and reads on the right, and
@@ -24,17 +25,23 @@ interface Reading {
 // useRoster polls GET /v1/actors/:actor/threads once for the whole screen: the rail's rows and the header's status
 // chip are the same listing read twice rather than two calls. The last good reading survives a
 // failure, so a server restart holds the rail rather than blanking it.
-const useRoster = (intervalMs: number) => {
+const useRoster = (actor: string | undefined, intervalMs: number) => {
   const [reading, setReading] = useState<Reading>({ roster: EMPTY_ROSTER, at: Date.now() })
   const [summaries, setSummaries] = useState<ReadonlyArray<ThreadSummary>>([])
   const [problem, setProblem] = useState<ProblemError | undefined>(undefined)
   const [ready, setReady] = useState(false)
 
   useEffect(() => {
+    setSummaries([])
+    setReading({ roster: EMPTY_ROSTER, at: Date.now() })
+    setProblem(undefined)
+    setReady(false)
+    if (actor === undefined) return
     let live = true
+    const selected = clientFor(actor)
     const read = async () => {
       try {
-        const all = await client.list()
+        const all = await selected.list()
         if (!live) return
         setSummaries(all)
         setReading({ roster: rosterOf(all), at: Date.now() })
@@ -52,25 +59,61 @@ const useRoster = (intervalMs: number) => {
       live = false
       clearInterval(timer)
     }
-  }, [intervalMs])
+  }, [actor, intervalMs])
 
   return { reading, summaries, problem, ready }
 }
 
+const useActors = (intervalMs: number) => {
+  const [actors, setActors] = useState<ReadonlyArray<ActorSummary>>([])
+  const [problem, setProblem] = useState<ProblemError | undefined>(undefined)
+  const [ready, setReady] = useState(false)
+  useEffect(() => {
+    let live = true
+    const read = async () => {
+      try {
+        const found = await client.actors()
+        if (!live) return
+        setActors(found)
+        setProblem(undefined)
+        setReady(true)
+      } catch (error) {
+        if (!live) return
+        setProblem(error instanceof ProblemError ? error : new ProblemError({ title: String(error), status: NO_ANSWER }))
+        setReady(true)
+      }
+    }
+    void read()
+    const timer = setInterval(read, intervalMs)
+    return () => {
+      live = false
+      clearInterval(timer)
+    }
+  }, [intervalMs])
+  return { actors, problem, ready }
+}
+
 export const App = (): ReactElement => {
   const route = useRoute()
-  const { problem, reading, summaries, ready } = useRoster(ROSTER_POLL_MS)
+  const discovered = useActors(ROSTER_POLL_MS)
+  const actor = route.actor ?? discovered.actors[0]?.name
+  const { problem, reading, summaries, ready } = useRoster(actor, ROSTER_POLL_MS)
   const status = summaries.find((summary) => summary.id === route.thread)?.status
+  useEffect(() => {
+    if (route.actor !== undefined || actor === undefined) return
+    navigate({ actor }, { replace: true })
+  }, [actor, route.actor])
   return (
     <div style={{ height: "100%", display: "flex", overflow: "hidden", position: "relative" }}>
+      <ActorRail actors={discovered.actors} problem={discovered.problem} selected={actor} />
       <Rail roster={reading.roster} now={reading.at} problem={problem} selected={route.thread} />
       <main style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        {route.thread === undefined && ready && summaries.length === 0 && problem === undefined ? (
-          <Quickstart />
+        {actor !== undefined && route.thread === undefined && ready && summaries.length === 0 && problem === undefined ? (
+          <Quickstart actor={actor} />
         ) : route.thread === undefined ? (
-          <div className="mono pane-empty">select a run</div>
+          <div className="mono pane-empty">{discovered.ready ? "select a run" : "loading actors"}</div>
         ) : (
-          <Thread id={route.thread} status={status} />
+          <Thread actor={actor ?? "agent"} id={route.thread} status={status} />
         )}
       </main>
       <ThemeToggle />

--- a/apps/voyager/src/Quickstart.tsx
+++ b/apps/voyager/src/Quickstart.tsx
@@ -10,10 +10,18 @@ export interface QuickstartCommands {
 }
 
 // quickstartCommands returns commands addressed to the server this tab is reading.
-export const quickstartCommands = (baseUrl: string): QuickstartCommands => ({
-  cli: `tdg run "Tell me what you can do" --url ${baseUrl}`,
+const baseQuickstartCommands = (baseUrl: string, actor: string): QuickstartCommands => ({
+  cli: `tdg run "Tell me what you can do" --actor ${actor} --url ${baseUrl}`,
   curl: `curl -X POST ${baseUrl}/v1/actors/agent/threads/hello/events \\\n+  -H 'content-type: application/json' \\\n+  -d '{"id":"hello-1","type":"MessageReceived","text":"Tell me what you can do"}'`
 })
+
+export const quickstartCommands = (baseUrl: string, actor = "agent"): QuickstartCommands => {
+  const commands = baseQuickstartCommands(baseUrl, actor)
+  return {
+    ...commands,
+    curl: commands.curl.replace("/v1/actors/agent/", `/v1/actors/${encodeURIComponent(actor)}/`)
+  }
+}
 
 const copyText = async (text: string): Promise<boolean> => {
   try {
@@ -64,8 +72,8 @@ const CommandCard = ({ command, label }: { readonly command: string; readonly la
   )
 }
 
-export const Quickstart = (): ReactElement => {
-  const commands = quickstartCommands(client.baseUrl)
+export const Quickstart = ({ actor = "agent" }: { readonly actor?: string | undefined }): ReactElement => {
+  const commands = quickstartCommands(client.baseUrl, actor)
   return (
     <div className="quickstart-empty">
       <div className="quickstart">

--- a/apps/voyager/src/Rail.tsx
+++ b/apps/voyager/src/Rail.tsx
@@ -78,7 +78,7 @@ export const Rail = ({
   return (
     <aside className={`rail${collapsed ? " rail-collapsed" : ""}`} style={{ width: collapsed ? COLLAPSED_RAIL_WIDTH : RAIL_WIDTH }}>
       <div className="rail-head">
-        <div className="rail-only rail-wordmark">voyager</div>
+        <div className="mono rail-only rail-section-title">runs</div>
         <button
           type="button"
           className="icon-btn"

--- a/apps/voyager/src/Thread.tsx
+++ b/apps/voyager/src/Thread.tsx
@@ -2,7 +2,7 @@ import { Fragment, useEffect, useLayoutEffect, useRef, useState, type ReactEleme
 
 import { NO_ANSWER, ProblemError, type ThreadStatus, type EventRow } from "@clavia/tardigrade-client"
 
-import { client } from "./client"
+import { clientFor } from "./client"
 import { fieldsOf, merged, momentsOf, stampOf, type Field, type Moment } from "./narrative"
 import { navigate, useRoute, type Route } from "./nav"
 import { BOTTOM_SLACK_PX, EVENT_STAMP_WIDTH, FIELD_COLLAPSED_HEIGHT, FIELD_WIDTH, LOG_POLL_MS, SUMMARY_WIDTH } from "./policy"
@@ -21,7 +21,7 @@ const lastSeq = (rows: ReadonlyArray<EventRow>): number => rows[rows.length - 1]
 // useLog holds the pane's rows. The first read is the whole log and the stream carries it forward
 // from that seq; when the browser gives up reconnecting, the same rows keep filling from `events`,
 // which is an ordinary fetch and survives what EventSource cannot (packages/client/src/stream.ts).
-const useLog = (id: string, pollMs: number) => {
+const useLog = (actor: string, id: string, pollMs: number) => {
   const [rows, setRows] = useState<ReadonlyArray<EventRow>>([])
   const [problem, setProblem] = useState<ProblemError | undefined>(undefined)
   const [dropped, setDropped] = useState(false)
@@ -31,6 +31,7 @@ const useLog = (id: string, pollMs: number) => {
   const seen = useRef(0)
 
   useEffect(() => {
+    const client = clientFor(actor)
     let attached = true
     let unsubscribe: (() => void) | undefined
     setRows([])
@@ -63,10 +64,11 @@ const useLog = (id: string, pollMs: number) => {
       attached = false
       unsubscribe?.()
     }
-  }, [id])
+  }, [actor, id])
 
   useEffect(() => {
     if (!dropped) return
+    const client = clientFor(actor)
     const timer = setInterval(() => {
       void client.events(id, { after: seen.current })
         .then((batch) => {
@@ -76,7 +78,7 @@ const useLog = (id: string, pollMs: number) => {
         .catch((error: unknown) => setProblem(errorOf(error)))
     }, pollMs)
     return () => clearInterval(timer)
-  }, [id, dropped, pollMs])
+  }, [actor, id, dropped, pollMs])
 
   return { rows, problem, dropped, loaded }
 }
@@ -201,11 +203,13 @@ const Head = ({ id, status }: { readonly id: string; readonly status: ThreadStat
 )
 
 export const Thread = ({
+  actor,
   fieldCollapsedHeight = FIELD_COLLAPSED_HEIGHT,
   id,
   stampWidth = EVENT_STAMP_WIDTH,
   status
 }: {
+  readonly actor: string
   readonly id: string
   readonly fieldCollapsedHeight?: number | undefined
   readonly stampWidth?: number | undefined
@@ -217,7 +221,7 @@ export const Thread = ({
   // read its value back out of that publication would render one step behind the handle (src/nav.ts).
   const [window, setWindow] = useState<Window | undefined>(windowOf(route))
   const [opened, setOpened] = useState<number | undefined>(undefined)
-  const { dropped, loaded, problem, rows } = useLog(id, LOG_POLL_MS)
+  const { dropped, loaded, problem, rows } = useLog(actor, id, LOG_POLL_MS)
 
   const pane = useRef<HTMLDivElement | null>(null)
   // Whether the reader is at the log's end. Auto-scroll follows a live log only from there; a reader
@@ -231,7 +235,7 @@ export const Thread = ({
     setOpened(undefined)
     atEnd.current = true
     seeded.current = false
-  }, [id])
+  }, [actor, id])
 
   // A route the pane did not write is one it must follow: a shared link, or a back button
   // (src/nav.ts, useRoute). A drag of its own lands here already equal and changes nothing.

--- a/apps/voyager/src/client.ts
+++ b/apps/voyager/src/client.ts
@@ -52,3 +52,13 @@ export const token = (): string | undefined => {
 // One client for the tab. The address and the token are read at load, which is when a reader could
 // have stated either: a different `api` param or a pasted token is a different page load.
 export const client: Client = makeClient({ baseUrl: apiUrl(), token: token() })
+
+const clients = new Map<string, Client>()
+
+export const clientFor = (actor: string): Client => {
+  const held = clients.get(actor)
+  if (held !== undefined) return held
+  const created = makeClient({ baseUrl: client.baseUrl, token: token(), actor })
+  clients.set(actor, created)
+  return created
+}

--- a/apps/voyager/src/nav.ts
+++ b/apps/voyager/src/nav.ts
@@ -11,6 +11,7 @@ import { useCallback, useSyncExternalStore } from "react"
 // A fraction is what the handle is dragged to, so the URL states the position the reader chose
 // rather than a seq the app would have to derive from it.
 export interface Route {
+  readonly actor: string | undefined
   readonly thread: string | undefined
   readonly from: number | undefined
   readonly to: number | undefined
@@ -25,7 +26,9 @@ const fraction = (raw: string | null): number | undefined => {
 const parse = (search: string): Route => {
   const params = new URLSearchParams(search)
   const thread = params.get("thread")
+  const actor = params.get("actor")
   return {
+    actor: actor === null || actor.length === 0 ? undefined : actor,
     thread: thread === null || thread.length === 0 ? undefined : thread,
     from: fraction(params.get("from")),
     to: fraction(params.get("to"))
@@ -43,6 +46,7 @@ export const navigate = (next: Partial<Route>, options: { readonly replace?: boo
     else params.set(name, String(value))
   }
   if ("thread" in next) write("thread", next.thread)
+  if ("actor" in next) write("actor", next.actor)
   if ("from" in next) write("from", next.from)
   if ("to" in next) write("to", next.to)
   const search = params.toString()

--- a/apps/voyager/src/policy.ts
+++ b/apps/voyager/src/policy.ts
@@ -6,6 +6,10 @@
 // measures against it.
 export const RAIL_WIDTH = 320
 
+// The actor pane's width in pixels. Actor names are shorter than run ids, so the first level keeps
+// a narrower measure than the run rail beside it.
+export const ACTOR_RAIL_WIDTH = 208
+
 // The width the rail keeps when it is collapsed, in pixels. It holds the toggle and nothing else,
 // so a reader can always open the list again from where they closed it.
 export const COLLAPSED_RAIL_WIDTH = 48

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -312,6 +312,89 @@ textarea {
   letter-spacing: -0.01em;
 }
 
+.rail-section-title,
+.actor-label {
+  color: var(--faint);
+  font-size: 10.5px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.actor-rail {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  min-height: 0;
+  border-right: 1px solid var(--hair);
+  background: var(--bg);
+}
+
+.actor-head {
+  display: grid;
+  gap: 3px;
+  padding: var(--space-4);
+}
+
+.actor-problem {
+  margin: 0 var(--space-3) var(--space-3);
+}
+
+.actor-list {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0 var(--space-2) var(--space-3);
+}
+
+.actor-row {
+  display: flex;
+  width: 100%;
+  min-height: var(--row-h);
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-2);
+  border: 0;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--ink-2);
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--fast) var(--ease), color var(--fast) var(--ease), transform var(--fast) var(--ease);
+}
+
+.actor-row:hover {
+  background: var(--sunken);
+  color: var(--ink);
+}
+
+.actor-row:active {
+  transform: scale(0.97);
+}
+
+.actor-row-selected,
+.actor-row-selected:hover {
+  background: var(--moss-wash);
+  color: var(--moss-ink);
+}
+
+.actor-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.actor-kind {
+  margin-left: auto;
+  color: var(--faint);
+  font-size: 9.5px;
+}
+
+@media (max-width: 900px) {
+  .actor-rail {
+    width: 160px !important;
+  }
+}
+
 /* Everything a collapsed rail hides. The toggle is outside the class, so the rail can always be
    opened again from where it was closed. */
 .rail-collapsed .rail-only {

--- a/packages/agent/src/artifact.test.ts
+++ b/packages/agent/src/artifact.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test"
+
+import { defineActor } from "./artifact"
+
+const actor = { reactors: [], keyOf: () => "root" }
+
+describe("defineActor", () => {
+  test("keeps a portable named actor", () => {
+    const definition = defineActor({ name: "release-analyst", actor })
+    expect(definition).toEqual({ name: "release-analyst", actor })
+  })
+
+  test("refuses a name that cannot be a path or directory segment", () => {
+    expect(() => defineActor({ name: "Release Analyst", actor })).toThrow("actor name must match")
+  })
+})

--- a/packages/agent/src/artifact.ts
+++ b/packages/agent/src/artifact.ts
@@ -1,0 +1,24 @@
+import type { Actor } from "@clavia/tardigrade-core/actor"
+
+export const ACTOR_NAME_PATTERN = /^[a-z][a-z0-9-]{0,62}$/u
+
+export const ACTOR_ARTIFACT_VERSION = 1
+
+export interface ActorArtifactManifest {
+  readonly schema: typeof ACTOR_ARTIFACT_VERSION
+  readonly name: string
+  readonly module: string
+  readonly digest: string
+}
+
+export interface ActorDefinition<R = never> {
+  readonly name: string
+  readonly actor: Actor<R>
+}
+
+export const defineActor = <R>(definition: ActorDefinition<R>): ActorDefinition<R> => {
+  if (!ACTOR_NAME_PATTERN.test(definition.name)) {
+    throw new Error(`actor name must match ${String(ACTOR_NAME_PATTERN)}, got ${JSON.stringify(definition.name)}`)
+  }
+  return definition
+}

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,4 +1,11 @@
 export { type AgentPolicy, type AgentR, type RlmR, receive } from "./turn"
+export {
+  ACTOR_ARTIFACT_VERSION,
+  ACTOR_NAME_PATTERN,
+  defineActor,
+  type ActorArtifactManifest,
+  type ActorDefinition
+} from "./artifact"
 
 // The parts a caller lists. An agent is capabilities over one log; the reactors underneath
 // remain reachable for a bespoke assembly.

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -54,6 +54,11 @@ const problemAnswer = (status: number, document: unknown) => () =>
   new Response(JSON.stringify(document), { status, headers: { "content-type": PROBLEM_CONTENT_TYPE } })
 
 describe("the address a call goes to", () => {
+  test("discovers actors at the collection", async () => {
+    await makeClient({ baseUrl: "http://localhost:4111", fetch: stub }).actors()
+    expect(lastUrl().pathname).toBe("/v1/actors")
+  })
+
   // The transport reads its default fetch once per process, so a stated one is the only way a
   // caller routes requests elsewhere: a global assigned later is never consulted (client.ts,
   // ClientOptions.fetch).

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -7,6 +7,7 @@ import {
   RESERVED_ACTOR,
   ResumeRefused,
   type Accepted,
+  type ActorSummary,
   type Append,
   type ThreadNode,
   type ThreadSummary,
@@ -103,6 +104,7 @@ export interface Client<P extends Projections = {}> {
   readonly baseUrl: string
   // The actor every call addresses, resolved once at construction (ClientOptions, actor).
   readonly actor: string
+  readonly actors: () => Promise<ReadonlyArray<ActorSummary>>
   readonly list: () => Promise<ReadonlyArray<ThreadSummary>>
   readonly tree: (thread: string) => Promise<ThreadNode>
   readonly events: (thread: string, options?: EventsOptions) => Promise<ReadonlyArray<EventRow>>
@@ -228,6 +230,7 @@ export const makeClient = <const P extends Projections = {}>(options: ClientOpti
   return {
     baseUrl,
     actor,
+    actors: () => run(api.actors.actors({})),
     list: () => run(api.threads.list({ params: { actor } })),
     tree: (thread) => run(api.threads.tree({ params: { actor, id: thread } })),
     events: (thread, events = {}) =>

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -198,6 +198,26 @@ export const Health = Schema.Struct({
 
 export type Health = typeof Health.Type
 
+export const ActorSummary = Schema.Struct({
+  name: Schema.String,
+  builtIn: Schema.Boolean,
+  digest: Schema.optionalKey(Schema.String)
+}).annotate({ identifier: "ActorSummary" })
+
+export type ActorSummary = typeof ActorSummary.Type
+
+export const ActorArtifact = Schema.Struct({
+  manifest: Schema.Struct({
+    schema: Schema.Literal(1),
+    name: Schema.String,
+    module: Schema.String,
+    digest: Schema.String
+  }),
+  module: Schema.String
+}).annotate({ identifier: "ActorArtifact" })
+
+export type ActorArtifact = typeof ActorArtifact.Type
+
 // One event to append. `type` is the only field the platform requires, because an event is one fact
 // and what its other fields mean is the actor's own knowledge: a brief is
 // `{ type: "MessageReceived", id, text }`, and a resume is a `TurnResumed`. The platform stamps `at`
@@ -264,6 +284,15 @@ export const threadsGroup = HttpApiGroup.make("threads").add(
 
 export const healthGroup = HttpApiGroup.make("health").add(
   HttpApiEndpoint.get("healthz", "/healthz", { success: Health })
+)
+
+export const actorsGroup = HttpApiGroup.make("actors").add(
+  HttpApiEndpoint.get("actors", "/v1/actors", { success: Schema.Array(ActorSummary) }),
+  HttpApiEndpoint.put("pushActor", "/v1/actors", {
+    payload: ActorArtifact,
+    success: ActorSummary,
+    error: [InvalidRequest.schema]
+  })
 )
 
 // A projection is a pure read of one thread's events, declared by the actor whose reactors wrote
@@ -366,7 +395,7 @@ export class RequestProblems extends HttpApiMiddleware.Service<RequestProblems>(
 // platform's to know: a server builds the API it serves from the actor it mounts
 // (apps/server/src/api.ts, ServerApi).
 export const apiOf = <const P extends Projections>(projections: P) =>
-  HttpApi.make("tardigrade").add(threadsGroup, projectionsGroupOf(projections), healthGroup)
+  HttpApi.make("tardigrade").add(actorsGroup, threadsGroup, projectionsGroupOf(projections), healthGroup)
     .middleware(RequestProblems)
     .annotateMerge(
       OpenApi.annotations({

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -23,6 +23,7 @@ export { CLOSED, stream, streamUrl, type EventSourceLike, type Frame, type OpenE
 
 export type {
   Accepted,
+  ActorSummary,
   ThreadNode,
   ThreadStatus,
   ThreadSummary,


### PR DESCRIPTION
Adds a portable actor artifact contract and the `tdg build` and `tdg push` commands. Local and hosted targets consume the same verified bundle, with exported storage defaults and an explicit target choice.

Adds server-side actor discovery, isolated Bun hosts and SQLite logs per actor, hot hosted pushes, actor-scoped CLI commands, and Voyager navigation from actors to runs to traces. This gives one process a multiple-actor world while preserving the built-in `agent` and its existing database.

Validation: `bun run gate` passes all 25 checks.