### PR TITLE
feat(cli): list available actors

### DIFF
--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { Cause, Console, Effect, Exit, Layer, Option } from "effect"
 import { CliError, Command } from "effect/unstable/cli"
 import { BunServices } from "@effect/platform-bun"
-import { ProblemError, RESERVED_ACTOR, type Accepted, type ThreadSummary, type Client, type EventRow, type TurnView } from "@clavia/tardigrade-client"
+import { ProblemError, RESERVED_ACTOR, type Accepted, type ActorSummary, type ThreadSummary, type Client, type EventRow, type TurnView } from "@clavia/tardigrade-client"
 
 import { NO_MODEL_NOTICE, problemLine, tdg } from "./commands"
 import { Cli, type CliProjections, type CliServices } from "./services"
@@ -32,6 +32,7 @@ const clientOf = (
   recorded: Recorded,
   answers: {
     readonly list?: ReadonlyArray<ThreadSummary>
+    readonly actors?: ReadonlyArray<ActorSummary>
     readonly events?: ReadonlyArray<EventRow>
     readonly turns?: ReadonlyArray<TurnView>
     readonly fail?: ProblemError
@@ -41,7 +42,9 @@ const clientOf = (
   return {
     baseUrl: "http://localhost:0",
     actor: RESERVED_ACTOR,
-    actors: () => Promise.resolve([{ name: RESERVED_ACTOR, builtIn: true }]),
+    actors: () => answers.fail === undefined
+      ? Promise.resolve(answers.actors ?? [{ name: RESERVED_ACTOR, builtIn: true }])
+      : Promise.reject(answers.fail),
     list: () => (answers.fail === undefined ? Promise.resolve(answers.list ?? []) : Promise.reject(answers.fail)),
     events: (thread, options) => {
       recorded.asked.push({ thread, options })
@@ -141,6 +144,7 @@ describe("parsing", () => {
     expect((await drive([])).lines.join("\n")).toContain("setup")
     expect((await drive([])).lines.join("\n")).toContain("build")
     expect((await drive([])).lines.join("\n")).toContain("push")
+    expect((await drive([])).lines.join("\n")).toContain("actors")
     const help = (await drive(["setup", "--help"])).lines.join("\n")
     expect(help).toContain("~/.tardigrade/config.json")
     expect(help).toContain("0600")
@@ -205,6 +209,27 @@ describe("ls", () => {
   test("--json prints the client's value verbatim", async () => {
     const ran = await drive(["ls", "--json"], { answers: { list: threads } })
     expect(JSON.parse(ran.lines[0] ?? "")).toEqual(threads)
+  })
+})
+
+describe("actors", () => {
+  const actors: ReadonlyArray<ActorSummary> = [
+    { name: "agent", builtIn: true },
+    { name: "reviewer", builtIn: false, digest: "sha256:abc" }
+  ]
+
+  test("the human rendering lists kind and digest", async () => {
+    const ran = await drive(["actors"], { answers: { actors } })
+    expect(ran.failed).toBe(false)
+    expect(ran.lines[0]).toContain("ACTOR")
+    expect(ran.lines[0]).toContain("reviewer")
+    expect(ran.lines[0]).toContain("pushed")
+    expect(ran.lines[0]).toContain("sha256:abc")
+  })
+
+  test("--json prints the summaries verbatim", async () => {
+    const ran = await drive(["actors", "--json"], { answers: { actors } })
+    expect(JSON.parse(ran.lines[0] ?? "")).toEqual(actors)
   })
 })
 

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -9,7 +9,7 @@ import { readFileConfig, resolveRemote, resolveServer } from "./config"
 import { availableDevPort, DEFAULT_MIN_PORT, DEV_URL_HOST, dev, openBrowser } from "./dev"
 import { DEFAULT_ACTOR_DIRECTORY, pushActor, pushSummary, PUSH_TARGETS } from "./push"
 import { homeOf, HOME_MISSING, setupJson, setupPrompt, setupSummary, writeSetup } from "./setup"
-import { threadsTable, DEFAULT_DETAIL_WIDTH, eventsTable, jsonOf, turnLines } from "./render"
+import { actorsTable, threadsTable, DEFAULT_DETAIL_WIDTH, eventsTable, jsonOf, turnLines } from "./render"
 import { Cli, type CliProjections } from "./services"
 
 // The command tree. Every command is a declaration: its flags, its arguments, and its description
@@ -390,6 +390,19 @@ export const lsCommand = Command.make("ls", remote, (flags) =>
     Command.withAlias("list")
   )
 
+export const actorsCommand = Command.make("actors", { url, token, json }, (flags) =>
+  Effect.gen(function*() {
+    const client = yield* clientOf({ ...flags, actor: RESERVED_ACTOR })
+    const actors = yield* call(() => client.actors())
+    yield* Console.log(flags.json ? jsonOf(actors) : actorsTable(actors))
+  })).pipe(
+    Command.withDescription("List every actor available on the server."),
+    Command.withExamples([
+      { command: "tdg actors", description: "List actors as a table" },
+      { command: "tdg actors --json", description: "Print the actor summaries as JSON" }
+    ])
+  )
+
 export const eventsCommand = Command.make("events", {
   thread: Argument.string("thread").pipe(Argument.withDescription("The thread whose log to read")),
   after: Flag.integer("after").pipe(
@@ -431,5 +444,5 @@ export const tdg = Command.make("tdg").pipe(
   Command.withDescription(
     "The tardigrade command. Every read is a projection of a durable log, and every failure is the server's own problem document."
   ),
-  Command.withSubcommands([setupCommand, buildCommand, pushCommand, devCommand, runCommand, sendCommand, lsCommand, eventsCommand])
+  Command.withSubcommands([setupCommand, buildCommand, pushCommand, devCommand, actorsCommand, runCommand, sendCommand, lsCommand, eventsCommand])
 )

--- a/apps/cli/src/render.test.ts
+++ b/apps/cli/src/render.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import type { ThreadSummary, EventRow } from "@clavia/tardigrade-client"
 
-import { threadsTable, ABSENT, DEFAULT_DETAIL_WIDTH, ELLIPSIS, eventsTable, table, turnLines } from "./render"
+import { actorsTable, threadsTable, ABSENT, DEFAULT_DETAIL_WIDTH, ELLIPSIS, eventsTable, table, turnLines } from "./render"
 
 // The human rendering. A table is plain aligned text, so these assert on columns rather than on
 // escape sequences, and a value the projection did not carry reads as absent rather than as empty.
@@ -31,6 +31,23 @@ describe("threadsTable", () => {
 
   test("an empty store says so", () => {
     expect(threadsTable([])).toBe("no threads")
+  })
+})
+
+describe("actorsTable", () => {
+  test("shows built-in and pushed actors", () => {
+    const rendered = actorsTable([
+      { name: "agent", builtIn: true },
+      { name: "reviewer", builtIn: false, digest: "sha256:abc" }
+    ])
+    expect(rendered).toContain("agent")
+    expect(rendered).toContain("built-in")
+    expect(rendered).toContain("reviewer")
+    expect(rendered).toContain("sha256:abc")
+  })
+
+  test("an empty server says so", () => {
+    expect(actorsTable([])).toBe("no actors")
   })
 })
 

--- a/apps/cli/src/render.ts
+++ b/apps/cli/src/render.ts
@@ -1,4 +1,4 @@
-import type { ThreadSummary, EventRow, TurnView } from "@clavia/tardigrade-client"
+import type { ActorSummary, ThreadSummary, EventRow, TurnView } from "@clavia/tardigrade-client"
 
 // What a command puts on stdout. Two renderings of the same value: aligned text for a person and
 // the client's own value for a pipe (`--json`), which is why every function here takes what the
@@ -51,6 +51,18 @@ export const threadsTable = (threads: ReadonlyArray<ThreadSummary>): string =>
         String(thread.events),
         timeOf(thread.lastAt),
         thread.parent ?? ABSENT
+      ])
+    )
+
+export const actorsTable = (actors: ReadonlyArray<ActorSummary>): string =>
+  actors.length === 0
+    ? "no actors"
+    : table(
+      ["ACTOR", "KIND", "DIGEST"],
+      actors.map((actor) => [
+        actor.name,
+        actor.builtIn ? "built-in" : "pushed",
+        actor.digest ?? ABSENT
       ])
     )
 


### PR DESCRIPTION
Adds `tdg actors` to list the actors available on a server. The human output shows each actor name, whether it is built in or pushed, and its bundle digest when present. `--json`, `--url`, and `--token` keep the command useful in scripts and against hosted servers.

Run listing remains actor-scoped through `tdg ls --actor <name>`. There is no combined actor and run output.

Validation: `bun run gate` passes all 25 checks.