### PR TITLE
feat(voyager): refine actor navigation

### DIFF
--- a/apps/voyager/src/ActorRail.tsx
+++ b/apps/voyager/src/ActorRail.tsx
@@ -2,15 +2,17 @@ import type { ActorSummary, ProblemError } from "@clavia/tardigrade-client"
 import { useState, type ReactElement } from "react"
 
 import { navigate } from "./nav"
-import { ACTOR_RAIL_WIDTH } from "./policy"
+import { ACTOR_RAIL_WIDTH, PANE_HEADER_HEIGHT } from "./policy"
 import { matches } from "./roster"
 
 export const ActorRail = ({
   actors,
+  headerHeight = PANE_HEADER_HEIGHT,
   problem,
   selected
 }: {
   readonly actors: ReadonlyArray<ActorSummary>
+  readonly headerHeight?: number | undefined
   readonly problem: ProblemError | undefined
   readonly selected: string | undefined
 }): ReactElement => {
@@ -18,18 +20,20 @@ export const ActorRail = ({
   const shown = actors.filter((actor) => matches(actor.name, query))
   return (
     <aside className="actor-rail" style={{ width: ACTOR_RAIL_WIDTH }}>
-      <div className="actor-head">
-        <div className="rail-wordmark">voyager</div>
-        <div className="mono actor-label">actors</div>
-      </div>
-      <div className="actor-search-wrap">
-        <input
-          className="input actor-search"
-          value={query}
-          placeholder="search name…"
-          aria-label="search actor name"
-          onChange={(changed) => setQuery(changed.target.value)}
-        />
+      <div className="pane-chrome" style={{ height: headerHeight }}>
+        <div className="actor-head">
+          <div className="rail-wordmark">voyager</div>
+          <div className="mono actor-label">actors</div>
+        </div>
+        <div className="actor-search-wrap">
+          <input
+            className="input actor-search"
+            value={query}
+            placeholder="search name…"
+            aria-label="search actor name"
+            onChange={(changed) => setQuery(changed.target.value)}
+          />
+        </div>
       </div>
       {problem === undefined ? null : (
         <div className="problem actor-problem">

--- a/apps/voyager/src/ActorRail.tsx
+++ b/apps/voyager/src/ActorRail.tsx
@@ -1,8 +1,9 @@
 import type { ActorSummary, ProblemError } from "@clavia/tardigrade-client"
-import type { ReactElement } from "react"
+import { useState, type ReactElement } from "react"
 
 import { navigate } from "./nav"
 import { ACTOR_RAIL_WIDTH } from "./policy"
+import { matches } from "./roster"
 
 export const ActorRail = ({
   actors,
@@ -12,34 +13,47 @@ export const ActorRail = ({
   readonly actors: ReadonlyArray<ActorSummary>
   readonly problem: ProblemError | undefined
   readonly selected: string | undefined
-}): ReactElement => (
-  <aside className="actor-rail" style={{ width: ACTOR_RAIL_WIDTH }}>
-    <div className="actor-head">
-      <div className="rail-wordmark">voyager</div>
-      <div className="mono actor-label">actors</div>
-    </div>
-    {problem === undefined ? null : (
-      <div className="problem actor-problem">
-        <div className="problem-title">{problem.title}</div>
-        {problem.detail === undefined ? null : <div className="problem-detail">{problem.detail}</div>}
+}): ReactElement => {
+  const [query, setQuery] = useState("")
+  const shown = actors.filter((actor) => matches(actor.name, query))
+  return (
+    <aside className="actor-rail" style={{ width: ACTOR_RAIL_WIDTH }}>
+      <div className="actor-head">
+        <div className="rail-wordmark">voyager</div>
+        <div className="mono actor-label">actors</div>
       </div>
-    )}
-    <div className="actor-list">
-      {actors.map((actor) => {
-        const chosen = actor.name === selected
-        return (
-          <button
-            type="button"
-            key={actor.name}
-            className={`actor-row${chosen ? " actor-row-selected" : ""}`}
-            aria-current={chosen ? "true" : undefined}
-            onClick={() => navigate({ actor: actor.name, thread: undefined, from: undefined, to: undefined })}
-          >
-            <span className="mono actor-name">{actor.name}</span>
-            {actor.builtIn ? <span className="mono actor-kind">built-in</span> : null}
-          </button>
-        )
-      })}
-    </div>
-  </aside>
-)
+      <div className="actor-search-wrap">
+        <input
+          className="input actor-search"
+          value={query}
+          placeholder="search name…"
+          aria-label="search actor name"
+          onChange={(changed) => setQuery(changed.target.value)}
+        />
+      </div>
+      {problem === undefined ? null : (
+        <div className="problem actor-problem">
+          <div className="problem-title">{problem.title}</div>
+          {problem.detail === undefined ? null : <div className="problem-detail">{problem.detail}</div>}
+        </div>
+      )}
+      <div className="actor-list">
+        {shown.map((actor) => {
+          const chosen = actor.name === selected
+          return (
+            <button
+              type="button"
+              key={actor.name}
+              className={`actor-row${chosen ? " actor-row-selected" : ""}`}
+              aria-current={chosen ? "true" : undefined}
+              onClick={() => navigate({ actor: actor.name, thread: undefined, from: undefined, to: undefined })}
+            >
+              <span className="mono actor-name">{actor.name}</span>
+              {actor.builtIn ? <span className="mono actor-kind">built-in</span> : null}
+            </button>
+          )
+        })}
+      </div>
+    </aside>
+  )
+}

--- a/apps/voyager/src/Rail.tsx
+++ b/apps/voyager/src/Rail.tsx
@@ -3,7 +3,7 @@ import { useState, type ReactElement } from "react"
 
 import type { ProblemError } from "@clavia/tardigrade-client"
 import { navigate } from "./nav"
-import { COLLAPSED_RAIL_WIDTH, ICON_SIZE, RAIL_WIDTH } from "./policy"
+import { COLLAPSED_RAIL_WIDTH, ICON_SIZE, PANE_HEADER_HEIGHT, RAIL_WIDTH } from "./policy"
 import { agoOf, countsOf, matches, type Roster, type RootRow } from "./roster"
 
 // The rail: the run's roots and nothing else (mock.html, the aside). A root is a run, and the tree
@@ -57,11 +57,13 @@ const Row = ({
 }
 
 export const Rail = ({
+  headerHeight = PANE_HEADER_HEIGHT,
   now,
   problem,
   roster,
   selected
 }: {
+  readonly headerHeight?: number | undefined
   readonly now: number
   readonly problem: ProblemError | undefined
   readonly roster: Roster
@@ -77,31 +79,33 @@ export const Rail = ({
   const label = collapsed ? "Expand the run list" : "Collapse the run list"
   return (
     <aside className={`rail${collapsed ? " rail-collapsed" : ""}`} style={{ width: collapsed ? COLLAPSED_RAIL_WIDTH : RAIL_WIDTH }}>
-      <div className="rail-head">
-        <div className="mono rail-only rail-section-title">runs</div>
-        <button
-          type="button"
-          className="icon-btn"
-          aria-label={label}
-          aria-expanded={!collapsed}
-          title={label}
-          onClick={() => {
-            const next = !collapsed
-            setCollapsed(next)
-            if (typeof localStorage !== "undefined") localStorage.setItem(RAIL_KEY, next ? "collapsed" : "open")
-          }}
-        >
-          <SidebarSimple size={ICON_SIZE} weight="light" aria-hidden="true" />
-        </button>
-      </div>
-      <div className="rail-only" style={{ padding: "0 var(--space-3) 10px" }}>
-        <input
-          className="input rail-search"
-          value={query}
-          placeholder="search id…"
-          aria-label="search id"
-          onChange={(changed) => setQuery(changed.target.value)}
-        />
+      <div className="pane-chrome" style={{ height: headerHeight }}>
+        <div className="rail-head">
+          <div className="mono rail-only rail-section-title">runs</div>
+          <button
+            type="button"
+            className="icon-btn"
+            aria-label={label}
+            aria-expanded={!collapsed}
+            title={label}
+            onClick={() => {
+              const next = !collapsed
+              setCollapsed(next)
+              if (typeof localStorage !== "undefined") localStorage.setItem(RAIL_KEY, next ? "collapsed" : "open")
+            }}
+          >
+            <SidebarSimple size={ICON_SIZE} weight="light" aria-hidden="true" />
+          </button>
+        </div>
+        <div className="rail-only" style={{ padding: "0 var(--space-3) 10px" }}>
+          <input
+            className="input rail-search"
+            value={query}
+            placeholder="search id…"
+            aria-label="search id"
+            onChange={(changed) => setQuery(changed.target.value)}
+          />
+        </div>
       </div>
       {problem === undefined ? null : (
         <div className="problem rail-only" style={{ margin: "0 var(--space-3) 10px" }}>

--- a/apps/voyager/src/Thread.tsx
+++ b/apps/voyager/src/Thread.tsx
@@ -5,7 +5,7 @@ import { NO_ANSWER, ProblemError, type ThreadStatus, type EventRow } from "@clav
 import { clientFor } from "./client"
 import { fieldsOf, merged, momentsOf, stampOf, type Field, type Moment } from "./narrative"
 import { navigate, useRoute, type Route } from "./nav"
-import { BOTTOM_SLACK_PX, EVENT_STAMP_WIDTH, FIELD_COLLAPSED_HEIGHT, FIELD_WIDTH, LOG_POLL_MS, SUMMARY_WIDTH } from "./policy"
+import { BOTTOM_SLACK_PX, EVENT_STAMP_WIDTH, FIELD_COLLAPSED_HEIGHT, FIELD_WIDTH, LOG_POLL_MS, PANE_HEADER_HEIGHT, SUMMARY_WIDTH } from "./policy"
 import { axisOf, defaultWindowOf, FULL_WINDOW, shared, shownIn, type Window } from "./window"
 import { WindowBrush } from "./WindowBrush"
 
@@ -205,6 +205,7 @@ const Head = ({ id, status }: { readonly id: string; readonly status: ThreadStat
 export const Thread = ({
   actor,
   fieldCollapsedHeight = FIELD_COLLAPSED_HEIGHT,
+  headerHeight = PANE_HEADER_HEIGHT,
   id,
   stampWidth = EVENT_STAMP_WIDTH,
   status
@@ -212,6 +213,7 @@ export const Thread = ({
   readonly actor: string
   readonly id: string
   readonly fieldCollapsedHeight?: number | undefined
+  readonly headerHeight?: number | undefined
   readonly stampWidth?: number | undefined
   readonly status: ThreadStatus | undefined
 }): ReactElement => {
@@ -278,7 +280,9 @@ export const Thread = ({
   if (problem !== undefined && problem.status === 404) {
     return (
       <>
-        <Head id={id} status={status} />
+        <div className="pane-chrome" style={{ height: headerHeight }}>
+          <Head id={id} status={status} />
+        </div>
         <Problem problem={problem} />
       </>
     )
@@ -286,8 +290,10 @@ export const Thread = ({
 
   return (
     <>
-      <Head id={id} status={status} />
-      <WindowBrush axis={axis} moments={moments} shown={shown} window={held} onChange={onWindow} />
+      <div className="pane-chrome" style={{ height: headerHeight }}>
+        <Head id={id} status={status} />
+        <WindowBrush axis={axis} moments={moments} shown={shown} window={held} onChange={onWindow} />
+      </div>
       {problem === undefined ? null : <Problem problem={problem} />}
       {!dropped ? null : <div className="mono stream-note">stream dropped; polling</div>}
       <div

--- a/apps/voyager/src/policy.ts
+++ b/apps/voyager/src/policy.ts
@@ -10,6 +10,10 @@ export const RAIL_WIDTH = 320
 // a narrower measure than the run rail beside it.
 export const ACTOR_RAIL_WIDTH = 208
 
+// The shared header band height in pixels. Actor rows, run rows, and trace events begin below this
+// same horizontal datum, and each pane accepts another height when embedded in a tighter shell.
+export const PANE_HEADER_HEIGHT = 156
+
 // The width the rail keeps when it is collapsed, in pixels. It holds the toggle and nothing else,
 // so a reader can always open the list again from where they closed it.
 export const COLLAPSED_RAIL_WIDTH = 48

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -335,6 +335,15 @@ textarea {
   padding: var(--space-4);
 }
 
+.actor-search-wrap {
+  padding: 0 var(--space-3) 10px;
+}
+
+.actor-search {
+  width: 100%;
+  height: 30px;
+}
+
 .actor-problem {
   margin: 0 var(--space-3) var(--space-3);
 }

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -329,6 +329,12 @@ textarea {
   background: var(--bg);
 }
 
+.pane-chrome {
+  flex-shrink: 0;
+  overflow: hidden;
+  border-bottom: 1px solid var(--hair);
+}
+
 .actor-head {
   display: grid;
   gap: 3px;


### PR DESCRIPTION
Adds actor-name search beside the existing run search so larger actor registries stay easy to navigate.

Aligns the actor, run, and trace controls to a shared header height so all three panes begin their content on the same horizontal line. The exported default remains overridable by each pane.

## Verification

- `bun run gate`