### PR TITLE
fix(voyager): refine actor navigation

### DIFF
--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -214,7 +214,7 @@ describe("ls", () => {
 
 describe("actors", () => {
   const actors: ReadonlyArray<ActorSummary> = [
-    { name: "agent", builtIn: true },
+    { name: "default", builtIn: true },
     { name: "reviewer", builtIn: false, digest: "sha256:abc" }
   ]
 

--- a/apps/cli/src/dev.test.ts
+++ b/apps/cli/src/dev.test.ts
@@ -141,10 +141,10 @@ describe("tdg dev", () => {
       const asset = await fetch(`${baseUrl}/assets/app-abc123.js`)
       // A path the router does not own, asked for by something that renders HTML, is the UI's own
       // route: a deep link into the explorer is not a 404.
-      const deep = await fetch(`${baseUrl}/v1/actors/agent/threads/root`, { headers: { accept: "text/html" } })
+      const deep = await fetch(`${baseUrl}/v1/actors/default/threads/root`, { headers: { accept: "text/html" } })
       // The same path asked for as JSON is still the API's answer, so a script sees the problem
       // document rather than a page.
-      const ghost = await fetch(`${baseUrl}/v1/actors/agent/threads/ghost/events`, { headers: { accept: "application/json" } })
+      const ghost = await fetch(`${baseUrl}/v1/actors/default/threads/ghost/events`, { headers: { accept: "application/json" } })
       return {
         health: { status: health.status, body: await health.json() },
         index: { status: index.status, body: await index.text(), type: index.headers.get("content-type") },
@@ -171,7 +171,7 @@ describe("tdg dev", () => {
   // the token set (docs/how-to/server.md).
   test("the API answers without a token, on loopback", async () => {
     const seen = await booted(async (baseUrl, hostname) => {
-      const listed = await fetch(`${baseUrl}/v1/actors/agent/threads`)
+      const listed = await fetch(`${baseUrl}/v1/actors/default/threads`)
       const index = await fetch(`${baseUrl}/`, { headers: { accept: "text/html" } })
       return {
         hostname,

--- a/apps/cli/src/render.test.ts
+++ b/apps/cli/src/render.test.ts
@@ -37,10 +37,10 @@ describe("threadsTable", () => {
 describe("actorsTable", () => {
   test("shows built-in and pushed actors", () => {
     const rendered = actorsTable([
-      { name: "agent", builtIn: true },
+      { name: "default", builtIn: true },
       { name: "reviewer", builtIn: false, digest: "sha256:abc" }
     ])
-    expect(rendered).toContain("agent")
+    expect(rendered).toContain("default")
     expect(rendered).toContain("built-in")
     expect(rendered).toContain("reviewer")
     expect(rendered).toContain("sha256:abc")

--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -118,13 +118,13 @@ const put = (base: string, path: string, body: unknown) =>
 // agentProjections).
 const turnOf = async (base: string, thread: string, turn: string): Promise<TurnView | undefined> => {
   const views = (await (await fetch(
-    `${base}/v1/actors/agent/threads/${thread}/turns?turn=${encodeURIComponent(turn)}`
+    `${base}/v1/actors/default/threads/${thread}/turns?turn=${encodeURIComponent(turn)}`
   )).json()) as ReadonlyArray<TurnView>
   return views[0]
 }
 
 const birth = async (base: string, id: string, message: { id: string; text: string }) => {
-  const response = await post(base, `/v1/actors/agent/threads/${id}/events`, {
+  const response = await post(base, `/v1/actors/default/threads/${id}/events`, {
     type: "MessageReceived",
     ...message
   })
@@ -146,8 +146,8 @@ describe("appending", () => {
   // other fields mean is the actor's knowledge (contract.ts, Append).
   test("a body with no type is refused", async () => {
     const problems = await serving(async (base) => {
-      const noType = await post(base, "/v1/actors/agent/threads/alpha/events", { id: "m1", text: "hello" })
-      const emptyType = await post(base, "/v1/actors/agent/threads/alpha/events", { type: "" })
+      const noType = await post(base, "/v1/actors/default/threads/alpha/events", { id: "m1", text: "hello" })
+      const emptyType = await post(base, "/v1/actors/default/threads/alpha/events", { type: "" })
       return [
         { status: noType.status, type: noType.headers.get("content-type"), body: await noType.json() },
         { status: emptyType.status, type: emptyType.headers.get("content-type"), body: await emptyType.json() }
@@ -167,8 +167,8 @@ describe("appending", () => {
   test("a redelivered message id answers the same and writes nothing", async () => {
     const counts = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
-      const before = ((await (await fetch(`${base}/v1/actors/agent/threads/alpha/events`)).json()) as ReadonlyArray<EventRow>).length
-      const again = await post(base, "/v1/actors/agent/threads/alpha/events", {
+      const before = ((await (await fetch(`${base}/v1/actors/default/threads/alpha/events`)).json()) as ReadonlyArray<EventRow>).length
+      const again = await post(base, "/v1/actors/default/threads/alpha/events", {
         type: "MessageReceived",
         id: "m1",
         text: "hello"
@@ -176,7 +176,7 @@ describe("appending", () => {
       expect(again.status).toBe(202)
       expect(await again.json()).toEqual({ actor: RESERVED_ACTOR, thread: "alpha" })
       await sleep(50)
-      const after = ((await (await fetch(`${base}/v1/actors/agent/threads/alpha/events`)).json()) as ReadonlyArray<EventRow>).length
+      const after = ((await (await fetch(`${base}/v1/actors/default/threads/alpha/events`)).json()) as ReadonlyArray<EventRow>).length
       return [before, after]
     })
     expect(counts[1]).toBe(counts[0]!)
@@ -237,7 +237,7 @@ describe("the listing", () => {
   test("a thread that has settled lists as settled", async () => {
     const listed = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
-      return (await (await fetch(`${base}/v1/actors/agent/threads`)).json()) as ReadonlyArray<ThreadSummary>
+      return (await (await fetch(`${base}/v1/actors/default/threads`)).json()) as ReadonlyArray<ThreadSummary>
     })
     expect(listed).toHaveLength(1)
     expect(listed[0]).toMatchObject({ id: "alpha", status: "settled" })
@@ -251,13 +251,13 @@ describe("events", () => {
     const read = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
       const json = async (path: string) => (await (await fetch(`${base}${path}`)).json()) as ReadonlyArray<EventRow>
-      const all = await json("/v1/actors/agent/threads/alpha/events")
+      const all = await json("/v1/actors/default/threads/alpha/events")
       return {
         all,
-        page: await json("/v1/actors/agent/threads/alpha/events?after=1&limit=2"),
-        completed: await json("/v1/actors/agent/threads/alpha/events?types=TurnCompleted"),
-        both: await json(`/v1/actors/agent/threads/alpha/events?after=1&types=MessageReceived,TurnCompleted`),
-        empty: await json("/v1/actors/agent/threads/alpha/events?types=NothingLikeThis")
+        page: await json("/v1/actors/default/threads/alpha/events?after=1&limit=2"),
+        completed: await json("/v1/actors/default/threads/alpha/events?types=TurnCompleted"),
+        both: await json(`/v1/actors/default/threads/alpha/events?after=1&types=MessageReceived,TurnCompleted`),
+        empty: await json("/v1/actors/default/threads/alpha/events?types=NothingLikeThis")
       }
     })
     expect(read.all.map((row) => row.seq)).toEqual(read.all.map((_, i) => i + 1))
@@ -276,7 +276,7 @@ describe("events", () => {
   test("a log that never existed is the only 404", async () => {
     const answers = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
-      const missing = await fetch(`${base}/v1/actors/agent/threads/ghost/events`)
+      const missing = await fetch(`${base}/v1/actors/default/threads/ghost/events`)
       return { status: missing.status, type: missing.headers.get("content-type"), body: await missing.json() }
     })
     expect(answers.status).toBe(404)
@@ -344,9 +344,9 @@ describe("the event stream", () => {
   test("a reconnect replays from Last-Event-ID and then runs live, once each", async () => {
     const read = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
-      const before = (await (await fetch(`${base}/v1/actors/agent/threads/alpha/events`)).json()) as ReadonlyArray<EventRow>
+      const before = (await (await fetch(`${base}/v1/actors/default/threads/alpha/events`)).json()) as ReadonlyArray<EventRow>
       const abort = new AbortController()
-      const response = await fetch(`${base}/v1/actors/agent/threads/alpha/events/stream?after=0`, {
+      const response = await fetch(`${base}/v1/actors/default/threads/alpha/events/stream?after=0`, {
         // The header wins over the query, which is the whole of what a resuming EventSource can
         // state: it replays the URL it was opened with and carries the id in the header.
         headers: { "last-event-id": "2" },
@@ -371,7 +371,7 @@ describe("the event stream", () => {
       expect(openStreams()).toBe(1)
 
       // Then a message delivered while the stream is open arrives on it.
-      await post(base, "/v1/actors/agent/threads/alpha/events", { type: "MessageReceived", id: "m2", text: "again" })
+      await post(base, "/v1/actors/default/threads/alpha/events", { type: "MessageReceived", id: "m2", text: "again" })
       await until("the live frames", async () => (framesOf(text).length > replayed.length ? true : undefined))
       const live = framesOf(text)
 
@@ -403,7 +403,7 @@ describe("projections", () => {
   test("a declared projection serves what the actor computes", async () => {
     const read = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
-      const response = await fetch(`${base}/v1/actors/agent/threads/alpha/turns`)
+      const response = await fetch(`${base}/v1/actors/default/threads/alpha/turns`)
       return { status: response.status, body: await response.json() as ReadonlyArray<TurnView> }
     })
     expect(read.status).toBe(200)
@@ -421,7 +421,7 @@ describe("projections", () => {
           body: await response.json() as Record<string, unknown>
         }
       }
-      return { ghost: await read("/v1/actors/agent/threads/alpha/facts"), actor: await read("/v1/actors/ghost/threads/alpha/facts") }
+      return { ghost: await read("/v1/actors/default/threads/alpha/facts"), actor: await read("/v1/actors/ghost/threads/alpha/facts") }
     })
     expect(answers.ghost.status).toBe(404)
     expect(answers.ghost.type).toContain(PROBLEM_CONTENT_TYPE)
@@ -444,7 +444,7 @@ describe("projections", () => {
   test("a reserved name still serves the log", async () => {
     const answers = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
-      const events = await fetch(`${base}/v1/actors/agent/threads/alpha/events`)
+      const events = await fetch(`${base}/v1/actors/default/threads/alpha/events`)
       return { status: events.status, type: events.headers.get("content-type") }
     })
     expect(answers.status).toBe(200)
@@ -456,7 +456,7 @@ describe("projections", () => {
     const read = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
       const json = async (path: string) => (await (await fetch(`${base}${path}`)).json()) as ReadonlyArray<TurnView>
-      return { now: await json("/v1/actors/agent/threads/alpha/turns"), atOne: await json("/v1/actors/agent/threads/alpha/turns?at=1") }
+      return { now: await json("/v1/actors/default/threads/alpha/turns"), atOne: await json("/v1/actors/default/threads/alpha/turns?at=1") }
     })
     expect(read.now).toEqual([{ turn: "m1", status: "completed", epoch: 0, output: "ok: hello" }])
     // One event stands before the cut: the message that asked for the turn, and nothing that
@@ -471,8 +471,8 @@ describe("projections", () => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
       const json = async (path: string) => (await (await fetch(`${base}${path}`)).json()) as ReadonlyArray<TurnView>
       return {
-        one: await json("/v1/actors/agent/threads/alpha/turns?turn=m1"),
-        ghost: await json("/v1/actors/agent/threads/alpha/turns?turn=m9")
+        one: await json("/v1/actors/default/threads/alpha/turns?turn=m1"),
+        ghost: await json("/v1/actors/default/threads/alpha/turns?turn=m9")
       }
     })
     expect(read.one).toEqual([{ turn: "m1", status: "completed", epoch: 0, output: "ok: hello" }])
@@ -493,9 +493,9 @@ describe("the tree", () => {
         return health.status === "resting" ? health : undefined
       })
       return {
-        tree: (await (await fetch(`${base}/v1/actors/agent/threads/root/tree`)).json()) as ThreadNode,
-        listed: (await (await fetch(`${base}/v1/actors/agent/threads`)).json()) as ReadonlyArray<ThreadSummary>,
-        ghost: (await fetch(`${base}/v1/actors/agent/threads/ghost/tree`)).status
+        tree: (await (await fetch(`${base}/v1/actors/default/threads/root/tree`)).json()) as ThreadNode,
+        listed: (await (await fetch(`${base}/v1/actors/default/threads`)).json()) as ReadonlyArray<ThreadSummary>,
+        ghost: (await fetch(`${base}/v1/actors/default/threads/ghost/tree`)).status
       }
     })
     expect(read.tree.id).toBe("root")

--- a/apps/server/src/contract.test.ts
+++ b/apps/server/src/contract.test.ts
@@ -113,7 +113,7 @@ describe("the OpenAPI document", () => {
       Effect.gen(function*() {
         const document = yield* client.get(OPENAPI_PATH)
         const page = yield* client.get(DOCS_PATH)
-        const gated = yield* client.get("/v1/actors/agent/threads")
+        const gated = yield* client.get("/v1/actors/default/threads")
         return [document.status, page.status, gated.status]
       }))
     expect(statuses).toEqual([200, 200, 401])
@@ -126,9 +126,9 @@ describe("problem documents", () => {
   test("carry type, title, status, and detail", async () => {
     const failures = await serving({}, (client) =>
       Effect.gen(function*() {
-        const unknownThread = yield* client.get("/v1/actors/agent/threads/ghost/events")
-        const unknownProjection = yield* client.get("/v1/actors/agent/threads/ghost/facts")
-        const unknownTurn = yield* client.get("/v1/actors/agent/threads/ghost/turns?at=1")
+        const unknownThread = yield* client.get("/v1/actors/default/threads/ghost/events")
+        const unknownProjection = yield* client.get("/v1/actors/default/threads/ghost/facts")
+        const unknownTurn = yield* client.get("/v1/actors/default/threads/ghost/turns?at=1")
         return [
           { status: unknownThread.status, type: unknownThread.headers["content-type"], body: yield* unknownThread.json },
           {
@@ -163,12 +163,12 @@ describe("problem documents", () => {
       Effect.gen(function*() {
         const post = (path: string, body: unknown) =>
           client.post(path, { body: HttpBody.jsonUnsafe(body) })
-        const repeated = yield* client.get("/v1/actors/agent/threads/ghost/turns?at=1&at=2")
-        const notANumber = yield* client.get("/v1/actors/agent/threads/ghost/events?after=soon")
-        const negative = yield* client.get("/v1/actors/agent/threads/ghost/events?limit=-1")
-        const missingField = yield* post("/v1/actors/agent/threads/ghost/events", { id: "m1" })
-        const emptyType = yield* post("/v1/actors/agent/threads/ghost/events", { type: "", id: "m1" })
-        const notAnObject = yield* post("/v1/actors/agent/threads/ghost/events", "hello")
+        const repeated = yield* client.get("/v1/actors/default/threads/ghost/turns?at=1&at=2")
+        const notANumber = yield* client.get("/v1/actors/default/threads/ghost/events?after=soon")
+        const negative = yield* client.get("/v1/actors/default/threads/ghost/events?limit=-1")
+        const missingField = yield* post("/v1/actors/default/threads/ghost/events", { id: "m1" })
+        const emptyType = yield* post("/v1/actors/default/threads/ghost/events", { type: "", id: "m1" })
+        const notAnObject = yield* post("/v1/actors/default/threads/ghost/events", "hello")
         return yield* Effect.forEach(
           [repeated, notANumber, negative, missingField, emptyType, notAnObject],
           (response) =>

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -137,7 +137,7 @@ describe("auth", () => {
 
     const anonymous = await serving({ config }, (client) =>
       Effect.gen(function*() {
-        const response = yield* client.get("/v1/actors/agent/threads")
+        const response = yield* client.get("/v1/actors/default/threads")
         return { status: response.status, contentType: response.headers["content-type"], body: yield* response.json }
       }))
     expect(anonymous.status).toBe(401)
@@ -145,11 +145,11 @@ describe("auth", () => {
     expect(anonymous.body).toMatchObject({ status: 401, title: "Unauthorized" })
 
     const wrong = await serving({ config }, (client) =>
-      client.execute(HttpClientRequest.bearerToken(HttpClientRequest.get("/v1/actors/agent/threads"), "guess")))
+      client.execute(HttpClientRequest.bearerToken(HttpClientRequest.get("/v1/actors/default/threads"), "guess")))
     expect(wrong.status).toBe(403)
 
     const right = await serving({ config }, (client) =>
-      client.execute(HttpClientRequest.bearerToken(HttpClientRequest.get("/v1/actors/agent/threads"), "secret")))
+      client.execute(HttpClientRequest.bearerToken(HttpClientRequest.get("/v1/actors/default/threads"), "secret")))
     expect(right.status).toBe(200)
 
     const health = await serving({ config }, (client) => client.get("/healthz"))
@@ -166,7 +166,7 @@ describe("cors", () => {
     const allowed = await serving({}, (client) =>
       Effect.map(
         client.execute(
-          HttpClientRequest.setHeaders(HttpClientRequest.options("/v1/actors/agent/threads"), {
+          HttpClientRequest.setHeaders(HttpClientRequest.options("/v1/actors/default/threads"), {
             origin: "http://localhost:5173",
             "access-control-request-method": "GET",
             "access-control-request-headers": ALLOWED_HEADERS.join(",")

--- a/apps/voyager/dev/fixture.ts
+++ b/apps/voyager/dev/fixture.ts
@@ -82,7 +82,7 @@ export const FIXTURE_BRIEFS: ReadonlyArray<{ readonly thread: string; readonly i
 ]
 
 const post = (thread: string, body: unknown) =>
-  fetch(`http://127.0.0.1:${FIXTURE_PORT}/v1/actors/agent/threads/${encodeURIComponent(thread)}/events`, {
+  fetch(`http://127.0.0.1:${FIXTURE_PORT}/v1/actors/default/threads/${encodeURIComponent(thread)}/events`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body)

--- a/apps/voyager/src/ActorRail.tsx
+++ b/apps/voyager/src/ActorRail.tsx
@@ -25,15 +25,15 @@ export const ActorRail = ({
           <div className="rail-wordmark">voyager</div>
           <div className="mono actor-label">actors</div>
         </div>
-        <div className="actor-search-wrap">
-          <input
-            className="input actor-search"
-            value={query}
-            placeholder="search name…"
-            aria-label="search actor name"
-            onChange={(changed) => setQuery(changed.target.value)}
-          />
-        </div>
+      </div>
+      <div className="actor-search-wrap">
+        <input
+          className="input actor-search"
+          value={query}
+          placeholder="search name…"
+          aria-label="search actor name"
+          onChange={(changed) => setQuery(changed.target.value)}
+        />
       </div>
       {problem === undefined ? null : (
         <div className="problem actor-problem">

--- a/apps/voyager/src/ActorRail.tsx
+++ b/apps/voyager/src/ActorRail.tsx
@@ -1,32 +1,63 @@
 import type { ActorSummary, ProblemError } from "@clavia/tardigrade-client"
+import { SidebarSimple } from "@phosphor-icons/react"
 import { useState, type ReactElement } from "react"
 
 import { navigate } from "./nav"
-import { ACTOR_RAIL_WIDTH, PANE_HEADER_HEIGHT } from "./policy"
+import { ACTOR_RAIL_WIDTH, COLLAPSED_ACTOR_RAIL_WIDTH, ICON_SIZE, PANE_HEADER_HEIGHT } from "./policy"
 import { matches } from "./roster"
+
+const ACTOR_RAIL_KEY = "voyager.actor-rail"
+
+const storedCollapsed = (): boolean => {
+  if (typeof localStorage === "undefined") return false
+  return localStorage.getItem(ACTOR_RAIL_KEY) === "collapsed"
+}
 
 export const ActorRail = ({
   actors,
+  collapsedWidth = COLLAPSED_ACTOR_RAIL_WIDTH,
   headerHeight = PANE_HEADER_HEIGHT,
   problem,
   selected
 }: {
   readonly actors: ReadonlyArray<ActorSummary>
+  readonly collapsedWidth?: number | undefined
   readonly headerHeight?: number | undefined
   readonly problem: ProblemError | undefined
   readonly selected: string | undefined
 }): ReactElement => {
   const [query, setQuery] = useState("")
+  const [collapsed, setCollapsed] = useState(storedCollapsed)
   const shown = actors.filter((actor) => matches(actor.name, query))
+  const label = collapsed ? "Expand the actor list" : "Collapse the actor list"
   return (
-    <aside className="actor-rail" style={{ width: ACTOR_RAIL_WIDTH }}>
+    <aside
+      className={`actor-rail${collapsed ? " actor-rail-collapsed" : ""}`}
+      style={{ width: collapsed ? collapsedWidth : ACTOR_RAIL_WIDTH }}
+    >
       <div className="pane-chrome" style={{ height: headerHeight }}>
         <div className="actor-head">
-          <div className="rail-wordmark">voyager</div>
-          <div className="mono actor-label">actors</div>
+          <div className="actor-only actor-identity">
+            <div className="rail-wordmark">voyager</div>
+            <div className="mono actor-label">actors</div>
+          </div>
+          <button
+            type="button"
+            className="icon-btn"
+            aria-label={label}
+            aria-expanded={!collapsed}
+            title={label}
+            onClick={() => {
+              const next = !collapsed
+              setCollapsed(next)
+              if (typeof localStorage !== "undefined") localStorage.setItem(ACTOR_RAIL_KEY, next ? "collapsed" : "open")
+            }}
+          >
+            <SidebarSimple size={ICON_SIZE} weight="light" aria-hidden="true" />
+          </button>
         </div>
       </div>
-      <div className="actor-search-wrap">
+      <div className="actor-only actor-search-wrap">
         <input
           className="input actor-search"
           value={query}
@@ -36,12 +67,12 @@ export const ActorRail = ({
         />
       </div>
       {problem === undefined ? null : (
-        <div className="problem actor-problem">
+        <div className="problem actor-only actor-problem">
           <div className="problem-title">{problem.title}</div>
           {problem.detail === undefined ? null : <div className="problem-detail">{problem.detail}</div>}
         </div>
       )}
-      <div className="actor-list">
+      <div className="actor-only actor-list">
         {shown.map((actor) => {
           const chosen = actor.name === selected
           return (

--- a/apps/voyager/src/ActorRail.tsx
+++ b/apps/voyager/src/ActorRail.tsx
@@ -1,5 +1,5 @@
 import type { ActorSummary, ProblemError } from "@clavia/tardigrade-client"
-import { SidebarSimple } from "@phosphor-icons/react"
+import { ArrowLeft, ArrowRight } from "@phosphor-icons/react"
 import { useState, type ReactElement } from "react"
 
 import { navigate } from "./nav"
@@ -53,7 +53,9 @@ export const ActorRail = ({
               if (typeof localStorage !== "undefined") localStorage.setItem(ACTOR_RAIL_KEY, next ? "collapsed" : "open")
             }}
           >
-            <SidebarSimple size={ICON_SIZE} weight="light" aria-hidden="true" />
+            {collapsed
+              ? <ArrowRight size={ICON_SIZE} weight="light" aria-hidden="true" />
+              : <ArrowLeft size={ICON_SIZE} weight="light" aria-hidden="true" />}
           </button>
         </div>
       </div>

--- a/apps/voyager/src/App.tsx
+++ b/apps/voyager/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type ReactElement } from "react"
 
 import { Thread } from "./Thread"
-import { NO_ANSWER, ProblemError, type ActorSummary, type ThreadSummary } from "@clavia/tardigrade-client"
+import { NO_ANSWER, ProblemError, RESERVED_ACTOR, type ActorSummary, type ThreadSummary } from "@clavia/tardigrade-client"
 
 import { client, clientFor } from "./client"
 import { navigate, useRoute } from "./nav"
@@ -113,7 +113,7 @@ export const App = (): ReactElement => {
         ) : route.thread === undefined ? (
           <div className="mono pane-empty">{discovered.ready ? "select a run" : "loading actors"}</div>
         ) : (
-          <Thread actor={actor ?? "agent"} id={route.thread} status={status} />
+          <Thread actor={actor ?? RESERVED_ACTOR} id={route.thread} status={status} />
         )}
       </main>
       <ThemeToggle />

--- a/apps/voyager/src/Quickstart.test.ts
+++ b/apps/voyager/src/Quickstart.test.ts
@@ -6,6 +6,6 @@ describe("quickstartCommands", () => {
   test("both commands address the server this tab reads", () => {
     const commands = quickstartCommands("http://localhost:4241")
     expect(commands.cli).toContain("--url http://localhost:4241")
-    expect(commands.curl).toContain("http://localhost:4241/v1/actors/agent/threads/hello/events")
+    expect(commands.curl).toContain("http://localhost:4241/v1/actors/default/threads/hello/events")
   })
 })

--- a/apps/voyager/src/Quickstart.tsx
+++ b/apps/voyager/src/Quickstart.tsx
@@ -12,14 +12,14 @@ export interface QuickstartCommands {
 // quickstartCommands returns commands addressed to the server this tab is reading.
 const baseQuickstartCommands = (baseUrl: string, actor: string): QuickstartCommands => ({
   cli: `tdg run "Tell me what you can do" --actor ${actor} --url ${baseUrl}`,
-  curl: `curl -X POST ${baseUrl}/v1/actors/agent/threads/hello/events \\\n+  -H 'content-type: application/json' \\\n+  -d '{"id":"hello-1","type":"MessageReceived","text":"Tell me what you can do"}'`
+  curl: `curl -X POST ${baseUrl}/v1/actors/default/threads/hello/events \\\n+  -H 'content-type: application/json' \\\n+  -d '{"id":"hello-1","type":"MessageReceived","text":"Tell me what you can do"}'`
 })
 
-export const quickstartCommands = (baseUrl: string, actor = "agent"): QuickstartCommands => {
+export const quickstartCommands = (baseUrl: string, actor = "default"): QuickstartCommands => {
   const commands = baseQuickstartCommands(baseUrl, actor)
   return {
     ...commands,
-    curl: commands.curl.replace("/v1/actors/agent/", `/v1/actors/${encodeURIComponent(actor)}/`)
+    curl: commands.curl.replace("/v1/actors/default/", `/v1/actors/${encodeURIComponent(actor)}/`)
   }
 }
 
@@ -72,7 +72,7 @@ const CommandCard = ({ command, label }: { readonly command: string; readonly la
   )
 }
 
-export const Quickstart = ({ actor = "agent" }: { readonly actor?: string | undefined }): ReactElement => {
+export const Quickstart = ({ actor = "default" }: { readonly actor?: string | undefined }): ReactElement => {
   const commands = quickstartCommands(client.baseUrl, actor)
   return (
     <div className="quickstart-empty">

--- a/apps/voyager/src/Rail.tsx
+++ b/apps/voyager/src/Rail.tsx
@@ -97,15 +97,15 @@ export const Rail = ({
             <SidebarSimple size={ICON_SIZE} weight="light" aria-hidden="true" />
           </button>
         </div>
-        <div className="rail-only" style={{ padding: "0 var(--space-3) 10px" }}>
-          <input
-            className="input rail-search"
-            value={query}
-            placeholder="search id…"
-            aria-label="search id"
-            onChange={(changed) => setQuery(changed.target.value)}
-          />
-        </div>
+      </div>
+      <div className="rail-only" style={{ padding: "10px var(--space-3)" }}>
+        <input
+          className="input rail-search"
+          value={query}
+          placeholder="search id…"
+          aria-label="search id"
+          onChange={(changed) => setQuery(changed.target.value)}
+        />
       </div>
       {problem === undefined ? null : (
         <div className="problem rail-only" style={{ margin: "0 var(--space-3) 10px" }}>

--- a/apps/voyager/src/Rail.tsx
+++ b/apps/voyager/src/Rail.tsx
@@ -1,23 +1,13 @@
-import { SidebarSimple } from "@phosphor-icons/react"
 import { useState, type ReactElement } from "react"
 
 import type { ProblemError } from "@clavia/tardigrade-client"
 import { navigate } from "./nav"
-import { COLLAPSED_RAIL_WIDTH, ICON_SIZE, PANE_HEADER_HEIGHT, RAIL_WIDTH } from "./policy"
+import { PANE_HEADER_HEIGHT, RAIL_WIDTH } from "./policy"
 import { agoOf, countsOf, matches, type Roster, type RootRow } from "./roster"
 
 // The rail: the run's roots and nothing else (mock.html, the aside). A root is a run, and the tree
 // under it is the run's own business, so the rail lists the six things a reader chooses between
 // rather than the twenty-four threads behind them.
-
-// Where the collapsed state is kept. It is the reader's shape of the screen, not the run's, so it
-// lives in the browser and never on the wire (src/theme.ts, THEME_KEY).
-const RAIL_KEY = "voyager.rail"
-
-const storedCollapsed = (): boolean => {
-  if (typeof localStorage === "undefined") return false
-  return localStorage.getItem(RAIL_KEY) === "collapsed"
-}
 
 const Row = ({
   now,
@@ -61,44 +51,28 @@ export const Rail = ({
   now,
   problem,
   roster,
-  selected
+  selected,
+  width = RAIL_WIDTH
 }: {
   readonly headerHeight?: number | undefined
   readonly now: number
   readonly problem: ProblemError | undefined
   readonly roster: Roster
   readonly selected: string | undefined
+  readonly width?: number | undefined
 }): ReactElement => {
   // The search is the rail's own state and reads ids alone: a reader who knows the id types it, and
   // nobody's prose is searched (mock.html, "search id…").
   const [query, setQuery] = useState("")
-  // Collapsed keeps the toggle and hides the list, and it survives a reload because a reader who
-  // closed the rail wants the pane wide on the next visit too.
-  const [collapsed, setCollapsed] = useState(storedCollapsed)
   const rows = roster.roots.filter((row) => matches(row.id, query))
-  const label = collapsed ? "Expand the run list" : "Collapse the run list"
   return (
-    <aside className={`rail${collapsed ? " rail-collapsed" : ""}`} style={{ width: collapsed ? COLLAPSED_RAIL_WIDTH : RAIL_WIDTH }}>
+    <aside className="rail" style={{ width }}>
       <div className="pane-chrome" style={{ height: headerHeight }}>
         <div className="rail-head">
-          <div className="mono rail-only rail-section-title">runs</div>
-          <button
-            type="button"
-            className="icon-btn"
-            aria-label={label}
-            aria-expanded={!collapsed}
-            title={label}
-            onClick={() => {
-              const next = !collapsed
-              setCollapsed(next)
-              if (typeof localStorage !== "undefined") localStorage.setItem(RAIL_KEY, next ? "collapsed" : "open")
-            }}
-          >
-            <SidebarSimple size={ICON_SIZE} weight="light" aria-hidden="true" />
-          </button>
+          <div className="mono rail-section-title">runs</div>
         </div>
       </div>
-      <div className="rail-only" style={{ padding: "10px var(--space-3)" }}>
+      <div style={{ padding: "10px var(--space-3)" }}>
         <input
           className="input rail-search"
           value={query}
@@ -108,12 +82,12 @@ export const Rail = ({
         />
       </div>
       {problem === undefined ? null : (
-        <div className="problem rail-only" style={{ margin: "0 var(--space-3) 10px" }}>
+        <div className="problem" style={{ margin: "0 var(--space-3) 10px" }}>
           <div className="problem-title">{problem.title}</div>
           {problem.detail === undefined ? null : <div className="problem-detail">{problem.detail}</div>}
         </div>
       )}
-      <div className="rail-only" style={{ flex: 1, overflowY: "auto", minHeight: 0 }}>
+      <div style={{ flex: 1, overflowY: "auto", minHeight: 0 }}>
         {rows.map((row) => (
           <Row key={row.id} row={row} now={now} selected={row.id === selected} />
         ))}

--- a/apps/voyager/src/Thread.tsx
+++ b/apps/voyager/src/Thread.tsx
@@ -292,8 +292,8 @@ export const Thread = ({
     <>
       <div className="pane-chrome" style={{ height: headerHeight }}>
         <Head id={id} status={status} />
-        <WindowBrush axis={axis} moments={moments} shown={shown} window={held} onChange={onWindow} />
       </div>
+      <WindowBrush axis={axis} moments={moments} shown={shown} window={held} onChange={onWindow} />
       {problem === undefined ? null : <Problem problem={problem} />}
       {!dropped ? null : <div className="mono stream-note">stream dropped; polling</div>}
       <div

--- a/apps/voyager/src/policy.ts
+++ b/apps/voyager/src/policy.ts
@@ -10,9 +10,9 @@ export const RAIL_WIDTH = 320
 // a narrower measure than the run rail beside it.
 export const ACTOR_RAIL_WIDTH = 208
 
-// The shared header band height in pixels. Actor rows, run rows, and trace events begin below this
-// same horizontal datum, and each pane accepts another height when embedded in a tighter shell.
-export const PANE_HEADER_HEIGHT = 156
+// The shared identity-row height in pixels. Each pane's title begins on the same horizontal datum,
+// and each pane accepts another height when embedded in a tighter shell.
+export const PANE_HEADER_HEIGHT = 64
 
 // The width the rail keeps when it is collapsed, in pixels. It holds the toggle and nothing else,
 // so a reader can always open the list again from where they closed it.

--- a/apps/voyager/src/policy.ts
+++ b/apps/voyager/src/policy.ts
@@ -4,7 +4,7 @@
 
 // The rail's width in pixels (mock.html, the aside). It is a number here because the layout
 // measures against it.
-export const RAIL_WIDTH = 320
+export const RAIL_WIDTH = 280
 
 // The actor pane's width in pixels. Actor names are shorter than run ids, so the first level keeps
 // a narrower measure than the run rail beside it.
@@ -14,9 +14,9 @@ export const ACTOR_RAIL_WIDTH = 208
 // and each pane accepts another height when embedded in a tighter shell.
 export const PANE_HEADER_HEIGHT = 64
 
-// The width the rail keeps when it is collapsed, in pixels. It holds the toggle and nothing else,
-// so a reader can always open the list again from where they closed it.
-export const COLLAPSED_RAIL_WIDTH = 48
+// The width the actor pane keeps when it is collapsed, in pixels. It holds the toggle and nothing
+// else, so a reader can always open the list again from where they closed it.
+export const COLLAPSED_ACTOR_RAIL_WIDTH = 48
 
 // The size every icon renders at, in pixels (voyager-design-system.md, the icon policy). One number
 // for the whole set, because a second size would be a second style.

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -336,9 +336,15 @@ textarea {
 }
 
 .actor-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: var(--space-4);
+}
+
+.actor-identity {
   display: grid;
   gap: 3px;
-  padding: var(--space-4);
 }
 
 .actor-search-wrap {
@@ -405,20 +411,19 @@ textarea {
 }
 
 @media (max-width: 900px) {
-  .actor-rail {
+  .actor-rail:not(.actor-rail-collapsed) {
     width: 160px !important;
   }
 }
 
-/* Everything a collapsed rail hides. The toggle is outside the class, so the rail can always be
-   opened again from where it was closed. */
-.rail-collapsed .rail-only {
+/* Everything a collapsed actor pane hides. The toggle is outside the class, so the pane can always
+   be opened again from where it was closed. */
+.actor-rail-collapsed .actor-only {
   display: none;
 }
 
-.rail-collapsed .rail-head {
+.actor-rail-collapsed .actor-head {
   justify-content: center;
-  padding-left: var(--space-3);
 }
 
 .rail-search {

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -301,9 +301,10 @@ textarea {
    that is left, and it centers on the narrow column. */
 .rail-head {
   display: flex;
-  align-items: center;
+  height: 100%;
+  align-items: flex-end;
   justify-content: space-between;
-  padding: var(--space-4) var(--space-3) 10px var(--space-4);
+  padding: var(--space-3) var(--space-4);
 }
 
 .rail-wordmark {
@@ -337,14 +338,17 @@ textarea {
 
 .actor-head {
   display: flex;
+  height: 100%;
   align-items: flex-start;
   justify-content: space-between;
-  padding: var(--space-4);
+  padding: var(--space-3) var(--space-4);
 }
 
 .actor-identity {
-  display: grid;
-  gap: 3px;
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
 .actor-search-wrap {

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -342,7 +342,7 @@ textarea {
 }
 
 .actor-search-wrap {
-  padding: 0 var(--space-3) 10px;
+  padding: 10px var(--space-3);
 }
 
 .actor-search {

--- a/docs/how-to/server.md
+++ b/docs/how-to/server.md
@@ -12,7 +12,7 @@ Bun 1.4 or later. `GET /healthz` answers once it is up.
 
 ## Endpoints
 
-Base path `/v1`. One actor is served today, named `agent`.
+Base path `/v1`. The built-in actor is named `default`.
 
 | | |
 | --- | --- |
@@ -25,11 +25,11 @@ Base path `/v1`. One actor is served today, named `agent`.
 | `GET /healthz` `GET /openapi.json` `GET /docs` | Unversioned |
 
 ```bash
-curl -X POST localhost:4242/v1/actors/agent/threads/inv-81/events \
+curl -X POST localhost:4242/v1/actors/default/threads/inv-81/events \
   -d '{"id":"m1","type":"MessageReceived","text":"audit the deploy"}'
 # {"actor":"agent","thread":"inv-81"}
 
-curl localhost:4242/v1/actors/agent/threads/inv-81/turns
+curl localhost:4242/v1/actors/default/threads/inv-81/turns
 # [{"turn":"m1","status":"completed","output":"…","epoch":0}]
 ```
 

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -65,12 +65,12 @@ describe("the address a call goes to", () => {
   test("sends every request through the stated fetch", async () => {
     await makeClient({ baseUrl: "http://localhost:4111", fetch: stub }).list()
     expect(calls).toHaveLength(1)
-    expect(lastUrl().pathname).toBe("/v1/actors/agent/threads")
+    expect(lastUrl().pathname).toBe("/v1/actors/default/threads")
   })
 
   test("a thread id is encoded into the path", async () => {
     await makeClient({ baseUrl: "http://localhost:4111" , fetch: stub }).events("ag/one two")
-    expect(lastUrl().pathname).toBe("/v1/actors/agent/threads/ag%2Fone%20two/events")
+    expect(lastUrl().pathname).toBe("/v1/actors/default/threads/ag%2Fone%20two/events")
   })
 
   test("a stated option is a query param and an absent one is absent", async () => {
@@ -83,7 +83,7 @@ describe("the address a call goes to", () => {
 
   test("a base with a trailing slash does not double it", async () => {
     await makeClient({ baseUrl: "http://127.0.0.1:4111/" , fetch: stub }).list()
-    expect(calls[0]!.url).toBe("http://127.0.0.1:4111/v1/actors/agent/threads")
+    expect(calls[0]!.url).toBe("http://127.0.0.1:4111/v1/actors/default/threads")
   })
 })
 
@@ -165,7 +165,7 @@ describe("a declared projection", () => {
   test("serves at the name it was declared under, and carries its own query", async () => {
     const client = makeClient({ baseUrl: "http://localhost:4111", fetch: stub, projections })
     await client.projection("root", "turns", { at: 3 })
-    expect(lastUrl().pathname).toBe("/v1/actors/agent/threads/root/turns")
+    expect(lastUrl().pathname).toBe("/v1/actors/default/threads/root/turns")
     expect(lastUrl().searchParams.get("at")).toBe("3")
   })
 
@@ -202,7 +202,7 @@ describe("resuming a turn", () => {
     let read = false
     return () => {
       if (read) {
-        return new Response(JSON.stringify({ actor: "agent", thread: "root" }), {
+        return new Response(JSON.stringify({ actor: "default", thread: "root" }), {
           status: 202,
           headers: { "content-type": "application/json" }
         })
@@ -236,14 +236,14 @@ describe("resuming a turn", () => {
   test("a failed turn appends the TurnResumed its reactors interpret", async () => {
     answer = accepting({ turn: "m1", status: "failed", epoch: 0, error: "boom" })
     const accepted = await client().resume("root", "m1")
-    expect(accepted).toEqual({ actor: "agent", thread: "root" })
+    expect(accepted).toEqual({ actor: "default", thread: "root" })
     // Two calls: the projection it read, then the append it made.
     expect(calls).toHaveLength(2)
     const read = new URL(calls[0]!.url)
-    expect(read.pathname).toBe("/v1/actors/agent/threads/root/turns")
+    expect(read.pathname).toBe("/v1/actors/default/threads/root/turns")
     expect(read.searchParams.get("turn")).toBe("m1")
     const appended = new URL(calls[1]!.url)
-    expect(appended.pathname).toBe("/v1/actors/agent/threads/root/events")
+    expect(appended.pathname).toBe("/v1/actors/default/threads/root/events")
     expect(JSON.parse(calls[1]!.body ?? "")).toEqual({
       type: "TurnResumed",
       turn: "m1",

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -29,7 +29,7 @@ export const V1_PREFIX = "/v1"
 // level is declared as a path parameter and answered for exactly this name: the shape is honest
 // about what a deploy will vary, and no URL has to be taught twice when it does
 // (apps/server/src/api.ts, actorOf).
-export const RESERVED_ACTOR = "agent"
+export const RESERVED_ACTOR = "default"
 
 // Where the derived OpenAPI document is served, and where the reference page renders it. Both are
 // open even when a token is set (apps/server/src/http.ts, UNAUTHENTICATED_PATHS), because a

--- a/packages/client/src/stream.test.ts
+++ b/packages/client/src/stream.test.ts
@@ -55,11 +55,11 @@ const following = (options: { readonly after?: number } = {}) => {
 describe("streamUrl", () => {
   test("the first connection carries after, and a thread id is encoded", () => {
     expect(streamUrl("http://localhost:4111/", "ag/one", 40))
-      .toBe("http://localhost:4111/v1/actors/agent/threads/ag%2Fone/events/stream?after=40")
+      .toBe("http://localhost:4111/v1/actors/default/threads/ag%2Fone/events/stream?after=40")
   })
 
   test("no after means the whole log", () => {
-    expect(streamUrl("http://localhost:4111", "root")).toBe("http://localhost:4111/v1/actors/agent/threads/root/events/stream")
+    expect(streamUrl("http://localhost:4111", "root")).toBe("http://localhost:4111/v1/actors/default/threads/root/events/stream")
   })
 })
 


### PR DESCRIPTION
Aligns only the identity row across the actor, run, and trace panes so the trace window stays in its natural content flow.

Moves the persistent expand and collapse control from Runs to Actors and uses directional arrows for the action. The run pane now stays open at a narrower 280px default. Both widths remain exported and overridable.

Renames the built-in actor from `agent` to `default` across the server contract, client defaults, CLI, quickstart, Voyager fixture, and server documentation. Requests to the built-in actor now use `/v1/actors/default`.

## Verification

- `bun run gate`
- Voyager typecheck and 81 tests