### PR TITLE
feat(voyager): render native API

### DIFF
--- a/apps/voyager/src/ActorRail.tsx
+++ b/apps/voyager/src/ActorRail.tsx
@@ -15,14 +15,12 @@ const storedCollapsed = (): boolean => {
 
 export const ActorRail = ({
   actors,
-  apiSelected,
   collapsedWidth = COLLAPSED_ACTOR_RAIL_WIDTH,
   headerHeight = PANE_HEADER_HEIGHT,
   problem,
   selected
 }: {
   readonly actors: ReadonlyArray<ActorSummary>
-  readonly apiSelected: boolean
   readonly collapsedWidth?: number | undefined
   readonly headerHeight?: number | undefined
   readonly problem: ProblemError | undefined
@@ -78,7 +76,7 @@ export const ActorRail = ({
       )}
       <div className="actor-only actor-list">
         {shown.map((actor) => {
-          const chosen = !apiSelected && actor.name === selected
+          const chosen = actor.name === selected
           return (
             <button
               type="button"
@@ -96,8 +94,7 @@ export const ActorRail = ({
       <div className="actor-footer">
         <button
           type="button"
-          className={`actor-api${apiSelected ? " actor-api-selected" : ""}`}
-          aria-current={apiSelected ? "page" : undefined}
+          className="actor-api"
           onClick={() => navigate({ thread: undefined, view: "api", from: undefined, to: undefined })}
         >
           <BracketsCurly size={ICON_SIZE} weight="light" aria-hidden="true" />

--- a/apps/voyager/src/ActorRail.tsx
+++ b/apps/voyager/src/ActorRail.tsx
@@ -95,7 +95,7 @@ export const ActorRail = ({
         <button
           type="button"
           className="actor-api"
-          onClick={() => navigate({ thread: undefined, view: "api", from: undefined, to: undefined })}
+          onClick={() => navigate({ thread: undefined, view: "api", operation: undefined, from: undefined, to: undefined })}
         >
           <BracketsCurly size={ICON_SIZE} weight="light" aria-hidden="true" />
           <span className="actor-only">API</span>

--- a/apps/voyager/src/ActorRail.tsx
+++ b/apps/voyager/src/ActorRail.tsx
@@ -1,5 +1,5 @@
 import type { ActorSummary, ProblemError } from "@clavia/tardigrade-client"
-import { ArrowLeft, ArrowRight } from "@phosphor-icons/react"
+import { ArrowLeft, ArrowRight, BracketsCurly } from "@phosphor-icons/react"
 import { useState, type ReactElement } from "react"
 
 import { navigate } from "./nav"
@@ -15,12 +15,14 @@ const storedCollapsed = (): boolean => {
 
 export const ActorRail = ({
   actors,
+  apiSelected,
   collapsedWidth = COLLAPSED_ACTOR_RAIL_WIDTH,
   headerHeight = PANE_HEADER_HEIGHT,
   problem,
   selected
 }: {
   readonly actors: ReadonlyArray<ActorSummary>
+  readonly apiSelected: boolean
   readonly collapsedWidth?: number | undefined
   readonly headerHeight?: number | undefined
   readonly problem: ProblemError | undefined
@@ -76,20 +78,31 @@ export const ActorRail = ({
       )}
       <div className="actor-only actor-list">
         {shown.map((actor) => {
-          const chosen = actor.name === selected
+          const chosen = !apiSelected && actor.name === selected
           return (
             <button
               type="button"
               key={actor.name}
               className={`actor-row${chosen ? " actor-row-selected" : ""}`}
               aria-current={chosen ? "true" : undefined}
-              onClick={() => navigate({ actor: actor.name, thread: undefined, from: undefined, to: undefined })}
+              onClick={() => navigate({ actor: actor.name, thread: undefined, view: undefined, from: undefined, to: undefined })}
             >
               <span className="mono actor-name">{actor.name}</span>
               {actor.builtIn ? <span className="mono actor-kind">built-in</span> : null}
             </button>
           )
         })}
+      </div>
+      <div className="actor-footer">
+        <button
+          type="button"
+          className={`actor-api${apiSelected ? " actor-api-selected" : ""}`}
+          aria-current={apiSelected ? "page" : undefined}
+          onClick={() => navigate({ thread: undefined, view: "api", from: undefined, to: undefined })}
+        >
+          <BracketsCurly size={ICON_SIZE} weight="light" aria-hidden="true" />
+          <span className="actor-only">API</span>
+        </button>
       </div>
     </aside>
   )

--- a/apps/voyager/src/ApiSurface.tsx
+++ b/apps/voyager/src/ApiSurface.tsx
@@ -1,21 +1,262 @@
-import { DOCS_PATH } from "@clavia/tardigrade-client/contract"
-import { ArrowLeft } from "@phosphor-icons/react"
-import type { ReactElement } from "react"
+import { DOCS_PATH, OPENAPI_PATH } from "@clavia/tardigrade-client/contract"
+import { ArrowLeft, ArrowSquareOut, MagnifyingGlass } from "@phosphor-icons/react"
+import { useEffect, useMemo, useState, type ReactElement } from "react"
 
+import {
+  apiDocumentOf,
+  apiGroupsOf,
+  matchesOperation,
+  resolvedSchema,
+  schemaTypeOf,
+  type ApiContent,
+  type ApiDocument,
+  type ApiOperation,
+  type ApiSchema
+} from "./api"
 import { client } from "./client"
-import { navigate } from "./nav"
-import { ICON_SIZE } from "./policy"
+import { navigate, useRoute } from "./nav"
+import { API_SCHEMA_DEPTH, ICON_SIZE } from "./policy"
+import { ThemeToggle } from "./ThemeToggle"
 
-export const ApiSurface = (): ReactElement => (
-  <main className="api-view">
-    <iframe className="api-surface" src={`${client.baseUrl}${DOCS_PATH}`} title="Tardigrade API reference" />
-    <button
-      type="button"
-      className="api-back"
-      onClick={() => navigate({ view: undefined }, { replace: true })}
-    >
-      <ArrowLeft size={ICON_SIZE} weight="light" aria-hidden="true" />
-      Voyager
-    </button>
-  </main>
+const useApiDocument = () => {
+  const [document, setDocument] = useState<ApiDocument | undefined>(undefined)
+  const [problem, setProblem] = useState<string | undefined>(undefined)
+  useEffect(() => {
+    const abort = new AbortController()
+    void fetch(`${client.baseUrl}${OPENAPI_PATH}`, { signal: abort.signal })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`API description returned ${response.status}`)
+        return response.json()
+      })
+      .then((value: unknown) => {
+        setDocument(apiDocumentOf(value))
+        setProblem(undefined)
+      })
+      .catch((error: unknown) => {
+        if (abort.signal.aborted) return
+        setProblem(error instanceof Error ? error.message : String(error))
+      })
+    return () => abort.abort()
+  }, [])
+  return { document, problem }
+}
+
+const SchemaView = ({
+  depth,
+  schema,
+  schemas
+}: {
+  readonly depth: number
+  readonly schema: ApiSchema
+  readonly schemas: Readonly<Record<string, ApiSchema>>
+}): ReactElement => {
+  const resolved = resolvedSchema(schema, schemas)
+  const shaped = resolved.type === "array" && resolved.items !== undefined
+    ? resolvedSchema(resolved.items, schemas)
+    : resolved
+  const properties = Object.entries(shaped.properties ?? {})
+  const required = new Set(shaped.required ?? [])
+  return (
+    <div className="api-schema">
+      <span className="mono api-type">{schemaTypeOf(schema)}</span>
+      {properties.length === 0 ? null : depth <= 0 ? (
+        <div className="mono api-schema-cut">nested fields hidden at depth 0</div>
+      ) : (
+        <div className="api-properties">
+          {properties.map(([name, property]) => {
+            const nested = resolvedSchema(property, schemas)
+            const hasNested = nested.properties !== undefined || nested.items !== undefined
+            return (
+              <div className="api-property" key={name}>
+                <div className="api-property-line">
+                  <span className="mono api-property-name">{name}</span>
+                  <span className="mono api-property-type">{schemaTypeOf(property)}</span>
+                  {required.has(name) ? <span className="api-required">required</span> : <span className="api-optional">optional</span>}
+                </div>
+                {property.description === undefined ? null : <p>{property.description}</p>}
+                {!hasNested ? null : <SchemaView schema={property} schemas={schemas} depth={depth - 1} />}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const Content = ({
+  content,
+  depth,
+  schemas
+}: {
+  readonly content: ReadonlyArray<ApiContent>
+  readonly depth: number
+  readonly schemas: Readonly<Record<string, ApiSchema>>
+}): ReactElement => (
+  <div className="api-content-list">
+    {content.map((entry) => (
+      <div className="api-content" key={entry.mediaType}>
+        <div className="mono api-media-type">{entry.mediaType}</div>
+        {entry.schema === undefined ? null : <SchemaView schema={entry.schema} schemas={schemas} depth={depth} />}
+      </div>
+    ))}
+  </div>
 )
+
+const OperationDetail = ({
+  depth,
+  document,
+  operation
+}: {
+  readonly depth: number
+  readonly document: ApiDocument
+  readonly operation: ApiOperation
+}): ReactElement => (
+  <article className="api-detail">
+    <header className="api-detail-head">
+      <div className="api-operation-title">
+        <span className={`mono api-method api-method-${operation.method}`}>{operation.method.toUpperCase()}</span>
+        <h1 className="mono">{operation.path}</h1>
+      </div>
+      {operation.operationId === undefined ? null : <div className="mono api-operation-id">{operation.operationId}</div>}
+      {operation.summary === undefined ? null : <p>{operation.summary}</p>}
+      {operation.description === undefined ? null : <p>{operation.description}</p>}
+    </header>
+    {operation.parameters.length === 0 ? null : (
+      <section className="api-section">
+        <h2>Parameters</h2>
+        <div className="api-parameters">
+          {operation.parameters.map((parameter) => (
+            <div className="api-parameter" key={`${parameter.in}:${parameter.name}`}>
+              <div>
+                <span className="mono api-property-name">{parameter.name}</span>
+                <span className="mono api-parameter-in">{parameter.in}</span>
+              </div>
+              <div className="mono api-property-type">
+                {parameter.schema === undefined ? "unknown" : schemaTypeOf(parameter.schema)}
+              </div>
+              <span className={parameter.required ? "api-required" : "api-optional"}>{parameter.required ? "required" : "optional"}</span>
+              {parameter.description === undefined ? null : <p>{parameter.description}</p>}
+            </div>
+          ))}
+        </div>
+      </section>
+    )}
+    {operation.request.length === 0 ? null : (
+      <section className="api-section">
+        <h2>Request body</h2>
+        <Content content={operation.request} schemas={document.schemas} depth={depth} />
+      </section>
+    )}
+    <section className="api-section">
+      <h2>Responses</h2>
+      <div className="api-responses">
+        {operation.responses.map((response) => (
+          <div className="api-response" key={response.status}>
+            <div className="api-response-head">
+              <span className={`mono api-status${response.status.startsWith("2") ? " api-status-ok" : ""}`}>{response.status}</span>
+              <span>{response.description}</span>
+            </div>
+            {response.content.length === 0 ? null : <Content content={response.content} schemas={document.schemas} depth={depth} />}
+          </div>
+        ))}
+      </div>
+    </section>
+  </article>
+)
+
+const Overview = ({ document }: { readonly document: ApiDocument }): ReactElement => (
+  <article className="api-detail api-overview">
+    <div className="mono api-eyebrow">API reference</div>
+    <h1>{document.title}</h1>
+    {document.version === undefined ? null : <span className="mono api-version">v{document.version}</span>}
+    {document.description === undefined ? null : <p>{document.description}</p>}
+    <dl className="api-facts">
+      <div><dt>Base URL</dt><dd className="mono">{client.baseUrl}</dd></div>
+      <div><dt>Operations</dt><dd className="mono">{document.operations.length}</dd></div>
+      <div><dt>Specification</dt><dd className="mono">OpenAPI 3.1</dd></div>
+    </dl>
+  </article>
+)
+
+export const ApiSurface = ({ schemaDepth = API_SCHEMA_DEPTH }: { readonly schemaDepth?: number | undefined }): ReactElement => {
+  const route = useRoute()
+  const { document, problem } = useApiDocument()
+  const [query, setQuery] = useState("")
+  const shown = useMemo(
+    () => document?.operations.filter((operation) => matchesOperation(operation, query)) ?? [],
+    [document, query]
+  )
+  const selected = document?.operations.find((operation) => operation.key === route.operation)
+  return (
+    <div className="api-view">
+      <aside className="api-nav">
+        <div className="api-nav-head">
+          <button
+            type="button"
+            className="icon-btn"
+            aria-label="Back to Voyager"
+            title="Back to Voyager"
+            onClick={() => navigate({ view: undefined, operation: undefined }, { replace: true })}
+          >
+            <ArrowLeft size={ICON_SIZE} weight="light" aria-hidden="true" />
+          </button>
+          <div>
+            <div className="rail-wordmark">voyager</div>
+            <div className="mono actor-label">api</div>
+          </div>
+        </div>
+        <label className="api-search-wrap">
+          <MagnifyingGlass size={ICON_SIZE} weight="light" aria-hidden="true" />
+          <input
+            value={query}
+            placeholder="search endpoints…"
+            aria-label="search API endpoints"
+            onChange={(changed) => setQuery(changed.target.value)}
+          />
+        </label>
+        <nav className="api-nav-list" aria-label="API endpoints">
+          <button
+            type="button"
+            className={`api-overview-link${route.operation === undefined ? " api-nav-selected" : ""}`}
+            onClick={() => navigate({ operation: undefined })}
+          >
+            Overview
+          </button>
+          {apiGroupsOf(shown).map(([tag, operations]) => (
+            <section className="api-group" key={tag}>
+              <h2 className="mono">{tag}</h2>
+              {operations.map((operation) => (
+                <button
+                  type="button"
+                  key={operation.key}
+                  className={`api-nav-row${selected?.key === operation.key ? " api-nav-selected" : ""}`}
+                  onClick={() => navigate({ operation: operation.key })}
+                >
+                  <span className={`mono api-method api-method-${operation.method}`}>{operation.method.toUpperCase()}</span>
+                  <span className="mono api-nav-path">{operation.path}</span>
+                </button>
+              ))}
+            </section>
+          ))}
+        </nav>
+        <a className="api-full-reference" href={`${client.baseUrl}${DOCS_PATH}`} target="_blank" rel="noreferrer">
+          Interactive reference
+          <ArrowSquareOut size={ICON_SIZE} weight="light" aria-hidden="true" />
+        </a>
+      </aside>
+      <main className="api-reading">
+        {problem !== undefined ? (
+          <div className="problem api-load-problem"><div className="problem-title">API description unavailable</div><div className="problem-detail">{problem}</div></div>
+        ) : document === undefined ? (
+          <div className="mono pane-empty">loading API description</div>
+        ) : selected === undefined ? (
+          <Overview document={document} />
+        ) : (
+          <OperationDetail operation={selected} document={document} depth={schemaDepth} />
+        )}
+      </main>
+      <ThemeToggle />
+    </div>
+  )
+}

--- a/apps/voyager/src/ApiSurface.tsx
+++ b/apps/voyager/src/ApiSurface.tsx
@@ -1,8 +1,21 @@
 import { DOCS_PATH } from "@clavia/tardigrade-client/contract"
+import { ArrowLeft } from "@phosphor-icons/react"
 import type { ReactElement } from "react"
 
 import { client } from "./client"
+import { navigate } from "./nav"
+import { ICON_SIZE } from "./policy"
 
 export const ApiSurface = (): ReactElement => (
-  <iframe className="api-surface" src={`${client.baseUrl}${DOCS_PATH}`} title="Tardigrade API reference" />
+  <main className="api-view">
+    <iframe className="api-surface" src={`${client.baseUrl}${DOCS_PATH}`} title="Tardigrade API reference" />
+    <button
+      type="button"
+      className="api-back"
+      onClick={() => navigate({ view: undefined }, { replace: true })}
+    >
+      <ArrowLeft size={ICON_SIZE} weight="light" aria-hidden="true" />
+      Voyager
+    </button>
+  </main>
 )

--- a/apps/voyager/src/ApiSurface.tsx
+++ b/apps/voyager/src/ApiSurface.tsx
@@ -19,6 +19,13 @@ import { navigate, useRoute } from "./nav"
 import { API_SCHEMA_DEPTH, ICON_SIZE } from "./policy"
 import { ThemeToggle } from "./ThemeToggle"
 
+const apiTarget = (operation: string | undefined): string => operation === undefined ? "api-overview" : `api-${operation}`
+
+const jumpTo = (operation: string | undefined): void => {
+  navigate({ operation })
+  globalThis.document.getElementById(apiTarget(operation))?.scrollIntoView({ block: "start" })
+}
+
 const useApiDocument = () => {
   const [document, setDocument] = useState<ApiDocument | undefined>(undefined)
   const [problem, setProblem] = useState<string | undefined>(undefined)
@@ -107,13 +114,11 @@ const Content = ({
 const OperationDetail = ({
   depth,
   document,
-  operation,
-  operations
+  operation
 }: {
   readonly depth: number
   readonly document: ApiDocument
   readonly operation: ApiOperation
-  readonly operations: ReadonlyArray<ApiOperation>
 }): ReactElement => {
   const requestContent = operation.request[0]
   const success = operation.responses.find((response) => response.status.startsWith("2")) ?? operation.responses[0]
@@ -130,24 +135,7 @@ const OperationDetail = ({
     ])
   ].join(" \\\n")
   return (
-    <article className="api-detail api-operation-detail">
-      <section className="api-tag-overview">
-        <div>
-          <div className="mono api-eyebrow">Resource</div>
-          <h1>{operation.tag}</h1>
-        </div>
-        <div className="api-operations-card">
-          <div className="api-card-title">Operations</div>
-          <div className="api-operations-list">
-            {operations.map((candidate) => (
-              <button type="button" key={candidate.key} onClick={() => navigate({ operation: candidate.key })}>
-                <span className={`mono api-method api-method-${candidate.method}`}>{candidate.method.toUpperCase()}</span>
-                <span className="mono">{candidate.path}</span>
-              </button>
-            ))}
-          </div>
-        </div>
-      </section>
+    <section className="api-endpoint" id={`api-${operation.key}`}>
       <header className="api-detail-head">
         <h2 className="mono">{operation.path}</h2>
         {operation.operationId === undefined ? null : <div className="mono api-operation-id">{operation.operationId}</div>}
@@ -216,12 +204,12 @@ const OperationDetail = ({
           )}
         </aside>
       </div>
-    </article>
+    </section>
   )
 }
 
 const Overview = ({ document }: { readonly document: ApiDocument }): ReactElement => (
-  <article className="api-detail api-overview">
+  <section className="api-overview" id="api-overview">
     <div className="mono api-eyebrow">API reference</div>
     <h1>{document.title}</h1>
     {document.version === undefined ? null : <span className="mono api-version">v{document.version}</span>}
@@ -231,6 +219,42 @@ const Overview = ({ document }: { readonly document: ApiDocument }): ReactElemen
       <div><dt>Operations</dt><dd className="mono">{document.operations.length}</dd></div>
       <div><dt>Specification</dt><dd className="mono">OpenAPI 3.1</dd></div>
     </dl>
+  </section>
+)
+
+const ApiReference = ({
+  depth,
+  document
+}: {
+  readonly depth: number
+  readonly document: ApiDocument
+}): ReactElement => (
+  <article className="api-detail api-operation-detail">
+    <Overview document={document} />
+    {apiGroupsOf(document.operations).map(([tag, operations]) => (
+      <section className="api-resource" key={tag}>
+        <div className="api-tag-overview">
+          <div>
+            <div className="mono api-eyebrow">Resource</div>
+            <h1>{tag}</h1>
+          </div>
+          <div className="api-operations-card">
+            <div className="api-card-title">Operations</div>
+            <div className="api-operations-list">
+              {operations.map((operation) => (
+                <button type="button" key={operation.key} onClick={() => jumpTo(operation.key)}>
+                  <span className={`mono api-method api-method-${operation.method}`}>{operation.method.toUpperCase()}</span>
+                  <span className="mono">{operation.path}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+        {operations.map((operation) => (
+          <OperationDetail key={operation.key} operation={operation} document={document} depth={depth} />
+        ))}
+      </section>
+    ))}
   </article>
 )
 
@@ -243,6 +267,11 @@ export const ApiSurface = ({ schemaDepth = API_SCHEMA_DEPTH }: { readonly schema
     [document, query]
   )
   const selected = document?.operations.find((operation) => operation.key === route.operation)
+  useEffect(() => {
+    if (document === undefined) return
+    const target = globalThis.document.getElementById(apiTarget(route.operation))
+    target?.scrollIntoView({ block: "start" })
+  }, [document, route.operation])
   return (
     <div className="api-view">
       <aside className="api-nav">
@@ -274,7 +303,7 @@ export const ApiSurface = ({ schemaDepth = API_SCHEMA_DEPTH }: { readonly schema
           <button
             type="button"
             className={`api-overview-link${route.operation === undefined ? " api-nav-selected" : ""}`}
-            onClick={() => navigate({ operation: undefined })}
+            onClick={() => jumpTo(undefined)}
           >
             Overview
           </button>
@@ -286,7 +315,7 @@ export const ApiSurface = ({ schemaDepth = API_SCHEMA_DEPTH }: { readonly schema
                   type="button"
                   key={operation.key}
                   className={`api-nav-row${selected?.key === operation.key ? " api-nav-selected" : ""}`}
-                  onClick={() => navigate({ operation: operation.key })}
+                  onClick={() => jumpTo(operation.key)}
                 >
                   <span className={`mono api-method api-method-${operation.method}`}>{operation.method.toUpperCase()}</span>
                   <span className="mono api-nav-path">{operation.path}</span>
@@ -305,15 +334,8 @@ export const ApiSurface = ({ schemaDepth = API_SCHEMA_DEPTH }: { readonly schema
           <div className="problem api-load-problem"><div className="problem-title">API description unavailable</div><div className="problem-detail">{problem}</div></div>
         ) : document === undefined ? (
           <div className="mono pane-empty">loading API description</div>
-        ) : selected === undefined ? (
-          <Overview document={document} />
         ) : (
-          <OperationDetail
-            operation={selected}
-            operations={document.operations.filter((operation) => operation.tag === selected.tag)}
-            document={document}
-            depth={schemaDepth}
-          />
+          <ApiReference document={document} depth={schemaDepth} />
         )}
       </main>
       <ThemeToggle />

--- a/apps/voyager/src/ApiSurface.tsx
+++ b/apps/voyager/src/ApiSurface.tsx
@@ -1,0 +1,8 @@
+import { DOCS_PATH } from "@clavia/tardigrade-client/contract"
+import type { ReactElement } from "react"
+
+import { client } from "./client"
+
+export const ApiSurface = (): ReactElement => (
+  <iframe className="api-surface" src={`${client.baseUrl}${DOCS_PATH}`} title="Tardigrade API reference" />
+)

--- a/apps/voyager/src/ApiSurface.tsx
+++ b/apps/voyager/src/ApiSurface.tsx
@@ -1,6 +1,6 @@
-import { DOCS_PATH, OPENAPI_PATH } from "@clavia/tardigrade-client/contract"
-import { ArrowLeft, ArrowSquareOut, MagnifyingGlass } from "@phosphor-icons/react"
-import { useEffect, useMemo, useState, type ReactElement } from "react"
+import { OPENAPI_PATH } from "@clavia/tardigrade-client/contract"
+import { ArrowLeft, MagnifyingGlass } from "@phosphor-icons/react"
+import { useEffect, useMemo, useRef, useState, type ReactElement } from "react"
 
 import {
   apiDocumentOf,
@@ -123,6 +123,8 @@ const OperationDetail = ({
   const requestContent = operation.request[0]
   const success = operation.responses.find((response) => response.status.startsWith("2")) ?? operation.responses[0]
   const responseContent = success?.content[0]
+  const headerParameters = operation.parameters.filter((parameter) => parameter.in === "header")
+  const otherParameters = operation.parameters.filter((parameter) => parameter.in !== "header")
   const requestExample = requestContent?.schema === undefined ? undefined : schemaExampleOf(requestContent.schema, document.schemas, depth)
   const responseExample = responseContent?.schema === undefined ? undefined : schemaExampleOf(responseContent.schema, document.schemas, depth)
   const curl = [
@@ -144,11 +146,24 @@ const OperationDetail = ({
       </header>
       <div className="api-operation-grid">
         <div className="api-operation-docs">
-          {operation.parameters.length === 0 ? null : (
+          <section className="api-section api-headers-section">
+            <h3>Headers</h3>
+            <div className="api-header-line">
+              <span className="mono api-property-name">Accept</span>
+              <span className="mono api-header-example">{responseContent?.mediaType ?? "*/*"}</span>
+            </div>
+            {headerParameters.map((parameter) => (
+              <div className="api-header-line" key={parameter.name}>
+                <span className="mono api-property-name">{parameter.name}</span>
+                <span className="mono api-header-example">{parameter.schema === undefined ? "unknown" : schemaTypeOf(parameter.schema)}</span>
+              </div>
+            ))}
+          </section>
+          {otherParameters.length === 0 ? null : (
             <section className="api-section">
               <h3>Parameters</h3>
               <div className="api-parameters">
-                {operation.parameters.map((parameter) => (
+                {otherParameters.map((parameter) => (
                   <div className="api-parameter" key={`${parameter.in}:${parameter.name}`}>
                     <div>
                       <span className="mono api-property-name">{parameter.name}</span>
@@ -174,13 +189,13 @@ const OperationDetail = ({
             <h3>Responses</h3>
             <div className="api-responses">
               {operation.responses.map((response) => (
-                <div className="api-response" key={response.status}>
-                  <div className="api-response-head">
+                <details className="api-response" key={response.status}>
+                  <summary className="api-response-head">
                     <span className={`mono api-status${response.status.startsWith("2") ? " api-status-ok" : ""}`}>{response.status}</span>
                     <span>{response.description}</span>
-                  </div>
+                  </summary>
                   {response.content.length === 0 ? null : <Content content={response.content} schemas={document.schemas} depth={depth} />}
-                </div>
+                </details>
               ))}
             </div>
           </section>
@@ -262,6 +277,9 @@ export const ApiSurface = ({ schemaDepth = API_SCHEMA_DEPTH }: { readonly schema
   const route = useRoute()
   const { document, problem } = useApiDocument()
   const [query, setQuery] = useState("")
+  const followingScroll = useRef(false)
+  const activeOperation = useRef(route.operation)
+  activeOperation.current = route.operation
   const shown = useMemo(
     () => document?.operations.filter((operation) => matchesOperation(operation, query)) ?? [],
     [document, query]
@@ -269,9 +287,48 @@ export const ApiSurface = ({ schemaDepth = API_SCHEMA_DEPTH }: { readonly schema
   const selected = document?.operations.find((operation) => operation.key === route.operation)
   useEffect(() => {
     if (document === undefined) return
+    if (followingScroll.current) {
+      followingScroll.current = false
+      return
+    }
     const target = globalThis.document.getElementById(apiTarget(route.operation))
     target?.scrollIntoView({ block: "start" })
   }, [document, route.operation])
+  useEffect(() => {
+    if (document === undefined) return
+    const reading = globalThis.document.querySelector<HTMLElement>(".api-reading")
+    if (reading === null) return
+    let frame: number | undefined
+    const sections: Array<readonly [string | undefined, HTMLElement]> = []
+    const overview = globalThis.document.getElementById(apiTarget(undefined))
+    if (overview !== null) sections.push([undefined, overview])
+    for (const operation of document.operations) {
+      const section = globalThis.document.getElementById(apiTarget(operation.key))
+      if (section !== null) sections.push([operation.key, section])
+    }
+    const track = () => {
+      if (frame !== undefined) cancelAnimationFrame(frame)
+      frame = requestAnimationFrame(() => {
+        const readingTop = reading.getBoundingClientRect().top
+        let next: string | undefined
+        for (const [key, section] of sections) {
+          const scrollMargin = Number.parseFloat(getComputedStyle(section).scrollMarginTop) || 0
+          if (section.getBoundingClientRect().top > readingTop + scrollMargin) break
+          next = key
+        }
+        if (next === activeOperation.current) return
+        activeOperation.current = next
+        followingScroll.current = true
+        navigate({ operation: next }, { replace: true })
+      })
+    }
+    reading.addEventListener("scroll", track, { passive: true })
+    track()
+    return () => {
+      reading.removeEventListener("scroll", track)
+      if (frame !== undefined) cancelAnimationFrame(frame)
+    }
+  }, [document])
   return (
     <div className="api-view">
       <aside className="api-nav">
@@ -324,10 +381,6 @@ export const ApiSurface = ({ schemaDepth = API_SCHEMA_DEPTH }: { readonly schema
             </section>
           ))}
         </nav>
-        <a className="api-full-reference" href={`${client.baseUrl}${DOCS_PATH}`} target="_blank" rel="noreferrer">
-          Interactive reference
-          <ArrowSquareOut size={ICON_SIZE} weight="light" aria-hidden="true" />
-        </a>
       </aside>
       <main className="api-reading">
         {problem !== undefined ? (

--- a/apps/voyager/src/ApiSurface.tsx
+++ b/apps/voyager/src/ApiSurface.tsx
@@ -7,6 +7,7 @@ import {
   apiGroupsOf,
   matchesOperation,
   resolvedSchema,
+  schemaExampleOf,
   schemaTypeOf,
   type ApiContent,
   type ApiDocument,
@@ -106,64 +107,118 @@ const Content = ({
 const OperationDetail = ({
   depth,
   document,
-  operation
+  operation,
+  operations
 }: {
   readonly depth: number
   readonly document: ApiDocument
   readonly operation: ApiOperation
-}): ReactElement => (
-  <article className="api-detail">
-    <header className="api-detail-head">
-      <div className="api-operation-title">
-        <span className={`mono api-method api-method-${operation.method}`}>{operation.method.toUpperCase()}</span>
-        <h1 className="mono">{operation.path}</h1>
-      </div>
-      {operation.operationId === undefined ? null : <div className="mono api-operation-id">{operation.operationId}</div>}
-      {operation.summary === undefined ? null : <p>{operation.summary}</p>}
-      {operation.description === undefined ? null : <p>{operation.description}</p>}
-    </header>
-    {operation.parameters.length === 0 ? null : (
-      <section className="api-section">
-        <h2>Parameters</h2>
-        <div className="api-parameters">
-          {operation.parameters.map((parameter) => (
-            <div className="api-parameter" key={`${parameter.in}:${parameter.name}`}>
-              <div>
-                <span className="mono api-property-name">{parameter.name}</span>
-                <span className="mono api-parameter-in">{parameter.in}</span>
-              </div>
-              <div className="mono api-property-type">
-                {parameter.schema === undefined ? "unknown" : schemaTypeOf(parameter.schema)}
-              </div>
-              <span className={parameter.required ? "api-required" : "api-optional"}>{parameter.required ? "required" : "optional"}</span>
-              {parameter.description === undefined ? null : <p>{parameter.description}</p>}
-            </div>
-          ))}
+  readonly operations: ReadonlyArray<ApiOperation>
+}): ReactElement => {
+  const requestContent = operation.request[0]
+  const success = operation.responses.find((response) => response.status.startsWith("2")) ?? operation.responses[0]
+  const responseContent = success?.content[0]
+  const requestExample = requestContent?.schema === undefined ? undefined : schemaExampleOf(requestContent.schema, document.schemas, depth)
+  const responseExample = responseContent?.schema === undefined ? undefined : schemaExampleOf(responseContent.schema, document.schemas, depth)
+  const curl = [
+    `curl ${client.baseUrl}${operation.path}`,
+    ...(operation.method === "get" ? [] : [`  --request ${operation.method.toUpperCase()}`]),
+    "  --header 'Accept: application/json'",
+    ...(requestExample === undefined ? [] : [
+      `  --header 'Content-Type: ${requestContent?.mediaType ?? "application/json"}'`,
+      `  --data '${JSON.stringify(requestExample, null, 2)}'`
+    ])
+  ].join(" \\\n")
+  return (
+    <article className="api-detail api-operation-detail">
+      <section className="api-tag-overview">
+        <div>
+          <div className="mono api-eyebrow">Resource</div>
+          <h1>{operation.tag}</h1>
+        </div>
+        <div className="api-operations-card">
+          <div className="api-card-title">Operations</div>
+          <div className="api-operations-list">
+            {operations.map((candidate) => (
+              <button type="button" key={candidate.key} onClick={() => navigate({ operation: candidate.key })}>
+                <span className={`mono api-method api-method-${candidate.method}`}>{candidate.method.toUpperCase()}</span>
+                <span className="mono">{candidate.path}</span>
+              </button>
+            ))}
+          </div>
         </div>
       </section>
-    )}
-    {operation.request.length === 0 ? null : (
-      <section className="api-section">
-        <h2>Request body</h2>
-        <Content content={operation.request} schemas={document.schemas} depth={depth} />
-      </section>
-    )}
-    <section className="api-section">
-      <h2>Responses</h2>
-      <div className="api-responses">
-        {operation.responses.map((response) => (
-          <div className="api-response" key={response.status}>
-            <div className="api-response-head">
-              <span className={`mono api-status${response.status.startsWith("2") ? " api-status-ok" : ""}`}>{response.status}</span>
-              <span>{response.description}</span>
+      <header className="api-detail-head">
+        <h2 className="mono">{operation.path}</h2>
+        {operation.operationId === undefined ? null : <div className="mono api-operation-id">{operation.operationId}</div>}
+        {operation.summary === undefined ? null : <p>{operation.summary}</p>}
+        {operation.description === undefined ? null : <p>{operation.description}</p>}
+      </header>
+      <div className="api-operation-grid">
+        <div className="api-operation-docs">
+          {operation.parameters.length === 0 ? null : (
+            <section className="api-section">
+              <h3>Parameters</h3>
+              <div className="api-parameters">
+                {operation.parameters.map((parameter) => (
+                  <div className="api-parameter" key={`${parameter.in}:${parameter.name}`}>
+                    <div>
+                      <span className="mono api-property-name">{parameter.name}</span>
+                      <span className="mono api-parameter-in">{parameter.in}</span>
+                    </div>
+                    <div className="mono api-property-type">
+                      {parameter.schema === undefined ? "unknown" : schemaTypeOf(parameter.schema)}
+                    </div>
+                    <span className={parameter.required ? "api-required" : "api-optional"}>{parameter.required ? "required" : "optional"}</span>
+                    {parameter.description === undefined ? null : <p>{parameter.description}</p>}
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+          {operation.request.length === 0 ? null : (
+            <section className="api-section">
+              <h3>Request body</h3>
+              <Content content={operation.request} schemas={document.schemas} depth={depth} />
+            </section>
+          )}
+          <section className="api-section">
+            <h3>Responses</h3>
+            <div className="api-responses">
+              {operation.responses.map((response) => (
+                <div className="api-response" key={response.status}>
+                  <div className="api-response-head">
+                    <span className={`mono api-status${response.status.startsWith("2") ? " api-status-ok" : ""}`}>{response.status}</span>
+                    <span>{response.description}</span>
+                  </div>
+                  {response.content.length === 0 ? null : <Content content={response.content} schemas={document.schemas} depth={depth} />}
+                </div>
+              ))}
             </div>
-            {response.content.length === 0 ? null : <Content content={response.content} schemas={document.schemas} depth={depth} />}
-          </div>
-        ))}
+          </section>
+        </div>
+        <aside className="api-operation-examples">
+          <section className="api-code-card">
+            <div className="api-code-head">
+              <div><span className={`mono api-method api-method-${operation.method}`}>{operation.method.toUpperCase()}</span><span className="mono">{operation.path}</span></div>
+              <span className="mono">Shell Curl</span>
+            </div>
+            <pre><code>{curl}</code></pre>
+          </section>
+          {responseExample === undefined ? null : (
+            <section className="api-code-card">
+              <div className="api-code-head">
+                <div><span className="mono api-status api-status-ok">{success?.status}</span><span>{success?.description}</span></div>
+                <span className="mono">{responseContent?.mediaType}</span>
+              </div>
+              <pre><code>{JSON.stringify(responseExample, null, 2)}</code></pre>
+            </section>
+          )}
+        </aside>
       </div>
-    </section>
-  </article>
-)
+    </article>
+  )
+}
 
 const Overview = ({ document }: { readonly document: ApiDocument }): ReactElement => (
   <article className="api-detail api-overview">
@@ -253,7 +308,12 @@ export const ApiSurface = ({ schemaDepth = API_SCHEMA_DEPTH }: { readonly schema
         ) : selected === undefined ? (
           <Overview document={document} />
         ) : (
-          <OperationDetail operation={selected} document={document} depth={schemaDepth} />
+          <OperationDetail
+            operation={selected}
+            operations={document.operations.filter((operation) => operation.tag === selected.tag)}
+            document={document}
+            depth={schemaDepth}
+          />
         )}
       </main>
       <ThemeToggle />

--- a/apps/voyager/src/App.tsx
+++ b/apps/voyager/src/App.tsx
@@ -104,14 +104,13 @@ export const App = (): ReactElement => {
     if (route.actor !== undefined || actor === undefined) return
     navigate({ actor }, { replace: true })
   }, [actor, route.actor])
+  if (route.view === "api") return <ApiSurface />
   return (
     <div style={{ height: "100%", display: "flex", overflow: "hidden", position: "relative" }}>
-      <ActorRail actors={discovered.actors} apiSelected={route.view === "api"} problem={discovered.problem} selected={actor} />
+      <ActorRail actors={discovered.actors} problem={discovered.problem} selected={actor} />
       <Rail roster={reading.roster} now={reading.at} problem={problem} selected={route.thread} />
       <main style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        {route.view === "api" ? (
-          <ApiSurface />
-        ) : actor !== undefined && route.thread === undefined && ready && summaries.length === 0 && problem === undefined ? (
+        {actor !== undefined && route.thread === undefined && ready && summaries.length === 0 && problem === undefined ? (
           <Quickstart actor={actor} />
         ) : route.thread === undefined ? (
           <div className="mono pane-empty">{discovered.ready ? "select a run" : "loading actors"}</div>

--- a/apps/voyager/src/App.tsx
+++ b/apps/voyager/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type ReactElement } from "react"
 
 import { Thread } from "./Thread"
+import { ApiSurface } from "./ApiSurface"
 import { NO_ANSWER, ProblemError, RESERVED_ACTOR, type ActorSummary, type ThreadSummary } from "@clavia/tardigrade-client"
 
 import { client, clientFor } from "./client"
@@ -105,10 +106,12 @@ export const App = (): ReactElement => {
   }, [actor, route.actor])
   return (
     <div style={{ height: "100%", display: "flex", overflow: "hidden", position: "relative" }}>
-      <ActorRail actors={discovered.actors} problem={discovered.problem} selected={actor} />
+      <ActorRail actors={discovered.actors} apiSelected={route.view === "api"} problem={discovered.problem} selected={actor} />
       <Rail roster={reading.roster} now={reading.at} problem={problem} selected={route.thread} />
       <main style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
-        {actor !== undefined && route.thread === undefined && ready && summaries.length === 0 && problem === undefined ? (
+        {route.view === "api" ? (
+          <ApiSurface />
+        ) : actor !== undefined && route.thread === undefined && ready && summaries.length === 0 && problem === undefined ? (
           <Quickstart actor={actor} />
         ) : route.thread === undefined ? (
           <div className="mono pane-empty">{discovered.ready ? "select a run" : "loading actors"}</div>

--- a/apps/voyager/src/App.tsx
+++ b/apps/voyager/src/App.tsx
@@ -9,7 +9,7 @@ import { navigate, useRoute } from "./nav"
 import { ROSTER_POLL_MS } from "./policy"
 import { Quickstart } from "./Quickstart"
 import { Rail } from "./Rail"
-import { EMPTY_ROSTER, rosterOf, type Roster } from "./roster"
+import { EMPTY_ROSTER, latestRootOf, rosterOf, type Roster } from "./roster"
 import { ThemeToggle } from "./ThemeToggle"
 import { ActorRail } from "./ActorRail"
 
@@ -104,6 +104,12 @@ export const App = (): ReactElement => {
     if (route.actor !== undefined || actor === undefined) return
     navigate({ actor }, { replace: true })
   }, [actor, route.actor])
+  useEffect(() => {
+    if (!ready || route.view !== undefined || route.thread !== undefined) return
+    const latest = latestRootOf(reading.roster)
+    if (latest === undefined) return
+    navigate({ thread: latest.id, from: undefined, to: undefined }, { replace: true })
+  }, [reading.roster, ready, route.thread, route.view])
   if (route.view === "api") return <ApiSurface />
   return (
     <div style={{ height: "100%", display: "flex", overflow: "hidden", position: "relative" }}>

--- a/apps/voyager/src/Rail.tsx
+++ b/apps/voyager/src/Rail.tsx
@@ -20,7 +20,7 @@ const Row = ({
 }): ReactElement => {
   // Choosing a run clears the window: the edges are fractions of the log a reader was looking at,
   // and they name nothing in the log they are moving to (src/nav.ts, Route).
-  const open = () => navigate({ thread: row.id, from: undefined, to: undefined })
+  const open = () => navigate({ thread: row.id, view: undefined, from: undefined, to: undefined })
   return (
     <div
       role="button"
@@ -87,7 +87,7 @@ export const Rail = ({
           {problem.detail === undefined ? null : <div className="problem-detail">{problem.detail}</div>}
         </div>
       )}
-      <div style={{ flex: 1, overflowY: "auto", minHeight: 0 }}>
+      <div className="run-list">
         {rows.map((row) => (
           <Row key={row.id} row={row} now={now} selected={row.id === selected} />
         ))}

--- a/apps/voyager/src/Thread.tsx
+++ b/apps/voyager/src/Thread.tsx
@@ -129,8 +129,19 @@ const FieldValue = ({ collapsedHeight, field }: { readonly collapsedHeight: numb
 // its values on the page's own ground on the right. There is no card, because the expansion is the
 // row saying more rather than a second surface (mock.html, .ev-detail). The keys and values are
 // src/narrative.ts's answer, so what a type shows is a tested fact rather than a render decision.
-const Detail = ({ collapsedHeight, moment }: { readonly collapsedHeight: number; readonly moment: Moment }): ReactElement => (
-  <div className="event-detail fade-in">
+const Detail = ({
+  collapsedHeight,
+  moment,
+  stampWidth
+}: {
+  readonly collapsedHeight: number
+  readonly moment: Moment
+  readonly stampWidth: number
+}): ReactElement => (
+  <div
+    className="event-detail fade-in"
+    style={{ marginLeft: `calc(${stampWidth}px + var(--space-2) + var(--space-3))` }}
+  >
     {fieldsOf(moment.event).map((field) => (
       <Fragment key={field.key}>
         <span className="mono event-key">{field.key}</span>
@@ -181,7 +192,7 @@ const Row = ({
           {moment.duration === undefined ? "" : ` · ${moment.duration}`}
         </span>
       </div>
-      {!open ? null : <Detail moment={moment} collapsedHeight={fieldCollapsedHeight} />}
+      {!open ? null : <Detail moment={moment} collapsedHeight={fieldCollapsedHeight} stampWidth={stampWidth} />}
     </div>
   )
 }

--- a/apps/voyager/src/api.test.ts
+++ b/apps/voyager/src/api.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 
-import { apiDocumentOf, apiGroupsOf, matchesOperation, resolvedSchema, schemaTypeOf } from "./api"
+import { apiDocumentOf, apiGroupsOf, matchesOperation, resolvedSchema, schemaExampleOf, schemaTypeOf } from "./api"
 
 const raw = {
   info: { title: "Tardigrade", version: "1" },
@@ -37,5 +37,12 @@ describe("apiDocumentOf", () => {
     const reference = { $ref: "#/components/schemas/Actor" }
     expect(resolvedSchema(reference, document.schemas).type).toBe("object")
     expect(schemaTypeOf({ type: "array", items: reference })).toBe("Actor[]")
+  })
+
+  test("builds examples from component schemas", () => {
+    const document = apiDocumentOf(raw)
+    expect(schemaExampleOf({ type: "array", items: { $ref: "#/components/schemas/Actor" } }, document.schemas, 3)).toEqual([
+      { name: "string" }
+    ])
   })
 })

--- a/apps/voyager/src/api.test.ts
+++ b/apps/voyager/src/api.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test"
+
+import { apiDocumentOf, apiGroupsOf, matchesOperation, resolvedSchema, schemaTypeOf } from "./api"
+
+const raw = {
+  info: { title: "Tardigrade", version: "1" },
+  paths: {
+    "/v1/actors": {
+      get: {
+        tags: ["actors"],
+        operationId: "actors.list",
+        parameters: [],
+        responses: { 200: { description: "Success", content: { "application/json": { schema: { type: "array", items: { $ref: "#/components/schemas/Actor" } } } } } }
+      }
+    }
+  },
+  components: { schemas: { Actor: { type: "object", properties: { name: { type: "string" } } } } }
+}
+
+describe("apiDocumentOf", () => {
+  test("projects paths into stable operations", () => {
+    const document = apiDocumentOf(raw)
+    expect(document.title).toBe("Tardigrade")
+    expect(document.operations[0]).toMatchObject({ key: "get:/v1/actors", method: "get", tag: "actors" })
+    expect(document.operations[0]?.responses[0]?.content[0]?.mediaType).toBe("application/json")
+  })
+
+  test("groups and searches operations", () => {
+    const operations = apiDocumentOf(raw).operations
+    expect(apiGroupsOf(operations)[0]?.[0]).toBe("actors")
+    expect(matchesOperation(operations[0]!, "LIST")).toBeTrue()
+    expect(matchesOperation(operations[0]!, "threads")).toBeFalse()
+  })
+
+  test("resolves component names and array labels", () => {
+    const document = apiDocumentOf(raw)
+    const reference = { $ref: "#/components/schemas/Actor" }
+    expect(resolvedSchema(reference, document.schemas).type).toBe("object")
+    expect(schemaTypeOf({ type: "array", items: reference })).toBe("Actor[]")
+  })
+})

--- a/apps/voyager/src/api.ts
+++ b/apps/voyager/src/api.ts
@@ -1,0 +1,168 @@
+const HTTP_METHODS = ["get", "post", "put", "patch", "delete", "options", "head"] as const
+
+type HttpMethod = typeof HTTP_METHODS[number]
+
+export interface ApiSchema {
+  readonly $ref?: string
+  readonly type?: string
+  readonly description?: string
+  readonly enum?: ReadonlyArray<unknown>
+  readonly anyOf?: ReadonlyArray<ApiSchema>
+  readonly allOf?: ReadonlyArray<ApiSchema>
+  readonly items?: ApiSchema
+  readonly properties?: Readonly<Record<string, ApiSchema>>
+  readonly required?: ReadonlyArray<string>
+}
+
+interface ApiParameter {
+  readonly name: string
+  readonly in: string
+  readonly required: boolean
+  readonly description: string | undefined
+  readonly schema: ApiSchema | undefined
+}
+
+export interface ApiContent {
+  readonly mediaType: string
+  readonly schema: ApiSchema | undefined
+}
+
+interface ApiResponse {
+  readonly status: string
+  readonly description: string
+  readonly content: ReadonlyArray<ApiContent>
+}
+
+export interface ApiOperation {
+  readonly key: string
+  readonly method: HttpMethod
+  readonly path: string
+  readonly tag: string
+  readonly operationId: string | undefined
+  readonly summary: string | undefined
+  readonly description: string | undefined
+  readonly parameters: ReadonlyArray<ApiParameter>
+  readonly request: ReadonlyArray<ApiContent>
+  readonly responses: ReadonlyArray<ApiResponse>
+}
+
+export interface ApiDocument {
+  readonly title: string
+  readonly version: string | undefined
+  readonly description: string | undefined
+  readonly operations: ReadonlyArray<ApiOperation>
+  readonly schemas: Readonly<Record<string, ApiSchema>>
+}
+
+type UnknownRecord = Readonly<Record<string, unknown>>
+
+const recordOf = (value: unknown): UnknownRecord | undefined =>
+  typeof value === "object" && value !== null && !Array.isArray(value) ? value as UnknownRecord : undefined
+
+const stringOf = (value: unknown): string | undefined => typeof value === "string" ? value : undefined
+
+const schemaOf = (value: unknown): ApiSchema | undefined => recordOf(value) as ApiSchema | undefined
+
+const contentOf = (value: unknown): ReadonlyArray<ApiContent> =>
+  Object.entries(recordOf(value) ?? {}).map(([mediaType, media]) => ({
+    mediaType,
+    schema: schemaOf(recordOf(media)?.schema)
+  }))
+
+const parametersOf = (value: unknown): ReadonlyArray<ApiParameter> =>
+  Array.isArray(value)
+    ? value.flatMap((item) => {
+      const parameter = recordOf(item)
+      const name = stringOf(parameter?.name)
+      const location = stringOf(parameter?.in)
+      return name === undefined || location === undefined
+        ? []
+        : [{
+          name,
+          in: location,
+          required: parameter?.required === true,
+          description: stringOf(parameter?.description),
+          schema: schemaOf(parameter?.schema)
+        }]
+    })
+    : []
+
+const responsesOf = (value: unknown): ReadonlyArray<ApiResponse> =>
+  Object.entries(recordOf(value) ?? {}).map(([status, raw]) => {
+    const response = recordOf(raw)
+    return {
+      status,
+      description: stringOf(response?.description) ?? "Response",
+      content: contentOf(response?.content)
+    }
+  })
+
+const operationKey = (method: HttpMethod, path: string): string => `${method}:${path}`
+
+export const apiDocumentOf = (value: unknown): ApiDocument => {
+  const document = recordOf(value) ?? {}
+  const info = recordOf(document.info) ?? {}
+  const operations: Array<ApiOperation> = []
+  for (const [path, rawPath] of Object.entries(recordOf(document.paths) ?? {})) {
+    const pathItem = recordOf(rawPath) ?? {}
+    for (const method of HTTP_METHODS) {
+      const operation = recordOf(pathItem[method])
+      if (operation === undefined) continue
+      const tags = Array.isArray(operation.tags) ? operation.tags : []
+      const requestBody = recordOf(operation.requestBody)
+      operations.push({
+        key: operationKey(method, path),
+        method,
+        path,
+        tag: stringOf(tags[0]) ?? "other",
+        operationId: stringOf(operation.operationId),
+        summary: stringOf(operation.summary),
+        description: stringOf(operation.description),
+        parameters: parametersOf(operation.parameters),
+        request: contentOf(requestBody?.content),
+        responses: responsesOf(operation.responses)
+      })
+    }
+  }
+  const schemas = recordOf(recordOf(document.components)?.schemas) ?? {}
+  return {
+    title: stringOf(info.title) ?? "API",
+    version: stringOf(info.version),
+    description: stringOf(info.description),
+    operations,
+    schemas: schemas as Readonly<Record<string, ApiSchema>>
+  }
+}
+
+export const apiGroupsOf = (operations: ReadonlyArray<ApiOperation>): ReadonlyArray<readonly [string, ReadonlyArray<ApiOperation>]> => {
+  const groups = new Map<string, Array<ApiOperation>>()
+  for (const operation of operations) {
+    const held = groups.get(operation.tag) ?? []
+    held.push(operation)
+    groups.set(operation.tag, held)
+  }
+  return [...groups.entries()]
+}
+
+export const matchesOperation = (operation: ApiOperation, query: string): boolean => {
+  const needle = query.trim().toLocaleLowerCase()
+  if (needle.length === 0) return true
+  return [operation.method, operation.path, operation.tag, operation.operationId, operation.summary]
+    .some((value) => value?.toLocaleLowerCase().includes(needle) === true)
+}
+
+const refNameOf = (schema: ApiSchema): string | undefined => schema.$ref?.split("/").at(-1)
+
+export const resolvedSchema = (schema: ApiSchema, schemas: Readonly<Record<string, ApiSchema>>): ApiSchema => {
+  const name = refNameOf(schema)
+  return name === undefined ? schema : schemas[name] ?? schema
+}
+
+export const schemaTypeOf = (schema: ApiSchema): string => {
+  const name = refNameOf(schema)
+  if (name !== undefined) return name
+  if (schema.enum !== undefined) return schema.enum.map(String).join(" | ")
+  if (schema.anyOf !== undefined) return schema.anyOf.map(schemaTypeOf).join(" | ")
+  if (schema.type === "array" && schema.items !== undefined) return `${schemaTypeOf(schema.items)}[]`
+  return schema.type ?? "unknown"
+}

--- a/apps/voyager/src/api.ts
+++ b/apps/voyager/src/api.ts
@@ -166,3 +166,28 @@ export const schemaTypeOf = (schema: ApiSchema): string => {
   if (schema.type === "array" && schema.items !== undefined) return `${schemaTypeOf(schema.items)}[]`
   return schema.type ?? "unknown"
 }
+
+export const schemaExampleOf = (
+  schema: ApiSchema,
+  schemas: Readonly<Record<string, ApiSchema>>,
+  depth: number
+): unknown => {
+  const resolved = resolvedSchema(schema, schemas)
+  if (resolved.enum !== undefined) return resolved.enum[0]
+  if (resolved.anyOf !== undefined && resolved.anyOf[0] !== undefined) return schemaExampleOf(resolved.anyOf[0], schemas, depth)
+  if (resolved.allOf !== undefined) {
+    return Object.assign({}, ...resolved.allOf.map((part) => schemaExampleOf(part, schemas, depth)))
+  }
+  if (depth <= 0) return resolved.type === "array" ? [] : resolved.type === "object" ? {} : null
+  if (resolved.type === "array") {
+    return resolved.items === undefined ? [] : [schemaExampleOf(resolved.items, schemas, depth - 1)]
+  }
+  if (resolved.type === "object" || resolved.properties !== undefined) {
+    return Object.fromEntries(
+      Object.entries(resolved.properties ?? {}).map(([name, property]) => [name, schemaExampleOf(property, schemas, depth - 1)])
+    )
+  }
+  if (resolved.type === "integer" || resolved.type === "number") return 0
+  if (resolved.type === "boolean") return true
+  return "string"
+}

--- a/apps/voyager/src/nav.test.ts
+++ b/apps/voyager/src/nav.test.ts
@@ -8,6 +8,7 @@ describe("routeOf", () => {
       actor: "default",
       thread: undefined,
       view: "api",
+      operation: undefined,
       from: undefined,
       to: undefined
     })
@@ -15,5 +16,9 @@ describe("routeOf", () => {
 
   test("an unknown view does not hide the trace", () => {
     expect(routeOf("?thread=root&view=unknown").view).toBeUndefined()
+  })
+
+  test("an API operation survives a refresh", () => {
+    expect(routeOf("?view=api&operation=get%3A%2Fhealthz").operation).toBe("get:/healthz")
   })
 })

--- a/apps/voyager/src/nav.test.ts
+++ b/apps/voyager/src/nav.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test"
+
+import { routeOf } from "./nav"
+
+describe("routeOf", () => {
+  test("the API surface is a shareable view", () => {
+    expect(routeOf("?actor=default&view=api")).toEqual({
+      actor: "default",
+      thread: undefined,
+      view: "api",
+      from: undefined,
+      to: undefined
+    })
+  })
+
+  test("an unknown view does not hide the trace", () => {
+    expect(routeOf("?thread=root&view=unknown").view).toBeUndefined()
+  })
+})

--- a/apps/voyager/src/nav.ts
+++ b/apps/voyager/src/nav.ts
@@ -14,6 +14,7 @@ export interface Route {
   readonly actor: string | undefined
   readonly thread: string | undefined
   readonly view: "api" | undefined
+  readonly operation: string | undefined
   readonly from: number | undefined
   readonly to: number | undefined
 }
@@ -29,10 +30,12 @@ const parse = (search: string): Route => {
   const thread = params.get("thread")
   const actor = params.get("actor")
   const view = params.get("view")
+  const operation = params.get("operation")
   return {
     actor: actor === null || actor.length === 0 ? undefined : actor,
     thread: thread === null || thread.length === 0 ? undefined : thread,
     view: view === "api" ? view : undefined,
+    operation: operation === null || operation.length === 0 ? undefined : operation,
     from: fraction(params.get("from")),
     to: fraction(params.get("to"))
   }
@@ -51,6 +54,7 @@ export const navigate = (next: Partial<Route>, options: { readonly replace?: boo
   if ("thread" in next) write("thread", next.thread)
   if ("actor" in next) write("actor", next.actor)
   if ("view" in next) write("view", next.view)
+  if ("operation" in next) write("operation", next.operation)
   if ("from" in next) write("from", next.from)
   if ("to" in next) write("to", next.to)
   const search = params.toString()

--- a/apps/voyager/src/nav.ts
+++ b/apps/voyager/src/nav.ts
@@ -1,8 +1,8 @@
 import { useCallback, useSyncExternalStore } from "react"
 
-// The URL is the app's only navigation state. `?thread=` chooses the screen and `?from=` and `?to=`
-// carry the window's two edges, so a view is shareable and survives a refresh (voyager-spec.md,
-// "Conventions"). There is no routing library: three params and pushState are the whole of it.
+// The URL is the app's only navigation state. `?thread=` chooses a trace, `?view=api` chooses the
+// API reference, and `?from=` and `?to=` carry the window's two edges, so a view is shareable and
+// survives a refresh (voyager-spec.md, "Conventions").
 
 // The params the app reads. Anything else in the query belongs to something other than navigation
 // and is preserved untouched by `navigate`.
@@ -13,6 +13,7 @@ import { useCallback, useSyncExternalStore } from "react"
 export interface Route {
   readonly actor: string | undefined
   readonly thread: string | undefined
+  readonly view: "api" | undefined
   readonly from: number | undefined
   readonly to: number | undefined
 }
@@ -27,9 +28,11 @@ const parse = (search: string): Route => {
   const params = new URLSearchParams(search)
   const thread = params.get("thread")
   const actor = params.get("actor")
+  const view = params.get("view")
   return {
     actor: actor === null || actor.length === 0 ? undefined : actor,
     thread: thread === null || thread.length === 0 ? undefined : thread,
+    view: view === "api" ? view : undefined,
     from: fraction(params.get("from")),
     to: fraction(params.get("to"))
   }
@@ -47,6 +50,7 @@ export const navigate = (next: Partial<Route>, options: { readonly replace?: boo
   }
   if ("thread" in next) write("thread", next.thread)
   if ("actor" in next) write("actor", next.actor)
+  if ("view" in next) write("view", next.view)
   if ("from" in next) write("from", next.from)
   if ("to" in next) write("to", next.to)
   const search = params.toString()

--- a/apps/voyager/src/policy.ts
+++ b/apps/voyager/src/policy.ts
@@ -18,6 +18,10 @@ export const PANE_HEADER_HEIGHT = 64
 // else, so a reader can always open the list again from where they closed it.
 export const COLLAPSED_ACTOR_RAIL_WIDTH = 48
 
+// How many nested object levels the API explorer renders before naming the remaining schema. The
+// explorer accepts another depth when a larger surface needs to show more of a recursive model.
+export const API_SCHEMA_DEPTH = 3
+
 // The size every icon renders at, in pixels (voyager-design-system.md, the icon policy). One number
 // for the whole set, because a second size would be a second style.
 export const ICON_SIZE = 15

--- a/apps/voyager/src/roster.test.ts
+++ b/apps/voyager/src/roster.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 
 import type { ThreadSummary } from "@clavia/tardigrade-client"
-import { agoOf, countsOf, matches, rosterOf } from "./roster"
+import { agoOf, countsOf, latestRootOf, matches, rosterOf } from "./roster"
 
 // The rail's decisions: which threads are rows, how big each root's family is, what a row's counts
 // say, and how an age reads. All pure, so none of them needs a server or a DOM.
@@ -24,6 +24,11 @@ describe("rosterOf", () => {
 
   test("the rows are the roots, in the order the listing published them", () => {
     expect(rosterOf(listing).roots.map((row) => row.id)).toEqual(["root", "alone"])
+  })
+
+  test("the latest root is the last published root", () => {
+    expect(latestRootOf(rosterOf(listing))?.id).toBe("alone")
+    expect(latestRootOf(rosterOf([]))).toBeUndefined()
   })
 
   test("a root's family is every thread under it, at any depth", () => {

--- a/apps/voyager/src/roster.ts
+++ b/apps/voyager/src/roster.ts
@@ -24,6 +24,8 @@ export interface Roster {
 
 export const EMPTY_ROSTER: Roster = { roots: [] }
 
+export const latestRootOf = (roster: Roster): RootRow | undefined => roster.roots.at(-1)
+
 // rootOf walks a thread's parents to the root of its family. Parentage is the server's fact: only
 // the forest can see it, and a summary states it (apps/server/src/projections.ts, treeOf). The
 // guard stops a claim cycle, which minted call ids cannot produce but an argument can.

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -453,44 +453,371 @@ textarea {
 }
 
 .api-view {
-  position: relative;
+  display: flex;
   width: 100%;
   height: 100%;
   overflow: hidden;
 }
 
-.api-surface {
-  width: 100%;
-  height: 100%;
-  border: 0;
-  background: var(--bg);
+.api-nav {
+  display: flex;
+  width: 320px;
+  min-width: 0;
+  flex-direction: column;
+  background: var(--surface);
+  border-right: 1px solid var(--hair);
 }
 
-.api-back {
-  position: absolute;
-  z-index: 2;
-  top: var(--space-3);
-  right: var(--space-3);
-  display: inline-flex;
-  min-height: var(--row-h);
+.api-nav-head {
+  display: flex;
+  min-height: 64px;
   align-items: center;
   gap: var(--space-2);
-  padding: 0 var(--space-3);
-  border: 1px solid var(--hair);
-  border-radius: var(--radius);
-  background: var(--surface);
-  color: var(--ink-2);
-  cursor: pointer;
-  box-shadow: var(--shadow);
-  transition: color var(--fast) var(--ease), transform var(--fast) var(--ease);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--hair);
 }
 
-.api-back:hover {
+.api-search-wrap {
+  display: flex;
+  height: 34px;
+  flex-shrink: 0;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 10px var(--space-3);
+  padding: 0 10px;
+  border: 1px solid var(--hair);
+  border-radius: var(--radius);
+  background: var(--bg);
+  color: var(--faint);
+}
+
+.api-search-wrap:focus-within {
+  border-color: var(--moss);
+}
+
+.api-search-wrap input {
+  width: 100%;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
   color: var(--ink);
 }
 
-.api-back:active {
+.api-nav-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0 var(--space-2) var(--space-3);
+}
+
+.api-overview-link,
+.api-nav-row {
+  display: flex;
+  width: 100%;
+  min-height: var(--row-h);
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-2);
+  border: 0;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--ink-2);
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--fast) var(--ease), color var(--fast) var(--ease), transform var(--fast) var(--ease);
+}
+
+.api-overview-link:hover,
+.api-nav-row:hover {
+  background: var(--sunken);
+  color: var(--ink);
+}
+
+.api-overview-link:active,
+.api-nav-row:active {
   transform: scale(0.97);
+}
+
+.api-nav-selected,
+.api-nav-selected:hover {
+  background: var(--moss-wash);
+  color: var(--moss-ink);
+}
+
+.api-group h2 {
+  margin: var(--space-4) var(--space-2) var(--space-1);
+  color: var(--faint);
+  font-size: 10.5px;
+  font-weight: 400;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.api-method {
+  display: inline-flex;
+  min-width: 42px;
+  justify-content: center;
+  font-size: 10.5px;
+  font-weight: 500;
+}
+
+.api-method-get {
+  color: var(--wait);
+}
+
+.api-method-post {
+  color: var(--ok);
+}
+
+.api-method-put,
+.api-method-patch {
+  color: var(--run);
+}
+
+.api-method-delete {
+  color: var(--fail);
+}
+
+.api-nav-path {
+  min-width: 0;
+  overflow: hidden;
+  color: inherit;
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.api-full-reference {
+  display: flex;
+  min-height: 48px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--space-4);
+  border-top: 1px solid var(--hair);
+  color: var(--ink-2);
+}
+
+.api-full-reference:hover {
+  color: var(--ink);
+}
+
+.api-reading {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  background: var(--bg);
+}
+
+.api-detail {
+  width: min(920px, 100%);
+  margin: 0 auto;
+  padding: 72px var(--space-6) 96px;
+}
+
+.api-detail-head {
+  padding-bottom: var(--space-6);
+  border-bottom: 1px solid var(--hair);
+}
+
+.api-operation-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.api-operation-title h1,
+.api-overview h1 {
+  margin: 0;
+  color: var(--ink);
+  font-size: var(--text-page);
+  font-weight: 500;
+  letter-spacing: -0.02em;
+}
+
+.api-operation-id,
+.api-eyebrow {
+  margin-top: var(--space-2);
+  color: var(--faint);
+  font-size: 11px;
+}
+
+.api-detail p {
+  max-width: var(--measure);
+  color: var(--ink-2);
+  line-height: 1.6;
+}
+
+.api-section {
+  padding: var(--space-6) 0;
+  border-bottom: 1px solid var(--hair);
+}
+
+.api-section h2 {
+  margin: 0 0 var(--space-4);
+  color: var(--ink);
+  font-size: var(--text-read);
+  font-weight: 500;
+}
+
+.api-parameters,
+.api-responses,
+.api-content-list {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.api-parameter,
+.api-response,
+.api-content {
+  padding: var(--space-3);
+  border: 1px solid var(--hair);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+
+.api-parameter {
+  display: grid;
+  grid-template-columns: minmax(140px, 1fr) minmax(100px, auto) auto;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.api-parameter p {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+
+.api-parameter-in {
+  margin-left: var(--space-2);
+  color: var(--faint);
+  font-size: 10.5px;
+}
+
+.api-response-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.api-status {
+  color: var(--fail);
+  font-weight: 500;
+}
+
+.api-status-ok {
+  color: var(--ok);
+}
+
+.api-response .api-content-list {
+  margin-top: var(--space-3);
+}
+
+.api-media-type {
+  margin-bottom: var(--space-2);
+  color: var(--faint);
+  font-size: 11px;
+}
+
+.api-type,
+.api-property-type {
+  color: var(--wait);
+  font-size: 11.5px;
+}
+
+.api-properties {
+  margin-top: var(--space-2);
+  border-top: 1px solid var(--hair);
+}
+
+.api-property {
+  padding: 10px 0 2px var(--space-3);
+  border-left: 1px solid var(--hair);
+}
+
+.api-property-line {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.api-property-name {
+  color: var(--ink);
+  font-size: 12px;
+}
+
+.api-required,
+.api-optional {
+  margin-left: auto;
+  color: var(--faint);
+  font-size: 10px;
+}
+
+.api-required {
+  color: var(--run);
+}
+
+.api-schema-cut {
+  margin-top: var(--space-2);
+  color: var(--faint);
+  font-size: 11px;
+}
+
+.api-overview {
+  padding-top: 96px;
+}
+
+.api-overview .api-eyebrow {
+  margin: 0 0 var(--space-2);
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.api-version {
+  display: inline-block;
+  margin-top: var(--space-2);
+  color: var(--faint);
+  font-size: 11px;
+}
+
+.api-facts {
+  display: grid;
+  gap: 0;
+  margin-top: var(--space-6);
+  border-top: 1px solid var(--hair);
+}
+
+.api-facts div {
+  display: grid;
+  grid-template-columns: 140px minmax(0, 1fr);
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--hair);
+}
+
+.api-facts dt {
+  color: var(--faint);
+}
+
+.api-facts dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.api-load-problem {
+  margin: var(--space-7);
+}
+
+@media (max-width: 760px) {
+  .api-nav {
+    width: 240px;
+  }
+
+  .api-detail {
+    padding-right: var(--space-4);
+    padding-left: var(--space-4);
+  }
 }
 
 @media (max-width: 900px) {

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -1341,7 +1341,9 @@ textarea {
   display: grid;
   grid-template-columns: max-content minmax(0, 1fr);
   gap: 5px 20px;
-  margin: 2px 0 10px 10px;
+  margin-top: 2px;
+  margin-right: 0;
+  margin-bottom: 10px;
   padding-left: 18px;
   border-left: 1px solid var(--hair);
 }

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -645,6 +645,26 @@ textarea {
   text-transform: lowercase;
 }
 
+.api-resource {
+  padding-top: var(--space-7);
+  scroll-margin-top: var(--space-5);
+}
+
+.api-resource + .api-resource {
+  margin-top: var(--space-7);
+  border-top: 1px solid var(--hair);
+}
+
+.api-endpoint {
+  scroll-margin-top: var(--space-5);
+}
+
+.api-endpoint + .api-endpoint {
+  margin-top: var(--space-7);
+  padding-top: var(--space-7);
+  border-top: 1px solid var(--hair);
+}
+
 .api-detail-head h2 {
   margin: 0;
   color: var(--ink);
@@ -902,7 +922,9 @@ textarea {
 }
 
 .api-overview {
-  padding-top: 96px;
+  padding: var(--space-4) 0 var(--space-7);
+  scroll-margin-top: var(--space-5);
+  border-bottom: 1px solid var(--hair);
 }
 
 .api-overview .api-eyebrow {

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -612,14 +612,13 @@ textarea {
 }
 
 .api-detail {
-  width: min(920px, 100%);
+  width: min(1240px, 100%);
   margin: 0 auto;
   padding: 72px var(--space-6) 96px;
 }
 
 .api-detail-head {
-  padding-bottom: var(--space-6);
-  border-bottom: 1px solid var(--hair);
+  padding: var(--space-7) 0 var(--space-5);
 }
 
 .api-operation-title {
@@ -637,6 +636,23 @@ textarea {
   letter-spacing: -0.02em;
 }
 
+.api-operation-detail h1 {
+  margin: var(--space-2) 0 0;
+  color: var(--ink);
+  font-size: 30px;
+  font-weight: 500;
+  letter-spacing: -0.03em;
+  text-transform: lowercase;
+}
+
+.api-detail-head h2 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 25px;
+  font-weight: 500;
+  letter-spacing: -0.025em;
+}
+
 .api-operation-id,
 .api-eyebrow {
   margin-top: var(--space-2);
@@ -651,15 +667,135 @@ textarea {
 }
 
 .api-section {
-  padding: var(--space-6) 0;
+  padding: var(--space-5) 0;
   border-bottom: 1px solid var(--hair);
 }
 
-.api-section h2 {
+.api-section h2,
+.api-section h3 {
   margin: 0 0 var(--space-4);
   color: var(--ink);
   font-size: var(--text-read);
   font-weight: 500;
+}
+
+.api-tag-overview {
+  display: grid;
+  min-height: 220px;
+  grid-template-columns: minmax(220px, 1fr) minmax(360px, 1fr);
+  align-items: start;
+  gap: var(--space-7);
+  padding-bottom: var(--space-7);
+  border-bottom: 1px solid var(--hair);
+}
+
+.api-tag-overview .api-eyebrow {
+  margin: 0;
+  color: var(--faint);
+  font-size: 10.5px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.api-operations-card,
+.api-code-card {
+  overflow: hidden;
+  border: 1px solid var(--hair);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+
+.api-card-title,
+.api-code-head {
+  min-height: 38px;
+  padding: 0 var(--space-3);
+  border-bottom: 1px solid var(--hair);
+  color: var(--ink-2);
+  font-size: 12px;
+}
+
+.api-card-title {
+  display: flex;
+  align-items: center;
+  font-weight: 500;
+}
+
+.api-operations-list {
+  padding: var(--space-2);
+}
+
+.api-operations-list button {
+  display: flex;
+  width: 100%;
+  min-height: 32px;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-2);
+  border: 0;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--ink-2);
+  cursor: pointer;
+  text-align: left;
+}
+
+.api-operations-list button:hover {
+  background: var(--sunken);
+  color: var(--ink);
+}
+
+.api-operations-list button:active {
+  transform: scale(0.97);
+}
+
+.api-operation-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(360px, 0.95fr);
+  gap: var(--space-7);
+}
+
+.api-operation-docs {
+  min-width: 0;
+}
+
+.api-operation-examples {
+  position: sticky;
+  top: var(--space-5);
+  display: grid;
+  align-self: start;
+  gap: var(--space-3);
+}
+
+.api-code-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.api-code-head > div {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.api-code-head > span {
+  color: var(--faint);
+  font-size: 10.5px;
+}
+
+.api-code-card pre {
+  max-height: 360px;
+  margin: 0;
+  overflow: auto;
+  padding: var(--space-4);
+  background: var(--sunken);
+  color: var(--ink-2);
+  font-size: 11.5px;
+  line-height: 1.65;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .api-parameters,
@@ -817,6 +953,21 @@ textarea {
   .api-detail {
     padding-right: var(--space-4);
     padding-left: var(--space-4);
+  }
+}
+
+@media (max-width: 1100px) {
+  .api-tag-overview,
+  .api-operation-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .api-tag-overview {
+    min-height: 0;
+  }
+
+  .api-operation-examples {
+    position: static;
   }
 }
 

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -447,15 +447,16 @@ textarea {
   transform: scale(0.97);
 }
 
-.actor-api-selected,
-.actor-api-selected:hover {
-  background: var(--moss-wash);
-  color: var(--moss-ink);
-}
-
 .actor-rail-collapsed .actor-api {
   justify-content: center;
   padding: 0;
+}
+
+.api-view {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
 }
 
 .api-surface {
@@ -463,6 +464,33 @@ textarea {
   height: 100%;
   border: 0;
   background: var(--bg);
+}
+
+.api-back {
+  position: absolute;
+  z-index: 2;
+  top: var(--space-3);
+  right: var(--space-3);
+  display: inline-flex;
+  min-height: var(--row-h);
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-3);
+  border: 1px solid var(--hair);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--ink-2);
+  cursor: pointer;
+  box-shadow: var(--shadow);
+  transition: color var(--fast) var(--ease), transform var(--fast) var(--ease);
+}
+
+.api-back:hover {
+  color: var(--ink);
+}
+
+.api-back:active {
+  transform: scale(0.97);
 }
 
 @media (max-width: 900px) {

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -589,21 +589,6 @@ textarea {
   white-space: nowrap;
 }
 
-.api-full-reference {
-  display: flex;
-  min-height: 48px;
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 var(--space-4);
-  border-top: 1px solid var(--hair);
-  color: var(--ink-2);
-}
-
-.api-full-reference:hover {
-  color: var(--ink);
-}
-
 .api-reading {
   flex: 1;
   min-width: 0;
@@ -832,6 +817,76 @@ textarea {
   border: 1px solid var(--hair);
   border-radius: var(--radius);
   background: var(--surface);
+}
+
+.api-operation-docs .api-section {
+  padding: var(--space-5) 0;
+}
+
+.api-operation-docs .api-response {
+  padding: 0;
+  border: 0;
+  border-bottom: 1px solid var(--hair);
+  border-radius: 0;
+  background: transparent;
+}
+
+.api-operation-docs .api-response:first-child {
+  border-top: 1px solid var(--hair);
+}
+
+.api-operation-docs .api-response-head {
+  min-height: 52px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.api-operation-docs .api-response-head::-webkit-details-marker {
+  display: none;
+}
+
+.api-operation-docs .api-response-head::before {
+  width: 7px;
+  height: 7px;
+  border-right: 1px solid var(--faint);
+  border-bottom: 1px solid var(--faint);
+  content: "";
+  transform: rotate(-45deg);
+  transition: transform var(--fast) var(--ease);
+}
+
+.api-operation-docs .api-response[open] .api-response-head::before {
+  transform: rotate(45deg);
+}
+
+.api-operation-docs .api-response .api-content-list {
+  margin: 0 0 var(--space-4) 22px;
+}
+
+.api-operation-docs .api-response .api-content {
+  border: 0;
+  background: transparent;
+}
+
+.api-headers-section {
+  padding-top: 0;
+}
+
+.api-header-line {
+  display: grid;
+  min-height: 44px;
+  grid-template-columns: 120px minmax(0, 1fr);
+  align-items: center;
+  border-top: 1px solid var(--hair);
+}
+
+.api-header-line:last-child {
+  border-bottom: 1px solid var(--hair);
+}
+
+.api-header-example {
+  color: var(--faint);
+  font-size: 11.5px;
 }
 
 .api-parameter {

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -365,6 +365,7 @@ textarea {
 }
 
 .actor-list {
+  flex: 1;
   min-height: 0;
   overflow-y: auto;
   padding: 0 var(--space-2) var(--space-3);
@@ -414,6 +415,56 @@ textarea {
   font-size: 9.5px;
 }
 
+.actor-footer {
+  flex-shrink: 0;
+  margin-top: auto;
+  padding: var(--space-2);
+  border-top: 1px solid var(--hair);
+}
+
+.actor-api {
+  display: flex;
+  width: 100%;
+  min-height: var(--row-h);
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-2);
+  border: 0;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--ink-2);
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--fast) var(--ease), color var(--fast) var(--ease), transform var(--fast) var(--ease);
+}
+
+.actor-api:hover {
+  background: var(--sunken);
+  color: var(--ink);
+}
+
+.actor-api:active {
+  transform: scale(0.97);
+}
+
+.actor-api-selected,
+.actor-api-selected:hover {
+  background: var(--moss-wash);
+  color: var(--moss-ink);
+}
+
+.actor-rail-collapsed .actor-api {
+  justify-content: center;
+  padding: 0;
+}
+
+.api-surface {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: var(--bg);
+}
+
 @media (max-width: 900px) {
   .actor-rail:not(.actor-rail-collapsed) {
     width: 160px !important;
@@ -437,11 +488,19 @@ textarea {
 
 /* A rail row is two lines: the id and its age, then the state chip and the counts. Selected is the
    moss wash; hover is the sunken wash. */
+.run-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0 var(--space-2) var(--space-3);
+}
+
 .rail-row {
   display: flex;
   flex-direction: column;
   gap: 2px;
   padding: var(--space-2) 14px;
+  border-radius: var(--radius);
   cursor: pointer;
   transition: background var(--fast) var(--ease);
 }


### PR DESCRIPTION
Adds an API button to the actor rail and renders the server's generated OpenAPI document as a native Voyager surface.

The API view replaces the actor and run panes with a searchable endpoint sidebar, overview, parameters, request bodies, responses, and structured schemas. Endpoint selection is stored in the URL for refreshes and shared links. Recursive schemas stop at an exported, overridable depth and state when nested fields are hidden.

The existing Scalar page remains available through an `Interactive reference` link for request execution. Actor and run selections also use the same inset gutter and rounded treatment.

## Verification

- `bun run gate`
- 87 Voyager tests
- Voyager production build
- Browser render at 1440 by 1000