### PR TITLE
fix(voyager): refine API presentation

### DIFF
--- a/apps/voyager/src/ActorRail.tsx
+++ b/apps/voyager/src/ActorRail.tsx
@@ -4,6 +4,7 @@ import { useState, type ReactElement } from "react"
 
 import { navigate } from "./nav"
 import { ACTOR_RAIL_WIDTH, COLLAPSED_ACTOR_RAIL_WIDTH, ICON_SIZE, PANE_HEADER_HEIGHT } from "./policy"
+import { ProductMark } from "./ProductMark"
 import { matches } from "./roster"
 
 const ACTOR_RAIL_KEY = "voyager.actor-rail"
@@ -38,7 +39,7 @@ export const ActorRail = ({
       <div className="pane-chrome" style={{ height: headerHeight }}>
         <div className="actor-head">
           <div className="actor-only actor-identity">
-            <div className="rail-wordmark">voyager</div>
+            <ProductMark />
             <div className="mono actor-label">actors</div>
           </div>
           <button

--- a/apps/voyager/src/ApiSurface.tsx
+++ b/apps/voyager/src/ApiSurface.tsx
@@ -181,7 +181,7 @@ const OperationDetail = ({
             </section>
           )}
           {operation.request.length === 0 ? null : (
-            <section className="api-section">
+            <section className="api-section api-request-section">
               <h3>Request body</h3>
               <Content content={operation.request} schemas={document.schemas} depth={depth} />
             </section>

--- a/apps/voyager/src/ApiSurface.tsx
+++ b/apps/voyager/src/ApiSurface.tsx
@@ -161,7 +161,7 @@ const OperationDetail = ({
             ))}
           </section>
           {otherParameters.length === 0 ? null : (
-            <section className="api-section">
+            <section className="api-section api-parameters-section">
               <h3>Parameters</h3>
               <div className="api-parameters">
                 {otherParameters.map((parameter) => (

--- a/apps/voyager/src/ApiSurface.tsx
+++ b/apps/voyager/src/ApiSurface.tsx
@@ -17,6 +17,7 @@ import {
 import { client } from "./client"
 import { navigate, useRoute } from "./nav"
 import { API_SCHEMA_DEPTH, ICON_SIZE } from "./policy"
+import { ProductMark } from "./ProductMark"
 import { ThemeToggle } from "./ThemeToggle"
 
 const apiTarget = (operation: string | undefined): string => operation === undefined ? "api-overview" : `api-${operation}`
@@ -343,7 +344,7 @@ export const ApiSurface = ({ schemaDepth = API_SCHEMA_DEPTH }: { readonly schema
             <ArrowLeft size={ICON_SIZE} weight="light" aria-hidden="true" />
           </button>
           <div>
-            <div className="rail-wordmark">voyager</div>
+            <ProductMark />
             <div className="mono actor-label">api</div>
           </div>
         </div>

--- a/apps/voyager/src/ProductMark.tsx
+++ b/apps/voyager/src/ProductMark.tsx
@@ -1,0 +1,8 @@
+import type { ReactElement } from "react"
+
+export const ProductMark = (): ReactElement => (
+  <div className="rail-wordmark">
+    <span>Tardigrade</span>
+    <span className="mono rail-product-context">[voyager]</span>
+  </div>
+)

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -879,6 +879,19 @@ textarea {
   background: transparent;
 }
 
+.api-operation-docs .api-request-section .api-content {
+  padding: var(--space-3) 0;
+  border: 0;
+  border-top: 1px solid var(--hair);
+  border-bottom: 1px solid var(--hair);
+  border-radius: 0;
+  background: transparent;
+}
+
+.api-operation-docs .api-request-section .api-media-type {
+  margin-bottom: var(--space-3);
+}
+
 .api-headers-section {
   padding-top: 0;
 }

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -308,9 +308,20 @@ textarea {
 }
 
 .rail-wordmark {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
   font-weight: 600;
   font-size: 14px;
   letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+
+.rail-product-context {
+  color: var(--faint);
+  font-size: 10px;
+  font-weight: 400;
+  letter-spacing: 0;
 }
 
 .rail-section-title,

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -892,6 +892,18 @@ textarea {
   margin-bottom: var(--space-3);
 }
 
+.api-operation-docs .api-parameters-section .api-parameter {
+  padding: var(--space-3) 0;
+  border: 0;
+  border-top: 1px solid var(--hair);
+  border-radius: 0;
+  background: transparent;
+}
+
+.api-operation-docs .api-parameters-section .api-parameter:last-child {
+  border-bottom: 1px solid var(--hair);
+}
+
 .api-headers-section {
   padding-top: 0;
 }


### PR DESCRIPTION
Updates the Voyager product mark to read Tardigrade [voyager] across the trace and API surfaces. Flattens the API request-body schema into the same divider-led presentation as headers and responses so the native reference reads as one cohesive document.