### PR TITLE
fix(cli): prepare npm release

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # Tardigrade
 
-[![npm version](https://img.shields.io/npm/v/@clavia/tardigrade.svg)](https://www.npmjs.com/package/@clavia/tardigrade)
+[![npm version](https://img.shields.io/npm/v/tardie.svg)](https://www.npmjs.com/package/tardie)
 
 A durable and modular agent harness built for self-improvement.
 
@@ -29,10 +29,11 @@ $$\lbrace\mathrm{transitions}\rbrace = f(\mathrm{log})$$
 
 ## Quickstart
 
-Run and observe the default agent. Use Bun 1.4 or later.
+Install the release candidate and run the default agent. Use Bun 1.4 or later.
 
 ```bash
-bunx tardie dev
+bun add --global tardie@next
+tdg dev
 ```
 
 Start a thread from another shell:
@@ -40,6 +41,8 @@ Start a thread from another shell:
 ```bash
 tdg run "read this repo and tell me what it does"
 ```
+
+Watch the live trajectory at [localhost:4242](http://localhost:4242).
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/assets/voyager-dark.png">

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -26,6 +26,7 @@
     "@clavia/tardigrade-core": "workspace:*",
     "@clavia/tardigrade-server": "workspace:*",
     "@effect/platform-bun": "4.0.0-rc.110",
+    "@effect/platform-node-shared": "4.0.0-rc.110",
     "effect": "4.0.0-rc.110"
   },
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "@clavia/tardigrade-core": "workspace:*",
         "@clavia/tardigrade-server": "workspace:*",
         "@effect/platform-bun": "4.0.0-rc.110",
+        "@effect/platform-node-shared": "4.0.0-rc.110",
         "effect": "4.0.0-rc.110",
       },
       "devDependencies": {
@@ -33,7 +34,6 @@
       "name": "@clavia/tardigrade-server",
       "version": "0.0.1",
       "dependencies": {
-        "tardie": "workspace:*",
         "@clavia/tardigrade-bun": "workspace:*",
         "@clavia/tardigrade-client": "workspace:*",
         "@clavia/tardigrade-code": "workspace:*",
@@ -41,6 +41,7 @@
         "@clavia/tardigrade-model": "workspace:*",
         "@effect/platform-bun": "4.0.0-rc.110",
         "effect": "4.0.0-rc.110",
+        "tardie": "workspace:*",
       },
     },
     "apps/voyager": {
@@ -54,7 +55,6 @@
         "react-dom": "^19.2.7",
       },
       "devDependencies": {
-        "tardie": "workspace:*",
         "@clavia/tardigrade-core": "workspace:*",
         "@clavia/tardigrade-server": "workspace:*",
         "@effect/platform-bun": "4.0.0-rc.110",
@@ -62,6 +62,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
         "effect": "4.0.0-rc.110",
+        "tardie": "workspace:*",
         "vite": "^8.0.16",
       },
     },
@@ -130,7 +131,6 @@
       "version": "0.0.1",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1079.0",
-        "tardie": "workspace:*",
         "@clavia/tardigrade-core": "workspace:*",
         "@smithy/fetch-http-handler": "^5.6.3",
         "@smithy/node-http-handler": "^4.11.2",
@@ -138,6 +138,7 @@
         "@tanstack/ai-bedrock": "0.2.3",
         "@tanstack/ai-openai": "0.20.0",
         "effect": "4.0.0-rc.110",
+        "tardie": "workspace:*",
       },
     },
   },
@@ -198,8 +199,6 @@
 
     "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
 
-    "tardie": ["tardie@workspace:packages/agent"],
-
     "@clavia/tardigrade-bun": ["@clavia/tardigrade-bun@workspace:platform/bun"],
 
     "@clavia/tardigrade-cli": ["@clavia/tardigrade-cli@workspace:apps/cli"],
@@ -220,7 +219,7 @@
 
     "@effect/platform-bun": ["@effect/platform-bun@4.0.0-rc.110", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-rc.110" }, "peerDependencies": { "effect": "^4.0.0-rc.110" } }, "sha512-f4AcFTWVwGby9RvSitqAcG/McN8OCDy7LW8PYRG4NIOO2eYphlW73S5Z7jm3UDP+FmIwwzjfgfIfBYkfPR+YfA=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-rc.111", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.3" }, "peerDependencies": { "effect": "^4.0.0-rc.111" } }, "sha512-iES0Q9vmjhaUKqeW9ceonuD45MUg/Ouk08LzRSptZ+B5qB0w9WlRjDmUz5TJmY2betNop5FRI5k4AD4mtQt3Bw=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-rc.110", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-rc.110" } }, "sha512-P8EZloxS7RtCOSL3VSBPyqSenUm93xLbXf9jkWoy67cibZ2wgZ9nAou9iN8f1i4vzgxUsWtDuy6BEmg67np6Zw=="],
 
     "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@4.0.0-rc.110", "", { "peerDependencies": { "effect": "^4.0.0-rc.110" } }, "sha512-Lam3gY1xszjQS/cebdLbWbtR21FtQI4ke7QHqbBQ6AyVJF0CGUtS/ePL9zNq6wHNmJ95FUDGS6W+Qx/l6RPSzA=="],
 
@@ -552,6 +551,8 @@
 
     "tabbable": ["tabbable@6.5.0", "", {}, "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA=="],
 
+    "tardie": ["tardie@workspace:packages/agent"],
+
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
@@ -575,6 +576,8 @@
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1111.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.8", "@aws-sdk/nested-clients": "^3.997.43", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A=="],
+
+    "@effect/platform-bun/@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-rc.111", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.3" }, "peerDependencies": { "effect": "^4.0.0-rc.111" } }, "sha512-iES0Q9vmjhaUKqeW9ceonuD45MUg/Ouk08LzRSptZ+B5qB0w9WlRjDmUz5TJmY2betNop5FRI5k4AD4mtQt3Bw=="],
 
     "rolldown/@oxc-project/types": ["@oxc-project/types@0.146.0", "", {}, "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA=="],
   }

--- a/docs/how-to/cli.md
+++ b/docs/how-to/cli.md
@@ -23,13 +23,16 @@ tdg run "read this repo and tell me what it does"
 | Command | |
 | --- | --- |
 | `tdg setup` | Save a provider, a model id, and a key |
+| `tdg build <entry>` | Build and validate an actor artifact |
+| `tdg push <entry> --target <local\|hosted>` | Build and push an actor |
 | `tdg dev` | Serve the API and the UI on one port |
+| `tdg actors` | List actors available on the server |
 | `tdg run <brief>` | Start a thread and wait for its answer |
 | `tdg send <thread> <brief>` | Send to a thread, do not wait |
 | `tdg ls` | List threads |
 | `tdg events <thread>` | Print a thread's log |
 
-Every command takes `--json`. Remote commands take `--url` and `--token`. `tdg <command> --help` prints the rest.
+Commands that print data take `--json` where their help lists it. Remote commands take `--url` and `--token`. `tdg <command> --help` prints the rest.
 
 ## Configuration
 
@@ -60,6 +63,9 @@ No shell: a directory or a host list can be scoped and a shell cannot.
 
 ```bash
 tdg run "summarize the open PRs" --json
+tdg actors
+tdg build ./actors/reviewer.ts
+tdg push ./actors/reviewer.ts --target local
 tdg ls --url https://tardigrade.example.com --token "$TOKEN"
 tdg events root --types TurnFailed
 tdg dev --port 8080 --db runs.sqlite

--- a/knip.json
+++ b/knip.json
@@ -26,6 +26,11 @@
         "src/**/*.ts"
       ]
     },
+    "apps/cli": {
+      "ignoreDependencies": [
+        "@effect/platform-node-shared"
+      ]
+    },
     "apps/voyager": {
       "entry": [
         "src/client.ts",


### PR DESCRIPTION
Makes the release candidate quickstart work across two shells, links directly to Voyager, documents the complete CLI surface, and corrects the npm badge. Aligns the Effect platform dependency so Bun installs the assembled tardie package without a peer warning.