### PR TITLE
fix: install stable package

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ $$\lbrace\mathrm{transitions}\rbrace = f(\mathrm{log})$$
 
 ## Quickstart
 
-Install the release candidate and run the default agent. Use Bun 1.4 or later.
+Install Tardigrade and run the default agent. Use Bun 1.4 or later.
 
 ```bash
-bun add --global tardie@next
+bun add -g tardie
 tdg dev
 ```
 


### PR DESCRIPTION
Updates the stable branch quickstart to install tardie from the latest npm tag. This also gives Release Please a releasable commit from which to prepare version 0.1.0.