### PR TITLE
feat(cli): add actor template

### DIFF
--- a/apps/cli/src/template.test.ts
+++ b/apps/cli/src/template.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 
 import { buildActor } from "./build"
-import { actorTemplate, defaultActorInstructions } from "./template"
+import { actorTemplate, renderActorTemplate } from "./template"
 
 let root = ""
 
@@ -20,11 +20,12 @@ const build = async (source: string) => {
 
 describe("actorTemplate", () => {
   test("builds a named actor with the useful local reach", async () => {
-    const source = actorTemplate({ name: "researcher" })
+    const source = await actorTemplate({ name: "reviewer" })
     const built = await build(source)
 
-    expect(built.manifest.name).toBe("researcher")
-    expect(source).toContain(defaultActorInstructions("researcher"))
+    expect(built.manifest.name).toBe("reviewer")
+    expect(source).toContain('const actorName = "reviewer"')
+    expect(source).toContain("You are ${actorName}, a focused research agent.")
     expect(source).toContain("filesPackage()")
     expect(source).toContain("fetchPackage()")
     expect(source).toContain("agentsPackage()")
@@ -32,7 +33,7 @@ describe("actorTemplate", () => {
   })
 
   test("keeps custom instructions valid inside the editable template literal", async () => {
-    const source = actorTemplate({
+    const source = await actorTemplate({
       name: "reviewer",
       instructions: "Review `src` and explain ${findings}.\nKeep Windows paths like C:\\code intact."
     })
@@ -43,10 +44,16 @@ describe("actorTemplate", () => {
     expect(source).toContain("C:\\\\code")
   })
 
-  test("refuses an invalid name or blank instructions", () => {
-    expect(() => actorTemplate({ name: "Release Analyst" })).toThrow("actor name must match")
-    expect(() => actorTemplate({ name: "reviewer", instructions: "   " })).toThrow(
+  test("refuses an invalid name or blank instructions", async () => {
+    await expect(actorTemplate({ name: "Release Analyst" })).rejects.toThrow("actor name must match")
+    await expect(actorTemplate({ name: "reviewer", instructions: "   " })).rejects.toThrow(
       "actor instructions must not be blank"
+    )
+  })
+
+  test("refuses a template without its editable fields", () => {
+    expect(() => renderActorTemplate("export default {}", { name: "reviewer" })).toThrow(
+      "quickstart template must contain one actorName declaration"
     )
   })
 })

--- a/apps/cli/src/template.test.ts
+++ b/apps/cli/src/template.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+import { buildActor } from "./build"
+import { actorTemplate, defaultActorInstructions } from "./template"
+
+let root = ""
+
+afterEach(async () => {
+  if (root.length > 0) await rm(root, { recursive: true, force: true })
+})
+
+const build = async (source: string) => {
+  root = await mkdtemp(join(process.cwd(), ".tdg-template-test-"))
+  const entry = join(root, "actor.ts")
+  await writeFile(entry, source, "utf8")
+  return buildActor(entry, { cwd: root, out: "output" })
+}
+
+describe("actorTemplate", () => {
+  test("builds a named actor with the useful local reach", async () => {
+    const source = actorTemplate({ name: "researcher" })
+    const built = await build(source)
+
+    expect(built.manifest.name).toBe("researcher")
+    expect(source).toContain(defaultActorInstructions("researcher"))
+    expect(source).toContain("filesPackage()")
+    expect(source).toContain("fetchPackage()")
+    expect(source).toContain("agentsPackage()")
+    expect(source).toContain("workspacePackage()")
+  })
+
+  test("keeps custom instructions valid inside the editable template literal", async () => {
+    const source = actorTemplate({
+      name: "reviewer",
+      instructions: "Review `src` and explain ${findings}.\nKeep Windows paths like C:\\code intact."
+    })
+    const built = await build(source)
+
+    expect(built.manifest.name).toBe("reviewer")
+    expect(source).toContain("Review \\`src\\` and explain \\${findings}.")
+    expect(source).toContain("C:\\\\code")
+  })
+
+  test("refuses an invalid name or blank instructions", () => {
+    expect(() => actorTemplate({ name: "Release Analyst" })).toThrow("actor name must match")
+    expect(() => actorTemplate({ name: "reviewer", instructions: "   " })).toThrow(
+      "actor instructions must not be blank"
+    )
+  })
+})

--- a/apps/cli/src/template.ts
+++ b/apps/cli/src/template.ts
@@ -1,0 +1,69 @@
+import { ACTOR_NAME_PATTERN } from "tardie"
+
+export interface ActorTemplateOptions {
+  readonly name: string
+  readonly instructions?: string
+}
+
+export const defaultActorInstructions = (name: string): string =>
+  [
+    `You are ${name}, a focused research agent.`,
+    "",
+    "Investigate the user's request carefully.",
+    "Use project files as evidence.",
+    "Delegate independent research when it helps.",
+    "Return a concise answer with concrete findings."
+  ].join("\n")
+
+const templateLiteralOf = (value: string): string =>
+  value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("`", "\\`")
+    .replaceAll("${", "\\${")
+
+export const actorTemplate = (options: ActorTemplateOptions): string => {
+  if (!ACTOR_NAME_PATTERN.test(options.name)) {
+    throw new Error(`actor name must match ${String(ACTOR_NAME_PATTERN)}, got ${JSON.stringify(options.name)}`)
+  }
+  const instructions = (options.instructions ?? defaultActorInstructions(options.name)).trim()
+  if (instructions.length === 0) throw new Error("actor instructions must not be blank")
+
+  return `import {
+  agentOf,
+  agentsPackage,
+  budget,
+  codeModeFor,
+  compaction,
+  defineActor,
+  fetchPackage,
+  filesPackage,
+  reply,
+  workspacePackage
+} from "tardie"
+
+const instructions = {
+  name: "instructions",
+  system: \`
+${templateLiteralOf(instructions)}
+\`.trim()
+}
+
+export default defineActor({
+  name: ${JSON.stringify(options.name)},
+  actor: agentOf([
+    instructions,
+    codeModeFor({
+      packages: [
+        filesPackage(),
+        fetchPackage(),
+        agentsPackage(),
+        workspacePackage()
+      ]
+    }),
+    reply,
+    budget,
+    compaction
+  ])
+})
+`
+}

--- a/apps/cli/src/template.ts
+++ b/apps/cli/src/template.ts
@@ -1,19 +1,16 @@
 import { ACTOR_NAME_PATTERN } from "tardie"
+import { existsSync } from "node:fs"
+import { readFile } from "node:fs/promises"
+import { fileURLToPath } from "node:url"
 
 export interface ActorTemplateOptions {
   readonly name: string
   readonly instructions?: string
 }
 
-export const defaultActorInstructions = (name: string): string =>
-  [
-    `You are ${name}, a focused research agent.`,
-    "",
-    "Investigate the user's request carefully.",
-    "Use project files as evidence.",
-    "Delegate independent research when it helps.",
-    "Return a concise answer with concrete findings."
-  ].join("\n")
+export const INSTALLED_ACTOR_TEMPLATE = "../../examples/quickstart/actor.ts"
+export const REPO_ACTOR_TEMPLATE = "../../../examples/quickstart/actor.ts"
+export const ACTOR_TEMPLATE_CANDIDATES: ReadonlyArray<string> = [INSTALLED_ACTOR_TEMPLATE, REPO_ACTOR_TEMPLATE]
 
 const templateLiteralOf = (value: string): string =>
   value
@@ -21,49 +18,45 @@ const templateLiteralOf = (value: string): string =>
     .replaceAll("`", "\\`")
     .replaceAll("${", "\\${")
 
-export const actorTemplate = (options: ActorTemplateOptions): string => {
+const replaceExactlyOnce = (source: string, pattern: RegExp, replacement: string, field: string): string => {
+  const matches = source.match(pattern)
+  if (matches === null || matches.length !== 1) throw new Error(`quickstart template must contain one ${field}`)
+  return source.replace(pattern, replacement)
+}
+
+export const renderActorTemplate = (source: string, options: ActorTemplateOptions): string => {
   if (!ACTOR_NAME_PATTERN.test(options.name)) {
     throw new Error(`actor name must match ${String(ACTOR_NAME_PATTERN)}, got ${JSON.stringify(options.name)}`)
   }
-  const instructions = (options.instructions ?? defaultActorInstructions(options.name)).trim()
+
+  let rendered = replaceExactlyOnce(
+    source,
+    /^const actorName = .+$/gmu,
+    `const actorName = ${JSON.stringify(options.name)}`,
+    "actorName declaration"
+  )
+  if (options.instructions === undefined) return rendered
+
+  const instructions = options.instructions.trim()
   if (instructions.length === 0) throw new Error("actor instructions must not be blank")
-
-  return `import {
-  agentOf,
-  agentsPackage,
-  budget,
-  codeModeFor,
-  compaction,
-  defineActor,
-  fetchPackage,
-  filesPackage,
-  reply,
-  workspacePackage
-} from "tardie"
-
-const instructions = {
-  name: "instructions",
-  system: \`
-${templateLiteralOf(instructions)}
-\`.trim()
+  rendered = replaceExactlyOnce(
+    rendered,
+    /^const actorInstructions = `[\s\S]*?`\.trim\(\)$/gmu,
+    `const actorInstructions = \`\n${templateLiteralOf(instructions)}\n\`.trim()`,
+    "actorInstructions declaration"
+  )
+  return rendered
 }
 
-export default defineActor({
-  name: ${JSON.stringify(options.name)},
-  actor: agentOf([
-    instructions,
-    codeModeFor({
-      packages: [
-        filesPackage(),
-        fetchPackage(),
-        agentsPackage(),
-        workspacePackage()
-      ]
-    }),
-    reply,
-    budget,
-    compaction
-  ])
-})
-`
+export const loadActorTemplate = async (candidates: ReadonlyArray<string>): Promise<string> => {
+  const found = candidates.find((candidate) => existsSync(candidate))
+  if (found === undefined) throw new Error(`quickstart template is missing. Looked in: ${candidates.join(", ")}`)
+  return readFile(found, "utf8")
 }
+
+export const actorTemplate = async (
+  options: ActorTemplateOptions,
+  candidates: ReadonlyArray<string> = ACTOR_TEMPLATE_CANDIDATES.map((candidate) =>
+    fileURLToPath(new URL(candidate, import.meta.url))
+  )
+): Promise<string> => renderActorTemplate(await loadActorTemplate(candidates), options)

--- a/examples/quickstart/actor.ts
+++ b/examples/quickstart/actor.ts
@@ -1,0 +1,41 @@
+import {
+  agentOf,
+  agentsPackage,
+  budget,
+  codeModeFor,
+  compaction,
+  defineActor,
+  fetchPackage,
+  filesPackage,
+  reply,
+  workspacePackage
+} from "tardie"
+
+const actorName = "researcher"
+
+const actorInstructions = `
+You are ${actorName}, a focused research agent.
+
+Investigate the user's request carefully.
+Use project files as evidence.
+Delegate independent research when it helps.
+Return a concise answer with concrete findings.
+`.trim()
+
+const instructions = {
+  name: "instructions",
+  system: actorInstructions
+}
+
+export default defineActor({
+  name: actorName,
+  actor: agentOf([
+    instructions,
+    codeModeFor({
+      packages: [filesPackage(), fetchPackage(), agentsPackage(), workspacePackage()]
+    }),
+    reply,
+    budget,
+    compaction
+  ])
+})

--- a/knip.json
+++ b/knip.json
@@ -4,7 +4,8 @@
     ".": {
       "entry": [
         "tools/*.ts",
-        "examples/*.ts"
+        "examples/*.ts",
+        "examples/quickstart/*.ts"
       ],
       "project": [
         "tools/**/*.ts",

--- a/tools/publish.ts
+++ b/tools/publish.ts
@@ -46,8 +46,10 @@ const BIN_ENTRY = "./src/cli/main.ts"
 // name is not the workspace directory's, so the candidate this command tries inside the repository
 // cannot match it (apps/cli/src/assets.ts, INSTALLED_ASSETS).
 const STAGED_ASSETS = "ui"
+const STAGED_EXAMPLES = "examples"
 
 const VOYAGER_SOURCE = "apps/voyager/dist"
+const QUICKSTART_SOURCE = "examples/quickstart"
 
 const VOYAGER_BUILD = ["bun", "run", "--cwd", "apps/voyager", "build"]
 
@@ -172,6 +174,7 @@ try {
     cp(join(root, "LICENSE"), join(stage, "LICENSE")),
     cp(join(root, "README.md"), join(stage, "README.md")),
     cp(join(root, VOYAGER_SOURCE), join(stage, STAGED_ASSETS), { recursive: true }),
+    cp(join(root, QUICKSTART_SOURCE), join(stage, STAGED_EXAMPLES, "quickstart"), { recursive: true }),
     ...packages.map(async (source) => {
       await cp(join(root, source.dir, "src"), join(stage, "src", source.namespace), {
         recursive: true,
@@ -201,7 +204,7 @@ try {
         : repository,
     bugs: publicSource.pkg.bugs,
     publishConfig: publicSource.pkg.publishConfig,
-    files: ["src", STAGED_ASSETS],
+    files: ["src", STAGED_ASSETS, STAGED_EXAMPLES],
     engines: publicSource.pkg.engines,
     type: "module",
     bin: { [BIN_NAME]: BIN_ENTRY },


### PR DESCRIPTION
Adds the source renderer that tdg init will use for a first actor. The generated actor exposes its instructions and reach, includes the default local packages and policies, validates actor names, preserves custom instructions, and builds through the production artifact path.