### PR TITLE
feat(cli): add init command

### DIFF
--- a/apps/cli/src/build.test.ts
+++ b/apps/cli/src/build.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { ACTOR_ARTIFACT_VERSION } from "tardie"
@@ -13,7 +14,7 @@ afterEach(async () => {
 })
 
 const entry = async (source: string): Promise<string> => {
-  root = await mkdtemp(join(process.cwd(), ".tdg-build-test-"))
+  root = await mkdtemp(join(tmpdir(), "tdg-build-test-"))
   const path = join(root, "actor.ts")
   await writeFile(path, source, "utf8")
   return path

--- a/apps/cli/src/build.ts
+++ b/apps/cli/src/build.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto"
 import { mkdtemp, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
-import { pathToFileURL } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 import {
   ACTOR_ARTIFACT_VERSION,
@@ -13,6 +13,7 @@ import {
 export const DEFAULT_BUILD_DIRECTORY = ".tardigrade/build"
 export const ACTOR_MODULE_FILE = "actor.mjs"
 export const ACTOR_MANIFEST_FILE = "manifest.json"
+export const TARDIE_ENTRY = fileURLToPath(import.meta.resolve("tardie"))
 
 export interface BuildActorOptions {
   readonly out?: string
@@ -45,6 +46,13 @@ const definitionOf = async (modulePath: string): Promise<ActorDefinition<unknown
   return candidate as ActorDefinition<unknown>
 }
 
+export const tardiePlugin = (entry: string = TARDIE_ENTRY): Bun.BunPlugin => ({
+  name: "tardie",
+  setup(builder) {
+    builder.onResolve({ filter: /^tardie$/ }, () => ({ path: entry }))
+  }
+})
+
 export const buildActor = async (entry: string, options: BuildActorOptions = {}): Promise<BuiltActor> => {
   const cwd = resolve(options.cwd ?? process.cwd())
   const source = resolve(cwd, entry)
@@ -59,7 +67,8 @@ export const buildActor = async (entry: string, options: BuildActorOptions = {})
       target: "bun",
       format: "esm",
       minify: false,
-      sourcemap: "none"
+      sourcemap: "none",
+      plugins: [tardiePlugin()]
     })
     if (!result.success) {
       const detail = result.logs.map((log) => log.message).join("\n")

--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -142,6 +142,7 @@ describe("parsing", () => {
   // is the first one a person runs, so it is the first one listed (commands.ts, tdg).
   test("the tree names setup, and its help says what it writes", async () => {
     expect((await drive([])).lines.join("\n")).toContain("setup")
+    expect((await drive([])).lines.join("\n")).toContain("init")
     expect((await drive([])).lines.join("\n")).toContain("build")
     expect((await drive([])).lines.join("\n")).toContain("push")
     expect((await drive([])).lines.join("\n")).toContain("actors")
@@ -166,6 +167,9 @@ describe("parsing", () => {
     expect(pushHelp).toContain("--target")
     expect(pushHelp).toContain("local")
     expect(pushHelp).toContain("hosted")
+    const initHelp = (await drive(["init", "--help"])).lines.join("\n")
+    expect(initHelp).toContain("--dir")
+    expect(initHelp).toContain("--force")
   })
 
   test("push requires an explicit target", async () => {

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -7,6 +7,7 @@ import { modelIsConfigured } from "@clavia/tardigrade-server/host"
 import { buildActor, buildSummary, DEFAULT_BUILD_DIRECTORY } from "./build"
 import { readFileConfig, resolveRemote, resolveServer } from "./config"
 import { availableDevPort, DEFAULT_MIN_PORT, DEV_URL_HOST, dev, openBrowser } from "./dev"
+import { initActor, initSummary } from "./init"
 import { DEFAULT_ACTOR_DIRECTORY, pushActor, pushSummary, PUSH_TARGETS } from "./push"
 import { homeOf, HOME_MISSING, setupJson, setupPrompt, setupSummary, writeSetup } from "./setup"
 import { actorsTable, threadsTable, DEFAULT_DETAIL_WIDTH, eventsTable, jsonOf, turnLines } from "./render"
@@ -156,6 +157,36 @@ export const setupCommand = Command.make("setup", { json }, (flags) =>
     ),
     Command.withExamples([
       { command: "tdg setup", description: "Answer four prompts and write the file" }
+    ])
+  )
+
+export const initCommand = Command.make("init", {
+  name: Argument.string("name").pipe(Argument.withDescription("The actor name")),
+  dir: Flag.string("dir").pipe(
+    Flag.withDescription("The directory to create. Defaults to a directory named after the actor."),
+    Flag.optional
+  ),
+  force: Flag.boolean("force").pipe(
+    Flag.withDescription("Replace actor.ts when it already exists."),
+    Flag.withDefault(false)
+  ),
+  json
+}, (flags) =>
+  Effect.gen(function*() {
+    const directory = stated(flags.dir)
+    const initialized = yield* Effect.tryPromise({
+      try: () => initActor(flags.name, {
+        ...(directory === undefined ? {} : { directory }),
+        force: flags.force
+      }),
+      catch: userErrorOf
+    })
+    yield* Console.log(flags.json ? jsonOf(initialized) : initSummary(initialized))
+  })).pipe(
+    Command.withDescription("Create an editable actor from the bundled quickstart."),
+    Command.withExamples([
+      { command: "tdg init researcher", description: "Create researcher/actor.ts and print the local workflow" },
+      { command: "tdg init reviewer --dir actors/reviewer", description: "Create the actor in a stated directory" }
     ])
   )
 
@@ -444,5 +475,5 @@ export const tdg = Command.make("tdg").pipe(
   Command.withDescription(
     "The tardigrade command. Every read is a projection of a durable log, and every failure is the server's own problem document."
   ),
-  Command.withSubcommands([setupCommand, buildCommand, pushCommand, devCommand, actorsCommand, runCommand, sendCommand, lsCommand, eventsCommand])
+  Command.withSubcommands([setupCommand, initCommand, buildCommand, pushCommand, devCommand, actorsCommand, runCommand, sendCommand, lsCommand, eventsCommand])
 )

--- a/apps/cli/src/init.test.ts
+++ b/apps/cli/src/init.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+import { buildActor } from "./build"
+import { DEFAULT_ACTOR_ENTRY, defaultInitDirectory, initActor, initSummary } from "./init"
+
+let root = ""
+
+afterEach(async () => {
+  if (root.length > 0) await rm(root, { recursive: true, force: true })
+})
+
+const temporaryRoot = async (): Promise<string> => {
+  root = await mkdtemp(join(process.cwd(), ".tdg-init-test-"))
+  return root
+}
+
+describe("initActor", () => {
+  test("creates a buildable named quickstart", async () => {
+    const cwd = await temporaryRoot()
+    const initialized = await initActor("reviewer", { cwd })
+    const source = await readFile(initialized.entry, "utf8")
+    const built = await buildActor(initialized.entry, { cwd: initialized.directory, out: "output" })
+
+    expect(defaultInitDirectory("reviewer")).toBe("reviewer")
+    expect(initialized.entry).toBe(join(cwd, "reviewer", DEFAULT_ACTOR_ENTRY))
+    expect(source).toContain('const actorName = "reviewer"')
+    expect(built.manifest.name).toBe("reviewer")
+  })
+
+  test("refuses to overwrite unless force is stated", async () => {
+    const cwd = await temporaryRoot()
+    const entry = join(cwd, "reviewer", DEFAULT_ACTOR_ENTRY)
+    await initActor("reviewer", { cwd })
+    await writeFile(entry, "keep me", "utf8")
+
+    await expect(initActor("reviewer", { cwd })).rejects.toThrow("pass --force")
+    expect(await readFile(entry, "utf8")).toBe("keep me")
+
+    await initActor("reviewer", { cwd, force: true })
+    expect(await readFile(entry, "utf8")).toContain('const actorName = "reviewer"')
+  })
+
+  test("writes into a stated directory", async () => {
+    const cwd = await temporaryRoot()
+    const initialized = await initActor("reviewer", { cwd, directory: "actors/custom" })
+
+    expect(initialized.entry).toBe(join(cwd, "actors", "custom", DEFAULT_ACTOR_ENTRY))
+  })
+})
+
+describe("initSummary", () => {
+  test("prints the complete local path", async () => {
+    const cwd = await temporaryRoot()
+    const initialized = await initActor("reviewer", { cwd })
+    const summary = initSummary(initialized, cwd)
+
+    expect(summary).toContain("created reviewer/actor.ts")
+    expect(summary).toContain("cd reviewer")
+    expect(summary).toContain("tdg build actor.ts")
+    expect(summary).toContain("tdg push actor.ts --target local")
+    expect(summary).toContain("tdg dev")
+    expect(summary).toContain('--actor reviewer')
+  })
+})

--- a/apps/cli/src/init.ts
+++ b/apps/cli/src/init.ts
@@ -1,0 +1,67 @@
+import { mkdir, writeFile } from "node:fs/promises"
+import { dirname, relative, resolve } from "node:path"
+
+import { actorTemplate } from "./template"
+
+export const DEFAULT_ACTOR_ENTRY = "actor.ts"
+
+export interface InitActorOptions {
+  readonly cwd?: string
+  readonly directory?: string
+  readonly force?: boolean
+}
+
+export interface InitializedActor {
+  readonly name: string
+  readonly directory: string
+  readonly entry: string
+}
+
+export const defaultInitDirectory = (name: string): string => name
+
+const existsError = (error: unknown): boolean =>
+  typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST"
+
+export const initActor = async (name: string, options: InitActorOptions = {}): Promise<InitializedActor> => {
+  const cwd = options.cwd ?? process.cwd()
+  const directory = resolve(cwd, options.directory ?? defaultInitDirectory(name))
+  const entry = resolve(directory, DEFAULT_ACTOR_ENTRY)
+  const source = await actorTemplate({ name })
+
+  await mkdir(dirname(entry), { recursive: true })
+  try {
+    await writeFile(entry, source, { encoding: "utf8", flag: options.force === true ? "w" : "wx" })
+  } catch (error) {
+    if (existsError(error)) {
+      throw new Error(`actor already exists at ${entry}. Choose another directory or pass --force.`)
+    }
+    throw error
+  }
+
+  return { name, directory, entry }
+}
+
+const shownPath = (cwd: string, path: string): string => {
+  const shown = relative(cwd, path)
+  return shown.length === 0 ? "." : shown
+}
+
+const shellWord = (value: string): string =>
+  /^[A-Za-z0-9_./-]+$/u.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`
+
+export const initSummary = (actor: InitializedActor, cwd: string = process.cwd()): string => {
+  const directory = shownPath(cwd, actor.directory)
+  const entry = shownPath(actor.directory, actor.entry)
+  return [
+    `created ${shownPath(cwd, actor.entry)}`,
+    "",
+    "next",
+    `  cd ${shellWord(directory)}`,
+    `  tdg build ${shellWord(entry)}`,
+    `  tdg push ${shellWord(entry)} --target local`,
+    "  tdg dev",
+    "",
+    "then, in another terminal",
+    `  tdg run "Read this repository and tell me what it does" --actor ${actor.name}`
+  ].join("\n")
+}


### PR DESCRIPTION
## Summary

Add `tdg init <name>` to create a named actor from the bundled quickstart. The command supports a custom directory, refuses overwrites by default, accepts `--force`, and prints the local build, push, dev, and run workflow.

Resolve `tardie` imports through the installed CLI during actor builds. This lets a global installation build generated actors in projects that do not install `tardie` locally.

## Testing

- `bun run gate`
- Built the npm tarball and installed it in a clean directory
- Ran the installed `tdg init` and `tdg build` from an unrelated directory