### PR TITLE
docs(example): explain quickstart actor

### DIFF
--- a/examples/quickstart/actor.ts
+++ b/examples/quickstart/actor.ts
@@ -39,9 +39,11 @@ export default defineActor({
       // packages grant access to local files, HTTP, child agents, and saved tool results.
       packages: [filesPackage(), fetchPackage(), agentsPackage(), workspacePackage()]
     }),
-    // reply, budget, and compaction provide completion, bounded work, and long-run context.
+    // reply returns a finished turn to the actor that delegated it.
     reply,
+    // budget stops work tools when the turn reaches its tool-call limit.
     budget,
+    // compaction summarizes older context when a long turn outgrows its context window.
     compaction
   ])
 })

--- a/examples/quickstart/actor.ts
+++ b/examples/quickstart/actor.ts
@@ -11,8 +11,10 @@ import {
   workspacePackage
 } from "tardie"
 
+// actorName is the stable name used by build, push, and run.
 const actorName = "researcher"
 
+// actorInstructions is the main place to describe the job and its expected answer.
 const actorInstructions = `
 You are ${actorName}, a focused research agent.
 
@@ -29,11 +31,15 @@ const instructions = {
 
 export default defineActor({
   name: actorName,
+  // agentOf combines small capabilities into the actor's behavior.
   actor: agentOf([
     instructions,
+    // codeModeFor gives the model one code tool over the packages listed here.
     codeModeFor({
+      // packages grant access to local files, HTTP, child agents, and saved tool results.
       packages: [filesPackage(), fetchPackage(), agentsPackage(), workspacePackage()]
     }),
+    // reply, budget, and compaction provide completion, bounded work, and long-run context.
     reply,
     budget,
     compaction


### PR DESCRIPTION
## Summary

Add compact comments to the quickstart actor. The comments identify the actor name, system prompt, capability assembly, code-mode packages, and lifecycle capabilities so a new author knows where to start editing.

Generated actors inherit the same comments because `tdg init` renders this file directly.

## Testing

- `bun test apps/cli/src/template.test.ts apps/cli/src/init.test.ts`
- `bunx oxlint examples/quickstart/actor.ts`
- `bun run tools/docs-lint.ts`