### PR TITLE
feat(voyager): show actor digest

### DIFF
--- a/apps/voyager/src/ActorRail.tsx
+++ b/apps/voyager/src/ActorRail.tsx
@@ -3,9 +3,15 @@ import { ArrowLeft, ArrowRight, BracketsCurly } from "@phosphor-icons/react"
 import { useState, type ReactElement } from "react"
 
 import { navigate } from "./nav"
-import { ACTOR_RAIL_WIDTH, COLLAPSED_ACTOR_RAIL_WIDTH, ICON_SIZE, PANE_HEADER_HEIGHT } from "./policy"
+import {
+  ACTOR_DIGEST_CHARS,
+  ACTOR_RAIL_WIDTH,
+  COLLAPSED_ACTOR_RAIL_WIDTH,
+  ICON_SIZE,
+  PANE_HEADER_HEIGHT
+} from "./policy"
 import { ProductMark } from "./ProductMark"
-import { matches } from "./roster"
+import { digestLabelOf, matches } from "./roster"
 
 const ACTOR_RAIL_KEY = "voyager.actor-rail"
 
@@ -17,12 +23,14 @@ const storedCollapsed = (): boolean => {
 export const ActorRail = ({
   actors,
   collapsedWidth = COLLAPSED_ACTOR_RAIL_WIDTH,
+  digestChars = ACTOR_DIGEST_CHARS,
   headerHeight = PANE_HEADER_HEIGHT,
   problem,
   selected
 }: {
   readonly actors: ReadonlyArray<ActorSummary>
   readonly collapsedWidth?: number | undefined
+  readonly digestChars?: number | undefined
   readonly headerHeight?: number | undefined
   readonly problem: ProblemError | undefined
   readonly selected: string | undefined
@@ -87,7 +95,11 @@ export const ActorRail = ({
               onClick={() => navigate({ actor: actor.name, thread: undefined, view: undefined, from: undefined, to: undefined })}
             >
               <span className="mono actor-name">{actor.name}</span>
-              {actor.builtIn ? <span className="mono actor-kind">built-in</span> : null}
+              {actor.builtIn ? (
+                <span className="mono actor-kind">built-in</span>
+              ) : actor.digest === undefined ? null : (
+                <span className="mono actor-kind" title={actor.digest}>sha {digestLabelOf(actor.digest, digestChars)}</span>
+              )}
             </button>
           )
         })}

--- a/apps/voyager/src/policy.ts
+++ b/apps/voyager/src/policy.ts
@@ -18,6 +18,10 @@ export const PANE_HEADER_HEIGHT = 64
 // else, so a reader can always open the list again from where they closed it.
 export const COLLAPSED_ACTOR_RAIL_WIDTH = 48
 
+// The hexadecimal characters shown from a pushed actor's digest. ActorRail accepts another length
+// when an embedding has a wider or narrower actor pane.
+export const ACTOR_DIGEST_CHARS = 7
+
 // How many nested object levels the API explorer renders before naming the remaining schema. The
 // explorer accepts another depth when a larger surface needs to show more of a recursive model.
 export const API_SCHEMA_DEPTH = 3

--- a/apps/voyager/src/roster.test.ts
+++ b/apps/voyager/src/roster.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 
 import type { ThreadSummary } from "@clavia/tardigrade-client"
-import { agoOf, countsOf, latestRootOf, matches, rosterOf } from "./roster"
+import { agoOf, countsOf, digestLabelOf, latestRootOf, matches, rosterOf } from "./roster"
 
 // The rail's decisions: which threads are rows, how big each root's family is, what a row's counts
 // say, and how an age reads. All pure, so none of them needs a server or a DOM.
@@ -68,6 +68,13 @@ describe("matches", () => {
     expect(matches("PR-shepherd", " shep ")).toBe(true)
     expect(matches("pr-shepherd", "deploy")).toBe(false)
     expect(matches("pr-shepherd", "")).toBe(true)
+  })
+})
+
+describe("digestLabelOf", () => {
+  test("an actor digest reads as short hexadecimal identity", () => {
+    expect(digestLabelOf("sha256:beb340c42043b306", 7)).toBe("beb340c")
+    expect(digestLabelOf("custom-digest", 6)).toBe("custom")
   })
 })
 

--- a/apps/voyager/src/roster.ts
+++ b/apps/voyager/src/roster.ts
@@ -1,5 +1,7 @@
 import type { ThreadStatus, ThreadSummary } from "@clavia/tardigrade-client"
 
+import { ACTOR_DIGEST_CHARS } from "./policy"
+
 // The rail's projections. GET /v1/actors/:actor/threads answers with every thread and its parent, and the rail shows
 // roots alone, so these functions turn one flat listing into the rows the rail renders. They are
 // pure, so the screen holds no arithmetic of its own.
@@ -67,6 +69,13 @@ export const rosterOf = (summaries: ReadonlyArray<ThreadSummary>): Roster => {
 // reader who knows what they are looking for finds it and nobody else's prose is scanned.
 export const matches = (id: string, query: string): boolean =>
   id.toLowerCase().includes(query.trim().toLowerCase())
+
+// digestLabelOf keeps the hexadecimal identity and drops the algorithm prefix. The visible length
+// is the caller's policy (roster.test.ts, "an actor digest reads as short hexadecimal identity").
+export const digestLabelOf = (digest: string, chars: number = ACTOR_DIGEST_CHARS): string => {
+  const hexadecimal = digest.startsWith("sha256:") ? digest.slice("sha256:".length) : digest
+  return hexadecimal.slice(0, chars)
+}
 
 // agoOf renders an age in one unit: seconds under a minute, minutes under an hour, hours beyond. A
 // timestamp ahead of the reader's clock reads as 0s rather than a negative age, because the

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -421,6 +421,7 @@ textarea {
 }
 
 .actor-kind {
+  flex-shrink: 0;
   margin-left: auto;
   color: var(--faint);
   font-size: 9.5px;


### PR DESCRIPTION
## Summary

Show each pushed actor's short SHA-256 digest in the actor sidebar. The full digest remains available as the label tooltip, while built-in actors keep their existing marker.

The visible digest length is exported as policy and can be overridden by an embedded actor rail.

## Testing

- `bun run gate`
- Opened the rebuilt Voyager against the live researcher trace