### PR TITLE
feat(voyager): add event inspector

### DIFF
--- a/apps/voyager/src/ActorRail.tsx
+++ b/apps/voyager/src/ActorRail.tsx
@@ -1,17 +1,21 @@
 import type { ActorSummary, ProblemError } from "@clavia/tardigrade-client"
+import { Avatar } from "@base-ui-components/react/avatar"
 import { ArrowLeft, ArrowRight, BracketsCurly } from "@phosphor-icons/react"
 import { useState, type ReactElement } from "react"
 
 import { navigate } from "./nav"
 import {
   ACTOR_DIGEST_CHARS,
-  ACTOR_RAIL_WIDTH,
+  ACTOR_MARK_CHARS,
+  ACTOR_MARK_SIZE,
   COLLAPSED_ACTOR_RAIL_WIDTH,
   ICON_SIZE,
-  PANE_HEADER_HEIGHT
+  PANE_HEADER_HEIGHT,
+  RAIL_WIDTH
 } from "./policy"
 import { ProductMark } from "./ProductMark"
-import { digestLabelOf, matches } from "./roster"
+import { actorMarkOf, digestLabelOf, matches } from "./roster"
+import { ThemeToggle } from "./ThemeToggle"
 
 const ACTOR_RAIL_KEY = "voyager.actor-rail"
 
@@ -25,15 +29,21 @@ export const ActorRail = ({
   collapsedWidth = COLLAPSED_ACTOR_RAIL_WIDTH,
   digestChars = ACTOR_DIGEST_CHARS,
   headerHeight = PANE_HEADER_HEIGHT,
+  markChars = ACTOR_MARK_CHARS,
+  markSize = ACTOR_MARK_SIZE,
   problem,
-  selected
+  selected,
+  width = RAIL_WIDTH
 }: {
   readonly actors: ReadonlyArray<ActorSummary>
   readonly collapsedWidth?: number | undefined
   readonly digestChars?: number | undefined
   readonly headerHeight?: number | undefined
+  readonly markChars?: number | undefined
+  readonly markSize?: number | undefined
   readonly problem: ProblemError | undefined
   readonly selected: string | undefined
+  readonly width?: number | undefined
 }): ReactElement => {
   const [query, setQuery] = useState("")
   const [collapsed, setCollapsed] = useState(storedCollapsed)
@@ -42,7 +52,7 @@ export const ActorRail = ({
   return (
     <aside
       className={`actor-rail${collapsed ? " actor-rail-collapsed" : ""}`}
-      style={{ width: collapsed ? collapsedWidth : ACTOR_RAIL_WIDTH }}
+      style={{ width: collapsed ? collapsedWidth : width }}
     >
       <div className="pane-chrome" style={{ height: headerHeight }}>
         <div className="actor-head">
@@ -83,6 +93,28 @@ export const ActorRail = ({
           {problem.detail === undefined ? null : <div className="problem-detail">{problem.detail}</div>}
         </div>
       )}
+      {!collapsed ? null : (
+        <div className="actor-mark-list" aria-label="actors">
+          {actors.map((actor) => {
+            const chosen = actor.name === selected
+            return (
+              <button
+                type="button"
+                key={actor.name}
+                className={`actor-mark-button${chosen ? " actor-mark-selected" : ""}`}
+                aria-label={`Open ${actor.name}`}
+                aria-current={chosen ? "true" : undefined}
+                title={actor.name}
+                onClick={() => navigate({ actor: actor.name, thread: undefined, view: undefined, from: undefined, to: undefined })}
+              >
+                <Avatar.Root className="mono actor-mark" style={{ width: markSize, height: markSize }} aria-hidden="true">
+                  <Avatar.Fallback>{actorMarkOf(actor.name, markChars)}</Avatar.Fallback>
+                </Avatar.Root>
+              </button>
+            )
+          })}
+        </div>
+      )}
       <div className="actor-only actor-list">
         {shown.map((actor) => {
           const chosen = actor.name === selected
@@ -113,6 +145,7 @@ export const ActorRail = ({
           <BracketsCurly size={ICON_SIZE} weight="light" aria-hidden="true" />
           <span className="actor-only">API</span>
         </button>
+        <ThemeToggle className="actor-api" label={<span className="actor-only">Theme</span>} />
       </div>
     </aside>
   )

--- a/apps/voyager/src/ApiSurface.tsx
+++ b/apps/voyager/src/ApiSurface.tsx
@@ -1,5 +1,5 @@
 import { OPENAPI_PATH } from "@clavia/tardigrade-client/contract"
-import { ArrowLeft, MagnifyingGlass } from "@phosphor-icons/react"
+import { ArrowLeft, BracketsCurly, MagnifyingGlass } from "@phosphor-icons/react"
 import { useEffect, useMemo, useRef, useState, type ReactElement } from "react"
 
 import {
@@ -16,7 +16,7 @@ import {
 } from "./api"
 import { client } from "./client"
 import { navigate, useRoute } from "./nav"
-import { API_SCHEMA_DEPTH, ICON_SIZE } from "./policy"
+import { API_SCHEMA_DEPTH, ICON_SIZE, PANE_HEADER_HEIGHT, RAIL_WIDTH } from "./policy"
 import { ProductMark } from "./ProductMark"
 import { ThemeToggle } from "./ThemeToggle"
 
@@ -274,7 +274,15 @@ const ApiReference = ({
   </article>
 )
 
-export const ApiSurface = ({ schemaDepth = API_SCHEMA_DEPTH }: { readonly schemaDepth?: number | undefined }): ReactElement => {
+export const ApiSurface = ({
+  headerHeight = PANE_HEADER_HEIGHT,
+  navWidth = RAIL_WIDTH,
+  schemaDepth = API_SCHEMA_DEPTH
+}: {
+  readonly headerHeight?: number | undefined
+  readonly navWidth?: number | undefined
+  readonly schemaDepth?: number | undefined
+}): ReactElement => {
   const route = useRoute()
   const { document, problem } = useApiDocument()
   const [query, setQuery] = useState("")
@@ -332,20 +340,22 @@ export const ApiSurface = ({ schemaDepth = API_SCHEMA_DEPTH }: { readonly schema
   }, [document])
   return (
     <div className="api-view">
-      <aside className="api-nav">
-        <div className="api-nav-head">
-          <button
-            type="button"
-            className="icon-btn"
-            aria-label="Back to Voyager"
-            title="Back to Voyager"
-            onClick={() => navigate({ view: undefined, operation: undefined }, { replace: true })}
-          >
-            <ArrowLeft size={ICON_SIZE} weight="light" aria-hidden="true" />
-          </button>
-          <div>
-            <ProductMark />
-            <div className="mono actor-label">api</div>
+      <aside className="api-nav" style={{ width: navWidth }}>
+        <div className="pane-chrome" style={{ height: headerHeight }}>
+          <div className="actor-head">
+            <div className="actor-identity">
+              <ProductMark />
+              <div className="mono actor-label">api</div>
+            </div>
+            <button
+              type="button"
+              className="icon-btn"
+              aria-label="Back to Voyager"
+              title="Back to Voyager"
+              onClick={() => navigate({ view: undefined, operation: undefined }, { replace: true })}
+            >
+              <ArrowLeft size={ICON_SIZE} weight="light" aria-hidden="true" />
+            </button>
           </div>
         </div>
         <label className="api-search-wrap">
@@ -382,6 +392,18 @@ export const ApiSurface = ({ schemaDepth = API_SCHEMA_DEPTH }: { readonly schema
             </section>
           ))}
         </nav>
+        <div className="actor-footer">
+          <button
+            type="button"
+            className="actor-api actor-api-active"
+            aria-current="page"
+            onClick={() => jumpTo(undefined)}
+          >
+            <BracketsCurly size={ICON_SIZE} weight="light" aria-hidden="true" />
+            <span>API</span>
+          </button>
+          <ThemeToggle className="actor-api" label={<span>Theme</span>} />
+        </div>
       </aside>
       <main className="api-reading">
         {problem !== undefined ? (
@@ -392,7 +414,6 @@ export const ApiSurface = ({ schemaDepth = API_SCHEMA_DEPTH }: { readonly schema
           <ApiReference document={document} depth={schemaDepth} />
         )}
       </main>
-      <ThemeToggle />
     </div>
   )
 }

--- a/apps/voyager/src/App.tsx
+++ b/apps/voyager/src/App.tsx
@@ -10,7 +10,6 @@ import { ROSTER_POLL_MS } from "./policy"
 import { Quickstart } from "./Quickstart"
 import { Rail } from "./Rail"
 import { EMPTY_ROSTER, latestRootOf, rosterOf, type Roster } from "./roster"
-import { ThemeToggle } from "./ThemeToggle"
 import { ActorRail } from "./ActorRail"
 
 // The app: one screen, two panes. The rail lists the run's roots and the center pane reads the
@@ -18,6 +17,7 @@ import { ActorRail } from "./ActorRail"
 // there is nowhere else to go: voyager reads a run and never writes to it.
 
 interface Reading {
+  readonly actor: string | undefined
   readonly roster: Roster
   // When the listing was read, so every age on screen is measured from one instant.
   readonly at: number
@@ -27,14 +27,14 @@ interface Reading {
 // chip are the same listing read twice rather than two calls. The last good reading survives a
 // failure, so a server restart holds the rail rather than blanking it.
 const useRoster = (actor: string | undefined, intervalMs: number) => {
-  const [reading, setReading] = useState<Reading>({ roster: EMPTY_ROSTER, at: Date.now() })
+  const [reading, setReading] = useState<Reading>({ actor: undefined, roster: EMPTY_ROSTER, at: Date.now() })
   const [summaries, setSummaries] = useState<ReadonlyArray<ThreadSummary>>([])
   const [problem, setProblem] = useState<ProblemError | undefined>(undefined)
   const [ready, setReady] = useState(false)
 
   useEffect(() => {
     setSummaries([])
-    setReading({ roster: EMPTY_ROSTER, at: Date.now() })
+    setReading({ actor, roster: EMPTY_ROSTER, at: Date.now() })
     setProblem(undefined)
     setReady(false)
     if (actor === undefined) return
@@ -45,7 +45,7 @@ const useRoster = (actor: string | undefined, intervalMs: number) => {
         const all = await selected.list()
         if (!live) return
         setSummaries(all)
-        setReading({ roster: rosterOf(all), at: Date.now() })
+        setReading({ actor, roster: rosterOf(all), at: Date.now() })
         setProblem(undefined)
         setReady(true)
       } catch (error) {
@@ -105,11 +105,11 @@ export const App = (): ReactElement => {
     navigate({ actor }, { replace: true })
   }, [actor, route.actor])
   useEffect(() => {
-    if (!ready || route.view !== undefined || route.thread !== undefined) return
+    if (!ready || reading.actor !== actor || route.view !== undefined || route.thread !== undefined) return
     const latest = latestRootOf(reading.roster)
     if (latest === undefined) return
     navigate({ thread: latest.id, from: undefined, to: undefined }, { replace: true })
-  }, [reading.roster, ready, route.thread, route.view])
+  }, [actor, reading.actor, reading.roster, ready, route.thread, route.view])
   if (route.view === "api") return <ApiSurface />
   return (
     <div style={{ height: "100%", display: "flex", overflow: "hidden", position: "relative" }}>
@@ -124,7 +124,6 @@ export const App = (): ReactElement => {
           <Thread actor={actor ?? RESERVED_ACTOR} id={route.thread} status={status} />
         )}
       </main>
-      <ThemeToggle />
     </div>
   )
 }

--- a/apps/voyager/src/ThemeToggle.tsx
+++ b/apps/voyager/src/ThemeToggle.tsx
@@ -1,16 +1,22 @@
 import { Moon, Sun } from "@phosphor-icons/react"
-import type { ReactElement } from "react"
+import type { ReactElement, ReactNode } from "react"
 
 import { ICON_SIZE } from "./policy"
 import { useTheme } from "./theme"
 
-// ThemeToggle switches between the two designed themes from a persistent app-shell position.
-export const ThemeToggle = (): ReactElement => {
+// ThemeToggle switches between the two designed themes from the shell position its caller owns.
+export const ThemeToggle = ({
+  className = "icon-btn",
+  label
+}: {
+  readonly className?: string | undefined
+  readonly label?: ReactNode
+} = {}): ReactElement => {
   const { theme, toggle } = useTheme()
   return (
     <button
       type="button"
-      className="icon-btn theme-toggle"
+      className={className}
       onClick={toggle}
       aria-label={theme === "dark" ? "Switch to the light theme" : "Switch to the dark theme"}
       title="Toggle theme"
@@ -20,6 +26,7 @@ export const ThemeToggle = (): ReactElement => {
       ) : (
         <Sun size={ICON_SIZE} weight="light" aria-hidden="true" />
       )}
+      {label}
     </button>
   )
 }

--- a/apps/voyager/src/Thread.tsx
+++ b/apps/voyager/src/Thread.tsx
@@ -1,17 +1,18 @@
 import { Fragment, useEffect, useLayoutEffect, useRef, useState, type ReactElement } from "react"
+import { X } from "@phosphor-icons/react"
 
 import { NO_ANSWER, ProblemError, type ThreadStatus, type EventRow } from "@clavia/tardigrade-client"
 
 import { clientFor } from "./client"
 import { fieldsOf, merged, momentsOf, stampOf, type Field, type Moment } from "./narrative"
 import { navigate, useRoute, type Route } from "./nav"
-import { BOTTOM_SLACK_PX, EVENT_STAMP_WIDTH, FIELD_COLLAPSED_HEIGHT, FIELD_WIDTH, LOG_POLL_MS, PANE_HEADER_HEIGHT, SUMMARY_WIDTH } from "./policy"
+import { BOTTOM_SLACK_PX, EVENT_INSPECTOR_WIDTH, EVENT_STAMP_WIDTH, FIELD_COLLAPSED_HEIGHT, FIELD_WIDTH, ICON_SIZE, LOG_POLL_MS, PANE_HEADER_HEIGHT } from "./policy"
 import { axisOf, defaultWindowOf, FULL_WINDOW, shared, shownIn, type Window } from "./window"
 import { WindowBrush } from "./WindowBrush"
 
 // The center pane: one thread's log as a flat chronological list under its own header and the window
 // brush (mock.html, the main element). The pane holds cursors only: which thread, which range the
-// window holds, which row is open. Every fact on it is the server's, read through src/client.ts.
+// window holds, which row is selected. Every fact on it is the server's, read through src/client.ts.
 
 const errorOf = (error: unknown): ProblemError =>
   error instanceof ProblemError ? error : new ProblemError({ title: String(error), status: NO_ANSWER })
@@ -125,43 +126,57 @@ const FieldValue = ({ collapsedHeight, field }: { readonly collapsedHeight: numb
   )
 }
 
-// An opened row's fields, hanging off the row on one hairline: the event's own names on the left,
-// its values on the page's own ground on the right. There is no card, because the expansion is the
-// row saying more rather than a second surface (mock.html, .ev-detail). The keys and values are
-// src/narrative.ts's answer, so what a type shows is a tested fact rather than a render decision.
-const Detail = ({
+// Inspector shows the selected event beside the trace. Its keys and values are fieldsOf's tested
+// projection, so selecting a row changes where the payload is read without changing its content
+// (src/narrative.test.ts, "known expanded fields follow the event's reading order").
+const Inspector = ({
   collapsedHeight,
+  headerHeight,
   moment,
-  stampWidth
+  onClose,
+  width
 }: {
   readonly collapsedHeight: number
+  readonly headerHeight: number
   readonly moment: Moment
-  readonly stampWidth: number
-}): ReactElement => (
-  <div
-    className="event-detail fade-in"
-    style={{ marginLeft: `calc(${stampWidth}px + var(--space-2) + var(--space-3))` }}
-  >
-    {fieldsOf(moment.event).map((field) => (
-      <Fragment key={field.key}>
-        <span className="mono event-key">{field.key}</span>
-        <FieldValue field={field} collapsedHeight={collapsedHeight} />
-      </Fragment>
-    ))}
-  </div>
-)
+  readonly onClose: () => void
+  readonly width: number
+}): ReactElement => {
+  const stamp = stampOf(moment.event.type)
+  return (
+    <aside className="event-inspector" style={{ width }} aria-label={`${moment.event.type} event details`}>
+      <div className="event-inspector-head" style={{ height: headerHeight }}>
+        <div className="event-inspector-title">
+          <span className="mono event-stamp" style={{ background: stamp.bg, color: stamp.fg }}>
+            {moment.event.type}
+          </span>
+          <span className="mono event-inspector-seq">event {moment.seq}</span>
+        </div>
+        <button type="button" className="icon-btn" aria-label="Close event details" title="Close event details" onClick={onClose}>
+          <X size={ICON_SIZE} weight="light" />
+        </button>
+      </div>
+      <div className="event-detail">
+        {fieldsOf(moment.event).map((field) => (
+          <Fragment key={field.key}>
+            <span className="mono event-key">{field.key}</span>
+            <FieldValue field={field} collapsedHeight={collapsedHeight} />
+          </Fragment>
+        ))}
+      </div>
+    </aside>
+  )
+}
 
 const Row = ({
   moment,
-  onToggle,
-  open,
-  fieldCollapsedHeight,
+  onSelect,
+  selected,
   stampWidth
 }: {
   readonly moment: Moment
-  readonly onToggle: () => void
-  readonly open: boolean
-  readonly fieldCollapsedHeight: number
+  readonly onSelect: () => void
+  readonly selected: boolean
   readonly stampWidth: number
 }): ReactElement => {
   const stamp = stampOf(moment.event.type)
@@ -170,29 +185,24 @@ const Row = ({
       <div
         role="button"
         tabIndex={0}
-        aria-expanded={open}
-        className={`event-row${open ? " event-row-open" : ""}`}
-        onClick={onToggle}
+        aria-pressed={selected}
+        className={`event-row${selected ? " event-row-selected" : ""}`}
+        onClick={onSelect}
         onKeyDown={(pressed) => {
           if (pressed.key !== "Enter" && pressed.key !== " ") return
           pressed.preventDefault()
-          onToggle()
+          onSelect()
         }}
       >
         <span className="mono event-stamp" style={{ background: stamp.bg, color: stamp.fg, width: stampWidth }}>
           {moment.event.type}
         </span>
-        {/* A collapsed line takes the pane's whole width; only the wrapped line an open row shows
-            keeps a measure (src/policy.ts, SUMMARY_WIDTH). */}
-        <span className="event-text" style={open ? { maxWidth: SUMMARY_WIDTH } : undefined}>
-          {moment.summary}
-        </span>
+        <span className="event-text">{moment.summary}</span>
         <span className="mono event-time">
           {moment.time}
           {moment.duration === undefined ? "" : ` · ${moment.duration}`}
         </span>
       </div>
-      {!open ? null : <Detail moment={moment} collapsedHeight={fieldCollapsedHeight} stampWidth={stampWidth} />}
     </div>
   )
 }
@@ -218,6 +228,7 @@ export const Thread = ({
   fieldCollapsedHeight = FIELD_COLLAPSED_HEIGHT,
   headerHeight = PANE_HEADER_HEIGHT,
   id,
+  inspectorWidth = EVENT_INSPECTOR_WIDTH,
   stampWidth = EVENT_STAMP_WIDTH,
   status
 }: {
@@ -225,6 +236,7 @@ export const Thread = ({
   readonly id: string
   readonly fieldCollapsedHeight?: number | undefined
   readonly headerHeight?: number | undefined
+  readonly inspectorWidth?: number | undefined
   readonly stampWidth?: number | undefined
   readonly status: ThreadStatus | undefined
 }): ReactElement => {
@@ -233,7 +245,7 @@ export const Thread = ({
   // a drag renders from one place: `navigate` publishes the URL synchronously, and a control that
   // read its value back out of that publication would render one step behind the handle (src/nav.ts).
   const [window, setWindow] = useState<Window | undefined>(windowOf(route))
-  const [opened, setOpened] = useState<number | undefined>(undefined)
+  const [selected, setSelected] = useState<number | undefined>(undefined)
   const { dropped, loaded, problem, rows } = useLog(actor, id, LOG_POLL_MS)
 
   const pane = useRef<HTMLDivElement | null>(null)
@@ -245,10 +257,19 @@ export const Thread = ({
   const seeded = useRef(false)
 
   useEffect(() => {
-    setOpened(undefined)
+    setSelected(undefined)
     atEnd.current = true
     seeded.current = false
   }, [actor, id])
+
+  useEffect(() => {
+    if (selected === undefined) return
+    const close = (pressed: KeyboardEvent) => {
+      if (pressed.key === "Escape") setSelected(undefined)
+    }
+    addEventListener("keydown", close)
+    return () => removeEventListener("keydown", close)
+  }, [selected])
 
   // A route the pane did not write is one it must follow: a shared link, or a back button
   // (src/nav.ts, useRoute). A drag of its own lands here already equal and changes nothing.
@@ -278,6 +299,7 @@ export const Thread = ({
 
   const held = window ?? FULL_WINDOW
   const shown = shownIn(moments, axis, held)
+  const inspected = selected === undefined ? undefined : moments.find((moment) => moment.seq === selected)
 
   // A drag replaces rather than pushes, so forty steps do not cost forty back presses.
   const onWindow = (next: Window) => {
@@ -300,37 +322,47 @@ export const Thread = ({
   }
 
   return (
-    <>
-      <div className="pane-chrome" style={{ height: headerHeight }}>
-        <Head id={id} status={status} />
-      </div>
-      <WindowBrush axis={axis} moments={moments} shown={shown} window={held} onChange={onWindow} />
-      {problem === undefined ? null : <Problem problem={problem} />}
-      {!dropped ? null : <div className="mono stream-note">stream dropped; polling</div>}
-      <div
-        ref={pane}
-        className="events"
-        onScroll={() => {
-          const element = pane.current
-          if (element === null) return
-          atEnd.current = element.scrollHeight - element.scrollTop - element.clientHeight <= BOTTOM_SLACK_PX
-        }}
-      >
-        {shown.length === 0
-          ? loaded && problem === undefined
-            ? <div className="mono pane-empty">{moments.length === 0 ? "no events yet" : "no events in the window"}</div>
-            : null
-          : shown.map((moment) => (
-              <Row
-                key={moment.seq}
-                moment={moment}
-                open={opened === moment.seq}
-                fieldCollapsedHeight={fieldCollapsedHeight}
-                stampWidth={stampWidth}
-                onToggle={() => setOpened(opened === moment.seq ? undefined : moment.seq)}
-              />
-            ))}
-      </div>
-    </>
+    <div className="thread-view">
+      <section className="thread-trace">
+        <div className="pane-chrome" style={{ height: headerHeight }}>
+          <Head id={id} status={status} />
+        </div>
+        <WindowBrush axis={axis} moments={moments} shown={shown} window={held} onChange={onWindow} />
+        {problem === undefined ? null : <Problem problem={problem} />}
+        {!dropped ? null : <div className="mono stream-note">stream dropped; polling</div>}
+        <div
+          ref={pane}
+          className="events"
+          onScroll={() => {
+            const element = pane.current
+            if (element === null) return
+            atEnd.current = element.scrollHeight - element.scrollTop - element.clientHeight <= BOTTOM_SLACK_PX
+          }}
+        >
+          {shown.length === 0
+            ? loaded && problem === undefined
+              ? <div className="mono pane-empty">{moments.length === 0 ? "no events yet" : "no events in the window"}</div>
+              : null
+            : shown.map((moment) => (
+                <Row
+                  key={moment.seq}
+                  moment={moment}
+                  selected={selected === moment.seq}
+                  stampWidth={stampWidth}
+                  onSelect={() => setSelected(selected === moment.seq ? undefined : moment.seq)}
+                />
+              ))}
+        </div>
+      </section>
+      {inspected === undefined ? null : (
+        <Inspector
+          moment={inspected}
+          collapsedHeight={fieldCollapsedHeight}
+          headerHeight={headerHeight}
+          width={inspectorWidth}
+          onClose={() => setSelected(undefined)}
+        />
+      )}
+    </div>
   )
 }

--- a/apps/voyager/src/narrative.test.ts
+++ b/apps/voyager/src/narrative.test.ts
@@ -121,14 +121,15 @@ const stamped = new Date(2024, 0, 1, 14, 2, 11, 480).getTime()
 const keysOf = (event: Event) => fieldsOf(event).map((field) => field.key)
 
 describe("fieldsOf", () => {
-  test("a message lists its id and its instant, and drops the text the row already is", () => {
+  test("a message lists its id, instant, and complete text", () => {
     expect(fieldsOf({ type: "MessageReceived", id: "m1", text: "spawn survey", at: stamped })).toEqual([
       { key: "id", value: "m1", kind: "text" },
-      { key: "at", value: "14:02:11.480", kind: "text" }
+      { key: "at", value: "14:02:11.480", kind: "text" },
+      { key: "text", value: "spawn survey", kind: "text" }
     ])
   })
 
-  test("a text the row had to cut is kept whole, because the cut line is not the value", () => {
+  test("a long message stays whole", () => {
     const text = "x".repeat(500)
     const fields = fieldsOf({ type: "MessageReceived", id: "m1", text, at: stamped })
     expect(fields.map((field) => field.key)).toEqual(["id", "at", "text"])
@@ -217,8 +218,8 @@ describe("fieldsOf", () => {
     expect(keysOf(event)).toEqual(["turn", "at", "output", "lane"])
   })
 
-  test("an output the row states verbatim is the row's line and not a field of its own", () => {
-    expect(keysOf({ type: "TurnCompleted", turn: "m1", output: "done", at: stamped })).toEqual(["turn", "at"])
+  test("a completed turn keeps its output", () => {
+    expect(keysOf({ type: "TurnCompleted", turn: "m1", output: "done", at: stamped })).toEqual(["turn", "at", "output"])
   })
 
   test("an absent optional is not a field, and the instant is the only clock", () => {

--- a/apps/voyager/src/narrative.ts
+++ b/apps/voyager/src/narrative.ts
@@ -242,12 +242,9 @@ const valueOf = (value: unknown, inlineChars: number, jsonDepth: number): { read
   return { text: compact.length <= inlineChars ? compact : JSON.stringify(shown, null, 2), json: true }
 }
 
-// fieldsOf is what an opened row shows: the event's own fields, in the order its type states, each
-// rendered for reading. `type` is dropped because the stamp already says it, and a field whose
-// rendered value is the summary string verbatim is dropped because the row above already is that
-// line. A summary the row had to cut is not verbatim, so the long text stays and the reader gets
-// the whole of it. Nothing else is dropped: ids, correlation keys, instants, and payloads are what
-// a row is opened for.
+// fieldsOf is what the inspector shows: every event field in the order its type states, rendered
+// for reading. `type` is dropped because the inspector's stamp already says it. IDs, correlation
+// keys, instants, and payloads remain because the inspector is the complete event view.
 export const fieldsOf = (
   event: Event,
   inlineChars: number = FIELD_INLINE_CHARS,
@@ -256,14 +253,12 @@ export const fieldsOf = (
   const own = Object.keys(event).filter((field) => field !== "type" && event[field] !== undefined)
   const order = ORDER[event.type] ?? []
   const keys = [...order.filter((field) => own.includes(field)), ...own.filter((field) => !order.includes(field))]
-  const summary = summaryOf(event, SUMMARY_CHARS, jsonDepth)
   const fields: Array<Field> = []
   for (const key of keys) {
     const raw = event[key]
     const rendered = TIME_FIELDS.includes(key) && typeof raw === "number"
       ? { text: instantOf(raw), json: false }
       : valueOf(raw, inlineChars, jsonDepth)
-    if (rendered.text === summary) continue
     const kind = event.type === "CodeDispatched" && key === "code" ? "code" : rendered.json ? "json" : "text"
     fields.push({ key, value: rendered.text, kind })
   }

--- a/apps/voyager/src/policy.ts
+++ b/apps/voyager/src/policy.ts
@@ -2,13 +2,9 @@
 // policy value the app applies (AGENTS.md, "Design"). A screen imports the default and takes an
 // override at the call site rather than reading a literal.
 
-// The rail's width in pixels (mock.html, the aside). It is a number here because the layout
-// measures against it.
-export const RAIL_WIDTH = 280
-
-// The actor pane's width in pixels. Actor names are shorter than run ids, so the first level keeps
-// a narrower measure than the run rail beside it.
-export const ACTOR_RAIL_WIDTH = 208
+// The list rail width in pixels. Actor, run, and API panes share the Flamecast v6 thread rail
+// measure (flamecast-v6/apps/web/src/system.css, .chat-split).
+export const RAIL_WIDTH = 236
 
 // The shared identity-row height in pixels. Each pane's title begins on the same horizontal datum,
 // and each pane accepts another height when embedded in a tighter shell.
@@ -22,6 +18,14 @@ export const COLLAPSED_ACTOR_RAIL_WIDTH = 48
 // when an embedding has a wider or narrower actor pane.
 export const ACTOR_DIGEST_CHARS = 7
 
+// The characters a collapsed actor's monogram keeps. ActorRail accepts another count when names
+// in an embedding need a shorter or longer mark.
+export const ACTOR_MARK_CHARS = 2
+
+// The collapsed actor monogram's square size in pixels. ActorRail accepts another size when its
+// collapsed width changes.
+export const ACTOR_MARK_SIZE = 28
+
 // How many nested object levels the API explorer renders before naming the remaining schema. The
 // explorer accepts another depth when a larger surface needs to show more of a recursive model.
 export const API_SCHEMA_DEPTH = 3
@@ -33,6 +37,10 @@ export const ICON_SIZE = 15
 // The event type pill's width in pixels. One shared width aligns every event summary, and Thread
 // accepts another width when an embedding uses a different event vocabulary.
 export const EVENT_STAMP_WIDTH = 164
+
+// The event inspector's preferred width in pixels. It yields space to the trace when the viewport
+// is narrow, and Thread accepts another width when its surrounding shell has a different measure.
+export const EVENT_INSPECTOR_WIDTH = 480
 
 // How often the rail re-reads GET /v1/actors/:actor/threads for the roster: the roots and their counts. The server
 // publishes no change feed for the listing, so the rail polls, and this is both the delay between a
@@ -81,11 +89,6 @@ export const COPY_CONFIRM_MS = 1200
 // The column the event type is padded to in copied text. The times, types, and summaries then line
 // up in a plain-text editor, which is where the copied window is read.
 export const COPY_TYPE_WIDTH = 16
-
-// The widest an opened row's wrapped summary grows, in pixels (mock.html, .ev-row.open .ev-text). A
-// collapsed row takes the pane's whole width, so collapsing the rail buys visible text; only the
-// wrapped line keeps a measure.
-export const SUMMARY_WIDTH = 680
 
 // The longest summary string the app puts in the DOM. The visible ellipsis is the pane's, and this
 // cap only keeps a megabyte-long code body out of a text node that shows one line of it.

--- a/apps/voyager/src/roster.test.ts
+++ b/apps/voyager/src/roster.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 
 import type { ThreadSummary } from "@clavia/tardigrade-client"
-import { agoOf, countsOf, digestLabelOf, latestRootOf, matches, rosterOf } from "./roster"
+import { actorMarkOf, agoOf, countsOf, digestLabelOf, latestRootOf, matches, rosterOf } from "./roster"
 
 // The rail's decisions: which threads are rows, how big each root's family is, what a row's counts
 // say, and how an age reads. All pure, so none of them needs a server or a DOM.
@@ -75,6 +75,16 @@ describe("digestLabelOf", () => {
   test("an actor digest reads as short hexadecimal identity", () => {
     expect(digestLabelOf("sha256:beb340c42043b306", 7)).toBe("beb340c")
     expect(digestLabelOf("custom-digest", 6)).toBe("custom")
+  })
+})
+
+describe("actorMarkOf", () => {
+  test("a single name keeps its leading characters", () => {
+    expect(actorMarkOf("researcher", 2)).toBe("RE")
+  })
+
+  test("a compound name uses its parts", () => {
+    expect(actorMarkOf("pr-shepherd", 2)).toBe("PS")
   })
 })
 

--- a/apps/voyager/src/roster.ts
+++ b/apps/voyager/src/roster.ts
@@ -1,6 +1,6 @@
 import type { ThreadStatus, ThreadSummary } from "@clavia/tardigrade-client"
 
-import { ACTOR_DIGEST_CHARS } from "./policy"
+import { ACTOR_DIGEST_CHARS, ACTOR_MARK_CHARS } from "./policy"
 
 // The rail's projections. GET /v1/actors/:actor/threads answers with every thread and its parent, and the rail shows
 // roots alone, so these functions turn one flat listing into the rows the rail renders. They are
@@ -75,6 +75,16 @@ export const matches = (id: string, query: string): boolean =>
 export const digestLabelOf = (digest: string, chars: number = ACTOR_DIGEST_CHARS): string => {
   const hexadecimal = digest.startsWith("sha256:") ? digest.slice("sha256:".length) : digest
   return hexadecimal.slice(0, chars)
+}
+
+// actorMarkOf derives a compact monogram from an actor name. A compound name contributes the
+// first character of each part; a single part contributes its first characters.
+export const actorMarkOf = (name: string, chars: number = ACTOR_MARK_CHARS): string => {
+  const parts = name.trim().split(/[^A-Za-z0-9]+/u).filter((part) => part.length > 0)
+  const mark = parts.length > 1
+    ? parts.map((part) => part[0] ?? "").join("")
+    : parts[0] ?? name.trim()
+  return mark.slice(0, chars).toUpperCase()
 }
 
 // agoOf renders an age in one unit: seconds under a minute, minutes under an hour, hours beyond. A

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -427,8 +427,57 @@ textarea {
   font-size: 9.5px;
 }
 
+.actor-mark-list {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-2) 0;
+  overflow-y: auto;
+}
+
+.actor-mark-button {
+  display: grid;
+  width: 100%;
+  min-height: var(--row-h);
+  padding: 0;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.actor-mark {
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius);
+  background: var(--sunken);
+  color: var(--ink-2);
+  font-size: 9.5px;
+  transition: color var(--fast) var(--ease), transform var(--fast) var(--ease);
+}
+
+.actor-mark-button:hover .actor-mark {
+  color: var(--ink);
+}
+
+.actor-mark-button:active .actor-mark {
+  transform: scale(0.97);
+}
+
+.actor-mark-selected .actor-mark,
+.actor-mark-selected:hover .actor-mark {
+  background: var(--moss-wash);
+  color: var(--moss-ink);
+}
+
 .actor-footer {
+  display: flex;
   flex-shrink: 0;
+  flex-direction: column;
+  gap: 2px;
   margin-top: auto;
   padding: var(--space-2);
   border-top: 1px solid var(--hair);
@@ -455,6 +504,12 @@ textarea {
   color: var(--ink);
 }
 
+.actor-api-active,
+.actor-api-active:hover {
+  background: var(--moss-wash);
+  color: var(--moss-ink);
+}
+
 .actor-api:active {
   transform: scale(0.97);
 }
@@ -466,27 +521,18 @@ textarea {
 
 .api-view {
   display: flex;
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   height: 100%;
   overflow: hidden;
 }
 
 .api-nav {
   display: flex;
-  width: 320px;
   min-width: 0;
   flex-direction: column;
-  background: var(--surface);
+  background: var(--bg);
   border-right: 1px solid var(--hair);
-}
-
-.api-nav-head {
-  display: flex;
-  min-height: 64px;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-3) var(--space-4);
-  border-bottom: 1px solid var(--hair);
 }
 
 .api-search-wrap {
@@ -1060,10 +1106,6 @@ textarea {
 }
 
 @media (max-width: 760px) {
-  .api-nav {
-    width: 240px;
-  }
-
   .api-detail {
     padding-right: var(--space-4);
     padding-left: var(--space-4);
@@ -1082,12 +1124,6 @@ textarea {
 
   .api-operation-examples {
     position: static;
-  }
-}
-
-@media (max-width: 900px) {
-  .actor-rail:not(.actor-rail-collapsed) {
-    width: 160px !important;
   }
 }
 
@@ -1181,19 +1217,6 @@ textarea {
 
 .icon-btn:active {
   transform: scale(0.97);
-}
-
-.theme-toggle {
-  position: absolute;
-  z-index: 2;
-  top: var(--space-3);
-  right: var(--space-5);
-}
-
-@media (max-width: 640px) {
-  .theme-toggle {
-    right: var(--space-4);
-  }
 }
 
 /* The copy control while it confirms. The glyph itself is swapped in React rather than by a rule,
@@ -1306,6 +1329,21 @@ textarea {
 }
 
 /* The event list: the log in log order, one row per event. */
+.thread-view {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+
+.thread-trace {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
 .events {
   flex: 1;
   min-width: 0;
@@ -1325,6 +1363,11 @@ textarea {
 
 .event-row:hover {
   background: var(--sunken);
+}
+
+.event-row-selected,
+.event-row-selected:hover {
+  background: var(--moss-wash);
 }
 
 /* The stamp carries the event type verbatim, so it is mono and it is wide enough for the longest
@@ -1363,25 +1406,44 @@ textarea {
   color: var(--faint);
 }
 
-/* An open row stops clamping its summary and wraps it instead: the reader asked for the whole line,
-   and it alone keeps a measure (src/policy.ts, SUMMARY_WIDTH). */
-.event-row-open .event-text {
-  white-space: pre-wrap;
-  overflow: visible;
-  text-overflow: clip;
+.event-inspector {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow-y: auto;
+  border-left: 1px solid var(--hair);
+  background: var(--bg);
 }
 
-/* An opened row's fields hang under it on one hairline: names in the left column, values in the
-   right, both on the page's own ground. No card and no fill, so the expansion reads as the row
-   continuing rather than as a second surface (mock.html, .ev-detail). */
+.event-inspector-head {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--space-4);
+  border-bottom: 1px solid var(--hair);
+}
+
+.event-inspector-title {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: var(--space-2);
+}
+
+.event-inspector-seq {
+  color: var(--faint);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+/* The selected event's fields use one hairline: names in the left column and values on the page's
+   own ground. No card or fill separates the payload from the inspector that already contains it. */
 .event-detail {
   display: grid;
   grid-template-columns: max-content minmax(0, 1fr);
   gap: 5px 20px;
-  margin-top: 2px;
-  margin-right: 0;
-  margin-bottom: 10px;
-  padding-left: 18px;
+  margin: var(--space-4);
+  padding-left: var(--space-3);
   border-left: 1px solid var(--hair);
 }
 
@@ -1448,21 +1510,6 @@ textarea {
 .event-json {
   line-height: 1.55;
   tab-size: 2;
-}
-
-/* Entrances only, opacity only (voyager-design-system.md, principle 4). */
-@keyframes fade-in {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
-.fade-in {
-  animation: fade-in var(--base) var(--ease) both;
 }
 
 /* The quiet line a pane with nothing to show stands on. */

--- a/knip.json
+++ b/knip.json
@@ -41,9 +41,6 @@
       "project": [
         "src/**/*.{ts,tsx}",
         "dev/**/*.ts"
-      ],
-      "ignoreDependencies": [
-        "@base-ui-components/react"
       ]
     }
   }


### PR DESCRIPTION
Adds a right-side event inspector to Voyager so code, JSON, messages, and outputs from an authored agent remain readable without expanding the trajectory inline.

The trace and API shells now share consistent rail sizing and controls. Collapsed actor rails use compact Base UI avatar marks, API navigation keeps the same shell width and color, and the theme control remains in the rail footer.

Actor roster readings now carry their actor identity so changing actors cannot restore a run from the previous actor.

Verified with bun run gate, including the Voyager production build and all 92 Voyager tests.