### PR TITLE
feat(cli): guide actor onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Copy this prompt into your coding agent:
 Use https://github.com/clavia-labs/tardigrade and follow skills/tardigrade/SKILL.md to create, author, build, push, and run a local Tardigrade actor. Finish by sharing the Voyager trace URL.
 ```
 
+### For developers
+
 Install Tardigrade and create an actor. Use Bun 1.4 or later.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $$\lbrace\mathrm{transitions}\rbrace = f(\mathrm{log})$$
 Copy this prompt into your coding agent:
 
 ```text
-Read https://github.com/clavia-labs/tardigrade/blob/next/skills/tardigrade/SKILL.md and follow it to create, author, build, push, and run a local Tardigrade actor. Finish by sharing the Voyager trace URL.
+Use https://github.com/clavia-labs/tardigrade and follow skills/tardigrade/SKILL.md to create, author, build, push, and run a local Tardigrade actor. Finish by sharing the Voyager trace URL.
 ```
 
 Install Tardigrade and create an actor. Use Bun 1.4 or later.

--- a/README.md
+++ b/README.md
@@ -29,20 +29,29 @@ $$\lbrace\mathrm{transitions}\rbrace = f(\mathrm{log})$$
 
 ## Quickstart
 
-Install Tardigrade and run the default agent. Use Bun 1.4 or later.
+Install Tardigrade and create an actor. Use Bun 1.4 or later.
 
 ```bash
 bun add -g tardie
+tdg init researcher
+cd researcher
+```
+
+Edit `actor.ts` to describe the agent, then build and push it into the local actor registry:
+
+```bash
+tdg build actor.ts
+tdg push actor.ts --target local
 tdg dev
 ```
 
-Start a thread from another shell:
+Keep `tdg dev` running. Start the actor from another shell in the same directory:
 
 ```bash
-tdg run "read this repo and tell me what it does"
+tdg run "read this repo and tell me what it does" --actor researcher
 ```
 
-Watch the live trajectory at [localhost:4242](http://localhost:4242).
+Voyager opens at [localhost:4242](http://localhost:4242) by default. `tdg run` prints the direct Voyager URL for the new trace.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/assets/voyager-dark.png">

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Voyager opens at [localhost:4242](http://localhost:4242) by default. `tdg run` p
 Copy this prompt into your coding agent:
 
 ```text
-Read skills/tardigrade/SKILL.md and follow it to create, author, build, push, and run a local Tardigrade actor. Finish by sharing the Voyager trace URL.
+Read https://github.com/clavia-labs/tardigrade/blob/next/skills/tardigrade/SKILL.md and follow it to create, author, build, push, and run a local Tardigrade actor. Finish by sharing the Voyager trace URL.
 ```
 
 ## Build one

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Voyager opens at [localhost:4242](http://localhost:4242) by default. `tdg run` p
   <img alt="The voyager: a thread's log, one row per event" src="docs/assets/voyager-light.png">
 </picture>
 
+### For agents
+
+Copy this prompt into your coding agent:
+
+```text
+Read skills/tardigrade/SKILL.md and follow it to create, author, build, push, and run a local Tardigrade actor. Finish by sharing the Voyager trace URL.
+```
+
 ## Build one
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ $$\lbrace\mathrm{transitions}\rbrace = f(\mathrm{log})$$
 
 ## Quickstart
 
+### For agents
+
+Copy this prompt into your coding agent:
+
+```text
+Read https://github.com/clavia-labs/tardigrade/blob/next/skills/tardigrade/SKILL.md and follow it to create, author, build, push, and run a local Tardigrade actor. Finish by sharing the Voyager trace URL.
+```
+
 Install Tardigrade and create an actor. Use Bun 1.4 or later.
 
 ```bash
@@ -57,14 +65,6 @@ Voyager opens at [localhost:4242](http://localhost:4242) by default. `tdg run` p
   <source media="(prefers-color-scheme: dark)" srcset="docs/assets/voyager-dark.png">
   <img alt="The voyager: a thread's log, one row per event" src="docs/assets/voyager-light.png">
 </picture>
-
-### For agents
-
-Copy this prompt into your coding agent:
-
-```text
-Read https://github.com/clavia-labs/tardigrade/blob/next/skills/tardigrade/SKILL.md and follow it to create, author, build, push, and run a local Tardigrade actor. Finish by sharing the Voyager trace URL.
-```
 
 ## Build one
 

--- a/apps/cli/src/build.test.ts
+++ b/apps/cli/src/build.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 
 import { ACTOR_ARTIFACT_VERSION } from "tardie"
 
-import { ACTOR_MANIFEST_FILE, ACTOR_MODULE_FILE, buildActor } from "./build"
+import { ACTOR_MANIFEST_FILE, ACTOR_MODULE_FILE, buildActor, buildSummary } from "./build"
 
 let root = ""
 
@@ -40,5 +40,18 @@ describe("buildActor", () => {
   test("refuses an unnamed module", async () => {
     const path = await entry("export default { actor: { reactors: [], keyOf: () => 'root' } }")
     await expect(buildActor(path, { cwd: root, out: "output" })).rejects.toThrow("name must match")
+  })
+
+  test("the summary hands the source to local push", async () => {
+    const path = await entry(`
+      import { defineActor } from "tardie"
+      export default defineActor({
+        name: "researcher",
+        actor: { reactors: [], keyOf: () => "root" }
+      })
+    `)
+    const built = await buildActor(path, { cwd: root, out: "output" })
+
+    expect(buildSummary(built, "my actor.ts")).toContain("tdg push 'my actor.ts' --target local")
   })
 })

--- a/apps/cli/src/build.ts
+++ b/apps/cli/src/build.ts
@@ -10,6 +10,8 @@ import {
   type ActorDefinition
 } from "tardie"
 
+import { shellWord } from "./workflow"
+
 export const DEFAULT_BUILD_DIRECTORY = ".tardigrade/build"
 export const ACTOR_MODULE_FILE = "actor.mjs"
 export const ACTOR_MANIFEST_FILE = "manifest.json"
@@ -108,9 +110,12 @@ export const buildActor = async (entry: string, options: BuildActorOptions = {})
   }
 }
 
-export const buildSummary = (built: BuiltActor): string =>
+export const buildSummary = (built: BuiltActor, entry: string): string =>
   [
     `built ${built.manifest.name}`,
     `at    ${built.directory}`,
-    `hash  ${built.manifest.digest}`
+    `hash  ${built.manifest.digest}`,
+    "",
+    "next",
+    `  tdg push ${shellWord(entry)} --target local`
   ].join("\n")

--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -294,7 +294,9 @@ describe("run", () => {
       }
     )
     expect(ran.failed).toBe(false)
-    expect(ran.lines[0]).toBe("root m1 completed\nthe summary")
+    expect(ran.lines[0]).toBe(
+      "root m1 completed\nthe summary\n\ntrace\n  http://localhost:0/?actor=default&thread=root"
+    )
   })
 
   test("a thread nobody named is minted, so a run births its own thread", async () => {

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -12,6 +12,7 @@ import { DEFAULT_ACTOR_DIRECTORY, pushActor, pushSummary, PUSH_TARGETS } from ".
 import { homeOf, HOME_MISSING, setupJson, setupPrompt, setupSummary, writeSetup } from "./setup"
 import { actorsTable, threadsTable, DEFAULT_DETAIL_WIDTH, eventsTable, jsonOf, turnLines } from "./render"
 import { Cli, type CliProjections } from "./services"
+import { traceUrlFor } from "./workflow"
 
 // The command tree. Every command is a declaration: its flags, its arguments, and its description
 // are values, so the help a person reads and the completions a shell installs are generated from
@@ -204,7 +205,7 @@ export const buildCommand = Command.make("build", {
       try: () => buildActor(flags.entry, out === undefined ? {} : { out }),
       catch: userErrorOf
     })
-    yield* Console.log(flags.json ? jsonOf(built) : buildSummary(built))
+    yield* Console.log(flags.json ? jsonOf(built) : buildSummary(built, flags.entry))
   })).pipe(
     Command.withDescription("Bundle and validate one named actor as a portable artifact."),
     Command.withExamples([
@@ -377,7 +378,13 @@ export const runCommand = Command.make("run", {
     const id = stated(flags.id) ?? cli.mintId()
     const accepted = yield* call(() => client.append(thread, { type: "MessageReceived", id, text: flags.brief }))
     const view = yield* settle(client, accepted.thread, id, flags.poll, flags.timeout)
-    yield* Console.log(flags.json ? jsonOf(view) : turnLines(accepted.thread, view))
+    yield* Console.log(
+      flags.json
+        ? jsonOf(view)
+        : view.status === SETTLED
+        ? `${turnLines(accepted.thread, view)}\n\ntrace\n  ${traceUrlFor(client.baseUrl, client.actor, accepted.thread)}`
+        : turnLines(accepted.thread, view)
+    )
     if (view.status !== SETTLED) {
       return yield* Effect.fail(userErrorOf(`turn ${view.turn} on thread ${accepted.thread} is ${view.status}`))
     }

--- a/apps/cli/src/dev.test.ts
+++ b/apps/cli/src/dev.test.ts
@@ -190,10 +190,12 @@ describe("tdg dev", () => {
       const listed = await drive(baseUrl, ["ls", "--json"])
       const logged = await drive(baseUrl, ["events", "root", "--types", "MessageReceived"])
       const ghost = await drive(baseUrl, ["events", "ghost"])
-      return { ran, listed, logged, ghost }
+      return { baseUrl, ran, listed, logged, ghost }
     })
     expect(seen.ran.failed).toBe(false)
-    expect(seen.ran.lines[0]).toBe("root m1 completed\nthe scripted answer")
+    expect(seen.ran.lines[0]).toBe(
+      `root m1 completed\nthe scripted answer\n\ntrace\n  ${seen.baseUrl}/?actor=default&thread=root`
+    )
     expect(JSON.parse(seen.listed.lines[0] ?? "")).toMatchObject([{ id: "root", status: "settled" }])
     expect(seen.logged.lines[0]).toContain("MessageReceived")
     expect(seen.logged.lines[0]).toContain("survey the log")

--- a/apps/cli/src/init.ts
+++ b/apps/cli/src/init.ts
@@ -2,6 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises"
 import { dirname, relative, resolve } from "node:path"
 
 import { actorTemplate } from "./template"
+import { runCommandFor, shellWord } from "./workflow"
 
 export const DEFAULT_ACTOR_ENTRY = "actor.ts"
 
@@ -46,9 +47,6 @@ const shownPath = (cwd: string, path: string): string => {
   return shown.length === 0 ? "." : shown
 }
 
-const shellWord = (value: string): string =>
-  /^[A-Za-z0-9_./-]+$/u.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`
-
 export const initSummary = (actor: InitializedActor, cwd: string = process.cwd()): string => {
   const directory = shownPath(cwd, actor.directory)
   const entry = shownPath(actor.directory, actor.entry)
@@ -62,6 +60,6 @@ export const initSummary = (actor: InitializedActor, cwd: string = process.cwd()
     "  tdg dev",
     "",
     "then, in another terminal",
-    `  tdg run "Read this repository and tell me what it does" --actor ${actor.name}`
+    `  ${runCommandFor(actor.name)}`
   ].join("\n")
 }

--- a/apps/cli/src/push.test.ts
+++ b/apps/cli/src/push.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 
 import { ACTOR_MANIFEST_FILE, ACTOR_MODULE_FILE } from "./build"
-import { PUSH_PATH, pushActor } from "./push"
+import { PUSH_PATH, pushActor, pushSummary } from "./push"
 
 let root = ""
 
@@ -30,6 +30,8 @@ describe("pushActor", () => {
     expect(await readFile(join(installed, ACTOR_MODULE_FILE), "utf8"))
       .toBe(await readFile(join(pushed.directory, ACTOR_MODULE_FILE), "utf8"))
     expect(JSON.parse(await readFile(join(installed, ACTOR_MANIFEST_FILE), "utf8"))).toEqual(pushed.manifest)
+    expect(pushSummary(pushed)).toContain("tdg dev")
+    expect(pushSummary(pushed)).toContain('--actor reviewer')
   })
 
   test("sends the same artifact to a hosted server", async () => {
@@ -53,5 +55,6 @@ describe("pushActor", () => {
     const payload = JSON.parse(await request!.text())
     expect(payload.manifest).toEqual(pushed.manifest)
     expect(payload.module).toBe(await readFile(join(pushed.directory, ACTOR_MODULE_FILE), "utf8"))
+    expect(pushSummary(pushed)).not.toContain("tdg dev")
   })
 })

--- a/apps/cli/src/push.ts
+++ b/apps/cli/src/push.ts
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path"
 import type { ActorArtifactManifest } from "tardie"
 
 import { ACTOR_MANIFEST_FILE, ACTOR_MODULE_FILE, buildActor, type BuildActorOptions, type BuiltActor } from "./build"
+import { runCommandFor } from "./workflow"
 
 export const DEFAULT_ACTOR_DIRECTORY = ".tardigrade/actors"
 export const PUSH_PATH = "/v1/actors"
@@ -98,10 +99,22 @@ export const pushActor = async (entry: string, options: PushActorOptions): Promi
   return options.target === "local" ? pushLocal(built, options) : pushHosted(built, options)
 }
 
-export const pushSummary = (pushed: PushedActor): string =>
-  [
+export const pushSummary = (pushed: PushedActor): string => {
+  const summary = [
     `pushed ${pushed.manifest.name}`,
     `to     ${pushed.target}`,
     `at     ${pushed.location}`,
     `hash   ${pushed.manifest.digest}`
-  ].join("\n")
+  ]
+  if (pushed.target === "local") {
+    summary.push(
+      "",
+      "next",
+      "  tdg dev",
+      "",
+      "then, in another terminal",
+      `  ${runCommandFor(pushed.manifest.name)}`
+    )
+  }
+  return summary.join("\n")
+}

--- a/apps/cli/src/workflow.test.ts
+++ b/apps/cli/src/workflow.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test"
+
+import { runCommandFor, shellWord, traceUrlFor } from "./workflow"
+
+describe("the onboarding workflow", () => {
+  test("shell words stay copyable", () => {
+    expect(shellWord("actor.ts")).toBe("actor.ts")
+    expect(shellWord("my actor.ts")).toBe("'my actor.ts'")
+    expect(runCommandFor("researcher")).toBe(
+      "tdg run 'Read this repository and tell me what it does' --actor researcher"
+    )
+  })
+
+  test("a run links to its Voyager trace", () => {
+    expect(traceUrlFor("http://localhost:4242/v1", "research agent", "thread/1")).toBe(
+      "http://localhost:4242/?actor=research+agent&thread=thread%2F1"
+    )
+  })
+})

--- a/apps/cli/src/workflow.ts
+++ b/apps/cli/src/workflow.ts
@@ -1,0 +1,23 @@
+// DEFAULT_ONBOARDING_BRIEF is the first local run suggested after an actor is pushed.
+export const DEFAULT_ONBOARDING_BRIEF = "Read this repository and tell me what it does"
+
+// shellWord quotes a generated shell argument when spaces or shell punctuation make a bare word unsafe (workflow.test.ts).
+export const shellWord = (value: string): string =>
+  /^[A-Za-z0-9_./-]+$/u.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`
+
+// runCommandFor renders the local quickstart command with its actor and brief stated.
+export const runCommandFor = (
+  actor: string,
+  brief: string = DEFAULT_ONBOARDING_BRIEF
+): string => `tdg run ${shellWord(brief)} --actor ${shellWord(actor)}`
+
+// traceUrlFor selects the actor and thread in the Voyager served at the API origin (apps/voyager/src/nav.ts, Route).
+export const traceUrlFor = (baseUrl: string, actor: string, thread: string): string => {
+  const url = new URL(baseUrl)
+  url.pathname = "/"
+  url.search = ""
+  url.hash = ""
+  url.searchParams.set("actor", actor)
+  url.searchParams.set("thread", thread)
+  return url.toString()
+}

--- a/skills/tardigrade/SKILL.md
+++ b/skills/tardigrade/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: tardigrade
+description: Create, author, build, push, run, and inspect Tardigrade actors with the tdg CLI. Use when a task works with actor.ts, the local actor registry, or a Tardigrade run.
+---
+
+# Tardigrade
+
+Use the generated quickstart as the starting point for a new actor:
+
+```bash
+tdg init researcher
+cd researcher
+```
+
+Edit `actor.ts`. Keep `actorName` stable because build, push, run, and stored traces use it as the actor identity. Put the agent's role and expected answer in `actorInstructions`. Add or remove packages in `codeModeFor` only when the task needs different capabilities.
+
+Build the source, push the same actor into the local registry, and start the local server from the actor directory:
+
+```bash
+tdg build actor.ts
+tdg push actor.ts --target local
+tdg dev
+```
+
+Keep the server running. Start a run from another shell in the same directory:
+
+```bash
+tdg run "Read this repository and tell me what it does" --actor researcher
+```
+
+Open the trace URL printed by `tdg run` to inspect the live trajectory in Voyager.
+
+State `--target local` or `--target hosted` on every push. When the server URL differs from the client default, pass the URL to commands that call it:
+
+```bash
+tdg run "Investigate the failure" --actor researcher --url http://localhost:4241
+```
+
+Use `--json` when another program consumes command output. Human output includes workflow guidance and trace links.


### PR DESCRIPTION
Guides a new actor through init, authoring, build, local push, development, and its first run.

Human command output now hands each local workflow step to the next one. A completed run prints its actor-specific Voyager trace URL, while JSON output remains machine-only. Shell arguments are quoted so every suggested command stays copyable.

The README quickstart now exercises an authored actor instead of the built-in default. The repository also includes a validated tardigrade skill so coding agents can follow the same workflow and preserve the important directory, target, actor, and server URL choices.

Verified with the full repository gate, all 93 CLI tests, the skill validator, and a clean-room model run against the generated researcher actor.