### PR TITLE
docs: link Tardigrade skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $$\lbrace\mathrm{transitions}\rbrace = f(\mathrm{log})$$
 
 ### For agents
 
-Copy this prompt into your coding agent:
+Copy this prompt into your coding agent, or install the [Tardigrade skill](skills/tardigrade/SKILL.md):
 
 ```text
 Use https://github.com/clavia-labs/tardigrade.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Voyager opens at [localhost:4242](http://localhost:4242) by default. `tdg run` p
   <img alt="The voyager: a thread's log, one row per event" src="docs/assets/voyager-light.png">
 </picture>
 
-## Build one
+## Build your own harness
 
 ```bash
 bun add tardie


### PR DESCRIPTION
Links the Tardigrade skill directly from the agent quickstart so readers can install it or copy the prompt below it.

Verified with the documentation lint and whitespace check.