### PR TITLE
docs: condense agent prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,7 @@ $$\lbrace\mathrm{transitions}\rbrace = f(\mathrm{log})$$
 Copy this prompt into your coding agent, or install the [Tardigrade skill](skills/tardigrade/SKILL.md):
 
 ```text
-Use https://github.com/clavia-labs/tardigrade.
-Follow skills/tardigrade/SKILL.md to create and author a local Tardigrade actor.
-Build, push, and run the actor.
-Finish by sharing the Voyager trace URL.
+Use https://github.com/clavia-labs/tardigrade and follow skills/tardigrade/SKILL.md to create, author, build, push, and run a local actor. Share its Voyager trace URL.
 ```
 
 ### For developers


### PR DESCRIPTION
Keeps the coding-agent quickstart prompt on one concise copyable line.

Verified with the documentation lint and whitespace check.