### PR TITLE
docs: link quickstart template

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ tdg init researcher
 cd researcher
 ```
 
-The `init` command creates `researcher/actor.ts` from the bundled quickstart template. Edit it to describe the agent, then build and push it into the local actor registry:
+The `init` command creates `researcher/actor.ts` from the bundled [quickstart template](examples/quickstart/actor.ts). Read its comments to understand the actor's parts, then edit it to describe the agent. Build and push the result into the local actor registry:
 
 ```bash
 tdg build actor.ts


### PR DESCRIPTION
Links the developer onboarding text to the actor template and asks readers to use its comments before editing their generated actor.

Verified with the documentation lint and whitespace check.