### PR TITLE
feat: name component output view

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ A durable and modular agent harness built for self-improvement.
 ### A harness made for self-improvement
 As models get increasingly smart, they will be capable of writing their own harnesses to improve themselves ([Meta-Harness](https://arxiv.org/abs/2603.28052)). A harness that is too rigid and complex is a bottleneck to this. We need something more composable, and easy to author.
 
-We took inspiration from React. React derives the component tree as a function of state (`UI = f(state)`). Tardigrade derives information and state transitions from the event log, an idea with roots in [Harel's statecharts](https://www.sciencedirect.com/science/article/pii/0167642387900359).
+We took inspiration from React. React derives its component tree and declared effects from state (`{ UI, effects } = f(state)`). Tardigrade derives a view and state transitions from the event log, an idea with roots in [Harel's statecharts](https://www.sciencedirect.com/science/article/pii/0167642387900359).
 
-$$\lbrace\mathrm{information},\ \mathrm{transitions}\rbrace = f(\mathrm{log})$$
+$$\lbrace\mathrm{view},\ \mathrm{transitions}\rbrace = f(\mathrm{log})$$
 
 ## Why Tardigrade
 
@@ -78,7 +78,7 @@ You can use `npm install tardie` instead. Install `tardie@next` to test a releas
 
 ### Create a component
 
-An agent is made of components. A component derives information and owed transitions from the log. Agent information includes system fragments, tool bindings, and context policy. This component gives the model one tool and owes no autonomous work:
+An agent is made of components. A component derives a view and owed transitions from the log. An agent view includes system fragments, tool bindings, and context policy. This component gives the model one tool and owes no autonomous work:
 
 ```ts
 import type { AgentComponent } from "tardie"
@@ -86,7 +86,7 @@ import type { AgentComponent } from "tardie"
 const deploys: AgentComponent = {
   name: "deploys",
   derive: () => ({
-    info: {
+    view: {
       system: ["Inspect recent deployments when a release may explain an incident."],
       tools: [{
         spec: {
@@ -109,9 +109,9 @@ const deploys: AgentComponent = {
 
 The call follows one route:
 
-1. The component adds `recent_deploys` to its derived information.
+1. The component adds `recent_deploys` to its derived view.
 2. The model selects it and returns a tool call. Tardigrade records `ToolCalled` in the log.
-3. The shared runtime finds the paired handler in the information that offered the call and asks it to serve against the current log.
+3. The shared runtime finds the paired handler in the view that offered the call and asks it to serve against the current log.
 4. Tardigrade records `ToolReturned`. The next model request includes the result.
 
 ### Compose an agent
@@ -133,7 +133,7 @@ const releaseAnalyst = actorOf(
 )
 ```
 
-`actorOf` combines the components under `agentRuntime`. The runtime interprets their information as inference and tool routing, while the core actor reconciles their transitions. The model sees `recent_deploys` and `execute` in one request. Policy components derive work from the same log.
+`actorOf` combines the components under `agentRuntime`. The runtime interprets their view as inference and tool routing, while the core actor reconciles their transitions. The model sees `recent_deploys` and `execute` in one request. Policy components derive work from the same log.
 
 This agent can inspect deployments, analyze results with JavaScript, compact a long investigation, and report to a parent agent. Change the list to create another harness.
 

--- a/docs/explanations/why.md
+++ b/docs/explanations/why.md
@@ -4,17 +4,17 @@ Building and running an agent in production is tough. Your agents can fail for a
 
 As models get increasingly smart, they will be capable of writing their own harnesses to improve themselves. To enable this, we need a harness that can be inspected, forked, and varied. 
 ### Log is all you need
-How can a harness be fully customizable, easy to author, and yet remain reliable in production? We took inspiration from React. Designing a harness is like designing a user interface, except the user is a language model. React declared the component tree as a function of state, `UI = f(state)`, and the set of valid state transitions as `{transitions} = f(state)` [1], an idea with roots in Harel's statecharts [2]. This simplicity enabled expressiveness in authoring applications without sacrificing reliability. A harness needs the same shape, but with the log as state.
+How can a harness be fully customizable, easy to author, and yet remain reliable in production? We took inspiration from React. Designing a harness is like designing a user interface, except the user is a language model. React derives its component tree and declared effects from state, `{ UI, effects } = f(state)` [1]. A harness has the same shape over its event log, `{ view, transitions } = f(log)`, with transitions grounded in Harel's statecharts [2]. This simplicity enables expressive authoring without sacrificing reliability.
 
-Tobi Lütke (CEO, Shopify) echoed a similar idea in an August 2026 [post](https://x.com/tobi/status/2086192833061323111) [3]: "everything that can be will be converted into `state = memo { f(log) }`... all other state management is just too complex at the limit." We take this idea further: all the state transitions of a harness can and should be described simply as a function over the log.
+Tobi Lütke (CEO, Shopify) echoed a similar idea in an August 2026 [post](https://x.com/tobi/status/2086192833061323111) [3]: "everything that can be will be converted into `state = memo { f(log) }`... all other state management is just too complex at the limit." We take this idea further: the view and all state transitions of a harness can be described as one function over the log.
 
 $$
-\{\mathrm{transitions}\} = f(\mathrm{log})
+\{\mathrm{view},\ \mathrm{transitions}\} = f(\mathrm{log})
 $$
 
 ```mermaid
 flowchart LR
-  log[("event log")] -->|"f(log)"| transitions["transitions"]
+  log[("event log")] -->|"f(log)"| view["view"] & transitions["transitions"]
   transitions -->|"new events"| log
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -53,26 +53,26 @@ type Reactor = (events: Event[]) => Transition[]
 ```
 ### Component
 
-A component derives information and transitions from the same log. Information is available to a consumer such as the agent runtime, while transitions go to actor reconciliation. Either side may be empty.
+A component derives a view and transitions from the same log. The view is available to a consumer such as the agent runtime, while transitions go to actor reconciliation. Either side may be empty.
 
 ```ts
-type Derivation<I> = {
-  info: I
+type Derivation<V> = {
+  view: V
   transitions: Transition[]
 }
 
-type Component<I> = {
+type Component<V> = {
   name: string
-  derive: (events: Event[]) => Derivation<I>
+  derive: (events: Event[]) => Derivation<V>
 }
 ```
 
-Components compose when their information type has an explicit combination rule. Transitions concatenate in component order. The information rule states how values combine, including ordering and collision policy.
+Components compose when their view type has an explicit combination rule. Transitions concatenate in component order. The view rule states how values combine, including ordering and collision policy.
 
 ```ts
-type InfoAlgebra<I> = {
-  empty: I
-  combine: (left: I, right: I) => I
+type ViewAlgebra<V> = {
+  empty: V
+  combine: (left: V, right: V) => V
 }
 ```
 ### Actor
@@ -92,9 +92,9 @@ const send = async (actor: Actor, event: Event): Promise<void>
 ```mermaid
 flowchart TB
   log[("event log")] -->|"events"| component["component"]
-  component -->|"info = f(log)"| info["information"]
+  component -->|"view = f(log)"| view["view"]
   component -->|"transitions = f(log)"| transitions["transitions"]
-  info --> consumer["consumer"]
+  view --> consumer["consumer"]
   transitions -->|"keys the log does not record"| act["act(input)"]
   act -->|"events, keyed record last"| log
 ```
@@ -195,7 +195,7 @@ const agent: Actor = { reactors: [infer, tools, compaction] }
 await send(agent, { type: "MessageReceived", text: "What changed in the deploy?" })
 ```
 
-This example constructs the low-level actor directly. The agent package groups related information and transitions into components, composes their information with an `InfoAlgebra`, and adapts their transitions into the same reactor list.
+This example constructs the low-level actor directly. The agent package groups related views and transitions into components, composes their views with a `ViewAlgebra`, and adapts their transitions into the same reactor list.
 #### Architecture
 The agent, as the loop: one log, three reactors deriving from it, fires landing back in it.
 
@@ -207,5 +207,4 @@ flowchart TB
   tools -->|"ToolReturned"| log
   compaction -->|"CompactionCompleted"| log
 ```
-
 

--- a/examples/quickstart/actor.ts
+++ b/examples/quickstart/actor.ts
@@ -28,14 +28,14 @@ Return a concise answer with concrete findings.
 const instructions = {
   name: "instructions",
   derive: () => ({
-    info: { system: [actorInstructions], tools: [], context: [] },
+    view: { system: [actorInstructions], tools: [], context: [] },
     transitions: []
   })
 }
 
 export default defineActor({
   name: actorName,
-  // actorOf composes components under the explicit agent information runtime.
+  // actorOf composes components under the explicit agent view runtime.
   actor: actorOf(
     agentRuntime(),
     [

--- a/packages/agent/src/components/budget.ts
+++ b/packages/agent/src/components/budget.ts
@@ -131,13 +131,13 @@ export const budgetReactorFor = (policy: Partial<BudgetPolicy> = {}): Reactor<ne
 // budgetReactor is that reactor on the default ceiling.
 export const budgetReactor: Reactor<never> = budgetReactorFor()
 
-// budgetFor derives budget transitions and contributes no agent information.
+// budgetFor derives budget transitions and contributes an empty agent view.
 export const budgetFor = (policy: Partial<BudgetPolicy>): AgentComponent => {
   const reactor = budgetReactorFor(policy)
   return {
     name: "budget",
     derive: (log) => ({
-      info: { system: [], tools: [], context: [] },
+      view: { system: [], tools: [], context: [] },
       transitions: reactor(log)
     })
   }

--- a/packages/agent/src/components/code.ts
+++ b/packages/agent/src/components/code.ts
@@ -80,7 +80,7 @@ export const codeModeFor = <
     name: "code",
     keys: codeKeys,
     derive: (log) => ({
-      info: {
+      view: {
         system: [typeof options.system === "function" ? options.system(log) : options.system ?? codeSystemFor(packages as ReadonlyArray<Package<unknown>>)],
         tools: [{ spec: EXECUTE_TOOL, serve: (call, current, answer) => serveCode(current, call, answer) }],
         context: []

--- a/packages/agent/src/components/compaction.ts
+++ b/packages/agent/src/components/compaction.ts
@@ -282,7 +282,7 @@ export const compactionFor = (policy: Partial<ContextPolicy>): AgentComponent<In
   return {
     name: "compaction",
     derive: (log) => ({
-      info: { system: [], tools: [], context: [{ component: "compaction", policy }] },
+      view: { system: [], tools: [], context: [{ component: "compaction", policy }] },
       transitions: reactor(log)
     })
   }

--- a/packages/agent/src/components/reply.ts
+++ b/packages/agent/src/components/reply.ts
@@ -66,11 +66,11 @@ export const replyReactor: Reactor<Router | Self> = (log) => {
   ]
 }
 
-// reply derives parent-delivery transitions and contributes no agent information.
+// reply derives parent-delivery transitions and contributes an empty agent view.
 export const reply: AgentComponent<Router | Self> = {
   name: "reply",
   derive: (log) => ({
-    info: { system: [], tools: [], context: [] },
+    view: { system: [], tools: [], context: [] },
     transitions: replyReactor(log)
   })
 }

--- a/packages/agent/src/components/tool-list.ts
+++ b/packages/agent/src/components/tool-list.ts
@@ -18,7 +18,7 @@ export const toolList = <R = never>(
 ): AgentComponent<R> => ({
   name: "tools",
   derive: (log) => ({
-    info: {
+    view: {
       system: [
         (typeof system === "function" ? system(log) : system) ||
           `You act on the world by calling the tools available to you: ${tools.map((tool) => tool.spec.name).join(", ")}.`

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -66,11 +66,11 @@ export {
 // The component assembly: code mode is the default, and an agent measured against a fixed tool
 // list mounts its own (runtime/agent.ts).
 export {
-  AGENT_INFO_ALGEBRA,
+  AGENT_VIEW_ALGEBRA,
   agentRuntime,
   renderOf,
   type AgentComponent,
-  type AgentInfo,
+  type AgentView,
   type AgentTool,
   type ContextFragment
 } from "./runtime/agent"
@@ -87,5 +87,5 @@ export {
   type ComponentRequirements,
   type ComponentRuntime,
   type Derivation,
-  type InfoAlgebra
+  type ViewAlgebra
 } from "@clavia/tardigrade-core/component"

--- a/packages/agent/src/runtime/agent.test.ts
+++ b/packages/agent/src/runtime/agent.test.ts
@@ -8,7 +8,7 @@ import { Facets } from "@clavia/tardigrade-core/facets"
 import { Self } from "@clavia/tardigrade-core/actor"
 import { actorOf } from "@clavia/tardigrade-core/component"
 import type { Package } from "@clavia/tardigrade-code/packages"
-import { agentRuntime, renderOf, type AgentComponent, type AgentInfo } from "./agent"
+import { agentRuntime, renderOf, type AgentComponent, type AgentView } from "./agent"
 import { CODE_SYSTEM, codeMode, codeModeFor } from "../components/code"
 import { budget } from "../components/budget"
 import { compaction, compactionFor } from "../components/compaction"
@@ -17,8 +17,8 @@ import { toolList } from "../components/tool-list"
 import { receive, type AgentR } from "../turn"
 import { Infer, type InferRequest } from "./infer"
 
-// The component assembly end to end: the render the model sees is the composed information
-// derivation, and a call routes through the same derived tool binding.
+// The component assembly end to end: the render the model sees is the composed view, and a call
+// routes through the same derived tool binding.
 
 // Ticker is a service no assembled agent provides, so a component that requires it is
 // distinguishable at compile time from one that does not.
@@ -57,12 +57,12 @@ const echoTable = toolList([
   }
 ])
 
-const informationComponent = (
+const viewComponent = (
   name: string,
-  info: AgentInfo | ((log: ReadonlyArray<Event>) => AgentInfo)
+  view: AgentView | ((log: ReadonlyArray<Event>) => AgentView)
 ): AgentComponent => ({
   name,
-  derive: (log) => ({ info: typeof info === "function" ? info(log) : info, transitions: [] })
+  derive: (log) => ({ view: typeof view === "function" ? view(log) : view, transitions: [] })
 })
 
 describe("agent runtime", () => {
@@ -126,7 +126,7 @@ describe("agent runtime", () => {
   })
 
   test("a duplicate tool derived after construction fails for that log", () => {
-    const later = informationComponent(
+    const later = viewComponent(
       "later",
       (log) => ({
         system: [],
@@ -142,8 +142,8 @@ describe("agent runtime", () => {
     expect(() => renderOf([echoTable, later], [{ type: "Ready" }])).toThrow('tool "echo" declared more than once')
   })
 
-  test("a tool remains routable from the information that offered its call", async () => {
-    const ephemeral = informationComponent(
+  test("a tool remains routable from the view that offered its call", async () => {
+    const ephemeral = viewComponent(
       "ephemeral",
       (log) => ({
         system: [],
@@ -177,10 +177,10 @@ describe("agent runtime", () => {
   })
 
   test("different values for one context field fail with both component names", () => {
-    const left = informationComponent("left", {
+    const left = viewComponent("left", {
       system: [], tools: [], context: [{ component: "left", policy: { messageRenderCap: 10 } }]
     })
-    const right = informationComponent("right", {
+    const right = viewComponent("right", {
       system: [], tools: [], context: [{ component: "right", policy: { messageRenderCap: 20 } }]
     })
 
@@ -198,7 +198,7 @@ describe("agent runtime", () => {
   test("a system fragment is a projection: it reads the log renderOf was handed", () => {
     const seen: ReadonlyArray<Event>[] = []
     const log: ReadonlyArray<Event> = [{ type: "PackageInstalled", name: "github" }, { type: "PackageInstalled", name: "slack" }]
-    const catalog = informationComponent(
+    const catalog = viewComponent(
       "catalog",
       (events: ReadonlyArray<Event>) => {
         seen.push(events)
@@ -218,7 +218,7 @@ describe("agent runtime", () => {
 
   test("renderOf over one log is deterministic", () => {
     const log: ReadonlyArray<Event> = [{ type: "PackageInstalled", name: "github" }]
-    const component = informationComponent(
+    const component = viewComponent(
       "catalog",
       (events: ReadonlyArray<Event>) => ({ system: [`count: ${events.length}`], tools: [], context: [] })
     )

--- a/packages/agent/src/runtime/agent.ts
+++ b/packages/agent/src/runtime/agent.ts
@@ -1,5 +1,5 @@
 import type { Reactor, Transition } from "@clavia/tardigrade-core/actor"
-import { composeComponents, type Component, type ComponentRuntime, type InfoAlgebra } from "@clavia/tardigrade-core/component"
+import { composeComponents, type Component, type ComponentRuntime, type ViewAlgebra } from "@clavia/tardigrade-core/component"
 import { messageKeys } from "@clavia/tardigrade-core/message"
 import type { Event } from "@clavia/tardigrade-core/event"
 import type { ToolSpec } from "../request"
@@ -27,20 +27,20 @@ export interface ContextFragment {
   readonly policy: Partial<ContextPolicy>
 }
 
-// AgentInfo is the information an agent runtime interprets. Arrays retain component order and
+// AgentView is the view an agent runtime interprets. Arrays retain component order and
 // postpone collision policy until the complete derivation is available.
-export interface AgentInfo {
+export interface AgentView {
   readonly system: ReadonlyArray<string>
   readonly tools: ReadonlyArray<AgentTool<unknown>>
   readonly context: ReadonlyArray<ContextFragment>
 }
 
-// AgentComponent is a core component whose information is interpreted by the agent runtime.
-export type AgentComponent<R = never> = Component<AgentInfo, R>
+// AgentComponent is a core component whose view is interpreted by the agent runtime.
+export type AgentComponent<R = never> = Component<AgentView, R>
 
-// AGENT_INFO_ALGEBRA preserves every information contribution in component order. renderOf
+// AGENT_VIEW_ALGEBRA preserves every view contribution in component order. renderOf
 // applies the agent-specific collision and rendering rules to the combined value.
-export const AGENT_INFO_ALGEBRA: InfoAlgebra<AgentInfo> = {
+export const AGENT_VIEW_ALGEBRA: ViewAlgebra<AgentView> = {
   empty: { system: [], tools: [], context: [] },
   combine: (left, right) => ({
     system: [...left.system, ...right.system],
@@ -74,8 +74,8 @@ const checkedTools = (tools: ReadonlyArray<AgentTool<unknown>>): ReadonlyArray<A
   return tools
 }
 
-const infoFrom = <R>(components: ReadonlyArray<AgentComponent<R>>, log: ReadonlyArray<Event>): AgentInfo =>
-  composeComponents("agent.info", AGENT_INFO_ALGEBRA, components).derive(log).info
+const viewFrom = <R>(components: ReadonlyArray<AgentComponent<R>>, log: ReadonlyArray<Event>): AgentView =>
+  composeComponents("agent.view", AGENT_VIEW_ALGEBRA, components).derive(log).view
 
 // offerLogFor returns the prefix from which inference offered a pending call's tools. ModelCalled
 // is appended before inference, so the preceding prefix is exactly the log passed to render
@@ -95,31 +95,31 @@ const offerLogFor = (log: ReadonlyArray<Event>, call: PendingCall): ReadonlyArra
   return log
 }
 
-const renderInfo = (
-  info: AgentInfo
+const renderView = (
+  view: AgentView
 ): { readonly system: string; readonly tools: ReadonlyArray<ToolSpec>; readonly context: Partial<ContextPolicy> } => ({
-  system: info.system.filter((fragment) => fragment !== "").join("\n"),
-  tools: checkedTools(info.tools).map((tool) => tool.spec),
-  context: contextOf(info.context)
+  system: view.system.filter((fragment) => fragment !== "").join("\n"),
+  tools: checkedTools(view.tools).map((tool) => tool.spec),
+  context: contextOf(view.context)
 })
 
-// renderOf derives the model request from the same component information that routing reads.
+// renderOf derives the model request from the same component view that routing reads.
 export const renderOf = <R>(
   components: ReadonlyArray<AgentComponent<R>>,
   log: ReadonlyArray<Event>
 ): { readonly system: string; readonly tools: ReadonlyArray<ToolSpec>; readonly context: Partial<ContextPolicy> } =>
-  renderInfo(infoFrom(components, log))
+  renderView(viewFrom(components, log))
 
-// agentRuntime interprets AgentInfo as inference and tool-routing reactors. actorOf supplies the
-// composed information projection and adds each component's own transition projection.
+// agentRuntime interprets AgentView as inference and tool-routing reactors. actorOf supplies the
+// composed view projection and adds each component's own transition projection.
 export const agentRuntime = (
   policy: Partial<InferPolicy> = {}
-): ComponentRuntime<AgentInfo, AgentR> => ({
+): ComponentRuntime<AgentView, AgentR> => ({
   name: "agent",
-  algebra: AGENT_INFO_ALGEBRA,
+  algebra: AGENT_VIEW_ALGEBRA,
   keys: [messageKeys, agentKeys],
-  reactors: <C>(infoOf: (log: ReadonlyArray<Event>) => AgentInfo): ReadonlyArray<Reactor<AgentR | C>> => {
-    const toolsOf = (log: ReadonlyArray<Event>): ReadonlyArray<AgentTool<unknown>> => checkedTools(infoOf(log).tools)
+  reactors: <C>(viewOf: (log: ReadonlyArray<Event>) => AgentView): ReadonlyArray<Reactor<AgentR | C>> => {
+    const toolsOf = (log: ReadonlyArray<Event>): ReadonlyArray<AgentTool<unknown>> => checkedTools(viewOf(log).tools)
     const offeredTools = (log: ReadonlyArray<Event>, call: PendingCall): ReadonlyArray<AgentTool<unknown>> =>
       toolsOf(offerLogFor(log, call))
     const serve = (call: PendingCall, log: ReadonlyArray<Event>, answer: Answer) => {
@@ -127,9 +127,9 @@ export const agentRuntime = (
       return tool?.serve(call, log, answer) as ReadonlyArray<Transition<never, AgentR | C>> | undefined
     }
 
-    renderInfo(infoOf([]))
+    renderView(viewOf([]))
     return [
-      inferReactorFor(policy, (log) => renderInfo(infoOf(log))) as Reactor<AgentR | C>,
+      inferReactorFor(policy, (log) => renderView(viewOf(log))) as Reactor<AgentR | C>,
       toolsReactorFrom(serve, (log, call) => offeredTools(log, call).map((tool) => tool.spec))
     ]
   }

--- a/packages/agent/src/runtime/tools.ts
+++ b/packages/agent/src/runtime/tools.ts
@@ -84,7 +84,7 @@ const decisionFor = (
 // Every branch here is component-independent policy; a tool binding decides only how a
 // work call becomes events.
 // toolsReactorFrom is the policy over a routed serve and a derived tool list: the component
-// assembly's entry (runtime/agent.ts), where the tools are information derived from the log.
+// assembly's entry (runtime/agent.ts), where the tools belong to the view derived from the log.
 export const toolsReactorFrom = <R = never>(
   serve: Serve<R>,
   toolsFor: (log: ReadonlyArray<Event>, call: PendingCall) => ReadonlyArray<{ readonly name: string }>

--- a/packages/core/src/component.test.ts
+++ b/packages/core/src/component.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { transition } from "./actor"
-import { actorOf, composeComponents, reactorOf, type Component, type ComponentRuntime, type InfoAlgebra } from "./component"
+import { actorOf, composeComponents, reactorOf, type Component, type ComponentRuntime, type ViewAlgebra } from "./component"
 import type { Event } from "./event"
 
 interface Facts {
   readonly names: ReadonlyArray<string>
 }
 
-const facts: InfoAlgebra<Facts> = {
+const facts: ViewAlgebra<Facts> = {
   empty: { names: [] },
   combine: (left, right) => ({ names: [...left.names, ...right.names] })
 }
@@ -16,7 +16,7 @@ const facts: InfoAlgebra<Facts> = {
 const component = (name: string, event: string): Component<Facts> => ({
   name,
   derive: (log) => ({
-    info: { names: log.some((entry) => entry.type === event) ? [name] : [] },
+    view: { names: log.some((entry) => entry.type === event) ? [name] : [] },
     transitions: log.some((entry) => entry.type === event)
       ? [transition({ key: name, input: name, act: () => Effect.succeed([]) })]
       : []
@@ -24,23 +24,23 @@ const component = (name: string, event: string): Component<Facts> => ({
 })
 
 describe("components", () => {
-  test("composition combines information and concatenates transitions in component order", () => {
+  test("composition combines views and concatenates transitions in component order", () => {
     const left = component("left", "Ready")
     const right = component("right", "Ready")
     const log: ReadonlyArray<Event> = [{ type: "Ready" }]
     const composed = composeComponents("both", facts, [left, right])
 
-    expect(composed.derive(log).info).toEqual({ names: ["left", "right"] })
+    expect(composed.derive(log).view).toEqual({ names: ["left", "right"] })
     expect(composed.derive(log).transitions.map((owed) => owed.key)).toEqual(["left", "right"])
   })
 
-  test("the empty composition derives the algebra's empty information and no work", () => {
+  test("the empty composition derives the algebra's empty view and no work", () => {
     const composed = composeComponents("empty", facts, [])
 
-    expect(composed.derive([])).toEqual({ info: facts.empty, transitions: [] })
+    expect(composed.derive([])).toEqual({ view: facts.empty, transitions: [] })
   })
 
-  test("composition is associative for information and transition order", () => {
+  test("composition is associative for view and transition order", () => {
     const left = component("left", "Ready")
     const middle = component("middle", "Ready")
     const right = component("right", "Ready")
@@ -54,7 +54,7 @@ describe("components", () => {
       composeComponents("middle-right", facts, [middle, right])
     ]).derive(log)
 
-    expect(leftGrouped.info).toEqual(rightGrouped.info)
+    expect(leftGrouped.view).toEqual(rightGrouped.view)
     expect(leftGrouped.transitions.map((owed) => owed.key)).toEqual(
       rightGrouped.transitions.map((owed) => owed.key)
     )
@@ -73,7 +73,7 @@ describe("components", () => {
     const keyed = (name: string): Component<Facts> => ({
       name,
       keys: { prefixes: ["x:"], keyOf: () => undefined },
-      derive: () => ({ info: facts.empty, transitions: [] })
+      derive: () => ({ view: facts.empty, transitions: [] })
     })
 
     expect(() => composeComponents("collision", facts, [keyed("left"), keyed("right")])).toThrow(
@@ -81,15 +81,15 @@ describe("components", () => {
     )
   })
 
-  test("actorOf gives composed information to its runtime and component work to reconciliation", () => {
+  test("actorOf gives the composed view to its runtime and component work to reconciliation", () => {
     const seen: Facts[] = []
     const runtime: ComponentRuntime<Facts> = {
       name: "facts",
       algebra: facts,
       keys: [],
-      reactors: (infoOf) => [
+      reactors: (viewOf) => [
         (log) => {
-          seen.push(infoOf(log))
+          seen.push(viewOf(log))
           return []
         }
       ]

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -2,56 +2,55 @@ import { actor, type Actor, type Reactor, type Transition } from "./actor"
 import type { Event } from "./event"
 import { composeKeys, type KeyFragment } from "./event-log"
 
-// Derivation is one component's reading of a log: information for consumers and transitions
-// for the actor runtime. The information follows tla/Projection.tla, ViewFaithful. The
+// Derivation is one component's reading of a log: a view for consumers and transitions for the
+// actor runtime. The view follows tla/Projection.tla, ViewFaithful. The
 // transitions follow tla/Reconcile.tla, NoVoid.
-export interface Derivation<I, R = never> {
-  readonly info: I
+export interface Derivation<V, R = never> {
+  readonly view: V
   readonly transitions: ReadonlyArray<Transition<never, R>>
 }
 
-// Component derives information and owed work from the same log. Its key fragment declares how
+// Component derives a view and owed work from the same log. Its key fragment declares how
 // the events its transitions append prove commitment to the actor runtime.
-export interface Component<I, R = never> {
+export interface Component<V, R = never> {
   readonly name: string
   readonly keys?: KeyFragment
-  readonly derive: (log: ReadonlyArray<Event>) => Derivation<I, R>
+  readonly derive: (log: ReadonlyArray<Event>) => Derivation<V, R>
 }
 
-// InfoAlgebra states how independently derived information composes. Callers supply the empty
-// value and combination rule because ordering, collisions, and overrides belong to the
-// information's consumer.
-export interface InfoAlgebra<I> {
-  readonly empty: I
-  readonly combine: (left: I, right: I) => I
+// ViewAlgebra states how independently derived views compose. Callers supply the empty value and
+// combination rule because ordering, collisions, and overrides belong to the view's consumer.
+export interface ViewAlgebra<V> {
+  readonly empty: V
+  readonly combine: (left: V, right: V) => V
 }
 
-// ComponentRuntime interprets composed information as reactors and supplies the key fragments
+// ComponentRuntime interprets a composed view as reactors and supplies the key fragments
 // for its protocol. The reactor factory is polymorphic in component requirements because an
 // interpreter may route work whose environment is declared by the component that contributed it.
-export interface ComponentRuntime<I, R = never> {
+export interface ComponentRuntime<V, R = never> {
   readonly name: string
-  readonly algebra: InfoAlgebra<I>
+  readonly algebra: ViewAlgebra<V>
   readonly keys: ReadonlyArray<KeyFragment>
-  readonly reactors: <C>(infoOf: (log: ReadonlyArray<Event>) => I) => ReadonlyArray<Reactor<R | C>>
+  readonly reactors: <C>(viewOf: (log: ReadonlyArray<Event>) => V) => ReadonlyArray<Reactor<R | C>>
 }
 
 // ComponentRequirements extracts a component's environment so composition carries the union of every
 // member's requirements to the actor that hosts it.
 export type ComponentRequirements<C> = C extends Component<unknown, infer R> ? R : never
 
-// composeComponents derives the algebraic sum of each component's information and concatenates
+// composeComponents derives the algebraic sum of each component's view and concatenates
 // its transitions in component order. The name is explicit because traces and collision errors
 // identify the resulting component with it.
 export const composeComponents = <
-  I,
-  const Cs extends ReadonlyArray<Component<I, never> | Component<I, unknown>>
+  V,
+  const Cs extends ReadonlyArray<Component<V, never> | Component<V, unknown>>
 >(
   name: string,
-  algebra: InfoAlgebra<I>,
+  algebra: ViewAlgebra<V>,
   components: Cs
-): Component<I, ComponentRequirements<Cs[number]>> => {
-  const members = components as ReadonlyArray<Component<I, ComponentRequirements<Cs[number]>>>
+): Component<V, ComponentRequirements<Cs[number]>> => {
+  const members = components as ReadonlyArray<Component<V, ComponentRequirements<Cs[number]>>>
   const fragments = members.flatMap((component) => component.keys === undefined ? [] : [component.keys])
   const keys = fragments.length === 0
     ? undefined
@@ -63,38 +62,38 @@ export const composeComponents = <
     name,
     ...(keys === undefined ? {} : { keys }),
     derive: (log) => {
-      let info = algebra.empty
+      let view = algebra.empty
       const transitions: Array<Transition<never, ComponentRequirements<Cs[number]>>> = []
       for (const component of members) {
         const derived = component.derive(log)
-        info = algebra.combine(info, derived.info)
+        view = algebra.combine(view, derived.view)
         transitions.push(...derived.transitions)
       }
-      return { info, transitions }
+      return { view, transitions }
     }
   }
 }
 
 // reactorOf exposes a component's owed-work projection to the existing actor reconciler.
-export const reactorOf = <I, R>(component: Component<I, R>): Reactor<R> =>
+export const reactorOf = <V, R>(component: Component<V, R>): Reactor<R> =>
   (log) => component.derive(log).transitions
 
-// actorOf composes components under one information runtime and adapts their transitions to the
+// actorOf composes components under one view runtime and adapts their transitions to the
 // existing actor reconciler. Runtime keys compose beside component keys with the same collision
 // rule as composeKeys.
 export const actorOf = <
-  I,
+  V,
   RuntimeR,
-  const Cs extends ReadonlyArray<Component<I, never> | Component<I, unknown>>
+  const Cs extends ReadonlyArray<Component<V, never> | Component<V, unknown>>
 >(
-  runtime: ComponentRuntime<I, RuntimeR>,
+  runtime: ComponentRuntime<V, RuntimeR>,
   components: Cs
 ): Actor<RuntimeR | ComponentRequirements<Cs[number]>> => {
   type ComponentR = ComponentRequirements<Cs[number]>
   type R = RuntimeR | ComponentR
-  const combined = composeComponents(runtime.name, runtime.algebra, components) as Component<I, R>
-  const infoOf = (log: ReadonlyArray<Event>): I => combined.derive(log).info
-  const reactors = runtime.reactors<ComponentR>(infoOf) as ReadonlyArray<Reactor<R>>
+  const combined = composeComponents(runtime.name, runtime.algebra, components) as Component<V, R>
+  const viewOf = (log: ReadonlyArray<Event>): V => combined.derive(log).view
+  const reactors = runtime.reactors<ComponentR>(viewOf) as ReadonlyArray<Reactor<R>>
   return actor(
     [...reactors, reactorOf(combined)],
     composeKeys(...runtime.keys, ...(combined.keys === undefined ? [] : [combined.keys]))

--- a/packages/core/tla/Component.tla
+++ b/packages/core/tla/Component.tla
@@ -1,6 +1,6 @@
 ---------------------------- MODULE Component ----------------------------
-(* A component derives information and transitions from one log. The agent
-   runtime interprets one kind of information as tool bindings. A binding
+(* A component derives a view and transitions from one log. The agent runtime
+   interprets one kind of view as tool bindings. A binding
    pairs a visible tool with its handler, but pairing at one log does not by
    itself keep the tool routable after ToolCalled extends that log.
 
@@ -40,7 +40,7 @@ Init ==
   /\ pending = FALSE
   /\ called = "none"
 
-(* Offer appends ModelCalled after deriving the information from the prior
+(* Offer appends ModelCalled after deriving the view from the prior
    prefix, the order inferReactorFor commits in runtime/infer.ts. *)
 Offer ==
   /\ offerAt = 0


### PR DESCRIPTION
## Summary

Names the descriptive output of a component its view. The core equation is now `{ view, transitions } = f(log)`.

- Renames `Derivation.info` to `Derivation.view` and `InfoAlgebra` to `ViewAlgebra`.
- Renames the agent surface from `AgentInfo` to `AgentView`.
- Updates every component, example, test, and public export to the new vocabulary.
- Relates the React equation `{ UI, effects } = f(state)` to the Tardigrade equation `{ view, transitions } = f(log)` in the documentation.

## Why

View describes the projection a component derives for its consumer. Context remains one downstream part of an agent view, alongside system fragments and tool bindings.

The shared word makes the descriptive and behavioral outputs of one log derivation clear without tying the core abstraction to agents.

## Verification

- bun run gate
- bun run gate --only=test:app-cli,test:app-server,test:code,test:platform-bun
- git diff --check