### PR TITLE
ci: add effect lint gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: ci
 
 # The gate runs on every PR and every push to main. `bun run gate` is the same command run locally
-# (lint, typecheck, tests, knip), so CI green and local green mean the same thing. Releases are
-# `.github/workflows/publish.yml` via release-please on main; this workflow does not publish.
+# (lint, Effect lint, typecheck, tests, knip), so CI green and local green mean the same thing.
+# Releases are `.github/workflows/publish.yml` via release-please on main; this workflow does not
+# publish.
 on:
   pull_request:
   push:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,9 @@ bun run setup
 bun run gate
 ```
 
-The gate runs lint (oxlint), prose lint (`tools/docs-lint.ts`), typecheck (every package plus root tools), tests (`bun test` per package), and dead-code analysis (knip) in parallel. It must exit 0. Narrow it with `bun run gate --only=typecheck` while iterating. The pre-push hook runs the whole gate.
+The gate runs lint (oxlint), prose lint (`tools/docs-lint.ts`), Effect lint (`@effect/tsgo`, one run per TypeScript project), typecheck (every package plus root tools), tests (`bun test` per package), and dead-code analysis (knip) in parallel. It must exit 0. Narrow it with `bun run gate --only=typecheck` while iterating. The pre-push hook runs the whole gate.
+
+The Effect lint reads rules the type checker does not carry: an effect nobody yielded, a requirement nobody provides, a wall clock read inside a replayed body, a schema that admits `NaN`. [tsconfig.effect.json](tsconfig.effect.json) names every installed rule with the severity this repository holds it to, and each rule that is off says why. The gate checks that list against the installed rule catalog, then fails on an error or warning. `bun run lint:effect` runs it alone. A source exception uses `// @effect-diagnostics-next-line <rule>:off` with its reason at the expression it covers.
 
 `any` is a lint error. It defeats the checks the rest of the framework leans on, and every place it looked necessary had an honest type behind it. The one exception is annotated where it sits, with the reason it can not be written any other way.
 

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -50,7 +50,7 @@ export const problemLine = (error: ProblemError): string => {
 // leaves the exit code non-zero, so a caller sees the server's sentence rather than a stack trace
 // (commands.test.ts, "a problem document prints its title, status, and detail").
 const userErrorOf = (cause: unknown): CliError.UserError =>
-  new CliError.UserError({
+  CliError.UserError.make({
     cause,
     userMessage: cause instanceof ProblemError ? problemLine(cause) : String(cause)
   })
@@ -122,10 +122,8 @@ const settle = (
       const view = views.find((candidate) => candidate.turn === turn)
       if (view !== undefined && view.status !== "pending") return view
       if ((yield* Clock.currentTimeMillis) - started >= timeoutMillis) {
-        return yield* Effect.fail(
-          userErrorOf(
-            `turn ${turn} on thread ${thread} was still pending after ${timeoutMillis}ms. It is still running: read it with \`tdg events ${thread}\`.`
-          )
+        return yield* userErrorOf(
+          `turn ${turn} on thread ${thread} was still pending after ${timeoutMillis}ms. It is still running: read it with \`tdg events ${thread}\`.`
         )
       }
       yield* Effect.sleep(pollMillis)
@@ -147,7 +145,7 @@ export const setupCommand = Command.make("setup", { json }, (flags) =>
   Effect.gen(function*() {
     const cli = yield* Cli
     const home = homeOf(cli.env)
-    if (home === undefined) return yield* Effect.fail(userErrorOf(HOME_MISSING))
+    if (home === undefined) return yield* userErrorOf(HOME_MISSING)
     const file = yield* readFileConfig(cli.env)
     const answers = yield* Effect.mapError(setupPrompt(file.model === undefined ? {} : { current: file.model }), userErrorOf)
     const path = yield* Effect.mapError(writeSetup(home, answers), userErrorOf)
@@ -348,7 +346,7 @@ export const devCommand = Command.make("dev", {
       }),
       catch: userErrorOf
     })
-    yield* Effect.mapError(Layer.launch(layer), userErrorOf)
+    return yield* Effect.mapError(Layer.launch(layer), userErrorOf)
   })).pipe(
       Command.withDescription(
         "Boot the API and serve the built UI at one URL, ungated on loopback. One process, one port: the API paths are the server's own and everything else is the UI."
@@ -391,7 +389,7 @@ export const runCommand = Command.make("run", {
         : turnLines(accepted.thread, view)
     )
     if (view.status !== SETTLED) {
-      return yield* Effect.fail(userErrorOf(`turn ${view.turn} on thread ${accepted.thread} is ${view.status}`))
+      return yield* userErrorOf(`turn ${view.turn} on thread ${accepted.thread} is ${view.status}`)
     }
   })).pipe(
     Command.withDescription(

--- a/apps/cli/src/setup.ts
+++ b/apps/cli/src/setup.ts
@@ -1,4 +1,5 @@
 import { Console, Effect, Redacted } from "effect"
+import type { PlatformError } from "effect/PlatformError"
 import { FileSystem } from "effect/FileSystem"
 import { Prompt } from "effect/unstable/cli"
 
@@ -266,7 +267,7 @@ export const homeOf = (env: Env): string | undefined => {
 export const writeSetup = (
   home: string,
   answers: SetupAnswers
-): Effect.Effect<string, unknown, FileSystem> =>
+): Effect.Effect<string, PlatformError, FileSystem> =>
   Effect.gen(function*() {
     const fs = yield* FileSystem
     const path = configPathIn(home)

--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -99,6 +99,8 @@ const until = async <A>(what: string, poll: () => Promise<A | undefined>, ms = 1
   }
 }
 
+const get = (base: string, path: string) => fetch(`${base}${path}`)
+
 const post = (base: string, path: string, body?: unknown) =>
   fetch(`${base}${path}`, {
     method: "POST",
@@ -216,8 +218,8 @@ describe("actors", () => {
             id: "m1",
             text: "inspect"
           })
-          const actors = await (await fetch(`${base}/v1/actors`)).json()
-          const events = await (await fetch(`${base}/v1/actors/reviewer/threads/review/events`)).json()
+          const actors = await (await get(base, "/v1/actors")).json()
+          const events = await (await get(base, "/v1/actors/reviewer/threads/review/events")).json()
           return { pushStatus: pushed.status, summary, accepted: await accepted.json(), actors, events }
         })
       }).pipe(Effect.provide(isolatedApp), Effect.scoped, Effect.runPromise)

--- a/apps/server/src/api.ts
+++ b/apps/server/src/api.ts
@@ -13,6 +13,7 @@ import {
   UnknownActor,
   UnknownProjection,
   UnknownThread,
+  type ActorSummary,
   type ProjectionDeclaration,
   type ThreadNode
 } from "@clavia/tardigrade-client/contract"
@@ -225,7 +226,7 @@ export const layerThreadsGroup = (options: ApiOptions = {}) => {
       .handle("list", ({ params }) =>
         Effect.gen(function*() {
           const threads = yield* actorOf(params.actor)
-          return flatten(treeOf(logsOf(yield* threads.list())))
+          return flatten(treeOf(logsOf(yield* threads.list)))
         }))
       .handle("events", ({ params, query }) =>
         Effect.gen(function*() {
@@ -245,7 +246,7 @@ export const layerThreadsGroup = (options: ApiOptions = {}) => {
           const threads = yield* actorOf(params.actor)
           // The forest is built over every log because parentage is a claim in the PARENT's log; a
           // subtree cannot be derived from the subtree's own events (projections.ts, treeOf).
-          const node = findNode(treeOf(logsOf(yield* threads.list())), params.id)
+          const node = findNode(treeOf(logsOf(yield* threads.list)), params.id)
           if (node === undefined) {
             return yield* Effect.fail(UnknownThread.of(unknownThreadDetail(params.id)))
           }
@@ -275,66 +276,62 @@ const readOf = (declaration: ProjectionDeclaration) =>
     return declaration.run(log, request.query)
   })
 
-export const layerProjectionsGroup = () =>
-  HttpApiBuilder.group(ServerApi, "projections", (handlers) => {
-    // Every declared name gets the same handler, built from the same record the endpoints were
-    // generated from, so the two cannot disagree about which names exist. The type is the group's
-    // own endpoint map with every key required: `handleAll` accepts a partial record, and a partial
-    // one would leave the group short a handler at run time (api.test.ts, "a declared projection
-    // serves what the actor computes").
-    type Endpoints = (typeof handlers)["~EndpointsByIdentifier"]
-    type Complete = {
-      readonly [Name in keyof Endpoints]: HttpApiEndpoint.Handler<
-        Endpoints[Name],
-        HttpApiEndpoint.MiddlewareError<Endpoints[Name]>,
-        Threads
-      >
-    }
-    const served = Object.fromEntries(
-      Object.entries(agentProjections).map(([name, declaration]) => [name, readOf(declaration)])
-    ) as unknown as Complete
-    return handlers.handleAll(served)
-  })
+export const layerProjectionsGroup = HttpApiBuilder.group(ServerApi, "projections", (handlers) => {
+  // Every declared name gets the same handler, built from the same record the endpoints were
+  // generated from, so the two cannot disagree about which names exist. The type is the group's
+  // own endpoint map with every key required: `handleAll` accepts a partial record, and a partial
+  // one would leave the group short a handler at run time (api.test.ts, "a declared projection
+  // serves what the actor computes").
+  type Endpoints = (typeof handlers)["~EndpointsByIdentifier"]
+  type Complete = {
+    readonly [Name in keyof Endpoints]: HttpApiEndpoint.Handler<
+      Endpoints[Name],
+      HttpApiEndpoint.MiddlewareError<Endpoints[Name]>,
+      Threads
+    >
+  }
+  const served = Object.fromEntries(
+    Object.entries(agentProjections).map(([name, declaration]) => [name, readOf(declaration)])
+  ) as unknown as Complete
+  return handlers.handleAll(served)
+})
 
 // The name a request asked for, when the actor never declared it. The declared names are literal
 // paths, and a literal segment beats a parameter in this router, so this route is reached only by a
 // name that matched nothing (api.test.ts, "a name the actor never declared says what does exist").
 // `events` and `stream` never reach here either, for the same reason: they are the log's own routes.
-export const layerUnknownProjection = () => {
-  const declared = Object.keys(agentProjections)
-  const detail = declared.length === 0
-    ? "This actor declares no projections."
-    : `This actor declares ${declared.map((name) => JSON.stringify(name)).join(", ")}.`
-  return HttpRouter.add(
-    "GET",
-    "/v1/actors/:actor/threads/:id/:name",
-    Effect.gen(function*() {
-      const params = yield* HttpRouter.params
-      const actor = paramOf(params, "actor")
-      const registry = yield* Threads
-      if (actor !== RESERVED_ACTOR && registry.actor?.(actor) === undefined) {
-        return problemResponse(UnknownActor.of(unknownActorDetail(actor)))
-      }
-      const name = paramOf(params, "name")
-      return problemResponse(
-        UnknownProjection.of(`No projection named ${JSON.stringify(name)} is mounted here. ${detail}`)
-      )
-    })
-  )
-}
+const declaredProjections = Object.keys(agentProjections)
+const declaredDetail = declaredProjections.length === 0
+  ? "This actor declares no projections."
+  : `This actor declares ${declaredProjections.map((name) => JSON.stringify(name)).join(", ")}.`
 
-export const layerActorsGroup = () =>
-  HttpApiBuilder.group(ServerApi, "actors", (handlers) =>
-    handlers
-      .handle("actors", () =>
-        Effect.flatMap(Threads, (threads) => threads.actors ?? Effect.succeed([
-          { name: RESERVED_ACTOR, builtIn: true }
-        ])))
-      .handle("pushActor", ({ payload }) =>
-        Effect.gen(function*() {
-          const threads = yield* Threads
-          if (threads.push === undefined) {
-            return yield* Effect.fail(InvalidRequest.of("This server does not accept actor pushes."))
-          }
-          return yield* Effect.mapError(threads.push(payload), (error) => InvalidRequest.of(error.message))
-        })))
+export const layerUnknownProjection = HttpRouter.add(
+  "GET",
+  "/v1/actors/:actor/threads/:id/:name",
+  Effect.gen(function*() {
+    const params = yield* HttpRouter.params
+    const actor = paramOf(params, "actor")
+    const registry = yield* Threads
+    if (actor !== RESERVED_ACTOR && registry.actor?.(actor) === undefined) {
+      return problemResponse(UnknownActor.of(unknownActorDetail(actor)))
+    }
+    const name = paramOf(params, "name")
+    return problemResponse(
+      UnknownProjection.of(`No projection named ${JSON.stringify(name)} is mounted here. ${declaredDetail}`)
+    )
+  })
+)
+
+export const layerActorsGroup = HttpApiBuilder.group(ServerApi, "actors", (handlers) =>
+  handlers
+    .handle("actors", () =>
+      Effect.flatMap(Threads, (threads): Effect.Effect<ReadonlyArray<ActorSummary>> =>
+        threads.actors ?? Effect.succeed([{ name: RESERVED_ACTOR, builtIn: true }])))
+    .handle("pushActor", ({ payload }) =>
+      Effect.gen(function*() {
+        const threads = yield* Threads
+        if (threads.push === undefined) {
+          return yield* Effect.fail(InvalidRequest.of("This server does not accept actor pushes."))
+        }
+        return yield* Effect.mapError(threads.push(payload), (error) => InvalidRequest.of(error.message))
+      })))

--- a/apps/server/src/contract.test.ts
+++ b/apps/server/src/contract.test.ts
@@ -18,7 +18,7 @@ import { layerGaugeResting, PROBLEM_CONTENT_TYPE, serve } from "./http"
 const layerThreadsEmpty = Layer.succeed(Threads)({
   append: () => Effect.void,
   events: () => Effect.succeed([]),
-  list: () => Effect.succeed([]),
+  list: Effect.succeed([]),
   settled: Effect.void
 })
 

--- a/apps/server/src/contract.ts
+++ b/apps/server/src/contract.ts
@@ -67,10 +67,10 @@ type Extends<A, B> = [A] extends [B] ? true : never
 
 const asserts = <_ extends true>(): void => {}
 
-asserts<Same<Projections.ThreadStatus, typeof ThreadStatus.Type>>()
-asserts<Same<Projections.ThreadSummary, typeof ThreadSummary.Type>>()
-asserts<Same<Projections.ThreadNode, typeof ThreadNode.Type>>()
-asserts<Same<Actor.TurnStatus, typeof TurnStatus.Type>>()
-asserts<Same<Actor.TurnViewShape, typeof TurnView.Type>>()
+asserts<Same<Projections.ThreadStatus, ThreadStatus>>()
+asserts<Same<Projections.ThreadSummary, ThreadSummary>>()
+asserts<Same<Projections.ThreadNode, ThreadNode>>()
+asserts<Same<Actor.TurnStatus, TurnStatus>>()
+asserts<Same<Actor.TurnViewShape, TurnView>>()
 asserts<Extends<typeof UnknownThread.schema.Type, Problem>>()
 asserts<Extends<typeof InvalidRequest.schema.Type, Problem>>()

--- a/apps/server/src/host.test.ts
+++ b/apps/server/src/host.test.ts
@@ -142,7 +142,7 @@ describe("the threads service", () => {
         yield* threads.append("alpha", brief("m1"))
         yield* threads.append("beta", brief("m2"))
         yield* threads.settled
-        return yield* threads.list()
+        return yield* threads.list
       })
     )
     expect(listed.map((entry) => entry.id)).toEqual(["alpha", "beta"])

--- a/apps/server/src/host.ts
+++ b/apps/server/src/host.ts
@@ -1,4 +1,4 @@
-import { Clock, Context, Effect, Layer } from "effect"
+import { Clock, Context, Data, Effect, Layer } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
 import { BunFileSystem, BunPath } from "@effect/platform-bun"
 import { createHash } from "node:crypto"
@@ -43,10 +43,18 @@ export const laneOf = (id: string): string => `${LANE_PREFIX}${id}`
 export const idOf = (lane: string): string | undefined =>
   lane.startsWith(LANE_PREFIX) ? lane.slice(LANE_PREFIX.length) : undefined
 
+// ActorPushRefused is why a pushed actor was not accepted, in the sentence the route prints. The
+// artifact checks and the swap both raise it, so a caller reads one failure rather than telling a
+// validation `Error` apart from a filesystem one by its message (api.ts, pushActor).
+export class ActorPushRefused extends Data.TaggedError("ActorPushRefused")<{
+  readonly message: string
+  readonly cause: unknown
+}> {}
+
 export interface ActorThreads {
   readonly append: (id: string, event: Event) => Effect.Effect<void>
   readonly events: (id: string) => Effect.Effect<ReadonlyArray<Event>>
-  readonly list: () => Effect.Effect<ReadonlyArray<{ readonly id: string; readonly events: ReadonlyArray<Event> }>>
+  readonly list: Effect.Effect<ReadonlyArray<{ readonly id: string; readonly events: ReadonlyArray<Event> }>>
   readonly settled: Effect.Effect<void>
 }
 
@@ -65,7 +73,7 @@ export class Threads extends Context.Service<
     readonly settled: ActorThreads["settled"]
     readonly actors?: Effect.Effect<ReadonlyArray<ActorSummary>>
     readonly actor?: (name: string) => ActorThreads | undefined
-    readonly push?: (artifact: ActorArtifact) => Effect.Effect<ActorSummary, Error>
+    readonly push?: (artifact: ActorArtifact) => Effect.Effect<ActorSummary, ActorPushRefused>
   }
 >()("tardigrade/server/Threads") {}
 
@@ -220,15 +228,14 @@ const runtimeOf = async (
         request()
       }),
     events: read,
-    list: () =>
-      Effect.gen(function*() {
-        const lanes = yield* Effect.promise(() => host.lanes())
-        const ids = lanes.flatMap((candidate) => {
-          const id = idOf(candidate)
-          return id === undefined ? [] : [id]
-        })
-        return yield* Effect.forEach(ids, (id) => Effect.map(read(id), (events) => ({ id, events })))
-      }),
+    list: Effect.gen(function*() {
+      const lanes = yield* Effect.promise(() => host.lanes())
+      const ids = lanes.flatMap((candidate) => {
+        const id = idOf(candidate)
+        return id === undefined ? [] : [id]
+      })
+      return yield* Effect.forEach(ids, (id) => Effect.map(read(id), (events) => ({ id, events })))
+    }),
     settled
   }
   return {
@@ -353,7 +360,7 @@ const make = (options: ThreadsOptions) =>
 
     const selected = (name: string): ActorThreads | undefined => runtimes.get(name)?.threads
     const primary = selected(RESERVED_ACTOR)!
-    const push = (artifact: ActorArtifact): Effect.Effect<ActorSummary, Error> =>
+    const push = (artifact: ActorArtifact): Effect.Effect<ActorSummary, ActorPushRefused> =>
       Effect.tryPromise({
         try: () => exclusive(async () => {
           const manifest = artifact.manifest as ActorArtifactManifest
@@ -394,7 +401,7 @@ const make = (options: ThreadsOptions) =>
             throw error
           }
         }),
-        catch: (error) => error instanceof Error ? error : new Error(String(error))
+        catch: (error) => new ActorPushRefused({ message: error instanceof Error ? error.message : String(error), cause: error })
       })
 
     const service: Context.Service.Shape<typeof Threads> = {

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -23,7 +23,7 @@ setDefaultTimeout(BOOT_MS)
 const layerThreadsEmpty = Layer.succeed(Threads)({
   append: () => Effect.void,
   events: () => Effect.succeed([]),
-  list: () => Effect.succeed([]),
+  list: Effect.succeed([]),
   settled: Effect.void
 })
 

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -161,9 +161,9 @@ export const layerApp = (options: ApiOptions = {}) =>
   Layer.mergeAll(
     Layer.provide(
       Layer.provide(HttpApiBuilder.layer(ServerApi, { openapiPath: OPENAPI_PATH }), [
-        layerActorsGroup(),
+        layerActorsGroup,
         layerThreadsGroup(options),
-        layerProjectionsGroup(),
+        layerProjectionsGroup,
         layerHealthGroup
       ]),
       layerRequestProblems
@@ -173,7 +173,7 @@ export const layerApp = (options: ApiOptions = {}) =>
     // After the declared routes and before the catch-all: a literal segment beats a parameter in
     // this router, so a projection the actor declared is served and every other name under a thread
     // is told what does exist (api.ts, layerUnknownProjection).
-    layerUnknownProjection(),
+    layerUnknownProjection,
     layerNotFound,
     layerCors,
     layerAuth

--- a/apps/voyager/dev/fixture.ts
+++ b/apps/voyager/dev/fixture.ts
@@ -90,7 +90,8 @@ const post = (thread: string, body: unknown) =>
 
 const seed = Effect.promise(async () => {
   for (const { thread, ...message } of FIXTURE_BRIEFS) await post(thread, { type: "MessageReceived", ...message })
-  console.log(`fixture: seeded ${FIXTURE_BRIEFS.length} briefs on http://127.0.0.1:${FIXTURE_PORT}`)
-})
+}).pipe(
+  Effect.tap(() => Effect.log(`fixture: seeded ${FIXTURE_BRIEFS.length} briefs on http://127.0.0.1:${FIXTURE_PORT}`))
+)
 
 BunRuntime.runMain(Layer.launch(Layer.effectDiscard(seed).pipe(Layer.provideMerge(app))))

--- a/bun.lock
+++ b/bun.lock
@@ -6,9 +6,10 @@
       "name": "tardigrade",
       "dependencies": {
         "@types/node": "^24",
-        "typescript": "6.0.3",
+        "typescript": "7.0.2",
       },
       "devDependencies": {
+        "@effect/tsgo": "0.36.5",
         "@types/bun": "^1.3.4",
         "beautiful-mermaid": "^1.1.3",
         "knip": "^6.15.0",
@@ -235,6 +236,22 @@
 
     "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@4.0.0-rc.110", "", { "peerDependencies": { "effect": "^4.0.0-rc.110" } }, "sha512-Lam3gY1xszjQS/cebdLbWbtR21FtQI4ke7QHqbBQ6AyVJF0CGUtS/ePL9zNq6wHNmJ95FUDGS6W+Qx/l6RPSzA=="],
 
+    "@effect/tsgo": ["@effect/tsgo@0.36.5", "", { "optionalDependencies": { "@effect/tsgo-darwin-arm64": "0.36.5", "@effect/tsgo-darwin-x64": "0.36.5", "@effect/tsgo-linux-arm": "0.36.5", "@effect/tsgo-linux-arm64": "0.36.5", "@effect/tsgo-linux-x64": "0.36.5", "@effect/tsgo-win32-arm64": "0.36.5", "@effect/tsgo-win32-x64": "0.36.5" }, "bin": { "effect-tsgo": "dist/effect-tsgo.cjs" } }, "sha512-BHxVjeRK1/XlqYHWXkbT4W9JpOrT3sNA2wrfwQPBTojD5OSyxI2TUIltobYhWudyfuCrn770qP6uOpDjdrmghA=="],
+
+    "@effect/tsgo-darwin-arm64": ["@effect/tsgo-darwin-arm64@0.36.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+JPS65Ekod5NS41Kg9OIyuUsygNcSw5/4Y+UNbY6Wob6dvP+CkEa51pGBAmHKQp3Z/D3g/A9GNE66ndu9kz8dw=="],
+
+    "@effect/tsgo-darwin-x64": ["@effect/tsgo-darwin-x64@0.36.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-S67mS1GTSvfeN5Tsij7QarJNuv3q7U/PMhjTbGtKO9mqgDTOA2IOlxq7YPIxkWq+AiOIv0H3aHGk7ToRjcPWxg=="],
+
+    "@effect/tsgo-linux-arm": ["@effect/tsgo-linux-arm@0.36.5", "", { "os": "linux", "cpu": "arm" }, "sha512-UqtTPUgoVMRHAOcHiK7sddxjUEj6kOkXAlu4Y2TL/MhGiu81ZBzZrg8TXf0ApNeEMOD0EIK8hwU2kik8O+buxA=="],
+
+    "@effect/tsgo-linux-arm64": ["@effect/tsgo-linux-arm64@0.36.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-bNLzLrQ/4Sf0N7NlAqcEpr+g+RW/ERIvmSFQN9Nu+hSFti4Kx9Nrfo1LJ4V0qASry5Rj2DG4Wa9C5ydQAD9qqA=="],
+
+    "@effect/tsgo-linux-x64": ["@effect/tsgo-linux-x64@0.36.5", "", { "os": "linux", "cpu": "x64" }, "sha512-QWdyuUcAb1kZBeItycHg1ZKloNbVDtlVm1C0bbDVHqZIZ/d2rqhKi6Zajm64GnHtfdwPTn8Oi1iOCH1IYgo0IQ=="],
+
+    "@effect/tsgo-win32-arm64": ["@effect/tsgo-win32-arm64@0.36.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-5tO5em1DfplFz5GqpQVGRSrAoE+kEgIc7Y0ClbT9jkxaK18IFVq9KIYybt4d6VT4+QnNQGdqWOahMcGE4JAZ8w=="],
+
+    "@effect/tsgo-win32-x64": ["@effect/tsgo-win32-x64@0.36.5", "", { "os": "win32", "cpu": "x64" }, "sha512-pmaKwdYAIs9GFpMV9glIUks0UZDHE1/xwP6+GCGhSFxB76cDLMnrHr/IBt5VfGddT65SK+Dyw/vAtcX7fRp4KA=="],
+
     "@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
@@ -459,6 +476,46 @@
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.1.0", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "oxc-transform-react": "^0.145.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler", "oxc-transform-react"] }, "sha512-qd2BzUBehkov86WFhg0JkEFEYyCLG9uPCe6qWTY/kRlss9OvJrOF2UbIWT7p+8IzZHkEu0DNGHc4HSv+JdDLsw=="],
 
     "beautiful-mermaid": ["beautiful-mermaid@1.1.3", "", { "dependencies": { "elkjs": "^0.11.0", "entities": "^7.0.1" } }, "sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg=="],
@@ -569,7 +626,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "unbash": ["unbash@4.0.10", "", {}, "sha512-b7zoBQvpWp0vuN5q2vK2RRBR2SvuruQAs50DApdDveBSn3eSYd84IaHodFqQIMlvY9K2VnyBUEXgwOBuGU9GBg=="],
 

--- a/knip.json
+++ b/knip.json
@@ -2,6 +2,10 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "workspaces": {
     ".": {
+      "ignoreDependencies": [
+        "@effect/tsgo",
+        "@effect/language-service"
+      ],
       "entry": [
         "tools/*.ts",
         "examples/*.ts",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "gate": "bun run tools/gate.ts",
     "lint": "oxlint",
+    "lint:effect": "bun run gate --only=lint:effect",
     "typecheck": "tsc --noEmit && bun run --filter './packages/*' typecheck",
     "test": "bun run --filter './packages/*' test",
     "knip": "knip",
@@ -21,9 +22,10 @@
   },
   "dependencies": {
     "@types/node": "^24",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   },
   "devDependencies": {
+    "@effect/tsgo": "0.36.5",
     "@types/bun": "^1.3.4",
     "beautiful-mermaid": "^1.1.3",
     "knip": "^6.15.0",

--- a/packages/agent/src/components/budget.test.ts
+++ b/packages/agent/src/components/budget.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, test } from "bun:test"
 import { Effect, Layer } from "effect"
+import { KeyValueStore } from "effect/unstable/persistence"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { EventLog, withWatermark } from "@clavia/tardigrade-core/event-log"
 import { actorOf } from "@clavia/tardigrade-core/component"
+import { Self } from "@clavia/tardigrade-core/actor"
+import { Facets } from "@clavia/tardigrade-core/facets"
+import { Router } from "@clavia/tardigrade-core/router"
+import { parseActorAddress } from "@clavia/tardigrade-core/communication/address"
+import { Infer } from "../turn"
+import { NativeOutputSupport } from "../runtime/infer"
 import { budget, budgetReactor, budgetReactorFor, budgetOf, usedOf, budgetPhase, budgetSpent, canRequestBudget } from "./budget"
 import { agentRuntime } from "../runtime/agent"
 import { codeMode } from "./code"
@@ -10,6 +17,22 @@ import { compaction } from "./compaction"
 import { reply } from "./reply"
 
 const toolsReactor = actorOf(agentRuntime(), [codeMode, reply, budget, compaction]).reactors[1]!
+
+// The rest of the agent's environment, which every reactor's `act` is typed against whether or not
+// it reaches for it. Naming it is what proves the tools gate answers from the log alone: no model
+// is asked, no actor is addressed, and no store is read (turn.test.ts, noRouter).
+const rest = Layer.mergeAll(
+  KeyValueStore.layerMemory,
+  Layer.succeed(Facets, { read: () => Effect.succeed([]) }),
+  Layer.succeed(Router, {
+    deliver: () => Effect.void,
+    call: () => Effect.succeed({ error: "no router bound" }),
+    resume: () => Effect.succeed({ error: "no router bound" })
+  }),
+  Layer.succeed(Self, parseActorAddress("test-agent")),
+  Layer.succeed(NativeOutputSupport, { withTools: true }),
+  Layer.succeed(Infer, { react: () => Effect.die("the tools gate never asks the model") })
+)
 
 // A turn: a `MessageReceived` head carrying `budget`, then `calls` execute tool-calls (each answered
 // except the last), then any extra events appended after.
@@ -32,7 +55,7 @@ const fire = async (log: ReadonlyArray<Event>): Promise<ReadonlyArray<Event>> =>
   }))
   const derived = budgetReactor(events)
   if (derived.length > 0) {
-    const out = await Effect.runPromise(derived[0]!.act(derived[0]!.input).pipe(Effect.provide(memory)) as Effect.Effect<ReadonlyArray<Event>>)
+    const out = await Effect.runPromise(derived[0]!.act(derived[0]!.input).pipe(Effect.provide(memory)))
     events.push(...out)
   }
   return events.slice(log.length)
@@ -104,7 +127,9 @@ describe("the tools gate reacts to BudgetExhausted", () => {
     }))
     const derived = toolsReactor(events)
     if (derived.length > 0) {
-      const out = await Effect.runPromise(derived[0]!.act(derived[0]!.input).pipe(Effect.provide(memory)) as Effect.Effect<ReadonlyArray<Event>>)
+      const out = await Effect.runPromise(
+        derived[0]!.act(derived[0]!.input).pipe(Effect.provide(Layer.mergeAll(memory, rest)))
+      )
       events.push(...out)
     }
     return events.slice(log.length)

--- a/packages/agent/src/components/compaction.test.ts
+++ b/packages/agent/src/components/compaction.test.ts
@@ -90,7 +90,7 @@ const mailbox = actor<Infer | EventLog>([compactionReactor], agentActorKeys)
 
 describe("the compaction pass", () => {
   const run = async (initial: ReadonlyArray<Event>) => {
-    const ref = Effect.runSync(Ref.make<ReadonlyArray<Event>>(initial))
+    const ref = Ref.makeUnsafe<ReadonlyArray<Event>>(initial)
     let briefed = ""
     const layers = Layer.mergeAll(
       Layer.succeed(

--- a/packages/agent/src/events.ts
+++ b/packages/agent/src/events.ts
@@ -54,7 +54,7 @@ export const ToolCalled = Schema.Struct({
   // recorded here so replay does not decide how this attempt ran from a current capability
   // (runtime/infer.ts, consequenceOf).
   mode: Schema.optional(Schema.Unknown),
-  at: Schema.Number
+  at: Schema.Finite
 })
 
 // ToolReturned is the answer: the world's reply to one call. A failed call is a returned error,
@@ -63,7 +63,7 @@ export const ToolReturned = Schema.Struct({
   type: Schema.Literal("ToolReturned"),
   callId: Schema.String,
   result: Schema.Unknown,
-  at: Schema.Number
+  at: Schema.Finite
 })
 
 // ModelCalled is the ask to the model and the attempt mark in one, appended before the inference
@@ -75,13 +75,13 @@ export const ModelCalled = Schema.Struct({
   callId: Schema.String,
   // The occurrence: distinct per physical attempt, the dedup key's scope. callId stays the
   // provider idempotency key, shared across retries of one logical attempt.
-  ordinal: Schema.optional(Schema.Number),
+  ordinal: Schema.optional(Schema.Finite),
   // The output policy this attempt ran under, when the turn declared a contract. Recorded on the
   // ask, so a replay reads which policy produced which response.
   output: Schema.optional(OutputPolicy),
-  epoch: Schema.optional(Schema.Number),
+  epoch: Schema.optional(Schema.Finite),
   turn: Schema.optional(Schema.String),
-  at: Schema.Number
+  at: Schema.Finite
 })
 
 // TextReturned is the prose the model emitted alongside its decision: working commentary,
@@ -89,7 +89,7 @@ export const ModelCalled = Schema.Struct({
 export const TextReturned = Schema.Struct({
   type: Schema.Literal("TextReturned"),
   text: Schema.String,
-  at: Schema.Number
+  at: Schema.Finite
 })
 
 // TurnCompleted is the success terminal, under every policy. The event carries the output.
@@ -103,8 +103,8 @@ export const TurnCompleted = Schema.Struct({
   attemptKey: Schema.optional(Schema.String),
   endpoint: Schema.optional(Endpoint),
   mode: Schema.optional(Schema.Unknown),
-  epoch: Schema.optional(Schema.Number),
-  at: Schema.Number
+  epoch: Schema.optional(Schema.Finite),
+  at: Schema.Finite
 })
 
 // TURN_FAILURE_CAUSES are the failure classes a turn ends in, each distinct because each has a
@@ -149,9 +149,9 @@ export const OutputRejected = Schema.Struct({
   mode: Schema.optional(Schema.Unknown),
   usage: Schema.optional(Schema.Unknown),
   endpoint: Schema.optional(Endpoint),
-  epoch: Schema.optional(Schema.Number),
+  epoch: Schema.optional(Schema.Finite),
   turn: Schema.optional(Schema.String),
-  at: Schema.Number
+  at: Schema.Finite
 })
 
 // OutputRetryRequested is a component's decision that a rejected response should be asked again,
@@ -169,9 +169,9 @@ export const OutputRetryRequested = Schema.Struct({
   feedback: Schema.String,
   by: Schema.String, // the component that decided
   decision: Schema.optional(Schema.Unknown),
-  epoch: Schema.optional(Schema.Number),
+  epoch: Schema.optional(Schema.Finite),
   turn: Schema.optional(Schema.String),
-  at: Schema.Number
+  at: Schema.Finite
 })
 
 // TurnFailed is the failure terminal for one execution epoch.
@@ -180,23 +180,23 @@ export const TurnFailed = Schema.Struct({
   error: Schema.String,
   // Present only on the fail a live attempt answered; the give-up terminal carries none.
   usage: Schema.optional(Schema.Unknown),
-  epoch: Schema.optional(Schema.Number),
+  epoch: Schema.optional(Schema.Finite),
   cause: Schema.optional(Schema.Literals(TURN_FAILURE_CAUSES)),
-  attempts: Schema.optional(Schema.Number),
+  attempts: Schema.optional(Schema.Finite),
   attemptKey: Schema.optional(Schema.String),
   policy: Schema.optional(Schema.Unknown),
   mode: Schema.optional(Schema.Unknown),
   endpoint: Schema.optional(Endpoint),
-  at: Schema.Number
+  at: Schema.Finite
 })
 
 // TurnResumed records the operator request that starts the next execution epoch.
 export const TurnResumed = Schema.Struct({
   type: Schema.Literal("TurnResumed"),
   turn: Schema.String,
-  failedEpoch: Schema.Number,
-  epoch: Schema.Number,
-  at: Schema.Number
+  failedEpoch: Schema.Finite,
+  epoch: Schema.Finite,
+  at: Schema.Finite
 })
 
 // ReplyDelivered records that the turn's terminal went home, or had no home to go to. The
@@ -204,17 +204,17 @@ export const TurnResumed = Schema.Struct({
 export const ReplyDelivered = Schema.Struct({
   type: Schema.Literal("ReplyDelivered"),
   to: Schema.optional(Schema.String), // absent = the inbound named no replyTo, and nothing was sent
-  at: Schema.Number
+  at: Schema.Finite
 })
 
 // BudgetExhausted is the wall, fired once when the spend passes the brief's budget. The tools
 // reactor reads it and refuses further execute, so the model answers with its best result.
 export const BudgetExhausted = Schema.Struct({
   type: Schema.Literal("BudgetExhausted"),
-  budget: Schema.Number,
-  used: Schema.Number,
+  budget: Schema.Finite,
+  used: Schema.Finite,
   turn: Schema.optional(Schema.String),
-  at: Schema.Number
+  at: Schema.Finite
 })
 
 // BudgetRequested opens the escalation lifecycle. At its wall an escalatable agent may ask its
@@ -225,20 +225,20 @@ export const BudgetRequested = Schema.Struct({
   type: Schema.Literal("BudgetRequested"),
   callId: Schema.String, // the request_budget call the parent's answer settles
   reason: Schema.String,
-  amount: Schema.Number,
+  amount: Schema.Finite,
   turn: Schema.optional(Schema.String),
-  at: Schema.Number
+  at: Schema.Finite
 })
 
 export const BudgetGranted = Schema.Struct({
   type: Schema.Literal("BudgetGranted"),
-  amount: Schema.Number, // the tool calls added to this turn's budget
+  amount: Schema.Finite, // the tool calls added to this turn's budget
   // The BudgetRequested this grant answers. The dedup key reads it: a grant is summed into the
   // ceiling (packages/agent/src/budget.ts), so a redelivered grant landing twice would silently
   // double the budget; keyed by the request it answers, the store absorbs the repeat.
   callId: Schema.optional(Schema.String),
   turn: Schema.optional(Schema.String),
-  at: Schema.Number
+  at: Schema.Finite
 })
 
 export const BudgetDenied = Schema.Struct({
@@ -247,7 +247,7 @@ export const BudgetDenied = Schema.Struct({
   // The BudgetRequested this denial answers, for the dedup key; symmetry with BudgetGranted.
   callId: Schema.optional(Schema.String),
   turn: Schema.optional(Schema.String),
-  at: Schema.Number
+  at: Schema.Finite
 })
 
 export const AgentEvent = Schema.Union([

--- a/packages/agent/src/spawn.test.ts
+++ b/packages/agent/src/spawn.test.ts
@@ -97,7 +97,13 @@ describe("agentsPackage", () => {
     const sent: Array<Sent> = []
     const pkg = agentsPackage()
     const parked = await Effect.runPromise(
-      pkg.methods.run!({ text: "sum 2+2" }, { callId: "c5" }).pipe(Effect.provide(env("mem:ag.root", sent)), Effect.flip)
+      // flip then orDie: the call must park, and a success is a defect rather than a failure
+      // typed as the method's own result.
+      pkg.methods.run!({ text: "sum 2+2" }, { callId: "c5" }).pipe(
+        Effect.provide(env("mem:ag.root", sent)),
+        Effect.flip,
+        Effect.orDie
+      )
     )
     expect(parked).toBeInstanceOf(Park)
     expect((parked as Park).awaiting).toBe(replyId("c5"))

--- a/packages/agent/src/spawn.ts
+++ b/packages/agent/src/spawn.ts
@@ -239,7 +239,7 @@ export const agentsPackage = (
             from: self,
             at
           })
-          return yield* Effect.fail(new Park({ callId: ctx.callId, awaiting: replyId(ctx.callId) }))
+          return yield* new Park({ callId: ctx.callId, awaiting: replyId(ctx.callId) })
         }),
       // Await a run already fired in the background: no delivery, the same reply-or-park read the
       // plain foreground branch of `run` takes. `id` is the `callId` an earlier `background: true`
@@ -264,7 +264,7 @@ export const agentsPackage = (
           if ("error" in declared) return declared
           const reply = yield* awaitedReply(source, id)
           if (reply !== undefined) return shape(answerOf(reply), address, id, declared.contract)
-          return yield* Effect.fail(new Park({ callId: ctx.callId, awaiting: replyId(id) }))
+          return yield* new Park({ callId: ctx.callId, awaiting: replyId(id) })
         }),
       // Resume a child parked on a budget ask. `grant` is the tool calls to add; a non-positive grant,
       // or a spent run budget, denies and the child finishes. The grant draws the run's budget like a

--- a/packages/agent/src/turn.test.ts
+++ b/packages/agent/src/turn.test.ts
@@ -133,8 +133,12 @@ describe("the agent with execute as the only tool", () => {
     const spies = { insert: 0, search: 0 }
     const agent = agentWith([zoho(spies)])
     const layers = Layer.mergeAll(
-    KeyValueStore.layerMemory,
-    memoryLog(), codeThenComplete(count), jsSandbox, noRouter)
+      KeyValueStore.layerMemory,
+      memoryLog(),
+      codeThenComplete(count),
+      jsSandbox,
+      noRouter
+    )
     const events = await run(
       Effect.gen(function* () {
         yield* receive(agent, { id: "m1", text: "add the JD and search candidates" })
@@ -188,7 +192,13 @@ describe("the agent with execute as the only tool", () => {
     const events = await run(readLog, memoryLog(spilled))
     const [answer] = toolsReactor(events)
     expect(answer).toBeDefined()
-    const returned = await run(answer!.act(answer!.input as never) as Effect.Effect<ReadonlyArray<Event>>, memoryLog())
+    // Every reactor's `act` is typed against the agent's whole environment, so a settle that only
+    // reads the log still states it. Providing it is what proves the settle never reaches for the
+    // sandbox or the model to answer from a pointer.
+    const returned = await run(
+      answer!.act(answer!.input as never),
+      Layer.mergeAll(KeyValueStore.layerMemory, memoryLog(), codeThenComplete({ calls: 0 }), jsSandbox, noRouter)
+    )
     expect(returned[0]!.type).toBe("ToolReturned")
     const result = (returned[0] as unknown as { result: { result: Record<string, unknown> } }).result.result
     expect(result.tmp).toBe("t1.result")

--- a/packages/channels/src/providers/slack.ts
+++ b/packages/channels/src/providers/slack.ts
@@ -177,31 +177,28 @@ const providerOf = (options: SlackOptions): ChannelProvider<SlackAddress> => {
       if (target.provider !== options.name || !isSlackAddress(target)) {
         return Effect.die(new Error(`invalid address for provider: ${options.name}`))
       }
-      return Effect.tryPromise({
-        try: async () => {
-          const result = await fetch(`${apiBaseUrl}/chat.postMessage`, {
-            method: "POST",
-            headers: {
-              authorization: `Bearer ${options.botToken}`,
-              "content-type": "application/json; charset=utf-8"
-            },
-            body: JSON.stringify({
-              channel: target.channel,
-              text: message.text,
-              thread_ts: target.thread
-            })
+      return Effect.promise(async () => {
+        const result = await fetch(`${apiBaseUrl}/chat.postMessage`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${options.botToken}`,
+            "content-type": "application/json; charset=utf-8"
+          },
+          body: JSON.stringify({
+            channel: target.channel,
+            text: message.text,
+            thread_ts: target.thread
           })
-          const body = await result.json() as { readonly ok?: unknown; readonly error?: unknown }
-          if (!result.ok || body.ok !== true) {
-            throw new Error(
-              typeof body.error === "string"
-                ? `Slack chat.postMessage failed: ${body.error}`
-                : `Slack chat.postMessage failed with status ${result.status}`
-            )
-          }
-        },
-        catch: (cause) => cause
-      }).pipe(Effect.orDie)
+        })
+        const body = await result.json() as { readonly ok?: unknown; readonly error?: unknown }
+        if (!result.ok || body.ok !== true) {
+          throw new Error(
+            typeof body.error === "string"
+              ? `Slack chat.postMessage failed: ${body.error}`
+              : `Slack chat.postMessage failed with status ${result.status}`
+          )
+        }
+      })
     }
   }
 }

--- a/packages/channels/src/providers/telegram.ts
+++ b/packages/channels/src/providers/telegram.ts
@@ -124,28 +124,25 @@ const providerOf = (options: TelegramOptions): ChannelProvider<TelegramAddress> 
       if (target.provider !== options.name || !isTelegramAddress(target)) {
         return Effect.die(new Error(`invalid address for provider: ${options.name}`))
       }
-      return Effect.tryPromise({
-        try: async () => {
-          const result = await fetch(`${apiBaseUrl}/bot${options.token}/sendMessage`, {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({
-              chat_id: target.chat,
-              text: message.text,
-              ...(target.topic === undefined ? {} : { message_thread_id: target.topic })
-            })
+      return Effect.promise(async () => {
+        const result = await fetch(`${apiBaseUrl}/bot${options.token}/sendMessage`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            chat_id: target.chat,
+            text: message.text,
+            ...(target.topic === undefined ? {} : { message_thread_id: target.topic })
           })
-          const body = await result.json() as { readonly ok?: unknown; readonly description?: unknown }
-          if (!result.ok || body.ok !== true) {
-            throw new Error(
-              typeof body.description === "string"
-                ? `Telegram sendMessage failed: ${body.description}`
-                : `Telegram sendMessage failed with status ${result.status}`
-            )
-          }
-        },
-        catch: (cause) => cause
-      }).pipe(Effect.orDie)
+        })
+        const body = await result.json() as { readonly ok?: unknown; readonly description?: unknown }
+        if (!result.ok || body.ok !== true) {
+          throw new Error(
+            typeof body.description === "string"
+              ? `Telegram sendMessage failed: ${body.description}`
+              : `Telegram sendMessage failed with status ${result.status}`
+          )
+        }
+      })
     }
   }
 }

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -222,7 +222,7 @@ describe("resuming a turn", () => {
         Schema.Struct({
           turn: Schema.String,
           status: Schema.Literals(["pending", "completed", "failed", "parked"]),
-          epoch: Schema.Number,
+          epoch: Schema.Finite,
           output: Schema.optionalKey(Schema.String),
           error: Schema.optionalKey(Schema.String)
         })

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -191,19 +191,20 @@ export const makeClient = <const P extends Projections = {}>(options: ClientOpti
   // the API's middleware asks a client for. RequestProblems asks for nothing, so nothing is left to
   // provide; the compiler proves that for a stated declaration and cannot for a generic one, which
   // is what the annotation states here rather than at every call site.
-  const api = Effect.runSync(
-    (HttpApiClient.make(apiOf(options.projections ?? ({} as P)), {
-      baseUrl,
-      ...(token === undefined
-        ? {}
-        : { transformClient: (client: HttpClient.HttpClient) => HttpClient.mapRequest(client, HttpClientRequest.bearerToken(token)) })
-    }).pipe(
-      Effect.provide(FetchHttpClient.layer),
-      options.fetch === undefined
-        ? (self) => self
-        : Effect.provideService(FetchHttpClient.Fetch, options.fetch)
-    ) as Effect.Effect<DerivedApi<P>>)
+  const derived = HttpApiClient.make(apiOf(options.projections ?? ({} as P)), {
+    baseUrl,
+    ...(token === undefined
+      ? {}
+      : { transformClient: (client: HttpClient.HttpClient) => HttpClient.mapRequest(client, HttpClientRequest.bearerToken(token)) })
+  }).pipe(
+    Effect.provide(FetchHttpClient.layer),
+    options.fetch === undefined
+      ? (self) => self
+      : Effect.provideService(FetchHttpClient.Fetch, options.fetch)
   )
+  // derived has no requirements for every concrete declaration, which a generic P cannot reduce.
+  // @effect-diagnostics-next-line unsafeEffectTypeAssertion:off
+  const api = Effect.runSync(derived as Effect.Effect<DerivedApi<P>>)
   // The actor this client addresses. One name today, because the server compiles one assembly in
   // and reserves that name for it (contract.ts, RESERVED_ACTOR); it is an option rather than a
   // literal at each call so a deploy that serves more than one is a client option, not a rewrite.
@@ -224,6 +225,8 @@ export const makeClient = <const P extends Projections = {}>(options: ClientOpti
         )
       })
     }
+    // call erases the selected endpoint failure before run converts it to ProblemError.
+    // @effect-diagnostics-next-line anyUnknownInErrorContext:off
     return await run(call({ params: { actor, id: thread }, query: { turn } })) as ReadonlyArray<TurnView>
   }
 
@@ -272,6 +275,8 @@ export const makeClient = <const P extends Projections = {}>(options: ClientOpti
     // those keys, so the lookup cannot miss. The types are recovered on the way out because an
     // index into a mapped record of endpoint methods is not one the compiler can narrow per call.
     projection: (thread, name, query) =>
+      // ProjectionCall erases the selected endpoint failure before run converts it to ProblemError.
+      // @effect-diagnostics-next-line anyUnknownInErrorContext:off
       run((api.projections as Record<string, ProjectionCall>)[name]!({
         params: { actor, id: thread },
         query: query ?? {}

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -134,8 +134,8 @@ export type ThreadStatus = typeof ThreadStatus.Type
 export const ThreadSummary = Schema.Struct({
   id: Schema.String,
   parent: Schema.optionalKey(Schema.String),
-  events: Schema.Number,
-  lastAt: Schema.optionalKey(Schema.Number),
+  events: Schema.Finite,
+  lastAt: Schema.optionalKey(Schema.Finite),
   status: ThreadStatus
 }).annotate({ identifier: "ThreadSummary" })
 
@@ -162,7 +162,7 @@ export type TurnStatus = typeof TurnStatus.Type
 export const TurnView = Schema.Struct({
   turn: Schema.String,
   status: TurnStatus,
-  epoch: Schema.Number,
+  epoch: Schema.Finite,
   output: Schema.optionalKey(Schema.String),
   error: Schema.optionalKey(Schema.String)
 }).annotate({ identifier: "TurnView" })
@@ -174,7 +174,7 @@ export type TurnView = typeof TurnView.Type
 // and `after` still means the same place (apps/server/src/api.test.ts, "after and limit page the
 // log, and types filters without renumbering it").
 export const EventRow = Schema.Struct({
-  seq: Schema.Number,
+  seq: Schema.Finite,
   event: Event
 }).annotate({ identifier: "EventRow" })
 
@@ -193,7 +193,7 @@ export type Accepted = typeof Accepted.Type
 
 export const Health = Schema.Struct({
   status: Schema.Literals(["resting", "driving"]),
-  dirty: Schema.Number
+  dirty: Schema.Finite
 }).annotate({ identifier: "Health" })
 
 export type Health = typeof Health.Type

--- a/packages/code/src/events.ts
+++ b/packages/code/src/events.ts
@@ -12,7 +12,7 @@ export const CodeDispatched = Schema.Struct({
   type: Schema.Literal("CodeDispatched"),
   execId: Schema.String,
   code: Schema.String,
-  at: Schema.Number
+  at: Schema.Finite
 })
 
 // PackageCalled records one package call from inside a code body. `callId` is `{execId}.{n}`
@@ -23,7 +23,7 @@ export const PackageCalled = Schema.Struct({
   callId: Schema.String,
   name: Schema.String,
   arguments: Schema.Unknown,
-  at: Schema.Number
+  at: Schema.Finite
 })
 
 // PackageReturned records the answer to one package call. The committed pair is the replay
@@ -32,7 +32,7 @@ export const PackageReturned = Schema.Struct({
   type: Schema.Literal("PackageReturned"),
   callId: Schema.String,
   result: Schema.Unknown,
-  at: Schema.Number
+  at: Schema.Finite
 })
 
 // BlockedOn is evidence, never a state: one attempt observed one reply absent. It suppresses
@@ -44,7 +44,7 @@ export const BlockedOn = Schema.Struct({
   callId: Schema.String,
   awaiting: Schema.String,
   turn: Schema.optional(Schema.String),
-  at: Schema.Number
+  at: Schema.Finite
 })
 
 // CodeSettled is the terminal of one execution: what the code returned, or why it threw. A
@@ -58,7 +58,7 @@ export const CodeSettled = Schema.Struct({
   // Captured console output, capped by the sandbox (packages/code/src/sandbox.ts,
   // SandboxResult.logs). Absent when the body printed nothing.
   logs: Schema.optional(Schema.Array(Schema.String)),
-  at: Schema.Number
+  at: Schema.Finite
 })
 
 export const CodeEvent = Schema.Union([

--- a/packages/code/src/execute.ts
+++ b/packages/code/src/execute.ts
@@ -165,13 +165,14 @@ const executeRecorded = <R = never>(
                   return { parked: false, result }
                 }
               }
-              // A non-Park failure or defect in the fn is TRANSIENCE (an RPC hiccup, a reset
-              // stub), and it takes the park branch: nothing recorded beyond the send, the
-              // body's promise never settles, the next attempt asks again. It must never
-              // become a rejection the body can catch: a rejection is an input that exists
-              // nowhere in the log, so replay would depend on infrastructure luck
-              // (execute.test.ts, "transience never reaches the body"; the 2026-08-16
-              // run-d7b8b037-183 drift). A method's real failure is an {error} RESULT.
+              // A defect in the fn is TRANSIENCE (an RPC hiccup, a reset stub), and it takes the
+              // park branch: nothing recorded beyond the send, the body's promise never settles,
+              // the next attempt asks again. It must never become a rejection the body can catch:
+              // a rejection is an input that exists nowhere in the log, so replay would depend on
+              // infrastructure luck (execute.test.ts, "transience never reaches the body"; the
+              // 2026-08-16 run-d7b8b037-183 drift). A method's real failure is an {error} RESULT,
+              // and its declared error channel carries `Park` alone (packages.ts, Package), so a
+              // failure that is not a park cannot arrive here to be caught.
               const parkOut = (awaiting?: string): Effect.Effect<CallOutcome, never, never> =>
                 Effect.gen(function* () {
                   parked = true
@@ -183,7 +184,6 @@ const executeRecorded = <R = never>(
               const attempt = yield* fn(args, { callId }).pipe(
                 Effect.map((result): CallOutcome => ({ parked: false, result })),
                 Effect.catchTag("Park", (p) => parkOut(p.awaiting)),
-                Effect.catch(() => parkOut()),
                 Effect.catchDefect(() => parkOut())
               )
               if (attempt.parked) return attempt

--- a/packages/code/src/files.test.ts
+++ b/packages/code/src/files.test.ts
@@ -16,12 +16,14 @@ const platform = Layer.mergeAll(BunFileSystem.layer, BunPath.layer)
 
 let root = ""
 
-const run = <A>(effect: Effect.Effect<A, never, FileSystem | Path>) =>
+// A method may fail with `Park`, so the helper carries the failure rather than asserting it away:
+// runPromise rejects, and a test that parks says so instead of reading a narrowed type.
+const run = <A, E>(effect: Effect.Effect<A, E, FileSystem | Path>) =>
   Effect.runPromise(Effect.provide(effect, platform))
 
 const call = (method: string, args: unknown) => {
   const pkg = filesPackage({ policy: { root } })
-  return run(pkg.methods[method]!(args, { callId: "c1" }) as Effect.Effect<unknown, never, never>)
+  return run(pkg.methods[method]!(args, { callId: "c1" }))
 }
 
 beforeAll(async () => {
@@ -75,7 +77,7 @@ describe("the files package", () => {
   test("a slice past the cap says truncated", async () => {
     const pkg = filesPackage({ policy: { root, readChars: 5 } })
     const answer = (await run(
-      pkg.methods["read"]!({ path: "notes.txt", length: 1000 }, { callId: "c1" }) as Effect.Effect<unknown, never, never>
+      pkg.methods["read"]!({ path: "notes.txt", length: 1000 }, { callId: "c1" })
     )) as { text: string; size: number; truncated?: boolean }
     expect(answer.text).toBe("alpha")
     expect(answer.size).toBe(17)
@@ -117,7 +119,7 @@ describe("the files package", () => {
   test("a match-heavy search stops at the cap and says truncated", async () => {
     const pkg = filesPackage({ policy: { root, maxMatches: 1 } })
     const answer = (await run(
-      pkg.methods["search"]!({ pattern: "beta" }, { callId: "c1" }) as Effect.Effect<unknown, never, never>
+      pkg.methods["search"]!({ pattern: "beta" }, { callId: "c1" })
     )) as { matches: ReadonlyArray<unknown>; truncated?: boolean }
     expect(answer.matches.length).toBe(1)
     expect(answer.truncated).toBe(true)

--- a/packages/code/src/files.ts
+++ b/packages/code/src/files.ts
@@ -188,7 +188,7 @@ export const filesPackage = (options: FilesOptions = {}): Package<FileSystem | P
           const entries = yield* Effect.forEach(kept, (name) =>
             fs.stat(path.join(confined.path, name)).pipe(
               Effect.map((info) => ({ name, type: String(info.type) })),
-              Effect.catch(() => Effect.succeed({ name, type: "Unknown" }))
+              Effect.orElseSucceed(() => ({ name, type: "Unknown" }))
             ))
           const truncated = names.names.length > kept.length
           return { entries, ...(truncated ? { truncated } : {}) }

--- a/packages/code/src/store.test.ts
+++ b/packages/code/src/store.test.ts
@@ -6,8 +6,8 @@ import { hydrate, refs, spill, WORKSPACE_REFS } from "./store"
 // The spill seam over a KeyValueStore: what goes in comes back out whole, and the reserved
 // manifest key indexes the refs one store holds.
 
-const run = <A>(effect: Effect.Effect<A, unknown, KeyValueStore.KeyValueStore>) =>
-  Effect.runPromise(effect.pipe(Effect.provide(KeyValueStore.layerMemory)) as Effect.Effect<A>)
+const run = <A, E>(effect: Effect.Effect<A, E, KeyValueStore.KeyValueStore>) =>
+  Effect.runPromise(effect.pipe(Effect.provide(KeyValueStore.layerMemory)))
 
 describe("spill and hydrate", () => {
   test("a spilled value round-trips exactly", async () => {

--- a/packages/code/src/store.ts
+++ b/packages/code/src/store.ts
@@ -56,6 +56,8 @@ export const hydrate = (
   Effect.flatMap(KeyValueStore.KeyValueStore, (store) => store.get(ref))
 
 // refs reads the manifest: the refs this store holds, in the order they were spilled.
+// refs is callable because @clavia/tardigrade-code/store exposes that shape to consumers.
+// @effect-diagnostics-next-line lazyEffect:off
 export const refs = (): Effect.Effect<
   ReadonlyArray<string>,
   KeyValueStore.KeyValueStoreError,

--- a/packages/code/src/workspace.test.ts
+++ b/packages/code/src/workspace.test.ts
@@ -15,11 +15,11 @@ const call = async (
   args: unknown,
   store: KeyValueStore.KeyValueStore
 ) =>
-  Effect.runPromise(
+  (await Effect.runPromise(
     pkg.methods[method]!(args, { callId: "c1" }).pipe(
       Effect.provideService(KeyValueStore.KeyValueStore, store)
-    ) as Effect.Effect<Record<string, unknown>>
-  )
+    )
+  )) as Record<string, unknown>
 
 // A store built straight from the memory layer, seeded through the spill path so the manifest is
 // the one grep reads.
@@ -32,7 +32,7 @@ const seeded = (values: Readonly<Record<string, string>>, store?: KeyValueStore.
       store === undefined
         ? Effect.provide(KeyValueStore.layerMemory)
         : Effect.provideService(KeyValueStore.KeyValueStore, store)
-    ) as Effect.Effect<KeyValueStore.KeyValueStore>
+    )
   )
 
 // A second backend with no shared code with the memory layer: a Map behind makeStringOnly. W6's

--- a/packages/core/src/communication/link.test.ts
+++ b/packages/core/src/communication/link.test.ts
@@ -11,7 +11,7 @@ describe("links", () => {
       chat: "-1001234567890",
       topic: "42"
     }
-    const target = Schema.decodeUnknownSync(ActorAddress)({
+    const target = Schema.decodeSync(ActorAddress)({
       actor: "support",
       thread: "telegram:-1001234567890:42"
     })

--- a/packages/core/src/communication/message.ts
+++ b/packages/core/src/communication/message.ts
@@ -17,7 +17,7 @@ export const MessageReceived = Schema.Struct({
   outcome: Schema.optional(Schema.Literals(["completed", "failed"])),
   input: Schema.optional(Schema.Unknown),
   data: Schema.optional(Schema.Unknown),
-  at: Schema.Number
+  at: Schema.Finite
 })
 export type MessageReceived = typeof MessageReceived.Type
 

--- a/packages/host/src/communication/ingress.ts
+++ b/packages/host/src/communication/ingress.ts
@@ -36,7 +36,7 @@ export const ingressFrom = (
       for (const delivery of deliveries) {
         const target = actorFor(delivery.link.target.actor)
         if (target === undefined) {
-          return yield* Effect.fail(new ActorUnavailable({ actor: delivery.link.target.actor }))
+          return yield* new ActorUnavailable({ actor: delivery.link.target.actor })
         }
         routed.push({ delivery, target })
       }

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { Effect } from "effect"
+import { Clock, Effect, Random } from "effect"
 import { StopReason } from "@aws-sdk/client-bedrock-runtime"
 import {
   codeMode,
@@ -601,6 +601,8 @@ describe("infer: throttle-shaped retry", () => {
       return calls === 1 ? new Response(JSON.stringify({ error: { message: "rate limited" } }), { status: 429 }) : okStream()
     }) as unknown as typeof globalThis.fetch
     const slept: Array<number> = []
+    const seed = "throttle retry"
+    const expectedDelay = Effect.runSync(Random.next.pipe(Random.withSeed(seed))) * 2_000
     const layer = infer({
       baseUrl: "https://model.test/v1",
       apiKey: "k",
@@ -613,14 +615,63 @@ describe("infer: throttle-shaped retry", () => {
     })
     const action = await Effect.runPromise(
       Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
-        Effect.provide(layer)
+        Effect.provide(layer),
+        Random.withSeed(seed)
       ) as Effect.Effect<unknown>
     )
     expect(action).toMatchObject({ kind: "complete", output: "ok" })
     expect(calls).toBe(2)
-    expect(slept).toHaveLength(1)
-    expect(slept[0]).toBeGreaterThanOrEqual(0)
-    expect(slept[0]).toBeLessThan(2_000)
+    expect(slept).toEqual([expectedDelay])
+  })
+
+  test("a retry reads the supplied Clock", async () => {
+    const now = 1_000_000
+    let clockReads = 0
+    const liveClock = Effect.runSync(Clock.Clock)
+    const clock: Clock.Clock = {
+      currentTimeMillisUnsafe: () => {
+        clockReads += 1
+        return now
+      },
+      currentTimeMillis: Effect.succeed(now),
+      currentTimeNanosUnsafe: () => liveClock.currentTimeNanosUnsafe(),
+      currentTimeNanos: liveClock.currentTimeNanos,
+      monotonicTimeNanosUnsafe: () => liveClock.monotonicTimeNanosUnsafe(),
+      monotonicTimeNanos: liveClock.monotonicTimeNanos,
+      sleep: (duration) => liveClock.sleep(duration)
+    }
+    let calls = 0
+    const slept: Array<number> = []
+    const seed = "clock retry"
+    const expectedDelay = Effect.runSync(Random.next.pipe(Random.withSeed(seed))) * 2_000
+    const layer = infer({
+      baseUrl: "https://model.test/v1",
+      apiKey: "k",
+      model: "test-model",
+      fetch: (async () => {
+        calls += 1
+        if (calls === 1) {
+          return new Response(JSON.stringify({ error: { message: "rate limited" } }), {
+            status: 429
+          })
+        }
+        return okStream()
+      }) as unknown as typeof globalThis.fetch,
+      sleep: (ms) => {
+        slept.push(ms)
+        return Promise.resolve()
+      }
+    })
+    const action = await Effect.runPromise(
+      Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
+        Effect.provide(layer),
+        Effect.provideService(Clock.Clock, clock),
+        Random.withSeed(seed)
+      ) as Effect.Effect<unknown>
+    )
+    expect(action).toMatchObject({ kind: "complete", output: "ok" })
+    expect(clockReads).toBe(1)
+    expect(slept).toEqual([expectedDelay])
   })
 
   test("retries exhaust after the bounded set and report the effective policy", async () => {
@@ -653,6 +704,7 @@ describe("infer: throttle-shaped retry", () => {
         attempts: 4,
         policy: {
           throttleRetryDelaysMs: [2_000, 8_000, 30_000],
+          retryAfterJitterMs: 1_000,
           stream: { firstChunkMs: 90_000, idleMs: 90_000, totalMs: 300_000 }
         }
       }
@@ -748,6 +800,7 @@ describe("model selection", () => {
 
 describe("retry-after", () => {
   const NOW = 1_000_000
+  const nextRandom = () => 0.5
 
   test("reads seconds and date forms, from any seat a failure carries headers in", () => {
     expect(retryAfterMsOf({ headers: { "Retry-After": "7" } }, NOW)).toBe(7_000)
@@ -760,24 +813,26 @@ describe("retry-after", () => {
   })
 
   test("a stated wait within the ceiling is honored; past it, retries stop", () => {
-    const stated = throttleDelayMs({ headers: { "retry-after": "7" } }, 0, NOW)
-    expect(stated).toBeGreaterThanOrEqual(7_000)
-    expect(stated).toBeLessThan(8_000)
-    expect(throttleDelayMs({ headers: { "retry-after": "300" } }, 0, NOW)).toBeUndefined()
+    const stated = throttleDelayMs({ headers: { "retry-after": "7" } }, 0, NOW, nextRandom)
+    expect(stated).toBe(7_500)
+    expect(throttleDelayMs({ headers: { "retry-after": "300" } }, 0, NOW, nextRandom)).toBeUndefined()
   })
 
   test("no stated wait falls back to the ladder, and the ladder still bounds retries", () => {
-    const fallback = throttleDelayMs({}, 1, NOW)
-    expect(fallback).toBeGreaterThanOrEqual(0)
-    expect(fallback).toBeLessThanOrEqual(8_000)
-    expect(throttleDelayMs({ headers: { "retry-after": "1" } }, 3, NOW)).toBeUndefined()
+    const fallback = throttleDelayMs({}, 1, NOW, nextRandom)
+    expect(fallback).toBe(4_000)
+    expect(throttleDelayMs({ headers: { "retry-after": "1" } }, 3, NOW, nextRandom)).toBeUndefined()
   })
 
   test("a caller-supplied ladder sets the retry count and the Retry-After ceiling", () => {
     const short = [100]
-    expect(throttleDelayMs({}, 0, NOW, short)).toBeLessThanOrEqual(100)
-    expect(throttleDelayMs({}, 1, NOW, short)).toBeUndefined()
-    expect(throttleDelayMs({ headers: { "retry-after": "1" } }, 0, NOW, short)).toBeUndefined()
+    expect(throttleDelayMs({}, 0, NOW, nextRandom, short)).toBe(50)
+    expect(throttleDelayMs({}, 1, NOW, nextRandom, short)).toBeUndefined()
+    expect(throttleDelayMs({ headers: { "retry-after": "1" } }, 0, NOW, nextRandom, short)).toBeUndefined()
+  })
+
+  test("a caller-supplied Retry-After jitter changes the stated wait", () => {
+    expect(throttleDelayMs({ headers: { "retry-after": "1" } }, 0, NOW, nextRandom, [2_000], 200)).toBe(1_100)
   })
 })
 

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer } from "effect"
+import { Clock, Effect, Layer, Random } from "effect"
 import { StreamProcessor, type ModelMessage, type ProcessorResult, type StreamChunk, type Tool, type ToolCall } from "@tanstack/ai"
 import { openaiCompatibleText } from "@tanstack/ai-openai/compatible"
 import * as BedrockRuntime from "@aws-sdk/client-bedrock-runtime"
@@ -216,6 +216,8 @@ export interface ModelConfig {
   readonly pricing?: ModelPricing
   // In-act backoff bases for throttle-shaped failures. Length is the retry count.
   readonly throttleRetryDelaysMs?: ReadonlyArray<number>
+  // retryAfterJitterMs adds a random wait to a provider's Retry-After value. Absent, DEFAULT_RETRY_AFTER_JITTER_MS.
+  readonly retryAfterJitterMs?: number
   readonly fetch?: FetchImpl // test seam
   readonly sleep?: (ms: number) => Promise<void> // test seam: swap the backoff wait for an instant one
 }
@@ -236,6 +238,7 @@ type NativeOutputProvided<C extends ModelConfig> = [C] extends [
 // trouble. `bounded()` below throws plain `Error`s for the same shape of failure (a stream that
 // never starts or stalls), so the message is checked too.
 export const DEFAULT_THROTTLE_RETRY_DELAYS_MS: ReadonlyArray<number> = [2_000, 8_000, 30_000]
+export const DEFAULT_RETRY_AFTER_JITTER_MS = 1_000
 
 const isThrottleShaped = (e: unknown): boolean => {
   const err = e as { status?: unknown; statusCode?: unknown; message?: unknown }
@@ -249,7 +252,7 @@ const isThrottleShaped = (e: unknown): boolean => {
 
 // Full jitter (AWS's term for it): a uniform draw between 0 and the base, so many attempts
 // throttled at the same instant do not retry in lockstep and re-trip the same limit together.
-const jittered = (baseMs: number): number => Math.random() * baseMs
+const jittered = (baseMs: number, nextRandom: () => number): number => nextRandom() * baseMs
 
 // retryAfterMsOf reads the provider's own wait from a thrown failure, in both forms the
 // specification allows (a count of seconds, or a date to wait until). The adapters differ in
@@ -278,20 +281,22 @@ export const retryAfterMsOf = (e: unknown, now: number): number | undefined => {
 }
 
 // throttleDelayMs decides one in-flight wait: the provider's stated Retry-After when it fits
-// the ladder's own ceiling (plus up to a second of jitter, so a herd released together does not
-// re-trip the limit), the jittered ladder otherwise, and undefined for a stated wait past the
-// ceiling. A stated wait past the ceiling ends the bounded retry set.
+// the ladder's own ceiling (plus the stated jitter, so a herd released together does not re-trip
+// the limit), the jittered ladder otherwise, and undefined for a stated wait past the ceiling. A
+// stated wait past the ceiling ends the bounded retry set.
 export const throttleDelayMs = (
   e: unknown,
   attempt: number,
   now: number,
-  delays: ReadonlyArray<number> = DEFAULT_THROTTLE_RETRY_DELAYS_MS
+  nextRandom: () => number,
+  delays: ReadonlyArray<number> = DEFAULT_THROTTLE_RETRY_DELAYS_MS,
+  retryAfterJitterMs: number = DEFAULT_RETRY_AFTER_JITTER_MS
 ): number | undefined => {
   if (attempt >= delays.length) return undefined
   const ceiling = delays[delays.length - 1]!
   const stated = retryAfterMsOf(e, now)
-  if (stated !== undefined) return stated > ceiling ? undefined : stated + Math.random() * 1_000
-  return jittered(delays[attempt]!)
+  if (stated !== undefined) return stated > ceiling ? undefined : stated + nextRandom() * retryAfterJitterMs
+  return jittered(delays[attempt]!, nextRandom)
 }
 
 const realSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
@@ -620,7 +625,8 @@ export const infer = <const C extends ModelConfig>(config: C): Layer.Layer<Infer
     totalMs: config.stream?.totalMs ?? DEFAULT_STREAM_BOUNDS.totalMs
   }
   const throttleDelays = config.throttleRetryDelaysMs ?? DEFAULT_THROTTLE_RETRY_DELAYS_MS
-  const failurePolicy = { throttleRetryDelaysMs: throttleDelays, stream: bounds }
+  const retryAfterJitterMs = config.retryAfterJitterMs ?? DEFAULT_RETRY_AFTER_JITTER_MS
+  const failurePolicy = { throttleRetryDelaysMs: throttleDelays, retryAfterJitterMs, stream: bounds }
   const attemptOnce = async (
     req: ModelRequest,
     mode: OutputMode,
@@ -719,42 +725,53 @@ export const infer = <const C extends ModelConfig>(config: C): Layer.Layer<Infer
     }
   }
   const layer = Layer.succeed(Infer, {
-    react: (request: InferRequest, key?: string) =>
-      Effect.gen(function* () {
-        const ladder = ladderOf(config.maxOutputTokens, config.maxTokensLadder)
-        const stats: { finish?: string; rung: number; waits: number; attempts: number } = {
-          rung: 0,
-          waits: 0,
-          attempts: 0
-        }
-        // The actor decides the request, render included; the platform maps it to the wire and
-        // streams it, holding no opinion about tools (tardie, runtime/agent.ts).
-        const req = modelRequest(request.trajectory, request, request.context ?? {})
-        // The contract's preflight runs before the first socket: an endpoint that cannot promise
-        // the declared schema, or a schema outside the profile both wires send unchanged, ends
-        // the turn having spent nothing (src/output.ts, outputPreflight).
-        const selected = outputModeOf(req, config)
-        if ("errors" in selected) {
-          const action: Action = {
-            kind: "fail",
-            error: selected.errors.join("\n"),
-            endpoint: endpointOf(config, undefined),
-            failure: {
-              cause: "output_unsupported",
-              attempts: 0,
-              policy: { provider: config.provider, model: config.model, output: capabilityOf(config) }
-            }
+    react: Effect.fn("llm.react", {
+      kind: "client",
+      attributes: {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.request.model": config.model,
+        "gen_ai.provider.name": config.provider === "bedrock" ? "aws.bedrock" : (config.provider ?? "openai")
+      }
+    })(function* (request: InferRequest, key?: string) {
+      // The retry ladder reads the wall clock to honour a provider's `Retry-After` date, and it
+      // reads it from the Clock the caller supplied rather than the global one, so a test drives
+      // the ladder without waiting on real time (model.test.ts, "infer: throttle-shaped retry").
+      const clock = yield* Clock.Clock
+      const random = yield* Random.Random
+      const ladder = ladderOf(config.maxOutputTokens, config.maxTokensLadder)
+      const stats: { finish?: string; rung: number; waits: number; attempts: number } = {
+        rung: 0,
+        waits: 0,
+        attempts: 0
+      }
+      // The actor decides the request, render included; the platform maps it to the wire and
+      // streams it, holding no opinion about tools (tardie, runtime/agent.ts).
+      const req = modelRequest(request.trajectory, request, request.context ?? {})
+      // The contract's preflight runs before the first socket: an endpoint that cannot promise
+      // the declared schema, or a schema outside the profile both wires send unchanged, ends
+      // the turn having spent nothing (src/output.ts, outputPreflight).
+      const selected = outputModeOf(req, config)
+      if ("errors" in selected) {
+        const action: Action = {
+          kind: "fail",
+          error: selected.errors.join("\n"),
+          endpoint: endpointOf(config, undefined),
+          failure: {
+            cause: "output_unsupported",
+            attempts: 0,
+            policy: { provider: config.provider, model: config.model, output: capabilityOf(config) }
           }
-          yield* Effect.annotateCurrentSpan("gen_ai.output.supported", false)
-          return action
         }
-        const mode = selected.mode
-        if (req.output?.kind === "contract") {
-          yield* Effect.annotateCurrentSpan("gen_ai.output.contract", req.output.contract.name)
-          yield* Effect.annotateCurrentSpan("gen_ai.output.mode", mode.name)
-          yield* Effect.annotateCurrentSpan("gen_ai.output.native", mode.kind === "native")
-        }
-        const action = yield* Effect.promise<Action>(async () => {
+        yield* Effect.annotateCurrentSpan("gen_ai.output.supported", false)
+        return action
+      }
+      const mode = selected.mode
+      if (req.output?.kind === "contract") {
+        yield* Effect.annotateCurrentSpan("gen_ai.output.contract", req.output.contract.name)
+        yield* Effect.annotateCurrentSpan("gen_ai.output.mode", mode.name)
+        yield* Effect.annotateCurrentSpan("gen_ai.output.native", mode.kind === "native")
+      }
+      const action = yield* Effect.promise<Action>(async () => {
         let rung = 0
         const parts: Usage[] = []
         let missed = false
@@ -816,7 +833,14 @@ export const infer = <const C extends ModelConfig>(config: C): Layer.Layer<Infer
                 failure: { cause: "inference_error", attempts: stats.attempts, policy: failurePolicy }
               })
             }
-            const delay = throttleDelayMs(e, attempt, Date.now(), throttleDelays)
+            const delay = throttleDelayMs(
+              e,
+              attempt,
+              clock.currentTimeMillisUnsafe(),
+              () => random.nextDoubleUnsafe(),
+              throttleDelays,
+              retryAfterJitterMs
+            )
             if (delay === undefined) {
               const message = e instanceof Error ? e.message : String(e)
               return ends({
@@ -833,38 +857,29 @@ export const infer = <const C extends ModelConfig>(config: C): Layer.Layer<Infer
             await sleep(delay)
           }
         }
-        })
-        // The wide-span discipline: everything a failure query filters by rides the one span.
-        // Names follow the GenAI semantic conventions where they exist (registry, 2026).
-        yield* Effect.annotateCurrentSpan("gen_ai.response.finish_reasons", [stats.finish ?? "unknown"])
-        yield* Effect.annotateCurrentSpan("retry.rung", stats.rung)
-        yield* Effect.annotateCurrentSpan("retry.throttle_waits", stats.waits)
-        yield* Effect.annotateCurrentSpan("retry.attempts", stats.attempts)
-        if (action.usage !== undefined) {
-          // The usage stamp may carry wire-reported provenance; the span follows the same rule.
-          if (action.usage.provider !== undefined) {
-            yield* Effect.annotateCurrentSpan("gen_ai.provider.name", action.usage.provider)
-          }
-          yield* Effect.annotateCurrentSpan("gen_ai.usage.input_tokens", action.usage.promptTokens)
-          yield* Effect.annotateCurrentSpan("gen_ai.usage.output_tokens", action.usage.completionTokens)
-          if (action.usage.costUsd !== undefined) {
-            yield* Effect.annotateCurrentSpan("gen_ai.usage.cost", action.usage.costUsd)
-            if (action.usage.costSource !== undefined) {
-              yield* Effect.annotateCurrentSpan("gen_ai.usage.cost_source", action.usage.costSource)
-            }
+      })
+      // The wide-span discipline: everything a failure query filters by rides the one span.
+      // Names follow the GenAI semantic conventions where they exist (registry, 2026).
+      yield* Effect.annotateCurrentSpan("gen_ai.response.finish_reasons", [stats.finish ?? "unknown"])
+      yield* Effect.annotateCurrentSpan("retry.rung", stats.rung)
+      yield* Effect.annotateCurrentSpan("retry.throttle_waits", stats.waits)
+      yield* Effect.annotateCurrentSpan("retry.attempts", stats.attempts)
+      if (action.usage !== undefined) {
+        // The usage stamp may carry wire-reported provenance; the span follows the same rule.
+        if (action.usage.provider !== undefined) {
+          yield* Effect.annotateCurrentSpan("gen_ai.provider.name", action.usage.provider)
+        }
+        yield* Effect.annotateCurrentSpan("gen_ai.usage.input_tokens", action.usage.promptTokens)
+        yield* Effect.annotateCurrentSpan("gen_ai.usage.output_tokens", action.usage.completionTokens)
+        if (action.usage.costUsd !== undefined) {
+          yield* Effect.annotateCurrentSpan("gen_ai.usage.cost", action.usage.costUsd)
+          if (action.usage.costSource !== undefined) {
+            yield* Effect.annotateCurrentSpan("gen_ai.usage.cost_source", action.usage.costSource)
           }
         }
-        return action
-      }).pipe(
-        Effect.withSpan("llm.react", {
-          kind: "client",
-          attributes: {
-            "gen_ai.operation.name": "chat",
-            "gen_ai.request.model": config.model,
-            "gen_ai.provider.name": config.provider === "bedrock" ? "aws.bedrock" : (config.provider ?? "openai")
-          }
-        })
-      )
+      }
+      return action
+    })
   })
   return (
     config.output?.guarantee === "native" && config.output.withTools

--- a/tools/effect-lint-policy.ts
+++ b/tools/effect-lint-policy.ts
@@ -1,0 +1,54 @@
+import { fileURLToPath } from "node:url"
+
+type EffectPolicy = {
+  readonly compilerOptions?: {
+    readonly plugins?: ReadonlyArray<{
+      readonly name?: string
+      readonly diagnosticSeverity?: Readonly<Record<string, unknown>>
+    }>
+  }
+}
+
+type EffectSchema = {
+  readonly definitions?: Readonly<Record<string, {
+    readonly properties?: Readonly<Record<string, unknown>>
+  }>>
+}
+
+const root = fileURLToPath(new URL("../", import.meta.url))
+const policyPath = `${root}tsconfig.effect.json`
+const schemaPath = `${root}node_modules/@effect/tsgo/schema.json`
+const policy = Bun.JSONC.parse(await Bun.file(policyPath).text()) as EffectPolicy
+const schema = await Bun.file(schemaPath).json() as EffectSchema
+const plugin = policy.compilerOptions?.plugins?.find(({ name }) => name === "@effect/language-service")
+const configuredRules = plugin?.diagnosticSeverity
+const shippedRules = schema.definitions?.effectLanguageServicePluginDiagnosticSeverityDefinition?.properties
+
+if (configuredRules === undefined) {
+  throw new Error(`${policyPath} does not define the @effect/language-service diagnosticSeverity policy`)
+}
+if (shippedRules === undefined) {
+  throw new Error(`${schemaPath} does not expose the Effect diagnostic rule catalog`)
+}
+
+const configured = Object.keys(configuredRules).sort()
+const shipped = Object.keys(shippedRules).sort()
+const configuredSet = new Set(configured)
+const shippedSet = new Set(shipped)
+const missing = shipped.filter((rule) => !configuredSet.has(rule))
+const unknown = configured.filter((rule) => !shippedSet.has(rule))
+const gateSeverities = new Set(["error", "off", "warning"])
+const nonGating = Object.entries(configuredRules)
+  .filter(([, severity]) => typeof severity !== "string" || !gateSeverities.has(severity))
+  .map(([rule, severity]) => `${rule}:${String(severity)}`)
+
+if (missing.length > 0 || unknown.length > 0 || nonGating.length > 0) {
+  const details = [
+    ...(missing.length === 0 ? [] : [`missing rules: ${missing.join(", ")}`]),
+    ...(unknown.length === 0 ? [] : [`unknown rules: ${unknown.join(", ")}`]),
+    ...(nonGating.length === 0 ? [] : [`non-gating severities: ${nonGating.join(", ")}`])
+  ]
+  throw new Error(`Effect lint policy does not match the installed rule catalog\n${details.join("\n")}`)
+}
+
+console.log(`Effect lint policy names all ${shipped.length} installed rules at gating severities`)

--- a/tools/gate.ts
+++ b/tools/gate.ts
@@ -1,4 +1,5 @@
 import { availableParallelism } from "node:os"
+import { basename, relative } from "node:path"
 import { fileURLToPath } from "node:url"
 
 type Task = {
@@ -18,10 +19,46 @@ const apps = ["cli", "server", "voyager"]
 // can resolve and emit them.
 const bundled = ["voyager"]
 
+const tsconfigsIn = (directory: string): ReadonlyArray<string> =>
+  [...new Bun.Glob("tsconfig*.json").scanSync({ cwd: directory, absolute: true, onlyFiles: true })]
+    .filter((path) => basename(path) !== "tsconfig.base.json" && basename(path) !== "tsconfig.effect.json")
+    .sort()
+
+const effectProjects = [
+  ...tsconfigsIn(root),
+  ...packages.flatMap((name) => tsconfigsIn(pkg(name))),
+  ...platforms.flatMap((name) => tsconfigsIn(platformPkg(name))),
+  ...apps.flatMap((name) => tsconfigsIn(appPkg(name)))
+]
+
+const effectTaskId = (project: string): string => {
+  const path = relative(root, project).replaceAll("\\", "/")
+  if (path === "tsconfig.json") return "lint:effect:tools"
+  return `lint:effect:${path
+    .replace(/\/tsconfig(?:\.([^.]+))?\.json$/, (_match, variant: string | undefined) => variant === undefined ? "" : `:${variant}`)
+    .replaceAll("/", ":")}`
+}
+
+// effectLint runs the Effect rules at the severities tsconfig.effect.json states. `--strict` makes
+// warnings fail, and one process per project lets the gate run the checks in parallel.
+const effectLint = (project: string): ReadonlyArray<string> => [
+  "bun",
+  "--bun",
+  "node_modules/.bin/effect-tsgo",
+  "diagnostics",
+  "--strict",
+  "--format",
+  "text",
+  "--project",
+  project
+]
+
 const tasks: ReadonlyArray<Task> = [
   { id: "lint", cmd: ["bun", "--bun", "node_modules/.bin/oxlint"] },
   // Prose carries house rules the code linter does not know, so it has its own check.
   { id: "lint:docs", cmd: ["bun", "run", "tools/docs-lint.ts"] },
+  { id: "lint:effect:policy", cmd: ["bun", "run", "tools/effect-lint-policy.ts"] },
+  ...effectProjects.map((project) => ({ id: effectTaskId(project), cmd: effectLint(project) })),
   // Root tsconfig covers tools/*.ts; each package typechecks itself against the shared base.
   { id: "typecheck:tools", cmd: ["bun", "--bun", "node_modules/.bin/tsc", "--noEmit"] },
   ...packages.map((name) => ({ id: `typecheck:${name}`, cwd: pkg(name), cmd: ["bun", "run", "typecheck"] })),

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,4 +1,7 @@
 {
+  // tsconfig.effect.json carries the Effect lint policy, so every project that extends this file is
+  // held to the same rules in the gate and in editors that run the Effect language service.
+  "extends": "./tsconfig.effect.json",
   "compilerOptions": {
     "strict": true,
     "exactOptionalPropertyTypes": true,

--- a/tsconfig.effect.json
+++ b/tsconfig.effect.json
@@ -1,0 +1,169 @@
+{
+  // The Effect lint policy. Every project extends it through tsconfig.base.json, and the gate finds
+  // every tsconfig in each workspace (tools/gate.ts, lint:effect). `tsc --noEmit` ignores plugins,
+  // so a type error and an Effect finding stay separate answers.
+  //
+  // Every rule the plugin ships is named here with the severity this repository holds it to.
+  // tools/effect-lint-policy.ts compares this map with the installed catalog, so an upgrade that
+  // adds or removes a rule fails until this policy answers for it. `error` is a correctness claim,
+  // `warning` is a simplification, and the gate fails on both (`--strict`). `off` carries the reason
+  // it is off. A source exception uses `// @effect-diagnostics-next-line <rule>:off` with its reason
+  // at the expression it covers.
+  //
+  // `@effect/language-service` is the plugin's name, not a dependency: `@effect/tsgo` carries the
+  // diagnostics, and knip is told both names for that reason (knip.json, ignoreDependencies). An
+  // editor running stock tsserver needs the standalone plugin installed to read this file.
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "diagnostics": true,
+        "diagnosticSeverity": {
+          // Correctness. Each of these describes code that does something other than what it reads
+          // as: an effect that never runs, a requirement nobody provides, a handler that cannot fire.
+          "catchUnfailableEffect": "error",
+          "classSelfMismatch": "error",
+          "duplicatePackage": "error",
+          "effectFnIife": "error",
+          "effectFnImplicitAny": "error",
+          "effectGenUsesAdapter": "error",
+          "effectInFailure": "error",
+          "effectInVoidSuccess": "error",
+          "floatingEffect": "error",
+          "floatingEffectInVitest": "error",
+          "genericEffectServices": "error",
+          "layerMergeAllWithDependencies": "error",
+          "lazyPromiseInEffectSync": "error",
+          "missingEffectContext": "error",
+          "missingEffectError": "error",
+          "missingEffectServiceDependency": "error",
+          "missingLayerContext": "error",
+          "missingReturnYieldStar": "error",
+          "missingStarInYieldEffectGen": "error",
+          "multipleEffectProvide": "error",
+          "nonObjectEffectServiceType": "error",
+          "outdatedApi": "error",
+          "overriddenSchemaConstructor": "error",
+          "promiseInEffectSuccess": "error",
+          "returnEffectInGen": "error",
+          "runEffectInsideEffect": "error",
+          "schemaLiteralNonFinite": "error",
+          "schemaOpaqueInstanceMember": "error",
+          "scopeInLayerEffect": "error",
+          "unsafeEffectTypeAssertion": "error",
+
+          // Determinism. A replayed body re-runs from the top and must take the same path to each
+          // call, so a wall clock, a random draw, or a socket reached from inside Effect code is a
+          // replay hazard rather than a style choice. Model-authored code already gets this
+          // guarantee by shimming the same ambients (packages/code/src/sandbox.ts, Ambient;
+          // defaults.test.ts, "replay-stable ambients"), and the framework's own code holds itself
+          // to it here. Most ambient rules outside Effect code are in the `off` block below because
+          // a build script and a browser are not replayed. globalRandom stays on across helper calls.
+          "cryptoRandomUUIDInEffect": "error",
+          "globalDateInEffect": "error",
+          "globalFetchInEffect": "error",
+          "globalRandom": "error",
+          "globalRandomInEffect": "error",
+          "globalTimersInEffect": "error",
+          "processEnvInEffect": "error",
+
+          // Typed failures. An untagged error merges with every other untagged error in the failure
+          // channel, which is the one place this framework promises a caller can tell them apart.
+          "anyUnknownInErrorContext": "warning",
+          "globalErrorInEffectCatch": "warning",
+          "globalErrorInEffectFailure": "warning",
+          "unknownInEffectCatch": "warning",
+
+          // Schema. A schema is the contract an event is written and read through, so a domain it
+          // states loosely is a decode that fails later, on replay, holding the log.
+          "instanceOfSchema": "warning",
+          "newSchemaClass": "warning",
+          "preferSchemaTypeProperty": "warning",
+          "preferTypedSchemaDecoder": "warning",
+          "redundantSchemaTagIdentifier": "warning",
+          "schemaNumber": "warning",
+          "schemaStructWithTag": "warning",
+          "schemaSyncInEffect": "warning",
+          "schemaUnionOfLiterals": "warning",
+
+          // Simplification. The shorter form the framework already ships, said the shorter way.
+          "abortControllerInEffect": "warning",
+          "catchAllToMapError": "warning",
+          "catchChainToFirstSuccessOf": "warning",
+          "catchTagToCatchReason": "warning",
+          "catchToIgnore": "warning",
+          "catchToOrElseSucceed": "warning",
+          "effectDoNotation": "warning",
+          "effectFnOpportunity": "warning",
+          "effectMapFlatten": "warning",
+          "effectMapVoid": "warning",
+          "effectSucceedWithVoid": "warning",
+          "flatMapToMap": "warning",
+          "globalConsoleInEffect": "warning",
+          "lazyEffect": "warning",
+          "leakingRequirements": "warning",
+          "multipleCatchTag": "warning",
+          "nestedEffectGenYield": "warning",
+          "preferUnsafeConstructor": "warning",
+          "redundantMapError": "warning",
+          "redundantOrDie": "warning",
+          "serviceNotAsClass": "warning",
+          "syncToSucceed": "warning",
+          "tryCatchInEffectGen": "warning",
+          "unnecessaryEffectGen": "warning",
+          "unnecessaryFailYieldableError": "warning",
+          "unnecessaryPipe": "warning",
+          "unnecessaryPipeChain": "warning",
+          "unnecessaryTypeofType": "warning",
+
+          // Off, and why. Each of these is a defensible rule that asks for something this repository
+          // has decided against, so leaving it on would mean suppressing it at every site instead.
+          // A decision recorded once here is a decision a reader can find and change.
+
+          // The host, the client, and an actor's own `act` are Promise surfaces on purpose: a
+          // caller holding a thread does not have to hold an Effect runtime (packages/host/src/
+          // host.ts, drive and wake; docs/quickstart.md).
+          "asyncFunction": "off",
+          "newPromise": "off",
+          // Exported functions take their arguments directly. There is no data-last overload to
+          // pair with, and adding one to every export would double the surface to no reader's gain.
+          "missingPipeableSignature": "off",
+          "missedPipeableOpportunity": "off",
+          // Service keys are named for the framework, not for the package path that happens to hold
+          // them: `tardigrade/Self` outlives a file move, `@clavia/tardigrade-core/actor/Self` does
+          // not.
+          "deterministicKeys": "off",
+          // The event log is JSON by contract. It is read by `clickhouse local`, by a SQLite
+          // client, and by anything else that opens the file, so the bytes are the interface and a
+          // codec would hide it (platform/bun/src/host.ts).
+          "preferSchemaOverJson": "off",
+          // Composing every layer at one entry point is what the hosts do; the sites this flags are
+          // those entry points.
+          "strictEffectProvide": "off",
+          // A platform package binds the runtime it is named for, so importing `node:fs` there is
+          // the job rather than a lapse.
+          "nodeBuiltinImport": "off",
+          // What a class extends is not what the rule above is about. The failure channel is held
+          // by `globalErrorInEffectFailure`, `globalErrorInEffectCatch`, and `unknownInEffectCatch`,
+          // which stay on. An error thrown across a Promise boundary to a JavaScript caller never
+          // reaches that channel, and it is an `Error` because that is what a caller catches
+          // (packages/client/src/problem.ts, ProblemError).
+          "extendsNativeError": "off",
+          // The clock, the environment, and the network, outside Effect code. Build scripts, the
+          // browser bundle, and terminal rendering are not replayed, and the `InEffect` halves above
+          // already hold the paths that are. Randomness stays on everywhere because a helper called
+          // from Effect code must take the Random service explicitly.
+          "cryptoRandomUUID": "off",
+          "globalConsole": "off",
+          "globalDate": "off",
+          "globalFetch": "off",
+          "globalTimers": "off",
+          "processEnv": "off",
+          // Formatting rules with no Effect content. oxlint owns that layer.
+          "strictBooleanExpressions": "off",
+          "unnecessaryArrowBlock": "off"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The gate could not see Effect-specific mistakes. TypeScript proved that types lined up and oxlint read syntax, while an Effect that never runs, a missing service, a dead handler, an ambient read in an Effect path, or an unsafe schema could pass both. This PR adds `@effect/tsgo` as a strict third lint layer and makes the same check run locally and in CI.

TypeScript moves from 6.0.3 to 7.0.2 because `@effect/tsgo` requires the native TypeScript binary. The upgrade also exposed requirements typed as `unknown` that TypeScript 6 had accepted at application boundaries.

## Policy

`tsconfig.effect.json` names all 95 installed rules as `error`, `warning`, or `off`. Errors and warnings both fail the gate. Each off rule states the repository decision that requires it, including Promise-facing APIs, direct function signatures, framework service keys, the JSON log contract, application layer composition, platform runtime imports, and ambient APIs outside Effect paths.

`tools/effect-lint-policy.ts` compares the policy with the installed plugin schema. A plugin upgrade that adds or removes a rule fails until the repository decides its severity, and a message or suggestion severity fails because it would not gate. The gate discovers every `tsconfig*.json` in each configured workspace, so the browser and Bun projects under Voyager are both checked. `bun run lint:effect` runs the 13 project checks and the policy check alone.

## Findings fixed

- Event and contract number schemas use `Schema.Finite`, so `NaN` and infinity cannot enter a value that persists through JSON.
- The server handler and test environments state their complete Effect requirements instead of asserting `unknown` away.
- Untagged failure channels, a dead catch, floating failure wrappers, redundant Promise error plumbing, and several unsafe Effect assertions are removed.
- Model retry time and jitter read Effect's `Clock` and `Random` services. `retryAfterJitterMs` exposes its default and override, and the effective value appears in recorded retry failure policy.
- Simplification findings use the Effect-native constructors and combinators that already express the same behavior.
- The previously omitted Voyager Bun fixture uses Effect logging and now passes its own project check.

## Compatibility

`refs()` in `@clavia/tardigrade-code/store` stays callable. Its `lazyEffect` exception is scoped to that declaration, and the client exceptions are scoped to the three expressions they cover. There are no file-wide Effect lint suppressions.

`Schema.Finite` rejects non-finite values at decode time. Such values cannot survive the log's JSON persistence because JSON serializes them as `null`.

## Verification

`bun install --frozen-lockfile` reports no changes. `bun run gate` passes all 41 tasks on the current `next`: oxlint, documentation lint, the 95-rule policy check, 13 Effect diagnostic projects, 12 typechecks, 11 test tasks, the Voyager production build, and knip.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3cec1bb0-e7c0-4e0e-9bb3-934a9987cb1d)
