### PR TITLE
feat: add migration onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ $$\lbrace\mathrm{view},\ \mathrm{transitions}\rbrace = f(\mathrm{log})$$
 
 Install Tardigrade and initialize an editable template actor. Use Bun 1.4 or later. If you are using a coding agent, the [Tardigrade skill](skills/tardigrade/SKILL.md) can help.
 
+If you have an existing agent application, follow the [migration guide](docs/how-to/migrate.md) to move its harness, history, API, client, and deployment configuration.
+
 ```bash
 bun add -g tardie
 tdg init researcher

--- a/apps/voyager/src/Quickstart.test.ts
+++ b/apps/voyager/src/Quickstart.test.ts
@@ -1,10 +1,25 @@
 import { describe, expect, test } from "bun:test"
 
-import { QUICKSTART_PROMPT } from "./Quickstart"
+import { MIGRATION_PROMPT, QUICKSTART_PROMPT } from "./Quickstart"
 
 describe("QUICKSTART_PROMPT", () => {
   test("points coding agents to the skill", () => {
     expect(QUICKSTART_PROMPT).toContain("skills/tardigrade/SKILL.md")
     expect(QUICKSTART_PROMPT).toContain("Share its Voyager trace URL")
+  })
+})
+
+describe("MIGRATION_PROMPT", () => {
+  test("sets the migration and report contract", () => {
+    expect(MIGRATION_PROMPT).toContain("https://github.com/clavia-labs/tardigrade/blob/next/docs/how-to/migrate.md")
+    expect(MIGRATION_PROMPT).toContain("end-to-end migration")
+    expect(MIGRATION_PROMPT).toContain("same representative task before and after")
+    expect(MIGRATION_PROMPT).toContain("Share the Voyager trace URL")
+    expect(MIGRATION_PROMPT).toContain("summarize the changes")
+    for (const metric of ["harness lines", "dependencies", "model tokens", "cost", "latency"]) {
+      expect(MIGRATION_PROMPT).toContain(metric)
+    }
+    expect(MIGRATION_PROMPT).toContain("percentage changes")
+    expect(MIGRATION_PROMPT).toContain("Mark unavailable metrics")
   })
 })

--- a/apps/voyager/src/Quickstart.tsx
+++ b/apps/voyager/src/Quickstart.tsx
@@ -7,6 +7,10 @@ import { COPY_CONFIRM_MS, ICON_SIZE } from "./policy"
 export const QUICKSTART_PROMPT =
   "Use https://github.com/clavia-labs/tardigrade and follow skills/tardigrade/SKILL.md to create, author, build, push, and run a local actor. Share its Voyager trace URL."
 
+// MIGRATION_PROMPT gives a coding agent the migration guide, verification target, and report contract.
+export const MIGRATION_PROMPT =
+  "Read https://github.com/clavia-labs/tardigrade/blob/next/docs/how-to/migrate.md. Implement and verify an end-to-end migration of this project's existing agent harness to Tardigrade. Preserve its behavior while moving the loop, tools, state, API, client, history, and deployment configuration. Run the existing tests and the same representative task before and after. Share the Voyager trace URL, summarize the changes, and report before/after harness lines, dependencies, model tokens, cost, and latency, including percentage changes when both values exist. Mark unavailable metrics."
+
 const copyText = async (text: string): Promise<boolean> => {
   try {
     await navigator.clipboard.writeText(text)
@@ -24,7 +28,7 @@ const copyText = async (text: string): Promise<boolean> => {
   }
 }
 
-const PromptCard = (): ReactElement => {
+const PromptCard = ({ label, prompt }: { readonly label: string; readonly prompt: string }): ReactElement => {
   const [copied, setCopied] = useState(false)
 
   useEffect(() => {
@@ -36,13 +40,13 @@ const PromptCard = (): ReactElement => {
   return (
     <section className="quickstart-card">
       <div className="quickstart-card-head">
-        <span className="mono quickstart-label">Prompt</span>
+        <span className="mono quickstart-label">{label}</span>
         <button
           type="button"
           className={`quickstart-copy${copied ? " quickstart-copy-done" : ""}`}
-          aria-label="Copy quickstart prompt"
+          aria-label={`Copy ${label.toLowerCase()} prompt`}
           onClick={() => {
-            void copyText(QUICKSTART_PROMPT).then((ok) => {
+            void copyText(prompt).then((ok) => {
               if (ok) setCopied(true)
             })
           }}
@@ -51,7 +55,7 @@ const PromptCard = (): ReactElement => {
           <span>{copied ? "copied" : "copy"}</span>
         </button>
       </div>
-      <pre className="quickstart-code"><code>{QUICKSTART_PROMPT}</code></pre>
+      <pre className="quickstart-code"><code>{prompt}</code></pre>
     </section>
   )
 }
@@ -60,10 +64,13 @@ export const Quickstart = (): ReactElement => (
   <div className="quickstart-empty">
     <div className="quickstart">
       <div className="quickstart-intro">
-        <h1>Create your first actor</h1>
-        <p>Copy this prompt into your coding agent.</p>
+        <h1>Create or migrate an actor</h1>
+        <p>Copy the prompt that fits your project into your coding agent.</p>
       </div>
-      <PromptCard />
+      <div className="quickstart-grid">
+        <PromptCard label="New actor" prompt={QUICKSTART_PROMPT} />
+        <PromptCard label="Existing agent" prompt={MIGRATION_PROMPT} />
+      </div>
     </div>
   </div>
 )

--- a/apps/voyager/src/tun.css
+++ b/apps/voyager/src/tun.css
@@ -1550,6 +1550,11 @@ textarea {
   font-size: var(--text-read);
 }
 
+.quickstart-grid {
+  display: grid;
+  gap: var(--space-3);
+}
+
 .quickstart-card {
   overflow: hidden;
   border: 1px solid var(--hair);

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 # tardigrade docs
 
 - [quickstart.md](quickstart.md): all the core concepts you need to get started.
+- [how-to/migrate.md](how-to/migrate.md): move an existing agent application and its history to tardigrade.
 - [output.md](output.md): typed result contracts, native provider capability, fallbacks, and failure classes.
 - [how-to/server.md](how-to/server.md): the HTTP server.
 - [how-to/cli.md](how-to/cli.md): the CLI.

--- a/docs/how-to/migrate.md
+++ b/docs/how-to/migrate.md
@@ -1,0 +1,189 @@
+# Migrate an existing agent
+
+This guide moves an existing agent application to Tardigrade. It uses Vercel AI SDK names because they are common, and the same inventory applies to another agent harness. The migration covers actor logic, stored conversations, the HTTP boundary, client updates, and deployment configuration.
+
+Read the [Tardigrade skill](../../skills/tardigrade/SKILL.md), the [quickstart](../quickstart.md), the [server guide](server.md), and the [structured output guide](../output.md) before editing the application.
+
+## Inventory and baseline
+
+Record the current behavior before changing code:
+
+- Find the agent definition, model configuration, system instructions, tools, stopping rules, structured outputs, persistence, API routes, client state, authentication, and deployment commands.
+- Run the existing tests and save their commands and results.
+- Choose one representative task with a stable input and an answer that can be checked for semantic parity.
+- Run that task once with the current harness. Record the provider, model, model settings, output, input tokens, output tokens, provider cost, and wall-clock latency. Vercel AI SDK exposes aggregate model usage through `totalUsage` on [`generateText`](https://ai-sdk.dev/docs/reference/ai-sdk-core/generate-text) and agent results.
+- Count nonblank, non-generated lines in the agent loop, tool adapters, persistence, API, and client integration. Report any one-time history import script separately.
+- List direct agent and model dependencies from the application manifest.
+
+Use the same provider, model, settings, task, data, and measurement boundary for the Tardigrade run. If a value cannot be collected on both runs, report it as unavailable.
+
+## Map the harness
+
+The current Vercel AI SDK agent surface includes [`ToolLoopAgent` and loop control](https://ai-sdk.dev/docs/agents/loop-control), [`generateText` and `streamText`](https://ai-sdk.dev/docs/ai-sdk-core/generating-text), [tools](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling), [structured output](https://ai-sdk.dev/docs/ai-sdk-core/generating-structured-data), and [UI stream responses](https://ai-sdk.dev/docs/reference/ai-sdk-core/create-agent-ui-stream-response). Map another framework by responsibility instead of type name.
+
+| Existing concern | Tardigrade home |
+| --- | --- |
+| `ToolLoopAgent`, `generateText`, `streamText`, or a manual model loop | `defineActor({ name, actor: agentOf(...) })` |
+| System instructions | An `AgentComponent` that contributes `view.system` |
+| Tool declarations and handlers | Packages mounted through `codeModeFor`, or fixed tools mounted through `toolList` |
+| `stopWhen`, maximum steps, and retry options | `budgetFor`, `agentOf` inference policy, and domain components with explicit policy values |
+| `prepareStep` and dynamic context | A component whose `derive(log)` changes its view from recorded events |
+| Message arrays and conversation storage | One append-only event log per thread |
+| Structured output | `output(...)` plus `outputFailFast` or `outputRepairFor(...)` |
+| Lifecycle callbacks and telemetry | Recorded events, Voyager, usage projections, and host telemetry |
+| AI SDK UI stream protocol | `makeClient().append()` plus the durable event stream from `follow()` |
+
+Install Tardigrade with the repository's package manager. Bun 1.4 or later runs the CLI and the durable SQLite host.
+
+```bash
+bun add tardie
+bunx tardie init agent --dir agents/agent
+```
+
+Edit the generated `agents/agent/actor.ts`. Keep the actor name stable across build, push, client configuration, and stored traces.
+
+### Instructions and tools
+
+Move static system text into an instructions component. A prompt that depends on the conversation becomes a component that derives its system fragment from the log. Keep application data out of the prompt when a scoped package can read it on demand.
+
+Use a package through `codeModeFor` when its methods are ordinary operations that the model can combine, filter, or repeat in JavaScript. This exposes one `execute` tool to the model and keeps package methods behind the code surface. Use `toolList` when a provider-visible tool call, approval step, or exact tool schema is part of the application contract.
+
+Preserve tool names, descriptions, input checks, authorization, side-effect rules, and result shapes during the first pass. Convert Zod or framework-specific schemas to the JSON Schema accepted by Tardigrade. Wrap asynchronous handlers in Effect and turn expected failures into serializable results that the model can act on.
+
+Move related tools to code packages only when the decision rule above applies. Measure the result because one `execute` schema can reduce repeated tool-schema context while code generation and compaction can add model work.
+
+### Policies and output
+
+State every policy that affects behavior. `budgetFor({ defaultToolBudget })` limits `execute` calls, so it is not a direct replacement for a model-step limit that counts completions and native tools. Express a custom stop condition as a component over the log. Pass `giveUpAfter` through the second argument to `agentOf`, and use `compactionFor(...)` when the application needs context thresholds that differ from `DEFAULT_CONTEXT_POLICY`.
+
+Convert each structured result to `output({ name, schema })`. Send that contract with the turn and mount one explicit fallback. Use `outputFailFast` when an invalid response should end the turn, or `outputRepairFor({ attempts, projectHistory })` when bounded correction is part of the product behavior.
+
+### Model binding
+
+Keep the baseline provider and model when the Tardigrade binding supports their transport. The built-in binding accepts OpenAI-compatible endpoints, including Vercel AI Gateway, and Bedrock Converse. Configure it with `tdg setup` or `MODEL_BASE_URL`, `MODEL_API_KEY`, `MODEL_ID`, and `MODEL_PROVIDER`.
+
+List every existing model option and confirm that the selected binding represents it. A custom transport or required option belongs in an application-owned `Infer` layer and custom host. Do not silently drop a temperature, provider option, retry bound, output guarantee, or timeout that affects behavior.
+
+## Move the application boundary
+
+Build and install the actor in the local registry, then start the API and Voyager:
+
+```bash
+bunx tardie build agents/agent/actor.ts
+bunx tardie push agents/agent/actor.ts --target local
+bunx tardie dev
+```
+
+Replace direct model invocation in the application backend with the generated client:
+
+```ts
+import { makeClient } from "tardie/client"
+
+const client = makeClient({
+  baseUrl: process.env.TARDIGRADE_URL!,
+  actor: "agent"
+})
+
+await client.append(threadId, {
+  type: "MessageReceived",
+  id: messageId,
+  text
+})
+```
+
+Mint `threadId` once per conversation and `messageId` once per user turn. Reuse the same message id when retrying delivery so the log absorbs the duplicate.
+
+Replace AI SDK UI transport and `useChat` state with application state derived from Tardigrade events. Follow a thread after its last rendered sequence:
+
+```ts
+const stop = client.follow(threadId, {
+  after: lastSequence,
+  onEvent: ({ seq, event }) => {
+    lastSequence = seq
+    render(event)
+  },
+  onError: showStreamError
+})
+```
+
+Render `MessageReceived` as the user turn, `TextReturned` as working text, `ToolCalled` and `ToolReturned` as progress, `TurnCompleted` as the final answer, and `TurnFailed` as the failure. The stream carries durable event-level updates. It does not carry provider token chunks.
+
+Browser `EventSource` cannot attach the bearer token used by `TARDIGRADE_TOKEN`. Keep a protected Tardigrade server private and relay its authenticated event stream through the application backend. Use `client.events(threadId, { after })` as a polling fallback when the relay is unavailable.
+
+Keep an existing public API route as an adapter until every caller uses the new event and result shapes. Remove the adapter after its consumers and tests move to the Tardigrade client.
+
+## Import conversation history
+
+Import history into a separate SQLite database. Keep the source store unchanged until the new system passes validation and its rollback window ends. Stop writes or take a consistent export before conversion.
+
+Use `createBunHost().seed()` for imported history. `seed` appends a complete batch without waking the actor, so recorded conversations do not run again during import.
+
+```ts
+import { createBunHost } from "tardie/bun/host"
+import type { Event } from "tardie/core/event"
+import { laneOf } from "tardie/server/host"
+
+const host = await createBunHost({
+  log: ".tardigrade/imported.sqlite",
+  actorFor: () => undefined
+})
+
+const turn = "legacy:conversation-42:message-7"
+const events: Event[] = [
+  { type: "MessageReceived", id: turn, text: "What changed?", at: 1_700_000_000_000 },
+  { type: "TurnCompleted", turn, output: "The deployment changed.", at: 1_700_000_001_000 },
+  { type: "ReplyDelivered", turn, at: 1_700_000_001_000 }
+]
+
+await host.seed(laneOf("legacy-conversation-42"), events)
+await host.close()
+```
+
+Derive stable thread, turn, and call ids from legacy identifiers. Preserve event order and timestamps. Every imported `MessageReceived` must have one terminal in its active epoch and a matching `ReplyDelivered`.
+
+Map a complete tool exchange between its message and terminal as `ToolCalled` followed by `ToolReturned`. Stamp both events with the turn id, keep call ids unique within the thread, and preserve the tool arguments and result. Map stored assistant working text to `TextReturned` with the same turn id.
+
+Map an incomplete legacy turn to `TurnFailed` with the same turn id, a clear import error, `cause: "inference_error"`, and a matching `ReplyDelivered`. Include any saved partial assistant text as `TextReturned` before the failure. This keeps every imported thread settled and makes the incomplete state visible.
+
+Refuse to write the import into an existing target database. A fresh target makes the script repeatable from the unchanged source and prevents duplicate unkeyed history events.
+
+Validate the import before cutover:
+
+1. Compare source conversation, message, tool call, tool result, and terminal counts with the target events.
+2. Check that timestamps and ids retain their order and that every call and turn is complete.
+3. Start `tdg dev --db .tardigrade/imported.sqlite`, inspect representative threads with `tdg events`, and confirm that no turn is pending and `tdg ls` reports no imported thread as running or blocked.
+4. Send a new message to an imported thread and verify that the model receives the imported context and produces one new terminal.
+5. Stop and restart the server, then confirm the imported history and new turn remain available.
+
+## Compare the result
+
+Run the same representative task once with Tardigrade. Use the same model, settings, input, data, and timer boundary as the baseline. Check semantic output parity before comparing efficiency.
+
+Use `usageIn(events, turn)` or the recorded attempt usage to total Tardigrade input and output tokens. Report cost only when the provider reports it or the application supplies an explicit price table. Measure latency from request delivery through the terminal event.
+
+For each numeric measure, report `change = Tardigrade - existing` and `percent = change / existing * 100`. A negative token, cost, latency, line, or dependency change is a reduction. Leave the percentage unavailable when the existing value is zero or either value is missing.
+
+| Measure | Existing | Tardigrade | Change | Method |
+| --- | ---: | ---: | ---: | --- |
+| Harness lines | | | | Nonblank, non-generated lines in the inventoried harness and integration files |
+| Direct dependencies | | | | Agent and model dependencies in the application manifest |
+| Input tokens | | | | One matched task |
+| Output tokens | | | | One matched task |
+| Cost | | | | Provider value or stated price table |
+| Latency | | | | Delivery through terminal |
+
+Treat one matched model run as a sample. State any output difference or provider variance that limits the comparison. Report a regression with the same detail as an improvement.
+
+## Cut over and report
+
+Prepare the production Tardigrade server, actor push, database path, credentials, health check, and client URL. Keep production deployment as a separate authorized action. The migration itself proves the local actor with `tdg build`, `tdg push --target local`, `tdg dev`, and a representative `tdg run`.
+
+Keep the existing endpoint and store available for rollback. Switch traffic only after tests pass, imported threads settle, a new turn succeeds, and the application renders event progress and terminals. Remove the existing harness dependencies after a repository search finds no remaining imports and the rollback window closes.
+
+Finish with a short report containing:
+
+- A summary of the actor, tool, policy, persistence, API, client, history, and deployment configuration changes.
+- Existing test results, migration checks, and the matched task result.
+- The comparison table with unavailable values labeled.
+- Known behavior gaps and rollback instructions.
+- The direct Voyager trace URL for the migrated task.

--- a/skills/tardigrade/SKILL.md
+++ b/skills/tardigrade/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tardigrade
-description: Create, author, build, push, run, inspect, and improve Tardigrade actors with the tdg CLI. Use when a task works with actor.ts, the local actor registry, a Tardigrade run, or GEPA harness optimization from run traces.
+description: Create, migrate, author, build, push, run, inspect, and improve Tardigrade actors with the tdg CLI. Use when a task works with an existing agent harness, actor.ts, the local actor registry, a Tardigrade run, or GEPA harness optimization from run traces.
 ---
 
 # Tardigrade
@@ -37,6 +37,12 @@ tdg run "Investigate the failure" --actor researcher --url http://localhost:4241
 ```
 
 Use `--json` when another program consumes command output. Human output includes workflow guidance and trace links.
+
+## Migrate an existing harness
+
+When the task moves an existing agent application to Tardigrade, read [the migration guide](../../docs/how-to/migrate.md) before editing. Inventory the existing loop, tools, policies, output, persistence, API, client, history, and deployment configuration. Capture one matched baseline, preserve behavior through the first pass, import complete history through the host seed path, and verify the result with the existing tests and a local Tardigrade run.
+
+Finish with the Voyager trace URL, a concise change summary, and before-and-after harness lines, dependencies, model tokens, cost, and latency. Calculate percentage changes only for comparable values and label unavailable metrics.
 
 ## Improve a harness
 


### PR DESCRIPTION
Adds an Existing agent prompt to Voyager while preserving the New actor prompt, with independent copy feedback and accessible labels. Adds a Vercel AI SDK-first migration guide covering harness mapping, explicit policies, API and UI replacement, durable history import, rollback, and matched efficiency reporting. Links migration guidance from the README, docs index, and Tardigrade skill so coding agents follow the complete workflow. Validation: `bun run gate` passed all 41 tasks, along with the responsive browser check and history seed smoke test.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3cec1bb0-e7c0-4e0e-9bb3-934a9987cb1d)
