### PR TITLE
refactor(agent): select output strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ The call follows one route:
 Mount the component beside the built-in parts that this task needs:
 
 ```ts
-import { agentOf, budget, codeMode, compaction, outputFailFast, reply } from "tardie"
+import { actorOf, agentRuntime, budget, codeMode, compaction, outputFailFast, reply } from "tardie"
 
-const releaseAnalyst = agentOf([
+const releaseAnalyst = actorOf(agentRuntime(), [
   deploys,     // recent_deploys and its paired handler
   codeMode,    // durable JavaScript execution
   budget,      // a per-turn code budget
@@ -124,7 +124,7 @@ const releaseAnalyst = agentOf([
 ])
 ```
 
-`agentOf` combines the components and carries their service requirements into the host type. The runtime interprets their view as inference and tool routing, while the core actor reconciles their transitions. The model sees `recent_deploys` and `execute` in one request. Policy components derive work from the same log.
+`actorOf` combines the components and carries their service requirements into the host type. `agentRuntime` interprets their view as inference and tool routing, while the core actor reconciles their transitions. The model sees `recent_deploys` and `execute` in one request. Policy components derive work from the same log.
 
 This agent can inspect deployments, analyze results with JavaScript, compact a long investigation, and report to a parent agent. Change the list to create another harness.
 

--- a/apps/server/src/actor.ts
+++ b/apps/server/src/actor.ts
@@ -2,7 +2,8 @@ import { Schema } from "effect"
 import type { Event } from "@clavia/tardigrade-core/event"
 import type { Actor } from "@clavia/tardigrade-core/actor"
 import {
-  agentOf,
+  actorOf,
+  agentRuntime,
   agentsPackage,
   budget,
   codeModeFor,
@@ -36,7 +37,7 @@ import { inboundOf } from "./projections"
 // requests to any host. There is no shell: a shell cannot be scoped the way a root or an origin can,
 // and this build has no place to ask an operator whether one command is allowed.
 export const assemblyOf = () =>
-  agentOf([
+  actorOf(agentRuntime(), [
     codeModeFor({ packages: [agentsPackage(), workspacePackage(), filesPackage(), fetchPackage()] }),
     reply,
     budget,

--- a/docs/output.md
+++ b/docs/output.md
@@ -60,7 +60,7 @@ The binding selects a mode for each call:
 | --- | --- |
 | Native output supports the call | Native |
 | Native output does not support the call and the agent mounts a fallback | The mounted fallback |
-| Native output does not support the call and the agent mounts no fallback | `output_unsupported` before the provider request |
+| Native output does not support the call and the selected strategy has no fallback | `output_unsupported` before the provider request |
 
 A mounted fallback does not disable native output. When native mode is available, fallback prompt text is omitted from the request.
 
@@ -75,31 +75,33 @@ Provider references:
 
 `Infer` is the injected Effect service. A model layer created by `infer(...)` provides it, and the agent runtime requests it for each attempt.
 
-`outputRepairFor(...)` is a typed agent component. It contributes an `OutputFallback` and the fallback prompt. `outputFailFast` and delegated fallbacks use the same component marker.
+Every agent assembly selects one output strategy component. `nativeOutput` selects provider-native output. `outputRepairFor(...)`, `outputFailFast`, and delegated fallbacks contribute an `OutputFallback` and any fallback prompt.
 
-`agentOf` reads that marker when it computes the assembled actor's Effect requirements:
+`actorOf` combines the runtime and component requirements:
 
-| Components | Required model services |
+| Output strategy | Required model services |
 | --- | --- |
-| No output fallback | `Infer` and `NativeOutputSupport` |
+| `nativeOutput` | `Infer` and `NativeOutputSupport` |
 | Repair, fail-fast, or delegated fallback | `Infer` |
 
 `infer(...)` provides `NativeOutputSupport` only when its statically known configuration declares `{ guarantee: "native", withTools: true }`.
 
 ```ts
-const nativeOnly = agentOf([codeMode, reply])
+import { actorOf, agentRuntime, codeMode, nativeOutput, outputRepairFor, reply } from "tardie"
+
+const nativeOnly = actorOf(agentRuntime(), [codeMode, reply, nativeOutput])
 const nativeModel = infer({ ...modelConfig, output: { guarantee: "native", withTools: true } })
 // nativeModel provides Infer and NativeOutputSupport.
 
-const portable = agentOf([codeMode, reply, outputRepairFor({ attempts: 1 })])
+const portable = actorOf(agentRuntime(), [codeMode, reply, outputRepairFor({ attempts: 1 })])
 const unprovenModel = infer({ ...modelConfig, output: { guarantee: "none" } })
 // portable requires Infer. unprovenModel provides it.
 // A host that binds nativeOnly to unprovenModel has a missing NativeOutputSupport type error.
 ```
 
-The host fails type checking when it connects a native-only agent to a statically unsupported model layer. This check covers the declared configuration and program wiring. TypeScript cannot verify a remote endpoint. A configuration widened to `ModelConfig` or read from the environment supplies no static proof until application code narrows it, so the usual dynamic host mounts an explicit fallback. A `withTools: false` declaration also supplies no proof because `agentOf` does not encode an empty tool surface in its type. `outputPreflight` checks each actual call before the provider request. Local validation catches an endpoint that breaks its declaration after the request.
+The host fails type checking when it connects a native-only agent to a statically unsupported model layer. This check covers the declared configuration and program wiring. TypeScript cannot verify a remote endpoint. A configuration widened to `ModelConfig` or read from the environment supplies no static proof until application code narrows it, so the usual dynamic host selects an explicit fallback. A `withTools: false` declaration also supplies no proof because `nativeOutput` does not encode an empty tool surface in its type. `outputPreflight` checks each actual call before the provider request. Local validation catches an endpoint that breaks its declaration after the request.
 
-Actor artifacts and server environment variables meet after TypeScript has run. The built-in server and generated actor template mount `outputFailFast` explicitly. A custom artifact that omits a fallback relies on the server's per-call preflight and native capability declaration.
+Actor artifacts and server environment variables meet after TypeScript has run. The built-in server and generated actor template select `outputFailFast` explicitly. A custom artifact that selects `nativeOutput` relies on the server's per-call preflight and native capability declaration.
 
 TypeScript also checks the schema profile for schema literals, derives the result type, and checks the closed `OutputFallback` union. `outputRepairFor` accepts `Partial<RepairPolicy>`, so policy field names and value types are checked at the call site. Construction rejects invalid numeric bounds, invalid booleans, malformed custom fallbacks, and multiple fallback components.
 
@@ -140,7 +142,9 @@ output({
 `outputFailFast` asks for JSON in the fallback prompt and validates one response. A mismatch ends the turn with `output_validation_failed`. It performs no correction attempt.
 
 ```ts
-const agent = agentOf([
+import { actorOf, agentRuntime, codeModeFor, outputFailFast, reply } from "tardie"
+
+const agent = actorOf(agentRuntime(), [
   codeModeFor({ packages: [] }),
   reply,
   outputFailFast
@@ -152,9 +156,9 @@ const agent = agentOf([
 `outputRepairFor` records an invalid response and asks again with the validation errors. Its policy is explicit:
 
 ```ts
-import { agentOf, codeModeFor, outputRepairFor, reply } from "tardie"
+import { actorOf, agentRuntime, codeModeFor, outputRepairFor, reply } from "tardie"
 
-const agent = agentOf([
+const agent = actorOf(agentRuntime(), [
   codeModeFor({ packages: [] }),
   reply,
   outputRepairFor({ attempts: 2, projectHistory: true })
@@ -184,6 +188,7 @@ const houseStyle = defineOutputFallback({
       output: [
         {
           component: "output.house-style",
+          kind: "fallback",
           fallback: { kind: "delegated", name: "house-style", projectHistory: true },
           system: "Reply with JSON matching the house schema."
         }

--- a/examples/quickstart/actor.ts
+++ b/examples/quickstart/actor.ts
@@ -1,5 +1,6 @@
 import {
-  agentOf,
+  actorOf,
+  agentRuntime,
   agentsPackage,
   budget,
   codeModeFor,
@@ -35,8 +36,8 @@ const instructions = {
 
 export default defineActor({
   name: actorName,
-  // agentOf carries component and output requirements into the host type.
-  actor: agentOf([
+  // actorOf carries component and output requirements into the host type.
+  actor: actorOf(agentRuntime(), [
     instructions,
     // codeModeFor gives the model one code tool over the packages listed here.
     codeModeFor({

--- a/examples/rlm-agent.ts
+++ b/examples/rlm-agent.ts
@@ -6,7 +6,7 @@
 
 // The workspace names resolve in this repository. Against the published package the last two
 // are "tardie/model" and "tardie/bun/host" (tools/publish.ts).
-import { agentOf, agentsPackage, boundaryOf, budget, codeModeFor, compaction, outputFailFast, reply, workspacePackage } from "tardie"
+import { actorOf, agentRuntime, agentsPackage, boundaryOf, budget, codeModeFor, compaction, outputFailFast, reply, workspacePackage } from "tardie"
 import { infer } from "@clavia/tardigrade-model/model"
 import { createBunHost } from "@clavia/tardigrade-bun/host"
 
@@ -14,7 +14,7 @@ import { createBunHost } from "@clavia/tardigrade-bun/host"
 // values, so the model's system fragment lists them and the assembly's requirements carry their
 // needs (Router, Self, and Facets for spawn; the spill store for workspace). The Bun host binds
 // all of those per lane.
-const rlm = agentOf([
+const rlm = actorOf(agentRuntime(), [
   codeModeFor({ packages: [agentsPackage(), workspacePackage()] }),
   reply, // reports each turn's terminal to whoever asked
   budget, // the per-turn code budget, inherited by spawned children

--- a/packages/agent/src/agent.types.test.ts
+++ b/packages/agent/src/agent.types.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from "bun:test"
 import type { Actor } from "@clavia/tardigrade-core/actor"
 import {
-  agentOf,
+  actorOf,
+  agentRuntime,
+  nativeOutput,
   outputRepair,
   type AgentComponent,
   type NativeOutputSupport,
@@ -18,8 +20,8 @@ const empty: AgentComponent = {
   })
 }
 
-const nativeOnly = agentOf([empty])
-const repaired = agentOf([empty, outputRepair])
+const nativeOnly = actorOf(agentRuntime(), [empty, nativeOutput])
+const repaired = actorOf(agentRuntime(), [empty, outputRepair])
 
 type Requirements<A> = A extends Actor<infer R> ? R : never
 type RequiresNative<A> = NativeOutputSupport extends Requirements<A> ? true : false
@@ -30,12 +32,12 @@ export const outputRequirements = (): void => {
   accepts<RequiresNative<typeof repaired>>(false)
 }
 
-// fallbackBrand proves that only defineOutputFallback and the built-in fallback constructors can discharge the native requirement.
+// fallbackBrand proves that only defineOutputFallback and the built-in fallback constructors can mark a fallback strategy.
 export const fallbackBrand = (): void => {
   // @ts-expect-error a plain component has not been checked as an always-present output fallback
   accepts<OutputFallbackComponent>(empty)
 }
 
-test("agentOf carries the output requirement without changing the runtime shape", () => {
+test("output strategy components carry their requirements without changing the runtime shape", () => {
   expect(nativeOnly.reactors).toHaveLength(repaired.reactors.length)
 })

--- a/packages/agent/src/components/budget.test.ts
+++ b/packages/agent/src/components/budget.test.ts
@@ -15,8 +15,9 @@ import { agentRuntime } from "../runtime/agent"
 import { codeMode } from "./code"
 import { compaction } from "./compaction"
 import { reply } from "./reply"
+import { nativeOutput } from "./native-output"
 
-const toolsReactor = actorOf(agentRuntime(), [codeMode, reply, budget, compaction]).reactors[1]!
+const toolsReactor = actorOf(agentRuntime(), [codeMode, reply, budget, compaction, nativeOutput]).reactors[1]!
 
 // The rest of the agent's environment, which every reactor's `act` is typed against whether or not
 // it reaches for it. Naming it is what proves the tools gate answers from the log alone: no model

--- a/packages/agent/src/components/native-output.ts
+++ b/packages/agent/src/components/native-output.ts
@@ -1,0 +1,16 @@
+import { NativeOutputSupport } from "../runtime/infer"
+import type { AgentComponent } from "../runtime/agent"
+
+// nativeOutput selects provider-native structured output and carries its model-layer requirement into the host type.
+export const nativeOutput: AgentComponent<NativeOutputSupport> = {
+  name: "output.native",
+  derive: () => ({
+    view: {
+      system: [],
+      tools: [],
+      context: [],
+      output: [{ component: "output.native", kind: "native" }]
+    },
+    transitions: []
+  })
+}

--- a/packages/agent/src/components/repair.ts
+++ b/packages/agent/src/components/repair.ts
@@ -58,7 +58,7 @@ export const outputRepairFor = (policy: Partial<RepairPolicy> = {}): OutputFallb
         system: [],
         tools: [],
         context: [],
-        output: [{ component: "output.repair", fallback, ...declaredSystem(log) }]
+        output: [{ component: "output.repair", kind: "fallback", fallback, ...declaredSystem(log) }]
       },
       transitions: []
     })
@@ -79,7 +79,7 @@ export const outputFailFast: OutputFallbackComponent = defineOutputFallback({
       system: [],
       tools: [],
       context: [],
-      output: [{ component: "output.fail-fast", fallback: FAIL_FAST_FALLBACK, ...declaredSystem(log) }]
+      output: [{ component: "output.fail-fast", kind: "fallback", fallback: FAIL_FAST_FALLBACK, ...declaredSystem(log) }]
     },
     transitions: []
   })

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -11,7 +11,7 @@ import { Infer, NativeOutputSupport, type InferRequest } from "./runtime/infer"
 import { boundaryOf } from "./boundary"
 import { resumeTurn } from "./resume"
 import { agentsPackage } from "./spawn"
-import { actorOf, agentRuntime, budgetFor, codeModeFor, compactionFor, reply, toolList, type AgentComponent } from "./index"
+import { actorOf, agentRuntime, budgetFor, codeModeFor, compactionFor, nativeOutput, reply, toolList, type AgentComponent } from "./index"
 import type { RlmR } from "./turn"
 
 const ROOT_LANE = "ag.root"
@@ -76,7 +76,7 @@ const hosted = (assembled: Actor<TestR>, mind: Mind, log: ReadonlyArray<Event> =
 // in-process host. The three policy components are always mounted, so a test that swaps the
 // work surface still runs the same turn loop, budget wall, and answer contract.
 const rlm = (mind: Mind, components: ReadonlyArray<AgentComponent<RlmR>> = [work()], log: ReadonlyArray<Event> = []) =>
-  hosted(actorOf(agentRuntime({}), [...components, reply, budgetFor({}), compactionFor({})]), mind, log)
+  hosted(actorOf(agentRuntime({}), [...components, reply, budgetFor({}), compactionFor({}), nativeOutput]), mind, log)
 
 const headText = (trajectory: ReadonlyArray<Event>): string => {
   for (let i = trajectory.length - 1; i >= 0; i--) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -69,6 +69,7 @@ export {
   DEFAULT_REPAIR_POLICY,
   type RepairPolicy
 } from "./components/repair"
+export { nativeOutput } from "./components/native-output"
 export { budgetReactorFor, DEFAULT_BUDGET_POLICY, type BudgetPolicy } from "./components/budget"
 export { toolsReactorFrom, type Answer, type PendingCall, type Serve } from "./runtime/tools"
 export { replyReactor } from "./components/reply"
@@ -126,7 +127,6 @@ export {
 // list mounts its own (runtime/agent.ts).
 export {
   AGENT_VIEW_ALGEBRA,
-  agentOf,
   agentRuntime,
   defineOutputFallback,
   renderOf,
@@ -134,6 +134,8 @@ export {
   type AgentView,
   type AgentTool,
   type ContextFragment,
+  type NativeOutputFragment,
+  type FallbackOutputFragment,
   type OutputFallbackComponent,
   type OutputFragment,
   type Rendered

--- a/packages/agent/src/request.test.ts
+++ b/packages/agent/src/request.test.ts
@@ -3,7 +3,7 @@ import { Effect } from "effect"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { trajectoryOf } from "@clavia/tardigrade-code/turns"
 import { modelRequest, renderMessages } from "./request"
-import { canonicalOf, codeMode, output, outputRepairFor, renderOf, toolList } from "./index"
+import { canonicalOf, codeMode, nativeOutput, output, outputRepairFor, renderOf, toolList } from "./index"
 
 // One declared contract, used wherever a turn needs one.
 const SCOUT = output({
@@ -16,7 +16,7 @@ const SCOUT = output({
   }
 })
 
-const CODE = renderOf([codeMode], [])
+const CODE = renderOf([codeMode, nativeOutput], [])
 
 // The request is a pure projection of the trajectory: the message conversation, and the tool and
 // prompt policy. Both live in the domain, so they test without a provider.
@@ -273,7 +273,8 @@ describe("the tool surface decides the tool table", () => {
       toolList([
         { spec: { name: "read", description: "read a file", inputSchema: {} }, run: () => Effect.succeed("") },
         { spec: { name: "grep", description: "search files", inputSchema: {} }, run: () => Effect.succeed("") }
-      ])
+      ]),
+      nativeOutput
     ],
     []
   )

--- a/packages/agent/src/request.ts
+++ b/packages/agent/src/request.ts
@@ -46,9 +46,10 @@ export type OutputRequest =
       readonly kind: "contract"
       readonly contract: OutputContract
       // What the turn does when native structured output is unavailable for this call, and the
-      // prompt that fallback needs. Absent means the assembly declared none, so such a call fails
-      // before it spends. The binding decides which of the two the attempt runs as, and the
-      // fallback's prompt reaches the model only then (platform/model/src/output.ts, outputModeOf).
+      // prompt that fallback needs. Absent means the assembly selected native output, so a call
+      // the provider cannot serve fails before it spends. The binding decides which strategy the
+      // attempt runs as, and the fallback's prompt reaches the model only then
+      // (platform/model/src/output.ts, outputModeOf).
       readonly fallback?: OutputFallback
       readonly fallbackSystem?: string
     }

--- a/packages/agent/src/runtime/agent.test.ts
+++ b/packages/agent/src/runtime/agent.test.ts
@@ -15,7 +15,8 @@ import { budget } from "../components/budget"
 import { compaction, compactionFor } from "../components/compaction"
 import { reply } from "../components/reply"
 import { toolList } from "../components/tool-list"
-import { receive, type AgentR } from "../turn"
+import { nativeOutput } from "../components/native-output"
+import { receive } from "../turn"
 import { Infer, NativeOutputSupport, type InferRequest } from "./infer"
 
 // The component assembly end to end: the render the model sees is the composed view, and a call
@@ -68,13 +69,17 @@ const viewComponent = (
 })
 
 describe("agent runtime", () => {
+  test("an assembly must declare one output strategy", () => {
+    expect(() => actorOf(agentRuntime(), [echoTable])).toThrow("must declare one output strategy")
+  })
+
   test("a marked output fallback must be present for every log", () => {
     const changing = defineOutputFallback(viewComponent("changing-output", (log) => ({
       system: [],
       tools: [],
       context: [],
       output: log.length === 0
-        ? [{ component: "changing-output", fallback: { kind: "local", name: "fail-fast" } }]
+        ? [{ component: "changing-output", kind: "fallback", fallback: { kind: "local", name: "fail-fast" } }]
         : []
     })))
     expect(() => changing.derive([{ type: "Ready" }])).toThrow("must declare one applicable fallback for every log")
@@ -93,7 +98,7 @@ describe("agent runtime", () => {
         )
       }
     })
-    const agent = actorOf(agentRuntime(), [echoTable, reply, budget, compaction])
+    const agent = actorOf(agentRuntime(), [echoTable, reply, budget, compaction, nativeOutput])
     const events = await run(
       Effect.gen(function* () {
         yield* receive(agent, { id: "m1", text: "go" })
@@ -120,7 +125,7 @@ describe("agent runtime", () => {
         )
       }
     })
-    const agent = actorOf(agentRuntime(), [echoTable, reply])
+    const agent = actorOf(agentRuntime(), [echoTable, reply, nativeOutput])
     const events = await run(
       Effect.gen(function* () {
         yield* receive(agent, { id: "m1", text: "go" })
@@ -134,7 +139,7 @@ describe("agent runtime", () => {
   })
 
   test("two components declaring one tool name collide at construction", () => {
-    expect(() => actorOf(agentRuntime(), [echoTable, toolList([{ spec: { name: "echo", description: "again", inputSchema: {} }, run: () => Effect.succeed({}) }])])).toThrow(
+    expect(() => actorOf(agentRuntime(), [echoTable, toolList([{ spec: { name: "echo", description: "again", inputSchema: {} }, run: () => Effect.succeed({}) }]), nativeOutput])).toThrow(
       'tool "echo" declared more than once'
     )
   })
@@ -151,10 +156,10 @@ describe("agent runtime", () => {
         output: []
       })
     )
-    const agent = actorOf(agentRuntime(), [echoTable, later])
+    const agent = actorOf(agentRuntime(), [echoTable, later, nativeOutput])
 
     expect(agent.reactors).toHaveLength(3)
-    expect(() => renderOf([echoTable, later], [{ type: "Ready" }])).toThrow('tool "echo" declared more than once')
+    expect(() => renderOf([echoTable, later, nativeOutput], [{ type: "Ready" }])).toThrow('tool "echo" declared more than once')
   })
 
   test("a tool remains routable from the view that offered its call", async () => {
@@ -178,7 +183,7 @@ describe("agent runtime", () => {
     })
     const events = await run(
       Effect.gen(function* () {
-        yield* receive(actorOf(agentRuntime(), [ephemeral]), { id: "m1", text: "go" })
+        yield* receive(actorOf(agentRuntime(), [ephemeral, nativeOutput]), { id: "m1", text: "go" })
         return yield* readLog
       }),
       Layer.mergeAll(memoryLog(), mind, noRouter, KeyValueStore.layerMemory)
@@ -188,7 +193,7 @@ describe("agent runtime", () => {
   })
 
   test("compactionFor's context reaches the render, so the guard and the request hold one policy", () => {
-    const render = renderOf<AgentR>([codeMode, compactionFor({ messageRenderCap: 1234 })], [])
+    const render = renderOf([codeMode, compactionFor({ messageRenderCap: 1234 }), nativeOutput], [])
     expect(render.context).toEqual({ messageRenderCap: 1234 })
   })
 
@@ -200,13 +205,13 @@ describe("agent runtime", () => {
       system: [], tools: [], context: [{ component: "right", policy: { messageRenderCap: 20 } }], output: []
     })
 
-    expect(() => renderOf([left, right], [])).toThrow(
+    expect(() => renderOf([left, right, nativeOutput], [])).toThrow(
       'context field "messageRenderCap" declared by components left and right'
     )
   })
 
   test("renderOf composes system fragments and tools in mount order", () => {
-    const render = renderOf([codeMode, echoTable], [])
+    const render = renderOf([codeMode, echoTable, nativeOutput], [])
     expect(render.tools.map((t) => t.name)).toEqual(["execute", "echo"])
     expect(render.system.indexOf("execute")).toBeLessThan(render.system.indexOf("echo"))
   })
@@ -226,7 +231,7 @@ describe("agent runtime", () => {
         }
       }
     )
-    const render = renderOf([catalog, echoTable], log)
+    const render = renderOf([catalog, echoTable, nativeOutput], log)
     expect(seen).toEqual([log])
     expect(render.system).toContain("packages: github, slack")
     // A constant fragment stays what it says, beside the derived one.
@@ -239,13 +244,13 @@ describe("agent runtime", () => {
       "catalog",
       (events: ReadonlyArray<Event>) => ({ system: [`count: ${events.length}`], tools: [], context: [], output: [] })
     )
-    expect(renderOf([codeMode, component], log)).toEqual(renderOf([codeMode, component], log))
+    expect(renderOf([codeMode, component, nativeOutput], log)).toEqual(renderOf([codeMode, component, nativeOutput], log))
   })
 
   test("codeModeFor takes a system fragment, and the bare component renders the exported default", () => {
-    const overridden = renderOf([codeModeFor({ system: (events) => `the packages in scope are:\n${events.length}` })], [{ type: "PackageInstalled" }])
+    const overridden = renderOf([codeModeFor({ system: (events) => `the packages in scope are:\n${events.length}` }), nativeOutput], [{ type: "PackageInstalled" }])
     expect(overridden.system).toBe("the packages in scope are:\n1")
-    expect(renderOf([codeMode], []).system).toBe(CODE_SYSTEM)
+    expect(renderOf([codeMode, nativeOutput], []).system).toBe(CODE_SYSTEM)
   })
 
   test("a mounted package names itself in the system fragment", () => {
@@ -256,11 +261,11 @@ describe("agent runtime", () => {
       description: "the team's notes",
       methods: { put: () => Effect.succeed(null) }
     }
-    const { system } = renderOf([codeModeFor({ packages: [notes] })], [])
+    const { system } = renderOf([codeModeFor({ packages: [notes] }), nativeOutput], [])
     expect(system).toContain("notes: the team's notes")
     expect(system).not.toContain("none")
     // An explicit fragment still wins over the derivation.
-    expect(renderOf([codeModeFor({ system: "my own scope", packages: [notes] })], []).system).toBe("my own scope")
+    expect(renderOf([codeModeFor({ system: "my own scope", packages: [notes] }), nativeOutput], []).system).toBe("my own scope")
   })
 
   test("a mounted package's requirements ride the component's type", () => {

--- a/packages/agent/src/runtime/agent.ts
+++ b/packages/agent/src/runtime/agent.ts
@@ -1,9 +1,7 @@
-import type { Actor, Reactor, Transition } from "@clavia/tardigrade-core/actor"
+import type { Reactor, Transition } from "@clavia/tardigrade-core/actor"
 import {
-  actorOf,
   composeComponents,
   type Component,
-  type ComponentRequirements,
   type ComponentRuntime,
   type ViewAlgebra
 } from "@clavia/tardigrade-core/component"
@@ -12,7 +10,7 @@ import type { Event } from "@clavia/tardigrade-core/event"
 import type { ToolSpec } from "../request"
 import { fallbackOf, type OutputFallback } from "../output"
 import { agentKeys } from "../events"
-import { inferReactorFor, type InferPolicy, type NativeOutputSupport } from "./infer"
+import { inferReactorFor, type InferPolicy } from "./infer"
 import { toolsReactorFrom, type Answer, type PendingCall } from "./tools"
 import type { ContextPolicy } from "../components/compaction"
 import type { AgentR } from "../turn"
@@ -35,18 +33,25 @@ export interface ContextFragment {
   readonly policy: Partial<ContextPolicy>
 }
 
-// OutputFragment names one component's output fallback contribution: what a turn does when
-// native structured output is unavailable for the call. An assembly that mounts none has no
-// fallback, so such a turn fails before it spends; two that disagree throw, because a turn has
-// one final response and one way to fall back (src/output.ts, OutputFallback).
-export interface OutputFragment {
+// NativeOutputFragment selects provider-native structured output without a fallback.
+export interface NativeOutputFragment {
   readonly component: string
+  readonly kind: "native"
+}
+
+// FallbackOutputFragment selects provider-native structured output with a fallback for calls the
+// provider cannot serve natively (src/output.ts, OutputFallback).
+export interface FallbackOutputFragment {
+  readonly component: string
+  readonly kind: "fallback"
   readonly fallback: OutputFallback
   // The prompt this fallback needs when it runs. It reaches the model only on an attempt whose
   // mode is this fallback, so a native attempt reads exactly what it would read with nothing
   // mounted (request.ts, OutputRequest; platform/model/src/model.ts).
   readonly system?: string
 }
+
+export type OutputFragment = NativeOutputFragment | FallbackOutputFragment
 
 // AgentView is the view an agent runtime interprets. Arrays retain component order and
 // postpone collision policy until the complete derivation is available.
@@ -62,7 +67,7 @@ export type AgentComponent<R = never> = Component<AgentView, R>
 
 const OutputFallbackMarker: unique symbol = Symbol("agent/OutputFallbackComponent")
 
-// OutputFallbackComponent marks a component whose fallback is present for every rendered turn. agentOf uses the marker to remove the NativeOutputSupport requirement.
+// OutputFallbackComponent marks a component whose fallback strategy is present for every rendered turn.
 export type OutputFallbackComponent<R = never> = AgentComponent<R> & { readonly [OutputFallbackMarker]: true }
 
 // defineOutputFallback validates and marks a component that always contributes one fallback.
@@ -70,7 +75,7 @@ export const defineOutputFallback = <R>(component: AgentComponent<R>): OutputFal
   const derive: AgentComponent<R>["derive"] = (log) => {
     const derived = component.derive(log)
     const output = derived.view.output
-    if (output.length !== 1 || fallbackOf(output[0]?.fallback) === undefined) {
+    if (output.length !== 1 || output[0]?.kind !== "fallback" || fallbackOf(output[0].fallback) === undefined) {
       throw new Error(`output fallback component ${component.name} must declare one applicable fallback for every log`)
     }
     return derived
@@ -91,16 +96,16 @@ export const AGENT_VIEW_ALGEBRA: ViewAlgebra<AgentView> = {
   })
 }
 
-// fallbackFrom resolves the one output fallback the assembly declares. A turn has one final
-// response, so a second declaration is an assembly error even when the two agree: a reader of the
-// mount list must be able to name the fallback from it.
-const fallbackFrom = (fragments: ReadonlyArray<OutputFragment>): OutputFragment | undefined => {
+// outputFrom resolves the output strategy the assembly declares. A turn has one final response,
+// so an absent or second declaration is an assembly error.
+const outputFrom = (fragments: ReadonlyArray<OutputFragment>): OutputFragment => {
   const first = fragments[0]
-  if (first === undefined) return undefined
+  if (first === undefined) throw new Error("agent assembly must declare one output strategy")
   const second = fragments[1]
   if (second !== undefined) {
-    throw new Error(`output fallback declared by components ${first.component} and ${second.component}`)
+    throw new Error(`output strategy declared by components ${first.component} and ${second.component}`)
   }
+  if (first.kind === "native") return first
   const fallback = fallbackOf(first.fallback)
   if (fallback === undefined) {
     throw new Error(
@@ -135,7 +140,10 @@ const checkedTools = (tools: ReadonlyArray<AgentTool<unknown>>): ReadonlyArray<A
   return tools
 }
 
-const viewFrom = <R>(components: ReadonlyArray<AgentComponent<R>>, log: ReadonlyArray<Event>): AgentView =>
+const viewFrom = <const Cs extends ReadonlyArray<AgentComponent<never> | AgentComponent<unknown>>>(
+  components: Cs,
+  log: ReadonlyArray<Event>
+): AgentView =>
   composeComponents("agent.view", AGENT_VIEW_ALGEBRA, components).derive(log).view
 
 // offerLogFor returns the prefix from which inference offered a pending call's tools. ModelCalled
@@ -158,7 +166,7 @@ const offerLogFor = (log: ReadonlyArray<Event>, call: PendingCall): ReadonlyArra
 
 // Rendered is what one derivation offers the model: the prompt, the tool table, the truncation
 // policy, and the fallback for a declared output contract native output cannot serve. `output` is
-// absent when the assembly declares no fallback.
+// absent when the assembly selects native output.
 export interface Rendered {
   readonly system: string
   readonly tools: ReadonlyArray<ToolSpec>
@@ -167,12 +175,12 @@ export interface Rendered {
 }
 
 const renderView = (view: AgentView): Rendered => {
-  const fragment = fallbackFrom(view.output)
+  const fragment = outputFrom(view.output)
   return {
     system: view.system.filter((piece) => piece !== "").join("\n"),
     tools: checkedTools(view.tools).map((tool) => tool.spec),
     context: contextOf(view.context),
-    ...(fragment === undefined
+    ...(fragment.kind === "native"
       ? {}
       : {
           output: {
@@ -184,14 +192,17 @@ const renderView = (view: AgentView): Rendered => {
 }
 
 // renderOf derives the model request from the same component view that routing reads.
-export const renderOf = <R>(components: ReadonlyArray<AgentComponent<R>>, log: ReadonlyArray<Event>): Rendered =>
+export const renderOf = <const Cs extends ReadonlyArray<AgentComponent<never> | AgentComponent<unknown>>>(
+  components: Cs,
+  log: ReadonlyArray<Event>
+): Rendered =>
   renderView(viewFrom(components, log))
 
 // agentRuntime interprets AgentView as inference and tool-routing reactors. actorOf supplies the
 // composed view projection and adds each component's own transition projection.
 export const agentRuntime = (
   policy: Partial<InferPolicy> = {}
-): ComponentRuntime<AgentView, AgentR | NativeOutputSupport> => ({
+): ComponentRuntime<AgentView, AgentR> => ({
   name: "agent",
   algebra: AGENT_VIEW_ALGEBRA,
   keys: [messageKeys, agentKeys],
@@ -211,21 +222,3 @@ export const agentRuntime = (
     ]
   }
 })
-
-type OutputRequirement<Cs extends ReadonlyArray<AgentComponent<never> | AgentComponent<unknown>>> = Extract<
-  Cs[number],
-  OutputFallbackComponent<unknown>
-> extends never
-  ? NativeOutputSupport
-  : never
-
-// agentOf assembles an agent and carries its output requirement into the host environment. An assembly without a marked fallback requires NativeOutputSupport from its model layer.
-export const agentOf = <
-  const Cs extends ReadonlyArray<AgentComponent<never> | AgentComponent<unknown>>
->(
-  components: Cs,
-  policy: Partial<InferPolicy> = {}
-): Actor<AgentR | ComponentRequirements<Cs[number]> | OutputRequirement<Cs>> =>
-  actorOf(agentRuntime(policy), components) as Actor<
-    AgentR | ComponentRequirements<Cs[number]> | OutputRequirement<Cs>
-  >

--- a/packages/agent/src/runtime/infer.ts
+++ b/packages/agent/src/runtime/infer.ts
@@ -46,7 +46,7 @@ export interface InferRequest {
   // the same numbers the compaction guard fires on (components/compaction.ts, compactionFor).
   readonly context?: Partial<ContextPolicy>
   // What the turn does when native structured output is unavailable for this call, and the
-  // prompt that fallback needs. Absent means the assembly declared none.
+  // prompt that fallback needs. Absent means the assembly selected native output.
   readonly output?: { readonly fallback: OutputFallback; readonly system?: string }
 }
 
@@ -67,7 +67,7 @@ export class Infer extends Context.Service<
   { readonly react: (request: InferRequest, key?: string) => Effect.Effect<Action> }
 >()("agent/Infer") {}
 
-// NativeOutputSupport is compile-time evidence that an injected Infer binding declares native structured output beside tools. The agent runtime does not read this service; the host type requires it when an assembly declares no fallback (runtime/agent.ts, agentOf).
+// NativeOutputSupport is compile-time evidence that an injected Infer binding declares native structured output beside tools. nativeOutput carries this requirement into the host type (components/native-output.ts).
 export class NativeOutputSupport extends Context.Service<
   NativeOutputSupport,
   { readonly withTools: true }

--- a/packages/agent/src/turn.test.ts
+++ b/packages/agent/src/turn.test.ts
@@ -23,6 +23,7 @@ import {
   codeModeFor,
   compaction,
   fingerprintOf,
+  nativeOutput,
   output,
   outputFailFast,
   repairFallback,
@@ -41,7 +42,7 @@ import {
 // packages are values the assembly passes, so a test that needs one names it here
 // (components/code.ts, codeModeFor).
 const agentWith = (packages: ReadonlyArray<Package>) =>
-  actorOf(agentRuntime(), [codeModeFor({ packages }), reply, budget, compaction])
+  actorOf(agentRuntime(), [codeModeFor({ packages }), reply, budget, compaction, nativeOutput])
 const rlmAgent = agentWith([])
 const inferReactor = rlmAgent.reactors[0]!
 const toolsReactor = rlmAgent.reactors[1]!
@@ -864,9 +865,9 @@ describe("the repair implementation", () => {
     })
   })
 
-  test("two components declaring a fallback collide at construction", () => {
+  test("two components declaring an output strategy collide at construction", () => {
     expect(() => actorOf(agentRuntime(), [codeModeFor({ packages: [] }), outputRepair, outputFailFast])).toThrow(
-      "output fallback declared by components output.repair and output.fail-fast"
+      "output strategy declared by components output.repair and output.fail-fast"
     )
   })
 
@@ -881,6 +882,7 @@ describe("the repair implementation", () => {
           output: [
             {
               component: "output.malformed",
+              kind: "fallback",
               fallback: { kind: "delegated", name: "", projectHistory: true } as never
             }
           ]
@@ -906,7 +908,8 @@ describe("the mind on a native surface", () => {
           }
         }
       ]),
-      reply
+      reply,
+      nativeOutput
     ])
     expect(mind.reactors).toHaveLength(3)
     const layers = Layer.mergeAll(
@@ -1020,7 +1023,7 @@ const houseStyle = (options: { readonly asks: number }): AgentComponent => ({
       system: [],
       tools: [],
       context: [],
-      output: [{ component: "output.house-style", fallback: HOUSE_STYLE }]
+      output: [{ component: "output.house-style", kind: "fallback" as const, fallback: HOUSE_STYLE }]
     }
     if (owed === undefined) return { view, transitions: [] }
     const spent = rejections.length
@@ -1125,7 +1128,7 @@ describe("a domain-specific implementation", () => {
     const silent: AgentComponent = {
       name: "output.silent",
       derive: () => ({
-        view: { system: [], tools: [], context: [], output: [{ component: "output.silent", fallback: HOUSE_STYLE }] },
+        view: { system: [], tools: [], context: [], output: [{ component: "output.silent", kind: "fallback", fallback: HOUSE_STYLE }] },
         transitions: []
       })
     }

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -3,6 +3,7 @@ import { Clock, Effect, Random } from "effect"
 import { StopReason } from "@aws-sdk/client-bedrock-runtime"
 import {
   codeMode,
+  nativeOutput,
   output,
   outputFrom,
   outputRepairFor,
@@ -13,7 +14,7 @@ import {
 } from "tardie"
 
 // reqOf wraps a trajectory in the render the actor would derive: the code surface half.
-const surfaceRender = renderOf([codeMode], [])
+const surfaceRender = renderOf([codeMode, nativeOutput], [])
 const reqOf = (trajectory: ReadonlyArray<Event>) => ({ trajectory, ...surfaceRender })
 import { Infer } from "tardie"
 import {
@@ -314,7 +315,10 @@ describe("infer end to end", () => {
       ...(options.capability === undefined ? {} : { output: options.capability }),
       fetch: fetchImpl
     })
-    const render = renderOf(options.fallback === undefined ? [codeMode] : [codeMode, options.fallback], declared())
+    const render = renderOf(
+      options.fallback === undefined ? [codeMode, nativeOutput] : [codeMode, options.fallback],
+      declared()
+    )
     const action = (await Effect.runPromise(
       Effect.flatMap(Infer, (model) => model.react({ trajectory: declared(), ...render })).pipe(
         Effect.provide(layer)


### PR DESCRIPTION
## Summary

Agent assemblies now select exactly one output strategy component. `nativeOutput` carries `NativeOutputSupport` as an ordinary component requirement, while repair and fail-fast strategies contribute their fallback through the composed view.

`agentRuntime` now declares only the services its reactors execute. Ordinary `actorOf` composition carries the complete requirement union, so the agent-specific `agentOf` constructor is removed. Examples, server assembly, tests, and structured-output documentation use the explicit strategy surface.

## Verification

- `bun run gate`