### PR TITLE
docs: show system prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,23 @@ The call follows one route:
 Mount the component beside the built-in parts that this task needs:
 
 ```ts
-import { actorOf, agentRuntime, budget, codeMode, compaction, outputFailFast, reply } from "tardie"
+import { actorOf, agentRuntime, budget, codeMode, compaction, outputFailFast, reply, type AgentComponent } from "tardie"
+
+const instructions: AgentComponent = {
+  name: "release-analyst.instructions",
+  derive: () => ({
+    view: {
+      system: ["You are a release analyst. Identify risky changes and recommend the safest next action."],
+      tools: [],
+      context: [],
+      output: []
+    },
+    transitions: []
+  })
+}
 
 const releaseAnalyst = actorOf(agentRuntime(), [
+  instructions, // the agent's system prompt
   deploys,     // recent_deploys and its paired handler
   codeMode,    // durable JavaScript execution
   budget,      // a per-turn code budget
@@ -124,7 +138,7 @@ const releaseAnalyst = actorOf(agentRuntime(), [
 ])
 ```
 
-`actorOf` combines the components and carries their service requirements into the host type. `agentRuntime` interprets their view as inference and tool routing, while the core actor reconciles their transitions. The model sees `recent_deploys` and `execute` in one request. Policy components derive work from the same log.
+`actorOf` combines the components and carries their service requirements into the host type. `agentRuntime` interprets their view as inference and tool routing, while the core actor reconciles their transitions. System fragments join in component order, so the model sees the release instructions beside `recent_deploys` and `execute` in one request. Policy components derive work from the same log.
 
 This agent can inspect deployments, analyze results with JavaScript, compact a long investigation, and report to a parent agent. Change the list to create another harness.
 


### PR DESCRIPTION
## Summary

Add an `instructions` component to the composed agent example so the system prompt has a visible home in the component list. The surrounding explanation states that system fragments join in component order.

This makes the README example show the complete agent assembly surface introduced by explicit component composition.

## Verification

- `bun run gate`