### PR TITLE
fix(agent): stop reply chains

### DIFF
--- a/packages/agent/src/components/reply.test.ts
+++ b/packages/agent/src/components/reply.test.ts
@@ -6,6 +6,27 @@ import { Self } from "@clavia/tardigrade-core/actor"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { replyReactor } from "./reply"
 
+const fireReply = async (log: ReadonlyArray<Event>, self: { readonly actor: string; readonly thread: string }) => {
+  const sent: Array<{ readonly link: unknown; readonly event: Event }> = []
+  const transition = replyReactor(log)[0]!
+  const layers = Layer.mergeAll(
+    Layer.succeed(Router, {
+      deliver: (link, event) => Effect.sync(() => sent.push({ link, event })),
+      call: () => Effect.succeed({ error: "unused" }),
+      resume: () => Effect.succeed({ error: "unused" })
+    }),
+    Layer.succeed(Self, self),
+    Layer.succeed(EventLog, withWatermark({
+      append: () => Effect.void,
+      read: Effect.succeed(log)
+    }))
+  )
+  const returned = await Effect.runPromise(
+    transition.act(transition.input).pipe(Effect.provide(layers))
+  )
+  return { returned, sent }
+}
+
 describe("replyReactor", () => {
   test("reverses the provider link persisted with the inbound message", async () => {
     const inbound: Event = {
@@ -22,24 +43,7 @@ describe("replyReactor", () => {
       inbound,
       { type: "TurnCompleted", turn: "m1", output: "fixed", at: 2 }
     ]
-    const sent: Array<{ readonly link: unknown; readonly event: Event }> = []
-    const transition = replyReactor(log)[0]!
-    const layers = Layer.mergeAll(
-      Layer.succeed(Router, {
-        deliver: (link, event) => Effect.sync(() => sent.push({ link, event })),
-        call: () => Effect.succeed({ error: "unused" }),
-        resume: () => Effect.succeed({ error: "unused" })
-      }),
-      Layer.succeed(Self, { actor: "support", thread: "incident" }),
-      Layer.succeed(EventLog, withWatermark({
-        append: () => Effect.void,
-        read: Effect.succeed(log)
-      }))
-    )
-
-    const returned = await Effect.runPromise(
-      transition.act(transition.input).pipe(Effect.provide(layers))
-    )
+    const { returned, sent } = await fireReply(log, { actor: "support", thread: "incident" })
 
     expect(sent[0]?.link).toEqual({
       source: { actor: "support", thread: "incident" },
@@ -57,5 +61,47 @@ describe("replyReactor", () => {
       to: "telegram-support",
       turn: "m1"
     })
+  })
+
+  describe("terminal reports cannot start reply chains", () => {
+    for (const outcome of ["completed", "failed"] as const) {
+      test(outcome, async () => {
+        const terminal: Event = outcome === "completed"
+          ? { type: "TurnCompleted", turn: "run-worker", output: "world built", at: 2 }
+          : { type: "TurnFailed", turn: "run-worker", error: "worker failed", at: 2 }
+        const first = await fireReply([
+          {
+            type: "MessageReceived",
+            id: "run-worker",
+            text: "build the world",
+            link: {
+              source: { actor: "factory", thread: "main" },
+              target: { actor: "factory", thread: "worker" }
+            },
+            at: 1
+          },
+          terminal
+        ], { actor: "factory", thread: "worker" })
+        const report = first.sent[0]
+        if (report === undefined) throw new Error("the worker did not send its terminal report")
+
+        expect(report.event).toMatchObject({
+          type: "MessageReceived",
+          id: "run-worker.reply",
+          outcome
+        })
+
+        const second = await fireReply([
+          { ...report.event, link: report.link } as Event,
+          { type: "TurnCompleted", turn: "run-worker.reply", output: "acknowledged", at: 3 }
+        ], { actor: "factory", thread: "main" })
+
+        expect(second.sent).toEqual([])
+        expect(second.returned).toEqual([
+          expect.objectContaining({ type: "ReplyDelivered", turn: "run-worker.reply" })
+        ])
+        expect(second.returned[0]).not.toHaveProperty("to")
+      })
+    }
   })
 })

--- a/packages/agent/src/components/reply.ts
+++ b/packages/agent/src/components/reply.ts
@@ -34,9 +34,10 @@ const owedTurn = (
   readonly replyTo?: string
   readonly text: string
   readonly outcome: "completed" | "failed"
+  readonly terminalReport: boolean
 } => {
   const view = replyView(log)
-  const inbound = view[0] as { id?: unknown; link?: unknown; replyTo?: unknown } | undefined
+  const inbound = view[0] as { id?: unknown; link?: unknown; replyTo?: unknown; outcome?: unknown } | undefined
   const id = String(inbound?.id)
   const terminal = turnTerminalOf(log, id) as
     | { output?: unknown; error?: unknown }
@@ -52,13 +53,16 @@ const owedTurn = (
     ...(inbound.replyTo === undefined ? {} : { replyTo: String(inbound.replyTo) }),
     text: terminal.error === undefined ? String(terminal.output) : `error: ${String(terminal.error)}`,
     // The outcome rides as a typed field, so a reader never sniffs the text for failure.
-    outcome: terminal.error === undefined ? "completed" : "failed"
+    outcome: terminal.error === undefined ? "completed" : "failed",
+    terminalReport: inbound.outcome === "completed" || inbound.outcome === "failed"
   }
 }
 
 // replyReactor derives one reply per turn: rd:<turn> is the key, the finished turn's terminal is
 // the input. The delivery is at-least-once inside the act; the receiver dedups the reply by its
-// message id, and the local record commits the key.
+// message id, and the local record commits the key. A terminal report carries `outcome` and
+// settles locally because another report would let two agents acknowledge each other without end
+// (reply.test.ts, "terminal reports cannot start reply chains").
 export const replyReactor: Reactor<Router | Self> = (log) => {
   if (replyView(log).length === 0) return []
   const turn = owedTurn(log)
@@ -69,6 +73,7 @@ export const replyReactor: Reactor<Router | Self> = (log) => {
       act: (input) =>
         Effect.gen(function* () {
           const at = yield* Clock.currentTimeMillis
+          if (input.terminalReport) return [replyDelivered({ turn: input.id, at })]
           const self = yield* Self
           const event = replyEvent({
             id: input.id,


### PR DESCRIPTION
A background agent terminal report can become a fresh turn when no package call is waiting for it. The stock reply component previously sent the result of that turn back across the same actor link. A peer with the same component could repeat the exchange indefinitely, causing repeated inference and unbounded log growth.

- Settle completed and failed terminal-report turns with a local `ReplyDelivered` event.
- Keep ordinary actor and provider replies unchanged.
- Cover both terminal outcomes with a two-agent regression that rejects a second outbound delivery.

Verification:

- `bun run gate`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d02ca89f-a7e2-4997-afd5-6f8a3468cf83)
