### PR TITLE
fix(ci): build candidate tree

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,8 @@ jobs:
           CANDIDATE_HEAD: ${{ needs.release-please.outputs.candidate_head }}
         run: |
           git fetch --no-tags origin "$CANDIDATE_HEAD"
-          git merge --no-commit --no-ff "$CANDIDATE_HEAD"
+          candidate_tree=$(git merge-tree --write-tree HEAD "$CANDIDATE_HEAD")
+          git read-tree --reset -u "$candidate_tree"
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: canary


### PR DESCRIPTION
The candidate job must combine the pinned trunk and release PR commits without requiring runner git identity. Git checks committer identity before a regular merge even when the command is told to stop before committing.

- Build the merged tree directly with `git merge-tree`.
- Check out that tree with `git read-tree` before testing and publishing.
- Preserve conflict detection without creating a commit in the runner.

Verified with Actionlint and a clean worktree simulation against the live release PR head. The resulting tree contains the fixed workflow and package version `0.5.0`.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d02ca89f-a7e2-4997-afd5-6f8a3468cf83)
