### PR TITLE
fix(agent): expose report settlement

### DIFF
--- a/packages/agent/src/components/reply.ts
+++ b/packages/agent/src/components/reply.ts
@@ -3,7 +3,7 @@ import { Router } from "@clavia/tardigrade-core/communication/router"
 import { Self, transition, type Reactor } from "@clavia/tardigrade-core/actor"
 import { replyDelivered } from "../events"
 import type { Event } from "@clavia/tardigrade-core/event"
-import { replyEvent } from "@clavia/tardigrade-core/communication/message"
+import { replyEvent, terminalReportOutcomeOf } from "@clavia/tardigrade-core/communication/message"
 import { turnTerminalOf, replyView } from "@clavia/tardigrade-code/turns"
 import type { AgentComponent } from "../runtime/agent"
 import { linkOf, reverseLink, type Link } from "@clavia/tardigrade-core/communication/link"
@@ -54,7 +54,7 @@ const owedTurn = (
     text: terminal.error === undefined ? String(terminal.output) : `error: ${String(terminal.error)}`,
     // The outcome rides as a typed field, so a reader never sniffs the text for failure.
     outcome: terminal.error === undefined ? "completed" : "failed",
-    terminalReport: inbound.outcome === "completed" || inbound.outcome === "failed"
+    terminalReport: terminalReportOutcomeOf(inbound) !== undefined
   }
 }
 

--- a/packages/agent/src/request.test.ts
+++ b/packages/agent/src/request.test.ts
@@ -91,6 +91,18 @@ describe("renderMessages", () => {
     const whole = renderMessages(trajectory)
     expect(whole[0]!.content).toBe("y".repeat(50))
   })
+
+  test("terminal reports disclose local settlement", () => {
+    for (const outcome of ["completed", "failed"] as const) {
+      const messages = renderMessages([
+        { type: "MessageReceived", id: "run-worker.reply", text: "world built", outcome, at: 0 }
+      ])
+      expect(messages[0]).toEqual({
+        role: "user",
+        content: `[Terminal report: ${outcome}. Your answer to this report stays in this thread and is not sent back to its sender.]\nworld built`
+      })
+    }
+  })
 })
 
 describe("modelRequest tool and prompt policy", () => {

--- a/packages/agent/src/request.ts
+++ b/packages/agent/src/request.ts
@@ -1,4 +1,5 @@
 import type { Event } from "@clavia/tardigrade-core/event"
+import { terminalReportOutcomeOf } from "@clavia/tardigrade-core/communication/message"
 import { checkpointOf, contextPolicyOf, keepFromIndex, type ContextPolicy } from "./components/compaction"
 import {
   correctionText,
@@ -121,12 +122,16 @@ const feedbackFor = (
 const userMessageOf = (e: Event, policy: ContextPolicy): AgentMessage => {
   const v = e as Record<string, unknown>
   const text = String(v.text ?? "")
+  const rendered =
+    text.length > policy.messageRenderCap
+      ? `${text.slice(0, policy.messageRenderCap)}…[truncated at ${policy.messageRenderCap} of ${text.length} chars; read the full message with logs.events on this facet, id ${String(v.id)}]`
+      : text
+  const report = terminalReportOutcomeOf(v)
   return {
     role: "user",
-    content:
-      text.length > policy.messageRenderCap
-        ? `${text.slice(0, policy.messageRenderCap)}…[truncated at ${policy.messageRenderCap} of ${text.length} chars; read the full message with logs.events on this facet, id ${String(v.id)}]`
-        : text
+    content: report === undefined
+      ? rendered
+      : `[Terminal report: ${report}. Your answer to this report stays in this thread and is not sent back to its sender.]\n${rendered}`
   }
 }
 

--- a/packages/core/src/communication/message.ts
+++ b/packages/core/src/communication/message.ts
@@ -14,12 +14,19 @@ export const MessageReceived = Schema.Struct({
   replyTo: Schema.optional(Schema.String),
   // The turn's declared output contract carries its schema identity and JSON Schema.
   output: Schema.optional(Schema.Struct({ name: Schema.String, schema: Schema.Unknown })),
+  // outcome marks a terminal report whose reaction turn settles locally without sending a reply (packages/agent/src/components/reply.test.ts, "terminal reports cannot start reply chains").
   outcome: Schema.optional(Schema.Literals(["completed", "failed"])),
   input: Schema.optional(Schema.Unknown),
   data: Schema.optional(Schema.Unknown),
   at: Schema.Finite
 })
 export type MessageReceived = typeof MessageReceived.Type
+
+// terminalReportOutcomeOf returns the terminal-report discriminator carried by a message.
+export const terminalReportOutcomeOf = (
+  message: { readonly outcome?: unknown }
+): "completed" | "failed" | undefined =>
+  message.outcome === "completed" || message.outcome === "failed" ? message.outcome : undefined
 
 // messageKeys derives the core's own dedup key: a MessageReceived names its occurrence by id. The fragment lives beside the event it keys, the owner of the derivation.
 export const messageKeys: KeyFragment = {


### PR DESCRIPTION
A terminal report starts a local reaction turn. Its final answer stays in the parent thread history and does not return to the reporter, so the model must see that delivery rule before it reacts.

- Mark completed and failed reports in the rendered conversation with a local-settlement notice.
- Define the report discriminator beside the `MessageReceived` schema and reuse it in the reply reactor.
- Cover both report outcomes in the renderer regression test.

Verification: `bun run gate`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3a250929-e8d7-43c3-b69b-a957bf4c6093)
