### PR TITLE
fix(ci): verify candidate tree

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  PUBLISHED_PACKAGE: tardie
   RC_TYPE: rc
   RC_NPM_TAG: next
   RELEASE_PR_BRANCH_PREFIX: release-please--
@@ -79,12 +80,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.release-please.outputs.candidate_base }}
       - name: Apply release candidate
+        id: candidate-tree
         env:
           CANDIDATE_HEAD: ${{ needs.release-please.outputs.candidate_head }}
         run: |
           git fetch --no-tags origin "$CANDIDATE_HEAD"
           candidate_tree=$(git merge-tree --write-tree HEAD "$CANDIDATE_HEAD")
           git read-tree --reset -u "$candidate_tree"
+          echo "sha=$candidate_tree" >> "$GITHUB_OUTPUT"
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: canary
@@ -98,7 +101,7 @@ jobs:
         id: candidate
         run: echo "version=$(jq -r .version package.json)-${RC_TYPE}.${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
       - name: Publish candidate
-        run: bun run tools/publish.ts --version ${{ steps.candidate.outputs.version }} --tag ${RC_NPM_TAG}
+        run: bun run tools/publish.ts --version ${{ steps.candidate.outputs.version }} --tag ${RC_NPM_TAG} --source-tree ${{ steps.candidate-tree.outputs.sha }}
 
   publish-stable:
     needs: release-please
@@ -111,6 +114,9 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v7
+      - name: Read stable tree
+        id: stable-tree
+        run: echo "sha=$(git rev-parse HEAD^{tree})" >> "$GITHUB_OUTPUT"
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: canary
@@ -120,5 +126,16 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
+      - name: Verify release candidate
+        if: github.event_name != 'workflow_dispatch' || !inputs.dry-run
+        env:
+          STABLE_TREE: ${{ steps.stable-tree.outputs.sha }}
+        run: |
+          candidate_tree=$(npm view "${PUBLISHED_PACKAGE}@${RC_NPM_TAG}" tardigrade.sourceTree)
+          if [ "$candidate_tree" != "$STABLE_TREE" ]; then
+            echo "::error::npm ${RC_NPM_TAG} was built from ${candidate_tree:-no recorded tree}; stable is ${STABLE_TREE}."
+            exit 1
+          fi
+          echo "npm ${RC_NPM_TAG} matches stable tree ${STABLE_TREE}."
       - name: Publish
-        run: bun run tools/publish.ts --tag ${STABLE_NPM_TAG} ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run && '--dry-run' || '' }}
+        run: bun run tools/publish.ts --tag ${STABLE_NPM_TAG} --source-tree ${{ steps.stable-tree.outputs.sha }} ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run && '--dry-run' || '' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,4 +38,4 @@ CI runs `bun install --frozen-lockfile` and then the same `bun run gate`. There 
 
 ## Releases
 
-Release Please keeps a release PR current with the version and changelog for the next stable release. Each revision is combined with a pinned `main` commit, tested, and published as `<version>-rc.<run number>` under the npm `next` tag. Merging the release PR creates the stable tag and publishes `<version>` under the npm `latest` tag. A normal merge to `main` only updates the release PR.
+Release Please keeps a release PR current with the version and changelog for the next stable release. Each revision is combined with a pinned `main` commit, tested, and published as `<version>-rc.<run number>` under the npm `next` tag. The package records the combined git tree. Merging the release PR creates the stable tag, and the stable publish proceeds only when npm `next` records the same tree. The stable version then publishes under the npm `latest` tag. A normal merge to `main` only updates the release PR.

--- a/tools/publish.ts
+++ b/tools/publish.ts
@@ -137,6 +137,7 @@ const rewriteSources = async (dir: string, rewrites: ReadonlyMap<string, string>
 const packages = await Promise.all(sources.map(async (source) => ({ ...source, pkg: await readPkg(source.dir) })))
 const publicSource = packages.find((source) => source.namespace === "agent")!
 const version = option("--version") ?? (await readPkg(".")).version
+const sourceTree = option("--source-tree")
 const prerelease = version.includes("-")
 const distTag = option("--tag") ?? (prerelease ? DEFAULT_PRERELEASE_NPM_TAG : DEFAULT_STABLE_NPM_TAG)
 if (prerelease && distTag === DEFAULT_STABLE_NPM_TAG) {
@@ -205,6 +206,7 @@ try {
         : repository,
     bugs: publicSource.pkg.bugs,
     publishConfig: publicSource.pkg.publishConfig,
+    ...(sourceTree === undefined ? {} : { tardigrade: { sourceTree } }),
     files: ["src", STAGED_ASSETS, STAGED_EXAMPLES],
     engines: publicSource.pkg.engines,
     type: "module",


### PR DESCRIPTION
Stable publication must prove that npm received an RC built from the exact release contents. Version ordering and workflow serialization alone cannot prove content identity when trunk changes near promotion.

- Record the combined git tree in each candidate package manifest.
- Read the stable commit tree before publication.
- Refuse stable publication unless npm `next` records the identical tree.
- Keep the package name and npm tags explicit at the workflow surface.

Verified with Actionlint, repository lint and tools typechecking, and an npm dry run whose packed manifest records the expected source tree.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d02ca89f-a7e2-4997-afd5-6f8a3468cf83)
