### PR TITLE
ci: guard release creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,26 @@ jobs:
       candidate_head: ${{ steps.candidate.outputs.head }}
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
+      - name: Verify stable candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          releases=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls?per_page=${RELEASE_PR_PAGE_SIZE}" | jq -c --arg prefix "$RELEASE_PR_BRANCH_PREFIX" --arg repo "$GITHUB_REPOSITORY" '[.[] | select(.merged_at != null and .base.ref == "main" and .head.repo.full_name == $repo and (.head.ref | startswith($prefix)))]')
+          count=$(jq length <<< "$releases")
+          if (( count > 1 )); then
+            echo "::error::Commit ${GITHUB_SHA} belongs to ${count} merged Release Please PRs."
+            exit 1
+          fi
+          if (( count == 0 )); then
+            exit 0
+          fi
+          stable_tree=$(gh api "repos/${GITHUB_REPOSITORY}/git/commits/${GITHUB_SHA}" --jq .tree.sha)
+          candidate_tree=$(npm view "${PUBLISHED_PACKAGE}@${RC_NPM_TAG}" tardigrade.sourceTree)
+          if [ "$candidate_tree" != "$stable_tree" ]; then
+            echo "::error::npm ${RC_NPM_TAG} was built from ${candidate_tree:-no recorded tree}; stable is ${stable_tree}."
+            exit 1
+          fi
+          echo "npm ${RC_NPM_TAG} matches stable tree ${stable_tree}."
       - uses: googleapis/release-please-action@v5
         id: release
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,4 +38,4 @@ CI runs `bun install --frozen-lockfile` and then the same `bun run gate`. There 
 
 ## Releases
 
-Release Please keeps a release PR current with the version and changelog for the next stable release. Each revision is combined with a pinned `main` commit, tested, and published as `<version>-rc.<run number>` under the npm `next` tag. The package records the combined git tree. Merging the release PR creates the stable tag, and the stable publish proceeds only when npm `next` records the same tree. The stable version then publishes under the npm `latest` tag. A normal merge to `main` only updates the release PR.
+Release Please keeps a release PR current with the version and changelog for the next stable release. Each revision is combined with a pinned `main` commit, tested, and published as `<version>-rc.<run number>` under the npm `next` tag. The package records the combined git tree. Merging the release PR triggers an exact-tree check against npm `next`. The GitHub release, stable tag, and npm `latest` publish proceed only when that tree matches. A normal merge to `main` only updates the release PR.


### PR DESCRIPTION
A stable release must verify its exact RC before Release Please creates any stable surface. Checking only in the npm publish job can leave a GitHub release and tag behind when the candidate does not match.

- Detect when the triggering commit came from a merged Release Please PR.
- Compare that commit's tree with the tree recorded by npm `next`.
- Stop before Release Please creates the GitHub release or tag when the trees differ.
- Keep the stable publish check as a second guard.

Verified with Actionlint, repository lint and tools typechecking, and live GitHub commit association queries for a normal PR and release PR.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d02ca89f-a7e2-4997-afd5-6f8a3468cf83)
