### PR TITLE
refactor(agent): compose infer root

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The call follows one route:
 
 1. The component adds `recent_deploys` to its derived view.
 2. The model selects it and returns a tool call. Tardigrade records `ToolCalled` in the log.
-3. The shared runtime finds the paired handler in the view that offered the call and asks it to serve against the current log.
+3. The infer root finds the paired handler in the view that offered the call and asks it to serve against the current log.
 4. Tardigrade records `ToolReturned`. The next model request includes the result.
 
 ### Compose an agent
@@ -112,33 +112,24 @@ The call follows one route:
 Mount the component beside the built-in parts that this task needs:
 
 ```ts
-import { actorOf, agentRuntime, budget, codeMode, compaction, outputFailFast, reply, type AgentComponent } from "tardie"
+import { actor, budget, codeMode, compaction, infer, outputValidateOnce, reply, system } from "tardie"
 
-const instructions: AgentComponent = {
-  name: "release-analyst.instructions",
-  derive: () => ({
-    view: {
-      system: ["You are a release analyst. Identify risky changes and recommend the safest next action."],
-      tools: [],
-      context: [],
-      output: []
-    },
-    transitions: []
-  })
-}
+const instructions = system(
+  "You are a release analyst. Identify risky changes and recommend the safest next action."
+)
 
-const releaseAnalyst = actorOf(agentRuntime(), [
+const releaseAnalyst = actor(infer([
   instructions, // the agent's system prompt
   deploys,     // recent_deploys and its paired handler
   codeMode,    // durable JavaScript execution
   budget,      // a per-turn code budget
   compaction,  // bounded model context
   reply,       // results for parent agents
-  outputFailFast // structured results without a retry fallback
-])
+  outputValidateOnce // validates one structured result without correction
+]))
 ```
 
-`actorOf` combines the components and carries their service requirements into the host type. `agentRuntime` interprets their view as inference and tool routing, while the core actor reconciles their transitions. System fragments join in component order, so the model sees the release instructions beside `recent_deploys` and `execute` in one request. Policy components derive work from the same log.
+`infer` composes its children, preserves their transitions, and adds inference and tool routing over their final view. `actor` adapts the root component to reconciliation and carries its service requirements into the host type. System fragments join in component order, so the model sees the release instructions beside `recent_deploys` and `execute` in one request. Policy components derive work from the same log.
 
 This agent can inspect deployments, analyze results with JavaScript, compact a long investigation, and report to a parent agent. Change the list to create another harness.
 

--- a/apps/server/src/actor.ts
+++ b/apps/server/src/actor.ts
@@ -2,15 +2,15 @@ import { Schema } from "effect"
 import type { Event } from "@clavia/tardigrade-core/event"
 import type { Actor } from "@clavia/tardigrade-core/actor"
 import {
-  actorOf,
-  agentRuntime,
+  actor,
   agentsPackage,
   budget,
   codeModeFor,
   compaction,
   fetchPackage,
   filesPackage,
-  outputFailFast,
+  infer,
+  outputValidateOnce,
   reply,
   workspacePackage
 } from "tardie"
@@ -29,7 +29,7 @@ import { inboundOf } from "./projections"
 // components. v1 runs this one assembly and forking is the customization path (apps-server-spec.md,
 // "Explicitly out of scope for v1").
 //
-// outputFailFast makes the server's handling explicit when its run-time model configuration supplies no native type proof.
+// outputValidateOnce makes the server's handling explicit when its run-time model configuration supplies no native type proof.
 //
 // What the four packages add up to is what this actor can reach. `agents` fans work out to children
 // and `workspace` reads what a result spilled, both inside the log. `files` reads and writes under
@@ -37,13 +37,13 @@ import { inboundOf } from "./projections"
 // requests to any host. There is no shell: a shell cannot be scoped the way a root or an origin can,
 // and this build has no place to ask an operator whether one command is allowed.
 export const assemblyOf = () =>
-  actorOf(agentRuntime(), [
+  actor(infer([
     codeModeFor({ packages: [agentsPackage(), workspacePackage(), filesPackage(), fetchPackage()] }),
     reply,
     budget,
     compaction,
-    outputFailFast
-  ])
+    outputValidateOnce
+  ]))
 
 // ServerR is what this assembly needs bound. It is read off the assembly rather than restated, so a
 // package added above lands in the host's obligation and a host that binds nothing for it fails to

--- a/bun.lock
+++ b/bun.lock
@@ -114,6 +114,9 @@
       "dependencies": {
         "effect": "4.0.0-rc.110",
       },
+      "devDependencies": {
+        "fast-check": "^4.9.0",
+      },
     },
     "packages/host": {
       "name": "@clavia/tardigrade-host",

--- a/docs/how-to/migrate.md
+++ b/docs/how-to/migrate.md
@@ -23,13 +23,13 @@ The current Vercel AI SDK agent surface includes [`ToolLoopAgent` and loop contr
 
 | Existing concern | Tardigrade home |
 | --- | --- |
-| `ToolLoopAgent`, `generateText`, `streamText`, or a manual model loop | `defineActor({ name, actor: agentOf(...) })` |
-| System instructions | An `AgentComponent` that contributes `view.system` |
+| `ToolLoopAgent`, `generateText`, `streamText`, or a manual model loop | `defineActor({ name, actor: actor(infer([...])) })` |
+| System instructions | `system(...)` |
 | Tool declarations and handlers | Packages mounted through `codeModeFor`, or fixed tools mounted through `toolList` |
-| `stopWhen`, maximum steps, and retry options | `budgetFor`, `agentOf` inference policy, and domain components with explicit policy values |
+| `stopWhen`, maximum steps, and retry options | `budgetFor`, `infer` policy, and domain components with explicit policy values |
 | `prepareStep` and dynamic context | A component whose `derive(log)` changes its view from recorded events |
 | Message arrays and conversation storage | One append-only event log per thread |
-| Structured output | `output(...)` plus `outputFailFast` or `outputRepairFor(...)` |
+| Structured output | `output(...)` plus `outputValidateOnce` or `outputRepairFor(...)` |
 | Lifecycle callbacks and telemetry | Recorded events, Voyager, usage projections, and host telemetry |
 | AI SDK UI stream protocol | `makeClient().append()` plus the durable event stream from `follow()` |
 
@@ -44,7 +44,7 @@ Edit the generated `agents/agent/actor.ts`. Keep the actor name stable across bu
 
 ### Instructions and tools
 
-Move static system text into an instructions component. A prompt that depends on the conversation becomes a component that derives its system fragment from the log. Keep application data out of the prompt when a scoped package can read it on demand.
+Move static system text into `system(...)`. Pass a log projection to `system` when the prompt depends on recorded events. Keep application data out of the prompt when a scoped package can read it on demand.
 
 Use a package through `codeModeFor` when its methods are ordinary operations that the model can combine, filter, or repeat in JavaScript. This exposes one `execute` tool to the model and keeps package methods behind the code surface. Use `toolList` when a provider-visible tool call, approval step, or exact tool schema is part of the application contract.
 
@@ -54,9 +54,9 @@ Move related tools to code packages only when the decision rule above applies. M
 
 ### Policies and output
 
-State every policy that affects behavior. `budgetFor({ defaultToolBudget })` limits `execute` calls, so it is not a direct replacement for a model-step limit that counts completions and native tools. Express a custom stop condition as a component over the log. Pass `giveUpAfter` through the second argument to `agentOf`, and use `compactionFor(...)` when the application needs context thresholds that differ from `DEFAULT_CONTEXT_POLICY`.
+State every policy that affects behavior. `budgetFor({ defaultToolBudget })` limits `execute` calls, so it is not a direct replacement for a model-step limit that counts completions and native tools. Express a custom stop condition as a component over the log. Pass `giveUpAfter` through the second argument to `infer`, and use `compactionFor(...)` when the application needs context thresholds that differ from `DEFAULT_CONTEXT_POLICY`.
 
-Convert each structured result to `output({ name, schema })`. Send that contract with the turn and mount one explicit fallback. Use `outputFailFast` when an invalid response should end the turn, or `outputRepairFor({ attempts, projectHistory })` when bounded correction is part of the product behavior.
+Convert each structured result to `output({ name, schema })`. Send that contract with the turn and mount one explicit fallback. Use `outputValidateOnce` when one invalid response should end the turn, or `outputRepairFor({ attempts, projectHistory })` when bounded correction is part of the product behavior.
 
 ### Model binding
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -73,35 +73,36 @@ Provider references:
 
 ## Dependency injection and type checks
 
-`Infer` is the injected Effect service. A model layer created by `infer(...)` provides it, and the agent runtime requests it for each attempt.
+`Infer` is the injected Effect service. A model layer created by `modelInfer(...)` provides it, and the infer root requests it for each attempt.
 
-Every agent assembly selects one output strategy component. `nativeOutput` selects provider-native output. `outputRepairFor(...)`, `outputFailFast`, and delegated fallbacks contribute an `OutputFallback` and any fallback prompt.
+Every agent assembly selects one output strategy component. `nativeOutput` selects provider-native output. `outputRepairFor(...)`, `outputValidateOnce`, and delegated fallbacks contribute an `OutputFallback` and any fallback prompt.
 
-`actorOf` combines the runtime and component requirements:
+`infer` combines its child requirements with the model loop, and `actor` carries the root requirements to the host:
 
 | Output strategy | Required model services |
 | --- | --- |
 | `nativeOutput` | `Infer` and `NativeOutputSupport` |
-| Repair, fail-fast, or delegated fallback | `Infer` |
+| Validate-once, repair, or delegated fallback | `Infer` |
 
-`infer(...)` provides `NativeOutputSupport` only when its statically known configuration declares `{ guarantee: "native", withTools: true }`.
+`modelInfer(...)` provides `NativeOutputSupport` only when its statically known configuration declares `{ guarantee: "native", withTools: true }`.
 
 ```ts
-import { actorOf, agentRuntime, codeMode, nativeOutput, outputRepairFor, reply } from "tardie"
+import { actor, codeMode, infer, nativeOutput, outputRepairFor, reply } from "tardie"
+import { infer as modelInfer } from "tardie/model"
 
-const nativeOnly = actorOf(agentRuntime(), [codeMode, reply, nativeOutput])
-const nativeModel = infer({ ...modelConfig, output: { guarantee: "native", withTools: true } })
+const nativeOnly = actor(infer([codeMode, reply, nativeOutput]))
+const nativeModel = modelInfer({ ...modelConfig, output: { guarantee: "native", withTools: true } })
 // nativeModel provides Infer and NativeOutputSupport.
 
-const portable = actorOf(agentRuntime(), [codeMode, reply, outputRepairFor({ attempts: 1 })])
-const unprovenModel = infer({ ...modelConfig, output: { guarantee: "none" } })
+const portable = actor(infer([codeMode, reply, outputRepairFor({ attempts: 1 })]))
+const unprovenModel = modelInfer({ ...modelConfig, output: { guarantee: "none" } })
 // portable requires Infer. unprovenModel provides it.
 // A host that binds nativeOnly to unprovenModel has a missing NativeOutputSupport type error.
 ```
 
 The host fails type checking when it connects a native-only agent to a statically unsupported model layer. This check covers the declared configuration and program wiring. TypeScript cannot verify a remote endpoint. A configuration widened to `ModelConfig` or read from the environment supplies no static proof until application code narrows it, so the usual dynamic host selects an explicit fallback. A `withTools: false` declaration also supplies no proof because `nativeOutput` does not encode an empty tool surface in its type. `outputPreflight` checks each actual call before the provider request. Local validation catches an endpoint that breaks its declaration after the request.
 
-Actor artifacts and server environment variables meet after TypeScript has run. The built-in server and generated actor template select `outputFailFast` explicitly. A custom artifact that selects `nativeOutput` relies on the server's per-call preflight and native capability declaration.
+Actor artifacts and server environment variables meet after TypeScript has run. The built-in server and generated actor template select `outputValidateOnce` explicitly. A custom artifact that selects `nativeOutput` relies on the server's per-call preflight and native capability declaration.
 
 TypeScript also checks the schema profile for schema literals, derives the result type, and checks the closed `OutputFallback` union. `outputRepairFor` accepts `Partial<RepairPolicy>`, so policy field names and value types are checked at the call site. Construction rejects invalid numeric bounds, invalid booleans, malformed custom fallbacks, and multiple fallback components.
 
@@ -137,18 +138,18 @@ output({
 
 `outputProfileErrors` applies the same rules to unknown values at run time. Tardigrade applies no fixed schema-depth limit to either check. The TypeScript compiler can still reach its own instantiation limit on an unusually deep literal.
 
-## Fail-fast fallback
+## Validate-once fallback
 
-`outputFailFast` asks for JSON in the fallback prompt and validates one response. A mismatch ends the turn with `output_validation_failed`. It performs no correction attempt.
+`outputValidateOnce` asks for JSON in the fallback prompt and validates one response. A mismatch ends the turn with `output_validation_failed`. It performs no correction attempt.
 
 ```ts
-import { actorOf, agentRuntime, codeModeFor, outputFailFast, reply } from "tardie"
+import { actor, codeModeFor, infer, outputValidateOnce, reply } from "tardie"
 
-const agent = actorOf(agentRuntime(), [
+const agent = actor(infer([
   codeModeFor({ packages: [] }),
   reply,
-  outputFailFast
-])
+  outputValidateOnce
+]))
 ```
 
 ## Repair fallback
@@ -156,13 +157,13 @@ const agent = actorOf(agentRuntime(), [
 `outputRepairFor` records an invalid response and asks again with the validation errors. Its policy is explicit:
 
 ```ts
-import { actorOf, agentRuntime, codeModeFor, outputRepairFor, reply } from "tardie"
+import { actor, codeModeFor, infer, outputRepairFor, reply } from "tardie"
 
-const agent = actorOf(agentRuntime(), [
+const agent = actor(infer([
   codeModeFor({ packages: [] }),
   reply,
   outputRepairFor({ attempts: 2, projectHistory: true })
-])
+]))
 ```
 
 `attempts` is the maximum number of correction requests for one turn epoch. A value of `2` permits at most three model calls: the initial call and two corrections. Exhaustion ends with `output_repairs_exhausted`. `DEFAULT_REPAIR_POLICY` provides the exported defaults, and `outputRepairFor` accepts overrides.
@@ -207,7 +208,7 @@ const houseStyle = defineOutputFallback({
 | --- | --- |
 | `output_unsupported` | The call has no usable native capability or fallback, the schema is outside the profile, or the declaration is invalid. This is detected before the provider request. |
 | `output_contract_violation` | An endpoint declared native strict output and returned a value that failed local validation. |
-| `output_validation_failed` | A fail-fast fallback returned a value that failed validation. |
+| `output_validation_failed` | A validate-once fallback returned a value that failed validation. |
 | `output_repairs_exhausted` | The repair fallback used every configured correction attempt. |
 | `refused` | The provider refused the request. |
 | `truncated` | The response reached the configured output ceiling. |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -53,7 +53,7 @@ type Reactor = (events: Event[]) => Transition[]
 ```
 ### Component
 
-A component derives a view and transitions from the same log. The view is available to a consumer such as the agent runtime, while transitions go to actor reconciliation. Either side may be empty.
+A component derives a view and transitions from the same log. A component may compose child components, interpret their combined view, and preserve their transitions. Either side may be empty.
 
 ```ts
 type Derivation<V> = {
@@ -77,7 +77,7 @@ type ViewAlgebra<V> = {
 ```
 ### Actor
 
-An actor is one event log and the reactors over it. The log is mailbox and state at once: a send lands as an event, reactors derive what it enables, fires append the results, and the new events enable the next round. Settling ends when no reactor enables a transition. `reactorOf(component)` adapts a component's transition projection to this unchanged runtime.
+An actor is one event log and the root components over it. The log is mailbox and state at once: a send lands as an event, components derive what it enables, fires append the results, and the new events enable the next round. Settling ends when no component enables a transition. `actor(...components)` adapts each root transition projection to a reactor and combines its committing keys.
 ```ts
 // An Actor is the single writer of one log and the reactors over it. The
 // platform serializes sends per actor, so appends never race
@@ -207,4 +207,3 @@ flowchart TB
   tools -->|"ToolReturned"| log
   compaction -->|"CompactionCompleted"| log
 ```
-

--- a/examples/quickstart/actor.ts
+++ b/examples/quickstart/actor.ts
@@ -1,6 +1,5 @@
 import {
-  actorOf,
-  agentRuntime,
+  actor,
   agentsPackage,
   budget,
   codeModeFor,
@@ -8,8 +7,10 @@ import {
   defineActor,
   fetchPackage,
   filesPackage,
-  outputFailFast,
+  infer,
+  outputValidateOnce,
   reply,
+  system,
   workspacePackage
 } from "tardie"
 
@@ -26,19 +27,11 @@ Delegate independent research when it helps.
 Return a concise answer with concrete findings.
 `.trim()
 
-const instructions = {
-  name: "instructions",
-  derive: () => ({
-    view: { system: [actorInstructions], tools: [], context: [], output: [] },
-    transitions: []
-  })
-}
-
 export default defineActor({
   name: actorName,
-  // actorOf carries component and output requirements into the host type.
-  actor: actorOf(agentRuntime(), [
-    instructions,
+  // actor carries component and output requirements into the host type.
+  actor: actor(infer([
+    system(actorInstructions),
     // codeModeFor gives the model one code tool over the packages listed here.
     codeModeFor({
       // packages grant access to local files, HTTP, child agents, and saved tool results.
@@ -50,7 +43,7 @@ export default defineActor({
     budget,
     // compaction summarizes older context when a long turn outgrows its context window.
     compaction,
-    // outputFailFast handles structured results on endpoints with no native guarantee without retrying.
-    outputFailFast
-  ])
+    // outputValidateOnce validates one structured result when the endpoint supplies no native guarantee.
+    outputValidateOnce
+  ]))
 })

--- a/examples/rlm-agent.ts
+++ b/examples/rlm-agent.ts
@@ -6,7 +6,7 @@
 
 // The workspace names resolve in this repository. Against the published package the last two
 // are "tardie/model" and "tardie/bun/host" (tools/publish.ts).
-import { actorOf, agentRuntime, agentsPackage, boundaryOf, budget, codeModeFor, compaction, outputFailFast, reply, workspacePackage } from "tardie"
+import { actor, infer as inferAgent, agentsPackage, boundaryOf, budget, codeModeFor, compaction, outputValidateOnce, reply, workspacePackage } from "tardie"
 import { infer } from "@clavia/tardigrade-model/model"
 import { createBunHost } from "@clavia/tardigrade-bun/host"
 
@@ -14,13 +14,13 @@ import { createBunHost } from "@clavia/tardigrade-bun/host"
 // values, so the model's system fragment lists them and the assembly's requirements carry their
 // needs (Router, Self, and Facets for spawn; the spill store for workspace). The Bun host binds
 // all of those per lane.
-const rlm = actorOf(agentRuntime(), [
+const rlm = actor(inferAgent([
   codeModeFor({ packages: [agentsPackage(), workspacePackage()] }),
   reply, // reports each turn's terminal to whoever asked
   budget, // the per-turn code budget, inherited by spawned children
   compaction, // bounded model context over long investigations
-  outputFailFast // handles structured results without adding a retry
-])
+  outputValidateOnce // handles structured results without adding a retry
+]))
 
 const model = infer({
   baseUrl: process.env.MODEL_BASE_URL!,

--- a/packages/agent/src/agent.types.test.ts
+++ b/packages/agent/src/agent.types.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test"
 import type { Actor } from "@clavia/tardigrade-core/actor"
 import {
-  actorOf,
-  agentRuntime,
+  actor,
+  infer,
   nativeOutput,
   outputRepair,
   type AgentComponent,
@@ -20,8 +20,8 @@ const empty: AgentComponent = {
   })
 }
 
-const nativeOnly = actorOf(agentRuntime(), [empty, nativeOutput])
-const repaired = actorOf(agentRuntime(), [empty, outputRepair])
+const nativeOnly = actor(infer([empty, nativeOutput]))
+const repaired = actor(infer([empty, outputRepair]))
 
 type Requirements<A> = A extends Actor<infer R> ? R : never
 type RequiresNative<A> = NativeOutputSupport extends Requirements<A> ? true : false

--- a/packages/agent/src/components/budget.test.ts
+++ b/packages/agent/src/components/budget.test.ts
@@ -3,7 +3,7 @@ import { Effect, Layer } from "effect"
 import { KeyValueStore } from "effect/unstable/persistence"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { EventLog, withWatermark } from "@clavia/tardigrade-core/event-log"
-import { actorOf } from "@clavia/tardigrade-core/component"
+import { actor } from "@clavia/tardigrade-core/component"
 import { Self } from "@clavia/tardigrade-core/actor"
 import { Facets } from "@clavia/tardigrade-core/facets"
 import { Router } from "@clavia/tardigrade-core/router"
@@ -11,13 +11,13 @@ import { parseActorAddress } from "@clavia/tardigrade-core/communication/address
 import { Infer } from "../turn"
 import { NativeOutputSupport } from "../runtime/infer"
 import { budget, budgetReactor, budgetReactorFor, budgetOf, usedOf, budgetPhase, budgetSpent, canRequestBudget } from "./budget"
-import { agentRuntime } from "../runtime/agent"
+import { infer } from "../runtime/agent"
 import { codeMode } from "./code"
 import { compaction } from "./compaction"
 import { reply } from "./reply"
 import { nativeOutput } from "./native-output"
 
-const toolsReactor = actorOf(agentRuntime(), [codeMode, reply, budget, compaction, nativeOutput]).reactors[1]!
+const rootReactor = actor(infer([codeMode, reply, budget, compaction, nativeOutput])).reactors[0]!
 
 // The rest of the agent's environment, which every reactor's `act` is typed against whether or not
 // it reaches for it. Naming it is what proves the tools gate answers from the log alone: no model
@@ -126,7 +126,7 @@ describe("the tools gate reacts to BudgetExhausted", () => {
       append: (more: ReadonlyArray<Event>) => Effect.sync(() => void events.push(...more)),
       read: Effect.sync(() => events as ReadonlyArray<Event>)
     }))
-    const derived = toolsReactor(events)
+    const derived = rootReactor(events)
     if (derived.length > 0) {
       const out = await Effect.runPromise(
         derived[0]!.act(derived[0]!.input).pipe(Effect.provide(Layer.mergeAll(memory, rest)))

--- a/packages/agent/src/components/compaction.test.ts
+++ b/packages/agent/src/components/compaction.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { Effect, Layer, Ref } from "effect"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { EventLog, withWatermark } from "@clavia/tardigrade-core/event-log"
-import { send, actor } from "@clavia/tardigrade-core/actor"
+import { actorFromReactors, send } from "@clavia/tardigrade-core/actor"
 import { Infer } from "../runtime/infer"
 import { composeKeys } from "@clavia/tardigrade-core/event-log"
 import { messageKeys } from "@clavia/tardigrade-core/message"
@@ -86,7 +86,7 @@ describe("the compaction measure and guard", () => {
   })
 })
 
-const mailbox = actor<Infer | EventLog>([compactionReactor], agentActorKeys)
+const mailbox = actorFromReactors<Infer | EventLog>([compactionReactor], agentActorKeys)
 
 describe("the compaction pass", () => {
   const run = async (initial: ReadonlyArray<Event>) => {

--- a/packages/agent/src/components/repair.ts
+++ b/packages/agent/src/components/repair.ts
@@ -68,18 +68,18 @@ export const outputRepairFor = (policy: Partial<RepairPolicy> = {}): OutputFallb
 // outputRepair is the component under the default policy.
 export const outputRepair: OutputFallbackComponent = outputRepairFor()
 
-// FAIL_FAST_FALLBACK validates one result and schedules no correction.
-export const FAIL_FAST_FALLBACK: OutputFallback = { kind: "local", name: "fail-fast" }
+// VALIDATE_ONCE_FALLBACK validates one result and schedules no correction.
+export const VALIDATE_ONCE_FALLBACK: OutputFallback = { kind: "local", name: "validate-once" }
 
-// outputFailFast contributes the fail-fast fallback and its contract instruction (turn.test.ts, "the fail-fast implementation").
-export const outputFailFast: OutputFallbackComponent = defineOutputFallback({
-  name: "output.fail-fast",
+// outputValidateOnce contributes one local validation and its contract instruction (turn.test.ts, "the validate-once implementation").
+export const outputValidateOnce: OutputFallbackComponent = defineOutputFallback({
+  name: "output.validate-once",
   derive: (log: ReadonlyArray<Event>) => ({
     view: {
       system: [],
       tools: [],
       context: [],
-      output: [{ component: "output.fail-fast", kind: "fallback", fallback: FAIL_FAST_FALLBACK, ...declaredSystem(log) }]
+      output: [{ component: "output.validate-once", kind: "fallback", fallback: VALIDATE_ONCE_FALLBACK, ...declaredSystem(log) }]
     },
     transitions: []
   })

--- a/packages/agent/src/components/system.ts
+++ b/packages/agent/src/components/system.ts
@@ -1,0 +1,18 @@
+import type { Event } from "@clavia/tardigrade-core/event"
+import type { AgentComponent } from "../runtime/agent"
+
+export type SystemText = string | ((log: ReadonlyArray<Event>) => string)
+
+// system contributes instructions derived from the current log.
+export const system = (text: SystemText): AgentComponent => ({
+  name: "system",
+  derive: (log) => ({
+    view: {
+      system: [typeof text === "function" ? text(log) : text],
+      tools: [],
+      context: [],
+      output: []
+    },
+    transitions: []
+  })
+})

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -11,7 +11,7 @@ import { Infer, NativeOutputSupport, type InferRequest } from "./runtime/infer"
 import { boundaryOf } from "./boundary"
 import { resumeTurn } from "./resume"
 import { agentsPackage } from "./spawn"
-import { actorOf, agentRuntime, budgetFor, codeModeFor, compactionFor, nativeOutput, reply, toolList, type AgentComponent } from "./index"
+import { actor, budgetFor, codeModeFor, compactionFor, infer, nativeOutput, reply, toolList, type AgentComponent } from "./index"
 import type { RlmR } from "./turn"
 
 const ROOT_LANE = "ag.root"
@@ -76,7 +76,7 @@ const hosted = (assembled: Actor<TestR>, mind: Mind, log: ReadonlyArray<Event> =
 // in-process host. The three policy components are always mounted, so a test that swaps the
 // work surface still runs the same turn loop, budget wall, and answer contract.
 const rlm = (mind: Mind, components: ReadonlyArray<AgentComponent<RlmR>> = [work()], log: ReadonlyArray<Event> = []) =>
-  hosted(actorOf(agentRuntime({}), [...components, reply, budgetFor({}), compactionFor({}), nativeOutput]), mind, log)
+  hosted(actor(infer([...components, reply, budgetFor({}), compactionFor({}), nativeOutput])), mind, log)
 
 const headText = (trajectory: ReadonlyArray<Event>): string => {
   for (let i = trajectory.length - 1; i >= 0; i--) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -61,11 +61,11 @@ export {
 export {
   outputRepair,
   outputRepairFor,
-  outputFailFast,
+  outputValidateOnce,
   outputSystemFor,
   repairFallback,
   repairPolicyOf,
-  FAIL_FAST_FALLBACK,
+  VALIDATE_ONCE_FALLBACK,
   DEFAULT_REPAIR_POLICY,
   type RepairPolicy
 } from "./components/repair"
@@ -127,7 +127,7 @@ export {
 // list mounts its own (runtime/agent.ts).
 export {
   AGENT_VIEW_ALGEBRA,
-  agentRuntime,
+  infer,
   defineOutputFallback,
   renderOf,
   type AgentComponent,
@@ -141,17 +141,17 @@ export {
   type Rendered
 } from "./runtime/agent"
 export { codeMode, codeModeFor, CODE_SYSTEM, codeSystemFor } from "./components/code"
+export { system, type SystemText } from "./components/system"
 export { toolList, type NativeTool } from "./components/tool-list"
 export { budget, budgetFor } from "./components/budget"
 export { compaction, compactionFor } from "./components/compaction"
 export { reply } from "./components/reply"
 export {
-  actorOf,
+  actor,
   composeComponents,
   reactorOf,
   type Component,
   type ComponentRequirements,
-  type ComponentRuntime,
   type Derivation,
   type ViewAlgebra
 } from "@clavia/tardigrade-core/component"

--- a/packages/agent/src/output.test.ts
+++ b/packages/agent/src/output.test.ts
@@ -332,6 +332,8 @@ describe("the history projection", () => {
       projectHistory: true
     })
     expect(modeOf({ kind: "native", name: "native" })).toEqual({ kind: "native", name: "native" })
+    expect(modeOf({ kind: "local", name: "validate-once" })).toEqual({ kind: "local", name: "validate-once" })
+    expect(modeOf({ kind: "local", name: "fail-fast" })).toEqual({ kind: "local", name: "validate-once" })
     expect(modeOf({ kind: "repair", name: "repair", attempts: -1 })).toBeUndefined()
     expect(modeOf({ kind: "repair", name: "repair", attempts: 2, projectHistory: "yes" })).toBeUndefined()
     expect(modeOf({ kind: "repair", name: "retry", attempts: 2, projectHistory: true })).toBeUndefined()

--- a/packages/agent/src/output.ts
+++ b/packages/agent/src/output.ts
@@ -456,7 +456,7 @@ type NoCorrections = { readonly attempts?: never }
 type NoHistory = { readonly projectHistory?: never }
 
 export type OutputFallback =
-  | ({ readonly kind: "local"; readonly name: "fail-fast" } & NoCorrections & NoHistory)
+  | ({ readonly kind: "local"; readonly name: "validate-once" } & NoCorrections & NoHistory)
   | {
       readonly kind: "repair"
       readonly name: "repair"
@@ -507,7 +507,10 @@ export const modeOf = (value: unknown): OutputMode | undefined => {
     return name === "native" && hasOnly(["kind", "name"]) ? { kind: "native", name } : undefined
   }
   if (kind === "local") {
-    return name === "fail-fast" && hasOnly(["kind", "name"]) ? { kind: "local", name } : undefined
+    if (!hasOnly(["kind", "name"])) return undefined
+    if (name === "validate-once") return { kind: "local", name }
+    // modeOf accepts fail-fast as the durable spelling of the validate-once policy.
+    return name === "fail-fast" ? { kind: "local", name: "validate-once" } : undefined
   }
   const projectHistory = carried["projectHistory"]
   if (kind === "delegated") {

--- a/packages/agent/src/output.types.test.ts
+++ b/packages/agent/src/output.types.test.ts
@@ -191,19 +191,19 @@ export const rejects = (): void => {
 // is a policy that reads as sensible and is not one.
 export const modes = (): void => {
   accepts<OutputMode>({ kind: "native", name: "native" })
-  accepts<OutputMode>({ kind: "local", name: "fail-fast" })
+  accepts<OutputMode>({ kind: "local", name: "validate-once" })
   accepts<OutputMode>({ kind: "repair", name: "repair", attempts: 2, projectHistory: true })
   accepts<OutputMode>({ kind: "delegated", name: "mine", projectHistory: false })
   // @ts-expect-error the native implementation has one durable identity
   accepts<OutputMode>({ kind: "native", name: "provider-native" })
-  // @ts-expect-error the local implementation is the exported fail-fast behavior
+  // @ts-expect-error the local implementation is the exported validate-once behavior
   accepts<OutputMode>({ kind: "local", name: "local" })
   // @ts-expect-error the framework repair behavior has one durable identity
   accepts<OutputMode>({ kind: "repair", name: "retry", attempts: 2, projectHistory: true })
   // @ts-expect-error a native mode has no correction bound to state
   accepts<OutputMode>({ kind: "native", name: "native", attempts: 100, projectHistory: true })
   // @ts-expect-error a local mode has no history to project: it never corrects
-  accepts<OutputMode>({ kind: "local", name: "fail-fast", projectHistory: true })
+  accepts<OutputMode>({ kind: "local", name: "validate-once", projectHistory: true })
   // @ts-expect-error the framework loop states its bound
   accepts<OutputMode>({ kind: "repair", name: "repair", projectHistory: true })
   // @ts-expect-error a delegated mode owns its own bound, so it states none here

--- a/packages/agent/src/runtime/agent.test.ts
+++ b/packages/agent/src/runtime/agent.test.ts
@@ -7,15 +7,16 @@ import { Router } from "@clavia/tardigrade-core/router"
 import { parseActorAddress } from "@clavia/tardigrade-core/communication/address"
 import { Facets } from "@clavia/tardigrade-core/facets"
 import { Self } from "@clavia/tardigrade-core/actor"
-import { actorOf } from "@clavia/tardigrade-core/component"
+import { actor } from "@clavia/tardigrade-core/component"
 import type { Package } from "@clavia/tardigrade-code/packages"
-import { agentRuntime, defineOutputFallback, renderOf, type AgentComponent, type AgentView } from "./agent"
+import { defineOutputFallback, infer, renderOf, type AgentComponent, type AgentView } from "./agent"
 import { CODE_SYSTEM, codeMode, codeModeFor } from "../components/code"
 import { budget } from "../components/budget"
 import { compaction, compactionFor } from "../components/compaction"
 import { reply } from "../components/reply"
 import { toolList } from "../components/tool-list"
 import { nativeOutput } from "../components/native-output"
+import { system } from "../components/system"
 import { receive } from "../turn"
 import { Infer, NativeOutputSupport, type InferRequest } from "./infer"
 
@@ -68,9 +69,9 @@ const viewComponent = (
   derive: (log) => ({ view: typeof view === "function" ? view(log) : view, transitions: [] })
 })
 
-describe("agent runtime", () => {
+describe("infer component", () => {
   test("an assembly must declare one output strategy", () => {
-    expect(() => actorOf(agentRuntime(), [echoTable])).toThrow("must declare one output strategy")
+    expect(() => actor(infer([echoTable]))).toThrow("must declare one output strategy")
   })
 
   test("a marked output fallback must be present for every log", () => {
@@ -79,7 +80,7 @@ describe("agent runtime", () => {
       tools: [],
       context: [],
       output: log.length === 0
-        ? [{ component: "changing-output", kind: "fallback", fallback: { kind: "local", name: "fail-fast" } }]
+        ? [{ component: "changing-output", kind: "fallback", fallback: { kind: "local", name: "validate-once" } }]
         : []
     })))
     expect(() => changing.derive([{ type: "Ready" }])).toThrow("must declare one applicable fallback for every log")
@@ -98,7 +99,7 @@ describe("agent runtime", () => {
         )
       }
     })
-    const agent = actorOf(agentRuntime(), [echoTable, reply, budget, compaction, nativeOutput])
+    const agent = actor(infer([echoTable, reply, budget, compaction, nativeOutput]))
     const events = await run(
       Effect.gen(function* () {
         yield* receive(agent, { id: "m1", text: "go" })
@@ -125,7 +126,7 @@ describe("agent runtime", () => {
         )
       }
     })
-    const agent = actorOf(agentRuntime(), [echoTable, reply, nativeOutput])
+    const agent = actor(infer([echoTable, reply, nativeOutput]))
     const events = await run(
       Effect.gen(function* () {
         yield* receive(agent, { id: "m1", text: "go" })
@@ -139,7 +140,7 @@ describe("agent runtime", () => {
   })
 
   test("two components declaring one tool name collide at construction", () => {
-    expect(() => actorOf(agentRuntime(), [echoTable, toolList([{ spec: { name: "echo", description: "again", inputSchema: {} }, run: () => Effect.succeed({}) }]), nativeOutput])).toThrow(
+    expect(() => actor(infer([echoTable, toolList([{ spec: { name: "echo", description: "again", inputSchema: {} }, run: () => Effect.succeed({}) }]), nativeOutput]))).toThrow(
       'tool "echo" declared more than once'
     )
   })
@@ -156,9 +157,9 @@ describe("agent runtime", () => {
         output: []
       })
     )
-    const agent = actorOf(agentRuntime(), [echoTable, later, nativeOutput])
+    const agent = actor(infer([echoTable, later, nativeOutput]))
 
-    expect(agent.reactors).toHaveLength(3)
+    expect(agent.reactors).toHaveLength(1)
     expect(() => renderOf([echoTable, later, nativeOutput], [{ type: "Ready" }])).toThrow('tool "echo" declared more than once')
   })
 
@@ -183,7 +184,7 @@ describe("agent runtime", () => {
     })
     const events = await run(
       Effect.gen(function* () {
-        yield* receive(actorOf(agentRuntime(), [ephemeral, nativeOutput]), { id: "m1", text: "go" })
+        yield* receive(actor(infer([ephemeral, nativeOutput])), { id: "m1", text: "go" })
         return yield* readLog
       }),
       Layer.mergeAll(memoryLog(), mind, noRouter, KeyValueStore.layerMemory)
@@ -236,6 +237,17 @@ describe("agent runtime", () => {
     expect(render.system).toContain("packages: github, slack")
     // A constant fragment stays what it says, beside the derived one.
     expect(render.system).toContain("echo")
+  })
+
+  test("system contributes static or projected instructions as a component", () => {
+    const log: ReadonlyArray<Event> = [{ type: "PackageInstalled", name: "github" }]
+    const render = renderOf([
+      system("review the repository"),
+      system((events) => `recorded events: ${events.length}`),
+      nativeOutput
+    ], log)
+
+    expect(render.system).toBe("review the repository\nrecorded events: 1")
   })
 
   test("renderOf over one log is deterministic", () => {

--- a/packages/agent/src/runtime/agent.ts
+++ b/packages/agent/src/runtime/agent.ts
@@ -2,9 +2,10 @@ import type { Reactor, Transition } from "@clavia/tardigrade-core/actor"
 import {
   composeComponents,
   type Component,
-  type ComponentRuntime,
+  type ComponentRequirements,
   type ViewAlgebra
 } from "@clavia/tardigrade-core/component"
+import { composeKeys, type KeyFragment } from "@clavia/tardigrade-core/event-log"
 import { messageKeys } from "@clavia/tardigrade-core/message"
 import type { Event } from "@clavia/tardigrade-core/event"
 import type { ToolSpec } from "../request"
@@ -53,7 +54,7 @@ export interface FallbackOutputFragment {
 
 export type OutputFragment = NativeOutputFragment | FallbackOutputFragment
 
-// AgentView is the view an agent runtime interprets. Arrays retain component order and
+// AgentView is the view the infer root interprets. Arrays retain component order and
 // postpone collision policy until the complete derivation is available.
 export interface AgentView {
   readonly system: ReadonlyArray<string>
@@ -62,7 +63,7 @@ export interface AgentView {
   readonly output: ReadonlyArray<OutputFragment>
 }
 
-// AgentComponent is a core component whose view is interpreted by the agent runtime.
+// AgentComponent is a core component whose view is interpreted by its infer root.
 export type AgentComponent<R = never> = Component<AgentView, R>
 
 const OutputFallbackMarker: unique symbol = Symbol("agent/OutputFallbackComponent")
@@ -198,27 +199,53 @@ export const renderOf = <const Cs extends ReadonlyArray<AgentComponent<never> | 
 ): Rendered =>
   renderView(viewFrom(components, log))
 
-// agentRuntime interprets AgentView as inference and tool-routing reactors. actorOf supplies the
-// composed view projection and adds each component's own transition projection.
-export const agentRuntime = (
-  policy: Partial<InferPolicy> = {}
-): ComponentRuntime<AgentView, AgentR> => ({
-  name: "agent",
-  algebra: AGENT_VIEW_ALGEBRA,
-  keys: [messageKeys, agentKeys],
-  reactors: <C>(viewOf: (log: ReadonlyArray<Event>) => AgentView): ReadonlyArray<Reactor<AgentR | C>> => {
-    const toolsOf = (log: ReadonlyArray<Event>): ReadonlyArray<AgentTool<unknown>> => checkedTools(viewOf(log).tools)
-    const offeredTools = (log: ReadonlyArray<Event>, call: PendingCall): ReadonlyArray<AgentTool<unknown>> =>
-      toolsOf(offerLogFor(log, call))
-    const serve = (call: PendingCall, log: ReadonlyArray<Event>, answer: Answer) => {
-      const tool = offeredTools(log, call).find((candidate) => candidate.spec.name === call.name)
-      return tool?.serve(call, log, answer) as ReadonlyArray<Transition<never, AgentR | C>> | undefined
-    }
-
-    renderView(viewOf([]))
-    return [
-      inferReactorFor(policy, (log) => renderView(viewOf(log))) as Reactor<AgentR | C>,
-      toolsReactorFrom(serve, (log, call) => offeredTools(log, call).map((tool) => tool.spec))
-    ]
+const rootKeys = (children: KeyFragment | undefined): KeyFragment => {
+  const fragments = [messageKeys, agentKeys, ...(children === undefined ? [] : [children])]
+  return {
+    prefixes: fragments.flatMap((fragment) => fragment.prefixes),
+    keyOf: composeKeys(...fragments)
   }
-})
+}
+
+// infer composes an agent's child components and adds the model loop over their final view.
+// Inference and dispatch derive from the same child projection, so a tool remains routed against
+// the view that offered it while every child transition remains part of the root derivation.
+export const infer = <
+  const Cs extends ReadonlyArray<AgentComponent<never> | AgentComponent<unknown>>
+>(
+  components: Cs,
+  policy: Partial<InferPolicy> = {}
+): AgentComponent<AgentR | ComponentRequirements<Cs[number]>> => {
+  type ComponentR = ComponentRequirements<Cs[number]>
+  type R = AgentR | ComponentR
+  const combined = composeComponents("infer.children", AGENT_VIEW_ALGEBRA, components) as AgentComponent<ComponentR>
+  const viewOf = (log: ReadonlyArray<Event>): AgentView => combined.derive(log).view
+
+  const toolsOf = (log: ReadonlyArray<Event>): ReadonlyArray<AgentTool<unknown>> => checkedTools(viewOf(log).tools)
+  const offeredTools = (log: ReadonlyArray<Event>, call: PendingCall): ReadonlyArray<AgentTool<unknown>> =>
+    toolsOf(offerLogFor(log, call))
+  const serve = (call: PendingCall, log: ReadonlyArray<Event>, answer: Answer) => {
+    const tool = offeredTools(log, call).find((candidate) => candidate.spec.name === call.name)
+    return tool?.serve(call, log, answer) as ReadonlyArray<Transition<never, R>> | undefined
+  }
+
+  renderView(viewOf([]))
+  const inference = inferReactorFor(policy, (log) => renderView(viewOf(log))) as Reactor<R>
+  const dispatch = toolsReactorFrom(serve, (log, call) => offeredTools(log, call).map((tool) => tool.spec))
+
+  return {
+    name: "infer",
+    keys: rootKeys(combined.keys),
+    derive: (log) => {
+      const children = combined.derive(log)
+      return {
+        view: children.view,
+        transitions: [
+          ...inference(log),
+          ...dispatch(log),
+          ...children.transitions
+        ]
+      }
+    }
+  }
+}

--- a/packages/agent/src/turn.test.ts
+++ b/packages/agent/src/turn.test.ts
@@ -17,17 +17,17 @@ import { turnFailed } from "./events"
 import type { AgentComponent } from "./runtime/agent"
 import type { OutputFallback } from "./output"
 import {
-  actorOf,
-  agentRuntime,
+  actor,
   budget,
   codeModeFor,
   compaction,
   fingerprintOf,
+  infer,
   nativeOutput,
   output,
-  outputFailFast,
+  outputValidateOnce,
   repairFallback,
-  FAIL_FAST_FALLBACK,
+  VALIDATE_ONCE_FALLBACK,
   NATIVE_MODE,
   outputOf,
   outputRepair,
@@ -37,15 +37,12 @@ import {
   toolList
 } from "./index"
 
-// The default assembly over a stated scope, and its runtime reactors, reconstructed the way
-// agentRuntime mounts them: reactors[0] is the infer loop, reactors[1] is the call router. The
-// packages are values the assembly passes, so a test that needs one names it here
-// (components/code.ts, codeModeFor).
+// The default assembly over a stated scope. The infer root contains model inference, call routing,
+// and every child transition in one projection.
 const agentWith = (packages: ReadonlyArray<Package>) =>
-  actorOf(agentRuntime(), [codeModeFor({ packages }), reply, budget, compaction, nativeOutput])
+  actor(infer([codeModeFor({ packages }), reply, budget, compaction, nativeOutput]))
 const rlmAgent = agentWith([])
-const inferReactor = rlmAgent.reactors[0]!
-const toolsReactor = rlmAgent.reactors[1]!
+const rootReactor = rlmAgent.reactors[0]!
 // The agent end to end: the model writes code, the code calls packages, every call is recorded,
 // and the turn completes. The sandbox test binding runs real JS with the package objects in
 // scope; no isolation is needed to test the machinery.
@@ -166,8 +163,7 @@ describe("the agent with execute as the only tool", () => {
     expect(events[8]).toMatchObject({ result: { jd_record_id: "jd-91", hits: 3 } })
     expect(spies).toEqual({ insert: 1, search: 1 })
     expect(count.calls).toBe(2)
-    expect(inferReactor(events)).toHaveLength(0)
-    expect(toolsReactor(events)).toHaveLength(0)
+    expect(rootReactor(events)).toHaveLength(0)
   })
 
   test("a spilled settle answers with its pointer, never an empty result", async () => {
@@ -191,7 +187,7 @@ describe("the agent with execute as the only tool", () => {
       }
     ]
     const events = await run(readLog, memoryLog(spilled))
-    const [answer] = toolsReactor(events)
+    const [answer] = rootReactor(events)
     expect(answer).toBeDefined()
     // Every reactor's `act` is typed against the agent's whole environment, so a settle that only
     // reads the log still states it. Providing it is what proves the settle never reaches for the
@@ -454,7 +450,7 @@ const completedTurns = (log: ReadonlyArray<Event>): ReadonlySet<string> =>
 const REPAIR_TWO = repairFallback({ attempts: 2 })
 
 const repairAgent = (policy: Parameters<typeof outputRepairFor>[0] = {}) =>
-  actorOf(agentRuntime(), [codeModeFor({ packages: [] }), reply, budget, compaction, outputRepairFor(policy)])
+  actor(infer([codeModeFor({ packages: [] }), reply, budget, compaction, outputRepairFor(policy)]))
 
 describe("a turn that declares an output contract", () => {
   test("a conforming response completes the turn, and outputOf reads it back typed", async () => {
@@ -866,8 +862,8 @@ describe("the repair implementation", () => {
   })
 
   test("two components declaring an output strategy collide at construction", () => {
-    expect(() => actorOf(agentRuntime(), [codeModeFor({ packages: [] }), outputRepair, outputFailFast])).toThrow(
-      "output strategy declared by components output.repair and output.fail-fast"
+    expect(() => actor(infer([codeModeFor({ packages: [] }), outputRepair, outputValidateOnce]))).toThrow(
+      "output strategy declared by components output.repair and output.validate-once"
     )
   })
 
@@ -890,14 +886,14 @@ describe("the repair implementation", () => {
         transitions: []
       })
     }
-    expect(() => actorOf(agentRuntime(), [malformed])).toThrow("output fallback declared by component output.malformed")
+    expect(() => actor(infer([malformed]))).toThrow("output fallback declared by component output.malformed")
   })
 })
 
 describe("the mind on a native surface", () => {
   test("a turn completes with no budget, code, or compaction reactors", async () => {
     const reads: string[] = []
-    const mind = actorOf(agentRuntime(), [
+    const mind = actor(infer([
       toolList([
         {
           spec: { name: "read", description: "read a file", inputSchema: { type: "object", properties: { path: { type: "string" } } } },
@@ -910,8 +906,8 @@ describe("the mind on a native surface", () => {
       ]),
       reply,
       nativeOutput
-    ])
-    expect(mind.reactors).toHaveLength(3)
+    ]))
+    expect(mind.reactors).toHaveLength(1)
     const layers = Layer.mergeAll(
       memoryLog(),
       noRouter,
@@ -948,8 +944,8 @@ describe("the mind on a native surface", () => {
   })
 })
 
-describe("the fail-fast implementation", () => {
-  const failFastAgent = actorOf(agentRuntime(), [codeModeFor({ packages: [] }), reply, budget, compaction, outputFailFast])
+describe("the validate-once implementation", () => {
+  const validateOnceAgent = actor(infer([codeModeFor({ packages: [] }), reply, budget, compaction, outputValidateOnce]))
 
   test("a missed response ends the turn with its own cause, and never asks again", async () => {
     let asked = 0
@@ -963,7 +959,7 @@ describe("the fail-fast implementation", () => {
           // with nothing mounted (request.ts, OutputRequest).
           expect(request.output?.system).toContain('conforming to the schema "scout"')
           expect(request.system).not.toContain("scout")
-          return Effect.succeed({ kind: "complete" as const, output: BAD_ANSWER, mode: FAIL_FAST_FALLBACK })
+          return Effect.succeed({ kind: "complete" as const, output: BAD_ANSWER, mode: VALIDATE_ONCE_FALLBACK })
         }
       }),
       jsSandbox,
@@ -971,7 +967,7 @@ describe("the fail-fast implementation", () => {
     )
     const events = await run(
       Effect.gen(function* () {
-        yield* receive(failFastAgent, { id: "m1", text: "decompose this topic", output: SCOUT })
+        yield* receive(validateOnceAgent, { id: "m1", text: "decompose this topic", output: SCOUT })
         return yield* readLog
       }),
       layers
@@ -989,13 +985,13 @@ describe("the fail-fast implementation", () => {
     const layers = Layer.mergeAll(
       memoryLog(),
       KeyValueStore.layerMemory,
-      Layer.succeed(Infer, { react: () => Effect.succeed({ kind: "complete" as const, output: JSON.stringify(GOOD_ANSWER), mode: FAIL_FAST_FALLBACK }) }),
+      Layer.succeed(Infer, { react: () => Effect.succeed({ kind: "complete" as const, output: JSON.stringify(GOOD_ANSWER), mode: VALIDATE_ONCE_FALLBACK }) }),
       jsSandbox,
       noRouter
     )
     const events = await run(
       Effect.gen(function* () {
-        yield* receive(failFastAgent, { id: "m1", text: "decompose this topic", output: SCOUT })
+        yield* receive(validateOnceAgent, { id: "m1", text: "decompose this topic", output: SCOUT })
         return yield* readLog
       }),
       layers
@@ -1088,7 +1084,7 @@ describe("a domain-specific implementation", () => {
       jsSandbox,
       noRouter
     )
-    const agent = actorOf(agentRuntime(), [codeModeFor({ packages: [] }), reply, houseStyle({ asks: 2 })])
+    const agent = actor(infer([codeModeFor({ packages: [] }), reply, houseStyle({ asks: 2 })]))
     const events = await run(
       Effect.gen(function* () {
         yield* receive(agent, { id: "m1", text: "decompose this topic", output: SCOUT })
@@ -1134,7 +1130,7 @@ describe("a domain-specific implementation", () => {
     }
     const events = await run(
       Effect.gen(function* () {
-        yield* receive(actorOf(agentRuntime(), [codeModeFor({ packages: [] }), silent]), {
+        yield* receive(actor(infer([codeModeFor({ packages: [] }), silent])), {
           id: "m1",
           text: "decompose this topic",
           output: SCOUT
@@ -1156,7 +1152,7 @@ describe("a domain-specific implementation", () => {
       jsSandbox,
       noRouter
     )
-    const agent = actorOf(agentRuntime(), [codeModeFor({ packages: [] }), reply, houseStyle({ asks: 1 })])
+    const agent = actor(infer([codeModeFor({ packages: [] }), reply, houseStyle({ asks: 1 })]))
     const events = await run(
       Effect.gen(function* () {
         yield* receive(agent, { id: "m1", text: "decompose this topic", output: SCOUT })

--- a/packages/agent/src/turn.ts
+++ b/packages/agent/src/turn.ts
@@ -14,7 +14,7 @@ import type { WorkspacePolicy } from "@clavia/tardigrade-code/workspace"
 
 export { Infer } from "./runtime/infer"
 
-// AgentR is the runtime's needs: Infer for the model, EventLog for settle, Router, Self, and
+// AgentR is the infer root's needs: Infer for the model, EventLog for settle, Router, Self, and
 // Facets for reply and spawn (the deliver, identity, and observe privileges; core/facets.ts), and
 // KeyValueStore for the spill store code mode writes bounded results to
 // (packages/code/src/spill.ts). Components add their own on top (core/component.ts,
@@ -25,7 +25,7 @@ export type RlmR = AgentR
 // AgentPolicy is every policy value an assembled agent applies, one field per part that applies
 // one, so a caller sets a single number without listing reactors. Each field is itself partial
 // and fills from its own exported default (infer.ts, budget.ts, compaction.ts,
-// packages/code/src/execute.ts). `infer` is the runtime's policy (agentRuntime takes it); `workspace`
+// packages/code/src/execute.ts). `infer` is the root component's policy; `workspace`
 // bounds the workspace package's own read and grep answers (packages/code/src/workspace.ts); the
 // rest ride their components (budgetFor, compactionFor, codeModeFor).
 export interface AgentPolicy {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,9 @@
   "dependencies": {
     "effect": "4.0.0-rc.110"
   },
+  "devDependencies": {
+    "fast-check": "^4.9.0"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "bun test"

--- a/packages/core/src/actor.ts
+++ b/packages/core/src/actor.ts
@@ -55,7 +55,8 @@ export interface Actor<R = never> {
   readonly keyOf: (e: Event) => string | undefined
 }
 
-export const actor = <R = never>(
+// actorFromReactors constructs the reconciler surface from low-level transition projections.
+export const actorFromReactors = <R = never>(
   reactors: ReadonlyArray<Reactor<R>>,
   keyOf: (e: Event) => string | undefined
 ): Actor<R> => ({ reactors, keyOf })

--- a/packages/core/src/component.properties.test.ts
+++ b/packages/core/src/component.properties.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import fc from "fast-check"
+import { enabled, transition } from "./actor"
+import { actor, composeComponents, type Component, type ViewAlgebra } from "./component"
+import type { Event } from "./event"
+
+interface Facts {
+  readonly names: ReadonlyArray<string>
+}
+
+interface Leaf {
+  readonly id: number
+  readonly trigger: "A" | "B" | "C"
+}
+
+const facts: ViewAlgebra<Facts> = {
+  empty: { names: [] },
+  combine: (left, right) => ({ names: [...left.names, ...right.names] })
+}
+
+const leafComponent = (leaf: Leaf): Component<Facts> => {
+  const name = `leaf-${leaf.id}`
+  const key = `${name}:work`
+  return {
+    name,
+    keys: {
+      prefixes: [`${name}:`],
+      keyOf: (event) =>
+        event.type === "Committed" && Number((event as { owner?: unknown }).owner) === leaf.id
+          ? key
+          : undefined
+    },
+    derive: (log) => {
+      const visible = log.some(
+        (event) => event.type === "Triggered" && String((event as { trigger?: unknown }).trigger) === leaf.trigger
+      )
+      return {
+        view: { names: visible ? [name] : [] },
+        transitions: visible
+          ? [transition({ key, input: { owner: leaf.id }, act: () => Effect.succeed([]) })]
+          : []
+      }
+    }
+  }
+}
+
+const regroup = (
+  leaves: ReadonlyArray<Component<Facts>>,
+  choices: ReadonlyArray<number>
+): Component<Facts> => {
+  if (leaves.length === 0) return composeComponents("nested-empty", facts, [])
+  const nodes = [...leaves]
+  let step = 0
+  while (nodes.length > 1) {
+    const choice = choices[step % Math.max(choices.length, 1)] ?? 0
+    const index = choice % (nodes.length - 1)
+    const pair = composeComponents(`nested-${step}`, facts, [nodes[index]!, nodes[index + 1]!])
+    nodes.splice(index, 2, pair)
+    step += 1
+  }
+  return nodes[0]!
+}
+
+const transitionFacts = (transitions: ReturnType<typeof enabled>) =>
+  transitions.map((owed) => ({ key: owed.key, input: owed.input }))
+
+const leavesArbitrary = fc.uniqueArray(
+  fc.record({ id: fc.integer({ min: 0, max: 30 }), trigger: fc.constantFrom("A", "B", "C") }),
+  { selector: (leaf) => leaf.id, maxLength: 10 }
+)
+
+const logArbitrary = fc.array(
+  fc.oneof(
+    fc.record({ type: fc.constant("Triggered"), trigger: fc.constantFrom("A", "B", "C") }),
+    fc.record({ type: fc.constant("Committed"), owner: fc.integer({ min: 0, max: 30 }) }),
+    fc.record({ type: fc.constant("Ignored"), value: fc.integer() })
+  ),
+  { maxLength: 30 }
+) as fc.Arbitrary<ReadonlyArray<Event>>
+
+describe("recursive component composition", () => {
+  test("every grouping agrees with the flat composition", () => {
+    fc.assert(
+      fc.property(
+        leavesArbitrary,
+        fc.array(fc.nat(), { maxLength: 20 }),
+        logArbitrary,
+        (leafSpecs, choices, log) => {
+          const leaves = leafSpecs.map(leafComponent)
+          const flat = composeComponents("flat", facts, leaves)
+          const nested = regroup(leaves, choices)
+          const flatDerivation = flat.derive(log)
+          const nestedDerivation = nested.derive(log)
+
+          expect(nestedDerivation.view).toEqual(flatDerivation.view)
+          expect(nestedDerivation.transitions.map((owed) => ({ key: owed.key, input: owed.input }))).toEqual(
+            flatDerivation.transitions.map((owed) => ({ key: owed.key, input: owed.input }))
+          )
+          expect(nested.keys?.prefixes).toEqual(flat.keys?.prefixes)
+          for (const event of log) expect(nested.keys?.keyOf(event)).toBe(flat.keys?.keyOf(event))
+          expect(transitionFacts(enabled(actor(nested), log))).toEqual(transitionFacts(enabled(actor(flat), log)))
+        }
+      ),
+      { numRuns: 500 }
+    )
+  })
+})

--- a/packages/core/src/component.test.ts
+++ b/packages/core/src/component.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { transition } from "./actor"
-import { actorOf, composeComponents, reactorOf, type Component, type ComponentRuntime, type ViewAlgebra } from "./component"
+import { actor, composeComponents, reactorOf, type Component, type ViewAlgebra } from "./component"
 import type { Event } from "./event"
 
 interface Facts {
@@ -81,24 +81,11 @@ describe("components", () => {
     )
   })
 
-  test("actorOf gives the composed view to its runtime and component work to reconciliation", () => {
-    const seen: Facts[] = []
-    const runtime: ComponentRuntime<Facts> = {
-      name: "facts",
-      algebra: facts,
-      keys: [],
-      reactors: (viewOf) => [
-        (log) => {
-          seen.push(viewOf(log))
-          return []
-        }
-      ]
-    }
-    const assembled = actorOf(runtime, [component("left", "Ready"), component("right", "Ready")])
+  test("actor adapts root components to reactors in component order", () => {
+    const assembled = actor(component("left", "Ready"), component("right", "Ready"))
     const log: ReadonlyArray<Event> = [{ type: "Ready" }]
 
     expect(assembled.reactors).toHaveLength(2)
     expect(assembled.reactors.flatMap((reactor) => reactor(log)).map((owed) => owed.key)).toEqual(["left", "right"])
-    expect(seen).toEqual([{ names: ["left", "right"] }])
   })
 })

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -1,4 +1,4 @@
-import { actor, type Actor, type Reactor, type Transition } from "./actor"
+import { actorFromReactors, type Actor, type Reactor, type Transition } from "./actor"
 import type { Event } from "./event"
 import { composeKeys, type KeyFragment } from "./event-log"
 
@@ -23,16 +23,6 @@ export interface Component<V, R = never> {
 export interface ViewAlgebra<V> {
   readonly empty: V
   readonly combine: (left: V, right: V) => V
-}
-
-// ComponentRuntime interprets a composed view as reactors and supplies the key fragments
-// for its protocol. The reactor factory is polymorphic in component requirements because an
-// interpreter may route work whose environment is declared by the component that contributed it.
-export interface ComponentRuntime<V, R = never> {
-  readonly name: string
-  readonly algebra: ViewAlgebra<V>
-  readonly keys: ReadonlyArray<KeyFragment>
-  readonly reactors: <C>(viewOf: (log: ReadonlyArray<Event>) => V) => ReadonlyArray<Reactor<R | C>>
 }
 
 // ComponentRequirements extracts a component's environment so composition carries the union of every
@@ -78,24 +68,14 @@ export const composeComponents = <
 export const reactorOf = <V, R>(component: Component<V, R>): Reactor<R> =>
   (log) => component.derive(log).transitions
 
-// actorOf composes components under one view runtime and adapts their transitions to the
-// existing actor reconciler. Runtime keys compose beside component keys with the same collision
-// rule as composeKeys.
-export const actorOf = <
-  V,
-  RuntimeR,
-  const Cs extends ReadonlyArray<Component<V, never> | Component<V, unknown>>
->(
-  runtime: ComponentRuntime<V, RuntimeR>,
-  components: Cs
-): Actor<RuntimeR | ComponentRequirements<Cs[number]>> => {
-  type ComponentR = ComponentRequirements<Cs[number]>
-  type R = RuntimeR | ComponentR
-  const combined = composeComponents(runtime.name, runtime.algebra, components) as Component<V, R>
-  const viewOf = (log: ReadonlyArray<Event>): V => combined.derive(log).view
-  const reactors = runtime.reactors<ComponentR>(viewOf) as ReadonlyArray<Reactor<R>>
-  return actor(
-    [...reactors, reactorOf(combined)],
-    composeKeys(...runtime.keys, ...(combined.keys === undefined ? [] : [combined.keys]))
-  )
+// actor composes root components at the execution boundary. Composite components own their
+// view algebra; the actor preserves root order, adapts each transition projection to a reactor,
+// and combines every committing key fragment for reconciliation.
+export const actor = <
+  const Cs extends ReadonlyArray<Component<unknown, never> | Component<unknown, unknown>>
+>(...components: Cs): Actor<ComponentRequirements<Cs[number]>> => {
+  type R = ComponentRequirements<Cs[number]>
+  const members = components as ReadonlyArray<Component<unknown, R>>
+  const keys = members.flatMap((component) => component.keys === undefined ? [] : [component.keys])
+  return actorFromReactors(members.map(reactorOf), composeKeys(...keys))
 }

--- a/packages/core/tla/Component.tla
+++ b/packages/core/tla/Component.tla
@@ -1,6 +1,6 @@
 ---------------------------- MODULE Component ----------------------------
-(* A component derives a view and transitions from one log. The agent runtime
-   interprets one kind of view as tool bindings. A binding
+(* A component derives a view and transitions from one log. The infer root
+   interprets its composed child view as tool bindings. A binding
    pairs a visible tool with its handler, but pairing at one log does not by
    itself keep the tool routable after ToolCalled extends that log.
 

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -9,7 +9,7 @@ import {
   outputRepairFor,
   renderOf,
   repairFallback,
-  FAIL_FAST_FALLBACK,
+  VALIDATE_ONCE_FALLBACK,
   NATIVE_MODE
 } from "tardie"
 
@@ -132,8 +132,8 @@ describe("the output mode one attempt runs in", () => {
   test("no native capability runs the declared fallback, and fails without one", () => {
     const config = { model: "m" }
     expect(outputModeOf({ output: withRepair, tools: [] }, config)).toEqual({ mode: REPAIR })
-    const failFast = { ...contract, fallback: FAIL_FAST_FALLBACK }
-    expect(outputModeOf({ output: failFast, tools: [] }, config)).toEqual({ mode: FAIL_FAST_FALLBACK })
+    const validateOnce = { ...contract, fallback: VALIDATE_ONCE_FALLBACK }
+    expect(outputModeOf({ output: validateOnce, tools: [] }, config)).toEqual({ mode: VALIDATE_ONCE_FALLBACK })
     const selected = outputModeOf({ output: contract, tools: [] }, config)
     expect("errors" in selected && selected.errors.join(" ")).toContain("declares no structured output capability")
     const declaredNone = outputModeOf({ output: contract, tools: [] }, { model: "m", output: { guarantee: "none" } })


### PR DESCRIPTION
This change makes inference the root agent component so component composition has one recursive contract from views through reconciliation.

- Add `actor(...)` as the component execution boundary and `infer(...)` as the root that composes child views, transitions, requirements, and keys.
- Preserve inference, historical tool routing, and transition order while removing `ComponentRuntime`, `agentRuntime`, and `actorOf`.
- Add `system(...)` and rename the single-validation policy to `outputValidateOnce`, with replay support for recorded `fail-fast` modes.
- Add Fast-check coverage for recursive grouping, ordered transitions, enabled work, and key derivation across 500 generated cases.
- Update the server, quickstart, examples, migration guidance, and output documentation.

Verification:

- `bun run gate`