### PR TITLE
refactor(code): compose package components

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ const instructions = system(
 const releaseAnalyst = actor(infer([
   instructions, // the agent's system prompt
   deploys,     // recent_deploys and its paired handler
-  codeMode,    // durable JavaScript execution
+  codeMode(),  // durable JavaScript execution over an empty package scope
   budget,      // a per-turn code budget
   compaction,  // bounded model context
   reply,       // results for parent agents
@@ -130,6 +130,8 @@ const releaseAnalyst = actor(infer([
 ```
 
 `infer` composes its children, preserves their transitions, and adds inference and tool routing over their final view. `actor` adapts the root component to reconciliation and carries its service requirements into the host type. System fragments join in component order, so the model sees the release instructions beside `recent_deploys` and `execute` in one request. Policy components derive work from the same log.
+
+`codeMode([...components])` applies the same structure to the code surface. Each package factory returns a leaf `CodeComponent`. Code mode composes their package views and transitions, then exposes the combined scope through one `execute` tool. Use `definePackage({...})` for a custom leaf. Use `composeComponents(name, CODE_VIEW_ALGEBRA, children)` when one code component groups other code components.
 
 This agent can inspect deployments, analyze results with JavaScript, compact a long investigation, and report to a parent agent. Change the list to create another harness.
 

--- a/apps/server/src/actor.ts
+++ b/apps/server/src/actor.ts
@@ -5,7 +5,7 @@ import {
   actor,
   agentsPackage,
   budget,
-  codeModeFor,
+  codeMode,
   compaction,
   fetchPackage,
   filesPackage,
@@ -38,7 +38,7 @@ import { inboundOf } from "./projections"
 // and this build has no place to ask an operator whether one command is allowed.
 export const assemblyOf = () =>
   actor(infer([
-    codeModeFor({ packages: [agentsPackage(), workspacePackage(), filesPackage(), fetchPackage()] }),
+    codeMode([agentsPackage(), workspacePackage(), filesPackage(), fetchPackage()]),
     reply,
     budget,
     compaction,

--- a/docs/how-to/migrate.md
+++ b/docs/how-to/migrate.md
@@ -25,7 +25,7 @@ The current Vercel AI SDK agent surface includes [`ToolLoopAgent` and loop contr
 | --- | --- |
 | `ToolLoopAgent`, `generateText`, `streamText`, or a manual model loop | `defineActor({ name, actor: actor(infer([...])) })` |
 | System instructions | `system(...)` |
-| Tool declarations and handlers | Packages mounted through `codeModeFor`, or fixed tools mounted through `toolList` |
+| Tool declarations and handlers | Package components mounted through `codeMode`, or fixed tools mounted through `toolList` |
 | `stopWhen`, maximum steps, and retry options | `budgetFor`, `infer` policy, and domain components with explicit policy values |
 | `prepareStep` and dynamic context | A component whose `derive(log)` changes its view from recorded events |
 | Message arrays and conversation storage | One append-only event log per thread |
@@ -46,7 +46,7 @@ Edit the generated `agents/agent/actor.ts`. Keep the actor name stable across bu
 
 Move static system text into `system(...)`. Pass a log projection to `system` when the prompt depends on recorded events. Keep application data out of the prompt when a scoped package can read it on demand.
 
-Use a package through `codeModeFor` when its methods are ordinary operations that the model can combine, filter, or repeat in JavaScript. This exposes one `execute` tool to the model and keeps package methods behind the code surface. Use `toolList` when a provider-visible tool call, approval step, or exact tool schema is part of the application contract.
+Use a package component through `codeMode([...components])` when its methods are ordinary operations that the model can combine, filter, or repeat in JavaScript. This exposes one `execute` tool to the model and keeps package methods behind the code surface. Use `toolList` when a provider-visible tool call, approval step, or exact tool schema is part of the application contract.
 
 Preserve tool names, descriptions, input checks, authorization, side-effect rules, and result shapes during the first pass. Convert Zod or framework-specific schemas to the JSON Schema accepted by Tardigrade. Wrap asynchronous handlers in Effect and turn expected failures into serializable results that the model can act on.
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -90,11 +90,11 @@ Every agent assembly selects one output strategy component. `nativeOutput` selec
 import { actor, codeMode, infer, nativeOutput, outputRepairFor, reply } from "tardie"
 import { infer as modelInfer } from "tardie/model"
 
-const nativeOnly = actor(infer([codeMode, reply, nativeOutput]))
+const nativeOnly = actor(infer([codeMode(), reply, nativeOutput]))
 const nativeModel = modelInfer({ ...modelConfig, output: { guarantee: "native", withTools: true } })
 // nativeModel provides Infer and NativeOutputSupport.
 
-const portable = actor(infer([codeMode, reply, outputRepairFor({ attempts: 1 })]))
+const portable = actor(infer([codeMode(), reply, outputRepairFor({ attempts: 1 })]))
 const unprovenModel = modelInfer({ ...modelConfig, output: { guarantee: "none" } })
 // portable requires Infer. unprovenModel provides it.
 // A host that binds nativeOnly to unprovenModel has a missing NativeOutputSupport type error.
@@ -143,10 +143,10 @@ output({
 `outputValidateOnce` asks for JSON in the fallback prompt and validates one response. A mismatch ends the turn with `output_validation_failed`. It performs no correction attempt.
 
 ```ts
-import { actor, codeModeFor, infer, outputValidateOnce, reply } from "tardie"
+import { actor, codeMode, infer, outputValidateOnce, reply } from "tardie"
 
 const agent = actor(infer([
-  codeModeFor({ packages: [] }),
+  codeMode(),
   reply,
   outputValidateOnce
 ]))
@@ -157,10 +157,10 @@ const agent = actor(infer([
 `outputRepairFor` records an invalid response and asks again with the validation errors. Its policy is explicit:
 
 ```ts
-import { actor, codeModeFor, infer, outputRepairFor, reply } from "tardie"
+import { actor, codeMode, infer, outputRepairFor, reply } from "tardie"
 
 const agent = actor(infer([
-  codeModeFor({ packages: [] }),
+  codeMode(),
   reply,
   outputRepairFor({ attempts: 2, projectHistory: true })
 ]))
@@ -235,7 +235,7 @@ A delegated fallback can run domain validation before it requests another attemp
 Code executed by the model can request structured output from a child agent. Register known contracts with `agentsPackage`:
 
 ```ts
-codeModeFor({ packages: [agentsPackage({ outputs: { review: REVIEW } })] })
+codeMode([agentsPackage({ outputs: { review: REVIEW } })])
 ```
 
 The model-written code names the registered contract:

--- a/examples/quickstart/actor.ts
+++ b/examples/quickstart/actor.ts
@@ -2,7 +2,7 @@ import {
   actor,
   agentsPackage,
   budget,
-  codeModeFor,
+  codeMode,
   compaction,
   defineActor,
   fetchPackage,
@@ -32,11 +32,11 @@ export default defineActor({
   // actor carries component and output requirements into the host type.
   actor: actor(infer([
     system(actorInstructions),
-    // codeModeFor gives the model one code tool over the packages listed here.
-    codeModeFor({
-      // packages grant access to local files, HTTP, child agents, and saved tool results.
-      packages: [filesPackage(), fetchPackage(), agentsPackage(), workspacePackage()]
-    }),
+    // codeMode gives the model one code tool over the components listed here.
+    codeMode([
+      // Package components grant access to local files, HTTP, child agents, and saved tool results.
+      filesPackage(), fetchPackage(), agentsPackage(), workspacePackage()
+    ]),
     // reply returns a finished turn to the actor that delegated it.
     reply,
     // budget stops work tools when the turn reaches its tool-call limit.

--- a/examples/rlm-agent.ts
+++ b/examples/rlm-agent.ts
@@ -6,7 +6,7 @@
 
 // The workspace names resolve in this repository. Against the published package the last two
 // are "tardie/model" and "tardie/bun/host" (tools/publish.ts).
-import { actor, infer as inferAgent, agentsPackage, boundaryOf, budget, codeModeFor, compaction, outputValidateOnce, reply, workspacePackage } from "tardie"
+import { actor, infer as inferAgent, agentsPackage, boundaryOf, budget, codeMode, compaction, outputValidateOnce, reply, workspacePackage } from "tardie"
 import { infer } from "@clavia/tardigrade-model/model"
 import { createBunHost } from "@clavia/tardigrade-bun/host"
 
@@ -15,7 +15,7 @@ import { createBunHost } from "@clavia/tardigrade-bun/host"
 // needs (Router, Self, and Facets for spawn; the spill store for workspace). The Bun host binds
 // all of those per lane.
 const rlm = actor(inferAgent([
-  codeModeFor({ packages: [agentsPackage(), workspacePackage()] }),
+  codeMode([agentsPackage(), workspacePackage()]),
   reply, // reports each turn's terminal to whoever asked
   budget, // the per-turn code budget, inherited by spawned children
   compaction, // bounded model context over long investigations

--- a/packages/agent/src/components/budget.test.ts
+++ b/packages/agent/src/components/budget.test.ts
@@ -17,7 +17,7 @@ import { compaction } from "./compaction"
 import { reply } from "./reply"
 import { nativeOutput } from "./native-output"
 
-const rootReactor = actor(infer([codeMode, reply, budget, compaction, nativeOutput])).reactors[0]!
+const rootReactor = actor(infer([codeMode(), reply, budget, compaction, nativeOutput])).reactors[0]!
 
 // The rest of the agent's environment, which every reactor's `act` is typed against whether or not
 // it reaches for it. Naming it is what proves the tools gate answers from the log alone: no model

--- a/packages/agent/src/components/code.ts
+++ b/packages/agent/src/components/code.ts
@@ -1,10 +1,16 @@
 import { Clock, Effect } from "effect"
 import type { KeyValueStore } from "effect/unstable/persistence"
 import { transition, type Transition } from "@clavia/tardigrade-core/actor"
+import { composeComponents, type ComponentRequirements } from "@clavia/tardigrade-core/component"
 import type { Event } from "@clavia/tardigrade-core/event"
+import { composeKeys, type KeyFragment } from "@clavia/tardigrade-core/event-log"
 import { codeDispatched, codeKeys } from "@clavia/tardigrade-code/events"
 import { codeReactorFor, type CodePolicy } from "@clavia/tardigrade-code/execute"
-import type { Package, PackageRequirements } from "@clavia/tardigrade-code/packages"
+import {
+  CODE_VIEW_ALGEBRA,
+  type CodeComponent,
+  type Package
+} from "@clavia/tardigrade-code/packages"
 import type { AgentComponent } from "../runtime/agent"
 import type { Answer, PendingCall } from "../runtime/tools"
 import type { ToolSpec } from "../request"
@@ -64,31 +70,55 @@ const serveCode = (log: ReadonlyArray<Event>, call: PendingCall, answer: Answer)
   ]
 }
 
-// codeModeFor derives the execute tool and code transitions from the same log and package scope.
-export const codeModeFor = <
-  const P extends ReadonlyArray<Package<never>> | ReadonlyArray<Package<unknown>> = readonly []
->(
-  options: {
-    readonly policy?: Partial<CodePolicy>
-    readonly system?: string | ((log: ReadonlyArray<Event>) => string)
-    readonly packages?: P
-  } = {}
-): AgentComponent<KeyValueStore.KeyValueStore | PackageRequirements<P[number]>> => {
-  const packages = (options.packages ?? []) as unknown as P
-  const reactor = codeReactorFor(options.policy ?? {}, packages)
+export interface CodeModeOptions {
+  readonly policy?: Partial<CodePolicy>
+  readonly system?: string | ((log: ReadonlyArray<Event>) => string)
+}
+
+const rootKeys = (children: KeyFragment | undefined): KeyFragment => {
+  const fragments = [codeKeys, ...(children === undefined ? [] : [children])]
   return {
-    name: "code",
-    keys: codeKeys,
-    derive: (log) => ({
-      view: {
-        system: [typeof options.system === "function" ? options.system(log) : options.system ?? codeSystemFor(packages as ReadonlyArray<Package<unknown>>)],
-        tools: [{ spec: EXECUTE_TOOL, serve: (call, current, answer) => serveCode(current, call, answer) }],
-        context: [],
-        output: []
-      },
-      transitions: reactor(log)
-    })
+    prefixes: fragments.flatMap((fragment) => fragment.prefixes),
+    keyOf: composeKeys(...fragments)
   }
 }
 
-export const codeMode: AgentComponent<KeyValueStore.KeyValueStore> = codeModeFor()
+// codeMode composes code components and exposes their package scope through one execute tool.
+export const codeMode = <
+  const Cs extends ReadonlyArray<CodeComponent<never> | CodeComponent<unknown>> = readonly []
+>(
+  components: Cs = [] as unknown as Cs,
+  options: CodeModeOptions = {}
+): AgentComponent<KeyValueStore.KeyValueStore | ComponentRequirements<Cs[number]>> => {
+  type ComponentR = ComponentRequirements<Cs[number]>
+  type R = KeyValueStore.KeyValueStore | ComponentR
+  const combined = composeComponents("code.children", CODE_VIEW_ALGEBRA, components) as CodeComponent<ComponentR>
+  const packagesOf = (log: ReadonlyArray<Event>): ReadonlyArray<Package<ComponentR>> =>
+    combined.derive(log).view.packages as unknown as ReadonlyArray<Package<ComponentR>>
+
+  codeReactorFor(options.policy ?? {}, packagesOf([]))
+  return {
+    name: "code",
+    keys: rootKeys(combined.keys),
+    derive: (log) => {
+      const children = combined.derive(log)
+      const packages = children.view.packages
+      const execution = codeReactorFor(
+        options.policy ?? {},
+        packages as unknown as ReadonlyArray<Package<ComponentR>>
+      )
+      return {
+        view: {
+          system: [typeof options.system === "function" ? options.system(log) : options.system ?? codeSystemFor(packages)],
+          tools: [{ spec: EXECUTE_TOOL, serve: (call, current, answer) => serveCode(current, call, answer) }],
+          context: [],
+          output: []
+        },
+        transitions: [
+          ...(execution(log) as ReadonlyArray<Transition<never, R>>),
+          ...(children.transitions as ReadonlyArray<Transition<never, R>>)
+        ]
+      }
+    }
+  }
+}

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -11,7 +11,7 @@ import { Infer, NativeOutputSupport, type InferRequest } from "./runtime/infer"
 import { boundaryOf } from "./boundary"
 import { resumeTurn } from "./resume"
 import { agentsPackage } from "./spawn"
-import { actor, budgetFor, codeModeFor, compactionFor, infer, nativeOutput, reply, toolList, type AgentComponent } from "./index"
+import { actor, budgetFor, codeMode, compactionFor, infer, nativeOutput, reply, toolList, type AgentComponent } from "./index"
 import type { RlmR } from "./turn"
 
 const ROOT_LANE = "ag.root"
@@ -29,7 +29,7 @@ type TestR = RlmR | NativeOutputSupport
 
 // work is the default work surface these tests assemble against: code mode with the spawn and
 // workspace packages in scope. The packages are values, so the same list mounts on any host.
-const work = () => codeModeFor({ packages: [agentsPackage({ budget: {} }), workspacePackage({ policy: {} })] })
+const work = () => codeMode([agentsPackage({ budget: {} }), workspacePackage({ policy: {} })])
 
 // hosted binds one assembled actor to an in-process host and drives the root lane. It is the
 // test's own driver: deliver a brief, drive to quiescence, read the boundary the settle left.

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -122,6 +122,14 @@ export {
   DEFAULT_FETCH_BODY_CHARS,
   type FetchPolicy
 } from "@clavia/tardigrade-code/fetch"
+export {
+  CODE_VIEW_ALGEBRA,
+  definePackage,
+  type CodeComponent,
+  type CodeView,
+  type Package,
+  type PackageDefinition
+} from "@clavia/tardigrade-code/packages"
 
 // The component assembly: code mode is the default, and an agent measured against a fixed tool
 // list mounts its own (runtime/agent.ts).
@@ -140,7 +148,7 @@ export {
   type OutputFragment,
   type Rendered
 } from "./runtime/agent"
-export { codeMode, codeModeFor, CODE_SYSTEM, codeSystemFor } from "./components/code"
+export { codeMode, CODE_SYSTEM, codeSystemFor, type CodeModeOptions } from "./components/code"
 export { system, type SystemText } from "./components/system"
 export { toolList, type NativeTool } from "./components/tool-list"
 export { budget, budgetFor } from "./components/budget"

--- a/packages/agent/src/request.test.ts
+++ b/packages/agent/src/request.test.ts
@@ -16,7 +16,7 @@ const SCOUT = output({
   }
 })
 
-const CODE = renderOf([codeMode, nativeOutput], [])
+const CODE = renderOf([codeMode(), nativeOutput], [])
 
 // The request is a pure projection of the trajectory: the message conversation, and the tool and
 // prompt policy. Both live in the domain, so they test without a provider.
@@ -135,7 +135,7 @@ describe("modelRequest tool and prompt policy", () => {
   // binding decides whether the model ever reads it (platform/model/src/output.ts, outputSystemFor).
   test("a mounted fallback rides the request, and adds nothing to the base prompt", () => {
     const bare = modelRequest(head([], true), CODE)
-    const repaired = renderOf([codeMode, outputRepairFor({ attempts: 1 })], head([], true))
+    const repaired = renderOf([codeMode(), outputRepairFor({ attempts: 1 })], head([], true))
     const req = modelRequest(head([], true), repaired)
     expect(req.output?.kind === "contract" && req.output.fallback).toEqual({
       kind: "repair",

--- a/packages/agent/src/runtime/agent.test.ts
+++ b/packages/agent/src/runtime/agent.test.ts
@@ -6,11 +6,16 @@ import { EventLog, withWatermark } from "@clavia/tardigrade-core/event-log"
 import { Router } from "@clavia/tardigrade-core/router"
 import { parseActorAddress } from "@clavia/tardigrade-core/communication/address"
 import { Facets } from "@clavia/tardigrade-core/facets"
-import { Self } from "@clavia/tardigrade-core/actor"
-import { actor } from "@clavia/tardigrade-core/component"
-import type { Package } from "@clavia/tardigrade-code/packages"
+import { Self, transition } from "@clavia/tardigrade-core/actor"
+import { actor, composeComponents } from "@clavia/tardigrade-core/component"
+import {
+  CODE_VIEW_ALGEBRA,
+  definePackage,
+  type CodeComponent,
+  type Package
+} from "@clavia/tardigrade-code/packages"
 import { defineOutputFallback, infer, renderOf, type AgentComponent, type AgentView } from "./agent"
-import { CODE_SYSTEM, codeMode, codeModeFor } from "../components/code"
+import { CODE_SYSTEM, codeMode } from "../components/code"
 import { budget } from "../components/budget"
 import { compaction, compactionFor } from "../components/compaction"
 import { reply } from "../components/reply"
@@ -194,7 +199,7 @@ describe("infer component", () => {
   })
 
   test("compactionFor's context reaches the render, so the guard and the request hold one policy", () => {
-    const render = renderOf([codeMode, compactionFor({ messageRenderCap: 1234 }), nativeOutput], [])
+    const render = renderOf([codeMode(), compactionFor({ messageRenderCap: 1234 }), nativeOutput], [])
     expect(render.context).toEqual({ messageRenderCap: 1234 })
   })
 
@@ -212,7 +217,7 @@ describe("infer component", () => {
   })
 
   test("renderOf composes system fragments and tools in mount order", () => {
-    const render = renderOf([codeMode, echoTable, nativeOutput], [])
+    const render = renderOf([codeMode(), echoTable, nativeOutput], [])
     expect(render.tools.map((t) => t.name)).toEqual(["execute", "echo"])
     expect(render.system.indexOf("execute")).toBeLessThan(render.system.indexOf("echo"))
   })
@@ -256,36 +261,81 @@ describe("infer component", () => {
       "catalog",
       (events: ReadonlyArray<Event>) => ({ system: [`count: ${events.length}`], tools: [], context: [], output: [] })
     )
-    expect(renderOf([codeMode, component, nativeOutput], log)).toEqual(renderOf([codeMode, component, nativeOutput], log))
+    expect(renderOf([codeMode(), component, nativeOutput], log)).toEqual(renderOf([codeMode(), component, nativeOutput], log))
   })
 
-  test("codeModeFor takes a system fragment, and the bare component renders the exported default", () => {
-    const overridden = renderOf([codeModeFor({ system: (events) => `the packages in scope are:\n${events.length}` }), nativeOutput], [{ type: "PackageInstalled" }])
+  test("codeMode takes a system fragment, and the empty scope renders the exported default", () => {
+    const overridden = renderOf([codeMode([], { system: (events) => `the packages in scope are:\n${events.length}` }), nativeOutput], [{ type: "PackageInstalled" }])
     expect(overridden.system).toBe("the packages in scope are:\n1")
-    expect(renderOf([codeMode, nativeOutput], []).system).toBe(CODE_SYSTEM)
+    expect(renderOf([codeMode(), nativeOutput], []).system).toBe(CODE_SYSTEM)
   })
 
   test("a mounted package names itself in the system fragment", () => {
     // The model is told what the code can name, from the same values the code reactor mounts:
     // one line per package, `name: description` (components/code.ts, codeSystemFor).
-    const notes: Package = {
+    const notes: Package = definePackage({
       name: "notes",
       description: "the team's notes",
       methods: { put: () => Effect.succeed(null) }
-    }
-    const { system } = renderOf([codeModeFor({ packages: [notes] }), nativeOutput], [])
+    })
+    const { system } = renderOf([codeMode([notes]), nativeOutput], [])
     expect(system).toContain("notes: the team's notes")
     expect(system).not.toContain("none")
     // An explicit fragment still wins over the derivation.
-    expect(renderOf([codeModeFor({ system: "my own scope", packages: [notes] }), nativeOutput], []).system).toBe("my own scope")
+    expect(renderOf([codeMode([notes], { system: "my own scope" }), nativeOutput], []).system).toBe("my own scope")
+  })
+
+  test("codeMode composes nested code components and preserves their work", () => {
+    const notes = definePackage({
+      name: "notes",
+      description: "the team's notes",
+      methods: { read: () => Effect.succeed(null) }
+    })
+    const search = definePackage({
+      name: "search",
+      description: "the team's index",
+      methods: { find: () => Effect.succeed(null) }
+    })
+    const upkeep: CodeComponent = {
+      name: "upkeep",
+      keys: {
+        prefixes: ["up:"],
+        keyOf: (event) => event.type === "CodeUpkeepCompleted" ? `up:${String(event.id)}` : undefined
+      },
+      derive: () => ({
+        view: { packages: [] },
+        transitions: [
+          transition({
+            key: "up:daily",
+            input: undefined,
+            act: () => Effect.succeed([{ type: "CodeUpkeepCompleted", id: "daily" }])
+          })
+        ]
+      })
+    }
+    const nested = composeComponents("knowledge", CODE_VIEW_ALGEBRA, [notes, upkeep, search])
+    const component = codeMode([nested])
+    const derived = component.derive([])
+
+    expect(derived.view.system[0]).toContain("notes: the team's notes\nsearch: the team's index")
+    expect(derived.transitions.map((candidate) => candidate.key)).toEqual(["up:daily"])
+    expect(component.keys?.keyOf({ type: "CodeUpkeepCompleted", id: "daily" })).toBe("up:daily")
+  })
+
+  test("codeMode rejects duplicate package names inside nested code components", () => {
+    const left = definePackage({ name: "notes", description: "left", methods: {} })
+    const right = definePackage({ name: "notes", description: "right", methods: {} })
+    const nested = composeComponents("duplicate", CODE_VIEW_ALGEBRA, [left, right])
+
+    expect(() => codeMode([nested])).toThrow('package "notes" declared twice')
   })
 
   test("a mounted package's requirements ride the component's type", () => {
-    // Compile-time only: `packages` arrives as an option property, and the const type parameter
-    // still infers the tuple, so R is the spill store plus exactly what the listed packages
-    // require. A widened `ReadonlyArray<Package<Ticker>>` would fail the empty-scope assertions
-    // below (components/code.ts, codeModeFor).
-    const ticker: Package<Ticker> = {
+    // Compile-time only: the const type parameter infers the component tuple, so R is the spill
+    // store plus exactly what the listed packages require. A widened
+    // `ReadonlyArray<Package<Ticker>>` would fail the empty-scope assertions below
+    // (components/code.ts, codeMode).
+    const ticker: Package<Ticker> = definePackage({
       name: "ticker",
       description: "the clock",
       methods: {
@@ -294,14 +344,14 @@ describe("infer component", () => {
             return { tick: yield* Ticker }
           })
       }
-    }
-    const scoped: AgentComponent<KeyValueStore.KeyValueStore | Ticker> = codeModeFor({ packages: [ticker] })
+    })
+    const scoped: AgentComponent<KeyValueStore.KeyValueStore | Ticker> = codeMode([ticker])
     // The union is exactly that: too wide (P falling back to Package<unknown>) fails the line
     // above, and too narrow (P collapsing to the empty tuple) fails the line below.
     // @ts-expect-error a component that requires Ticker cannot pass as one that does not
-    const narrowed: AgentComponent<KeyValueStore.KeyValueStore> = codeModeFor({ packages: [ticker] })
-    const empty: AgentComponent<KeyValueStore.KeyValueStore> = codeModeFor({})
-    const bare: AgentComponent<KeyValueStore.KeyValueStore> = codeModeFor()
+    const narrowed: AgentComponent<KeyValueStore.KeyValueStore> = codeMode([ticker])
+    const empty: AgentComponent<KeyValueStore.KeyValueStore> = codeMode([])
+    const bare: AgentComponent<KeyValueStore.KeyValueStore> = codeMode()
     expect([scoped.name, narrowed.name, empty.name, bare.name]).toEqual(["code", "code", "code", "code"])
   })
 })

--- a/packages/agent/src/spawn.ts
+++ b/packages/agent/src/spawn.ts
@@ -2,7 +2,7 @@ import { Clock, Effect } from "effect"
 import { Router } from "@clavia/tardigrade-core/communication/router"
 import { Self } from "@clavia/tardigrade-core/actor"
 import { Facets } from "@clavia/tardigrade-core/facets"
-import type { Package } from "@clavia/tardigrade-code/packages"
+import { definePackage, type Package } from "@clavia/tardigrade-code/packages"
 import { budgetPolicyOf, type BudgetPolicy } from "./components/budget"
 import { Park } from "@clavia/tardigrade-code/errors"
 import { replyId } from "@clavia/tardigrade-core/communication/message"
@@ -89,7 +89,7 @@ export const agentsPackage = (
   const defaultBudget = budgetPolicyOf(options.budget).defaultToolBudget
   const outputs = options.outputs ?? {}
   const declared_ = Object.keys(outputs)
-  return {
+  return definePackage({
     name: "agents",
     description: "Ad-hoc agents. run({text}) starts a fresh agent with the brief and waits for its answer; add background: true for a long job, and result({id}) awaits the reply later. An escalatable run can ask for more budget at its wall; continue() answers the ask.",
     annotations: {
@@ -291,7 +291,7 @@ export const agentsPackage = (
           return shape(answer, address, turn, declared.contract)
         })
     }
-  }
+  })
 }
 
 // outputAsked resolves what a code body asked the child to answer in. A name is a contract the

--- a/packages/agent/src/turn.test.ts
+++ b/packages/agent/src/turn.test.ts
@@ -4,7 +4,7 @@ import { KeyValueStore } from "effect/unstable/persistence"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { EventLog, withWatermark } from "@clavia/tardigrade-core/event-log"
 import { send, settleActor, transition } from "@clavia/tardigrade-core/actor"
-import type { Package } from "@clavia/tardigrade-code/packages"
+import { definePackage, type Package } from "@clavia/tardigrade-code/packages"
 import { Sandbox, type Bindings } from "@clavia/tardigrade-code/sandbox"
 import { Router } from "@clavia/tardigrade-core/router"
 import { parseActorAddress } from "@clavia/tardigrade-core/communication/address"
@@ -19,7 +19,7 @@ import type { OutputFallback } from "./output"
 import {
   actor,
   budget,
-  codeModeFor,
+  codeMode,
   compaction,
   fingerprintOf,
   infer,
@@ -40,7 +40,7 @@ import {
 // The default assembly over a stated scope. The infer root contains model inference, call routing,
 // and every child transition in one projection.
 const agentWith = (packages: ReadonlyArray<Package>) =>
-  actor(infer([codeModeFor({ packages }), reply, budget, compaction, nativeOutput]))
+  actor(infer([codeMode(packages), reply, budget, compaction, nativeOutput]))
 const rlmAgent = agentWith([])
 const rootReactor = rlmAgent.reactors[0]!
 // The agent end to end: the model writes code, the code calls packages, every call is recorded,
@@ -76,7 +76,7 @@ const jsSandbox = Layer.succeed(Sandbox, {
     })
 })
 
-const zoho = (spies: { insert: number; search: number }): Package => ({
+const zoho = (spies: { insert: number; search: number }): Package => definePackage({
   name: "zohorecruit",
   description: "the ATS",
   methods: {
@@ -450,7 +450,7 @@ const completedTurns = (log: ReadonlyArray<Event>): ReadonlySet<string> =>
 const REPAIR_TWO = repairFallback({ attempts: 2 })
 
 const repairAgent = (policy: Parameters<typeof outputRepairFor>[0] = {}) =>
-  actor(infer([codeModeFor({ packages: [] }), reply, budget, compaction, outputRepairFor(policy)]))
+  actor(infer([codeMode(), reply, budget, compaction, outputRepairFor(policy)]))
 
 describe("a turn that declares an output contract", () => {
   test("a conforming response completes the turn, and outputOf reads it back typed", async () => {
@@ -862,7 +862,7 @@ describe("the repair implementation", () => {
   })
 
   test("two components declaring an output strategy collide at construction", () => {
-    expect(() => actor(infer([codeModeFor({ packages: [] }), outputRepair, outputValidateOnce]))).toThrow(
+    expect(() => actor(infer([codeMode(), outputRepair, outputValidateOnce]))).toThrow(
       "output strategy declared by components output.repair and output.validate-once"
     )
   })
@@ -945,7 +945,7 @@ describe("the mind on a native surface", () => {
 })
 
 describe("the validate-once implementation", () => {
-  const validateOnceAgent = actor(infer([codeModeFor({ packages: [] }), reply, budget, compaction, outputValidateOnce]))
+  const validateOnceAgent = actor(infer([codeMode(), reply, budget, compaction, outputValidateOnce]))
 
   test("a missed response ends the turn with its own cause, and never asks again", async () => {
     let asked = 0
@@ -1084,7 +1084,7 @@ describe("a domain-specific implementation", () => {
       jsSandbox,
       noRouter
     )
-    const agent = actor(infer([codeModeFor({ packages: [] }), reply, houseStyle({ asks: 2 })]))
+    const agent = actor(infer([codeMode(), reply, houseStyle({ asks: 2 })]))
     const events = await run(
       Effect.gen(function* () {
         yield* receive(agent, { id: "m1", text: "decompose this topic", output: SCOUT })
@@ -1130,7 +1130,7 @@ describe("a domain-specific implementation", () => {
     }
     const events = await run(
       Effect.gen(function* () {
-        yield* receive(actor(infer([codeModeFor({ packages: [] }), silent])), {
+        yield* receive(actor(infer([codeMode(), silent])), {
           id: "m1",
           text: "decompose this topic",
           output: SCOUT
@@ -1152,7 +1152,7 @@ describe("a domain-specific implementation", () => {
       jsSandbox,
       noRouter
     )
-    const agent = actor(infer([codeModeFor({ packages: [] }), reply, houseStyle({ asks: 1 })]))
+    const agent = actor(infer([codeMode(), reply, houseStyle({ asks: 1 })]))
     const events = await run(
       Effect.gen(function* () {
         yield* receive(agent, { id: "m1", text: "decompose this topic", output: SCOUT })

--- a/packages/agent/src/turn.ts
+++ b/packages/agent/src/turn.ts
@@ -27,7 +27,7 @@ export type RlmR = AgentR
 // and fills from its own exported default (infer.ts, budget.ts, compaction.ts,
 // packages/code/src/execute.ts). `infer` is the root component's policy; `workspace`
 // bounds the workspace package's own read and grep answers (packages/code/src/workspace.ts); the
-// rest ride their components (budgetFor, compactionFor, codeModeFor).
+// rest ride their components (budgetFor, compactionFor, codeMode).
 export interface AgentPolicy {
   readonly infer: Partial<InferPolicy>
   readonly budget: Partial<BudgetPolicy>

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -323,7 +323,7 @@ export const projection = <Params extends Schema.Struct.Fields, Result extends S
 
 // The two names a projection may not claim. The log is not a projection of itself: `events` is the
 // log read back and `stream` is the same log followed, and both are the platform's own guarantee
-// rather than anything an actor derives (projectionsOf refuses either, the way agentRuntime refuses a
+// rather than anything an actor derives (projectionsOf refuses either, the way infer refuses a
 // duplicate tool).
 export const RESERVED_PROJECTIONS: ReadonlyArray<string> = ["events", "stream"]
 

--- a/packages/code/src/contract.test.ts
+++ b/packages/code/src/contract.test.ts
@@ -6,7 +6,7 @@ import { composeKeys, EventLog, withWatermark } from "@clavia/tardigrade-core/ev
 import { settleActor } from "@clavia/tardigrade-core/actor"
 import { messageKeys } from "@clavia/tardigrade-core/message"
 import { checkInput, renderSignature } from "./contract"
-import type { Package } from "./packages"
+import { definePackage, type Package } from "./packages"
 import { Sandbox, type Bindings } from "./sandbox"
 import { codeReactorFor } from "./execute"
 import { codeKeys } from "./events"
@@ -144,7 +144,7 @@ const memoryLog = (initial: ReadonlyArray<Event>) =>
   )
 
 let ran: Array<unknown> = []
-const notesLike: Package = {
+const notesLike: Package = definePackage({
   name: "notes",
   description: "a package with one declared method and one undeclared",
   annotations: {
@@ -156,7 +156,7 @@ const notesLike: Package = {
     put: (args) => Effect.sync(() => (ran.push(args), { ok: true })),
     free: (args) => Effect.sync(() => (ran.push(args), { ok: "unchecked" }))
   }
-}
+})
 
 const settled = async (code: string): Promise<ReadonlyArray<Event>> => {
   ran = []

--- a/packages/code/src/execute.test.ts
+++ b/packages/code/src/execute.test.ts
@@ -5,7 +5,7 @@ import type { Event } from "@clavia/tardigrade-core/event"
 import { composeKeys, EventLog, withWatermark } from "@clavia/tardigrade-core/event-log"
 import { settleActor, type Reactor } from "@clavia/tardigrade-core/actor"
 import { messageKeys } from "@clavia/tardigrade-core/message"
-import type { Package } from "./packages"
+import { definePackage, type Package } from "./packages"
 import { Sandbox, type Bindings } from "./sandbox"
 import { codeReactor, codeReactorFor } from "./execute"
 import { codeKeys } from "./events"
@@ -46,7 +46,7 @@ const memoryLog = (initial: ReadonlyArray<Event>) =>
 
 // A read, a closed-world write, an open-world write, and a method that declares nothing: the four
 // cells the router rule distinguishes.
-const worldPackage: Package = {
+const worldPackage: Package = definePackage({
   name: "world",
   description: "a package standing in for one owned surface and one open one",
   annotations: {
@@ -60,7 +60,7 @@ const worldPackage: Package = {
     openWrite: () => Effect.succeed({ ok: "openWrite" }),
     mystery: () => Effect.succeed({ ok: "mystery" })
   }
-}
+})
 
 const code = `
   const a = await world.read({})
@@ -88,7 +88,7 @@ describe("transience never reaches the body", () => {
   // next attempt drifted). The failing call parks instead; the next attempt asks again.
   test("a transiently failing call parks and the re-drive gets the real answer", async () => {
     let attempts = 0
-    const flakyPackage: Package = {
+    const flakyPackage: Package = definePackage({
       name: "flaky",
       description: "fails once, then answers",
       annotations: { read: { readOnlyHint: true, openWorldHint: true } },
@@ -99,7 +99,7 @@ describe("transience never reaches the body", () => {
             return attempts === 1 ? Effect.die(new Error("transient RPC reset")) : Effect.succeed({ ok: "real" })
           })
       }
-    }
+    })
     // The body's catch is the trap: if transience rejects, the fallback becomes data.
     const code = `
       const a = await flaky.read({}).catch(() => ({ fell: "back" }))
@@ -239,7 +239,7 @@ describe("a package's requirements ride its type", () => {
   // context (execute.ts, executeRecorded).
   class Ticker extends Context.Service<Ticker, string>()("code/test/Ticker") {}
 
-  const tickerPackage: Package<Ticker> = {
+  const tickerPackage: Package<Ticker> = definePackage({
     name: "ticker",
     description: "answers with the value the environment bound",
     annotations: { now: { readOnlyHint: true, openWorldHint: false } },
@@ -249,7 +249,7 @@ describe("a package's requirements ride its type", () => {
           return { tick: yield* Ticker }
         })
     }
-  }
+  })
 
   test("a package method reads its service through the funnel", async () => {
     const log: Event[] = [

--- a/packages/code/src/execute.ts
+++ b/packages/code/src/execute.ts
@@ -291,8 +291,8 @@ export interface CodePolicy {
 // package's requirements ride its type"). Which packages are passed is the component scope: the
 // code can only name these, and the empty array is the powerless lane (packages.ts, Package).
 // Two packages under one name would make `pkg.name` ambiguous in the body's scope, so a duplicate
-// is a construction-time error, the same reading agentRuntime takes of two components claiming one
-// tool name (packages/agent/src/runtime/agent.ts, agentRuntime).
+// is a construction-time error, the same reading the infer root takes of two components claiming
+// one tool name (packages/agent/src/runtime/agent.ts, infer).
 export const codeReactorFor = <const P extends ReadonlyArray<Package<never>> | ReadonlyArray<Package<unknown>>>(
   policy: Partial<CodePolicy>,
   packages: P

--- a/packages/code/src/fetch.ts
+++ b/packages/code/src/fetch.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect"
 import { HttpClient, HttpClientRequest } from "effect/unstable/http"
-import type { Package } from "./packages"
+import { definePackage, type Package } from "./packages"
 
 // The fetch package: one HTTP request, made through `HttpClient` rather than through a global
 // fetch. The service is the same one the derived client speaks (packages/client), so a consumer
@@ -106,7 +106,7 @@ export const fetchPackage = (options: FetchOptions = {}): Package<HttpClient.Htt
       error: { type: "string" }
     }
   }
-  return {
+  return definePackage({
     name: "fetch",
     description:
       "HTTP requests to any host. fetch.get reads a URL; fetch.request sends any method with headers and a body. The answer carries the status, the response headers, and the body as text.",
@@ -161,5 +161,5 @@ export const fetchPackage = (options: FetchOptions = {}): Package<HttpClient.Htt
           return send(policy, method, a.url, headersOf(a.headers), body)
         })
     }
-  }
+  })
 }

--- a/packages/code/src/files.ts
+++ b/packages/code/src/files.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect"
 import { FileSystem } from "effect/FileSystem"
 import { Path } from "effect/Path"
-import type { Package } from "./packages"
+import { definePackage, type Package } from "./packages"
 
 // The files package: a directory the code may read and write, and nothing outside it. The methods
 // are built on `FileSystem` and `Path` rather than on a runtime's own file API, so the package is a
@@ -80,7 +80,7 @@ export interface FilesOptions {
 export const filesPackage = (options: FilesOptions = {}): Package<FileSystem | Path> => {
   const policy = filesPolicyOf(options.policy)
   const root = policy.root
-  return {
+  return definePackage({
     name: "files",
     description:
       "The files under one root directory. files.read and files.list see what is there, files.search finds text across it, and files.write puts a file back. Every path is relative to the root and a path outside it is refused.",
@@ -264,5 +264,5 @@ export const filesPackage = (options: FilesOptions = {}): Package<FileSystem | P
           }).pipe(Effect.catch((error) => Effect.succeed({ error: failure(error) })))
         })
     }
-  }
+  })
 }

--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -1,4 +1,13 @@
-// The package root exposes the code reactor and its event keys. Agent assemblies adapt these
-// through codeModeFor in packages/agent/src/components/code.ts.
+// The package root exposes code components, the code reactor, and its event keys. Agent
+// assemblies adapt code components through codeMode in packages/agent/src/components/code.ts.
 export { codeReactor } from "./execute"
 export { codeKeys } from "./events"
+export {
+  CODE_VIEW_ALGEBRA,
+  definePackage,
+  type CodeComponent,
+  type CodeView,
+  type Package,
+  type PackageDefinition,
+  type PackageRequirements
+} from "./packages"

--- a/packages/code/src/packages.properties.test.ts
+++ b/packages/code/src/packages.properties.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import fc from "fast-check"
+import { composeComponents } from "@clavia/tardigrade-core/component"
+import {
+  CODE_VIEW_ALGEBRA,
+  definePackage,
+  type CodeComponent,
+  type Package
+} from "./packages"
+
+const packageFor = (name: string): Package =>
+  definePackage({
+    name,
+    description: `${name} package`,
+    methods: { read: () => Effect.succeed(name) }
+  })
+
+const regroup = (
+  leaves: ReadonlyArray<CodeComponent>,
+  choices: ReadonlyArray<number>
+): CodeComponent => {
+  if (leaves.length === 0) return composeComponents("nested-empty", CODE_VIEW_ALGEBRA, [])
+  const nodes = [...leaves]
+  let step = 0
+  while (nodes.length > 1) {
+    const choice = choices[step % Math.max(choices.length, 1)] ?? 0
+    const index = choice % (nodes.length - 1)
+    const pair = composeComponents(`nested-${step}`, CODE_VIEW_ALGEBRA, [nodes[index]!, nodes[index + 1]!])
+    nodes.splice(index, 2, pair)
+    step += 1
+  }
+  return nodes[0]!
+}
+
+const namesOf = (component: CodeComponent): ReadonlyArray<string> =>
+  component.derive([]).view.packages.map((pkg) => pkg.name)
+
+describe("recursive code component composition", () => {
+  test("every grouping preserves package identity and order", () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(fc.stringMatching(/^[a-z][a-z0-9_]{0,12}$/), { maxLength: 12 }),
+        fc.array(fc.nat(), { maxLength: 24 }),
+        (names, choices) => {
+          const leaves = names.map(packageFor)
+          const flat = composeComponents("flat", CODE_VIEW_ALGEBRA, leaves)
+          const nested = regroup(leaves, choices)
+
+          expect(namesOf(nested)).toEqual(namesOf(flat))
+          expect(nested.derive([]).view.packages).toEqual(leaves)
+          expect(nested.derive([]).transitions).toEqual([])
+        }
+      ),
+      { numRuns: 500 }
+    )
+  })
+})

--- a/packages/code/src/packages.ts
+++ b/packages/code/src/packages.ts
@@ -1,4 +1,5 @@
 import type { Effect } from "effect"
+import type { Component, ViewAlgebra } from "@clavia/tardigrade-core/component"
 import type { Park } from "./errors"
 
 // DoorRequest is a request through a connection's door: method, a RELATIVE path (the door
@@ -83,6 +84,21 @@ export const ANNOTATION_DEFAULTS: Required<MethodAnnotations> = {
   openWorldHint: true
 }
 
+// CodeView is the package scope a code component offers to code mode. Package order is visible
+// in the model's scope description and duplicate names fail when code mode derives the view.
+export interface CodeView {
+  readonly packages: ReadonlyArray<Package<unknown>>
+}
+
+// CODE_VIEW_ALGEBRA composes package scopes in component order.
+export const CODE_VIEW_ALGEBRA: ViewAlgebra<CodeView> = {
+  empty: { packages: [] },
+  combine: (left, right) => ({ packages: [...left.packages, ...right.packages] })
+}
+
+// CodeComponent derives package scope and package-level work from the log.
+export interface CodeComponent<R = never> extends Component<CodeView, R> {}
+
 // annotationsOf resolves one method's annotations over the dangerous defaults. It reads the name
 // table only, so a package's requirements are irrelevant to it: `unknown` is the shape every
 // `Package<R>` widens to.
@@ -91,13 +107,10 @@ export const annotationsOf = (pkg: Package<unknown>, method: string): Required<M
   ...pkg.annotations?.[method]
 })
 
-// Package is one named unit of an actor's world face, the dual of an AgentComponent on its model
-// face (packages/agent/src/runtime/agent.ts). A component derives what the model is offered
-// (`tools`, `system`) and what settles its calls (`serve`); a package declares what code is
-// offered (`name`, `description`, `docs`) and what settles its calls (`methods`). Code calls
-// methods as `zohorecruit.insert_record(args)`. The platform binds the methods to providers;
-// tests bind fakes. An MCP server becomes a package through one adapter, never a second
-// concept.
+// Package is a leaf CodeComponent on an actor's world face. It declares what code is offered
+// (`name`, `description`, `docs`) and what settles its calls (`methods`). Code calls methods as
+// `zohorecruit.insert_record(args)`. The platform binds the methods to providers; tests bind
+// fakes. An MCP adapter produces the same package shape.
 //
 // `ctx.callId` is the call's recorded pair key. A method that sends a message across actors
 // uses it as the message id, so a replayed call carries the same id and the receiver absorbs
@@ -107,15 +120,15 @@ export const annotationsOf = (pkg: Package<unknown>, method: string): Required<M
 // deliberately outside Package: it belongs to the host boundary and gets its own concept once a
 // consumer exists.
 //
-// Which packages an assembly passes is component scoping: a task that must never send messages
-// is given no sending package, and the code cannot name what the assembly did not pass. The
-// powerless default is the empty array (execute.ts, codeReactor).
+// Which package components an assembly passes is component scoping: a task that cannot send
+// messages is given no sending package, and the code cannot name what the assembly did not pass.
+// The powerless default is the empty array (execute.ts, codeReactor).
 //
 // `R` is what a package's methods need from the environment, the dual of `AgentComponent<R>` on the
 // model face. A package that reaches for a service names it in its type, and the reactor that
 // runs the package declares the union of what its packages need (execute.ts, codeReactorFor); a
 // package that reaches for nothing is `Package<never>` and runs anywhere.
-export interface Package<R = never> {
+export interface Package<R = never> extends CodeComponent<R> {
   readonly name: string
   readonly description: string
   // Method docs, two levels: describe({name}) lists names and one-liners; describe({name,
@@ -132,6 +145,22 @@ export interface Package<R = never> {
   readonly methods: Readonly<
     Record<string, (args: unknown, ctx: { readonly callId: string }) => Effect.Effect<unknown, Park, R>>
   >
+}
+
+// PackageDefinition is the leaf declaration accepted by definePackage.
+export type PackageDefinition<R = never> = Omit<Package<R>, "derive" | "keys">
+
+// definePackage makes a package declaration a leaf code component.
+export const definePackage = <R>(definition: PackageDefinition<R>): Package<R> => {
+  let pkg: Package<R>
+  pkg = {
+    ...definition,
+    derive: () => ({
+      view: { packages: [pkg as Package<unknown>] },
+      transitions: []
+    })
+  }
+  return pkg
 }
 
 // PackageRequirements extracts one package's R, so a mixed list infers the union of what its

--- a/packages/code/src/workspace.ts
+++ b/packages/code/src/workspace.ts
@@ -1,6 +1,6 @@
 import { Context, Effect } from "effect"
 import { KeyValueStore } from "effect/unstable/persistence"
-import type { Package } from "./packages"
+import { definePackage, type Package } from "./packages"
 import { hydrate, refs } from "./store"
 
 // The workspace package: the model's own view of the store its spilled values live in (store.ts).
@@ -84,7 +84,7 @@ export const workspacePackage = (options: WorkspaceOptions = {}): Package<KeyVal
       properties: { rows: { type: "array" }, truncated: { type: "boolean" }, error: { type: "string" } }
     }
   }
-  return {
+  return definePackage({
     name: "workspace",
     description:
       runner === undefined
@@ -178,7 +178,7 @@ export const workspacePackage = (options: WorkspaceOptions = {}): Package<KeyVal
           return { matches, ...(truncated ? { truncated } : {}) }
         })
     }
-  }
+  })
 }
 
 // workspaceFor builds the package from the lane's own bindings: the SQL surface, if the platform

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -14,7 +14,7 @@ import {
 } from "tardie"
 
 // reqOf wraps a trajectory in the render the actor would derive: the code surface half.
-const surfaceRender = renderOf([codeMode, nativeOutput], [])
+const surfaceRender = renderOf([codeMode(), nativeOutput], [])
 const reqOf = (trajectory: ReadonlyArray<Event>) => ({ trajectory, ...surfaceRender })
 import { Infer } from "tardie"
 import {
@@ -316,7 +316,7 @@ describe("infer end to end", () => {
       fetch: fetchImpl
     })
     const render = renderOf(
-      options.fallback === undefined ? [codeMode, nativeOutput] : [codeMode, options.fallback],
+      options.fallback === undefined ? [codeMode(), nativeOutput] : [codeMode(), options.fallback],
       declared()
     )
     const action = (await Effect.runPromise(

--- a/skills/tardigrade/SKILL.md
+++ b/skills/tardigrade/SKILL.md
@@ -12,7 +12,7 @@ tdg init researcher
 cd researcher
 ```
 
-Edit `actor.ts`. Keep `actorName` stable because build, push, run, and stored traces use it as the actor identity. Put the agent's role and expected answer in `actorInstructions`. Add or remove packages in `codeModeFor` only when the task needs different capabilities.
+Edit `actor.ts`. Keep `actorName` stable because build, push, run, and stored traces use it as the actor identity. Put the agent's role and expected answer in `actorInstructions`. Add or remove package components in `codeMode([...components])` only when the task needs different capabilities.
 
 Build the source, push the same actor into the local registry, and start the local server from the actor directory:
 


### PR DESCRIPTION
This change gives code mode the same recursive component contract used by agent composition. Packages become leaf CodeComponent values, and codeMode composes their views, transitions, keys, and service requirements before exposing the combined scope through execute.

- Add CodeView, CodeComponent, CODE_VIEW_ALGEBRA, and definePackage to the public code surface.
- Replace codeModeFor with codeMode([...components]) and keep codeMode() as the powerless empty scope.
- Preserve durable package execution, duplicate-name checks, policy overrides, package ordering, and host requirement inference.
- Add focused coverage for nested transitions and keys, plus 500 Fast-check cases for recursive package grouping.
- Update built-in packages, the server, model tests, examples, documentation, migration guidance, and the bundled skill.

Verification:

- bun run gate