### PR TITLE
ci: reject AI coauthors

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, edited, reopened, synchronize]
 
 permissions:
+  contents: read
   pull-requests: read
 
 jobs:
@@ -17,3 +18,25 @@ jobs:
         with:
           task_types: '["build","chore","ci","docs","feat","fix","perf","refactor","revert","style","test"]'
           add_label: "false"
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Reject AI co-author trailers
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nocasematch
+          while IFS= read -r sha; do
+            while IFS= read -r trailer; do
+              key=${trailer%%:*}
+              value=${trailer#*:}
+              if [[ ${key} == "co-authored-by" && ${value} =~ (^|[^[:alnum:]_])(claude|cursor|codex)([^[:alnum:]_]|$) ]]; then
+                echo "::error title=Prohibited co-author::Commit ${sha} contains ${trailer}"
+                exit 1
+              fi
+            done < <(git show -s --format=%B "${sha}" | git interpret-trailers --parse)
+          done < <(git rev-list "${BASE_SHA}..${HEAD_SHA}")


### PR DESCRIPTION
This change extends the existing required pull request check to reject prohibited AI co-author trailers across every commit in a pull request.

- Fetch the full pull request history with read-only contents permission.
- Parse Git trailers for every commit between the base and head revisions.
- Reject Co-authored-by values containing Claude, Cursor, or Codex, case-insensitively.
- Report the offending commit and trailer while preserving the existing required check name.

Verification:

- Local trailer simulations cover all prohibited names and allowed human names.
- bun run gate --only=lint