### PR TITLE
fix: validate runtime policy inputs

### DIFF
--- a/packages/agent/src/spawn.test.ts
+++ b/packages/agent/src/spawn.test.ts
@@ -124,6 +124,36 @@ describe("agentsPackage", () => {
     )
     expect(answer).toEqual({ error: "nope" })
   })
+
+  test("a fractional budget is refused with its unit, never floored to zero", async () => {
+    // The budget is a count of tool calls. 0.7 floored would draw zero and read as an exhausted
+    // run, so the unit error goes back to the caller before any draw or delivery (spawn.ts, run).
+    const sent: Array<Sent> = []
+    const draws: number[] = []
+    const pkg = agentsPackage({
+      reserve: async (_id, want) => {
+        draws.push(want)
+        return want
+      }
+    })
+    const answer = await Effect.runPromise(
+      pkg.methods.run!({ text: "draft", budget: 0.7 }, { callId: "c8" }).pipe(Effect.provide(env("mem:ag.root", sent)))
+    )
+    expect(answer).toEqual({ error: "agents.run takes budget as a whole number of tool calls, at least 1; got 0.7" })
+    expect(draws.length).toBe(0)
+    expect(sent.length).toBe(0)
+  })
+
+  test("a fractional grant is refused, never floored into a denial", async () => {
+    const sent: Array<Sent> = []
+    const pkg = agentsPackage()
+    const answer = await Effect.runPromise(
+      pkg.methods.continue!({ handle: { address: "mem:ag.c9", turn: "c9" }, grant: 0.5 }, { callId: "c10" }).pipe(
+        Effect.provide(env("mem:ag.root", sent))
+      )
+    )
+    expect(answer).toEqual({ error: "agents.continue takes grant as a whole number of tool calls; got 0.5" })
+  })
 })
 
 // The contracts a host declares for its children. A name resolves to one of these; anything else

--- a/packages/agent/src/spawn.ts
+++ b/packages/agent/src/spawn.ts
@@ -107,7 +107,7 @@ export const agentsPackage = (
             background: { type: "boolean", description: "true: return { callId } at once, the reply arrives later via result()" },
             output: { description: "a declared contract's name, or a JSON schema for a structured answer" },
             model: { type: "string", enum: ["haiku", "sonnet", "opus"], description: "which model runs the agent; default sonnet" },
-            budget: { type: "number", description: "max tool calls before the agent must answer; keeps a research agent bounded" },
+            budget: { type: "integer", description: "max tool calls before the agent must answer, a whole number of calls; keeps a research agent bounded" },
             escalatable: { type: "boolean", description: "true: at its budget the agent may ask for more instead of answering; the run returns a request you resolve with continue()" }
           },
           required: ["text"]
@@ -129,7 +129,7 @@ export const agentsPackage = (
           type: "object",
           properties: {
             handle: { type: "object", description: "the handle from a requesting run: where the child is, and which turn" },
-            grant: { type: "number", description: "extra tool calls to grant; 0 or less denies" }
+            grant: { type: "integer", description: "extra tool calls to grant, a whole number of calls; 0 or less denies" }
           },
           required: ["handle", "grant"]
         },
@@ -162,9 +162,17 @@ export const agentsPackage = (
           // The model name rides the brief's envelope: the child's log records the choice, so its
           // Infer resolves it from trajectory and replay agrees by construction.
           const model = a?.model === "haiku" || a?.model === "sonnet" || a?.model === "opus" ? a.model : undefined
-          // The tool-call budget rides the brief like the model does; the child's budget reactor reads
-          // it from its own trajectory. A run without a stated budget wants the per-agent default.
-          const want = typeof a?.budget === "number" && a.budget > 0 ? Math.floor(a.budget) : defaultBudget
+          // asked is the tool-call budget carried on the brief. It accepts a whole positive count
+          // because rounding could turn a requested child into an exhausted run (spawn.test.ts,
+          // "a fractional budget"). An absent budget takes the per-agent default.
+          const asked = a?.budget
+          let want = defaultBudget
+          if (asked !== undefined) {
+            if (typeof asked !== "number" || !Number.isInteger(asked) || asked < 1) {
+              return { error: `agents.run takes budget as a whole number of tool calls, at least 1; got ${JSON.stringify(asked)}` }
+            }
+            want = asked
+          }
           // Draw from the run's single budget before the child spawns, so the whole tree is bounded by
           // it whatever the fan-out. A partial budget grants what is left; a spent budget grants 0, and
           // then no agent spawns, which is how the tree stops. The draw is keyed on this call's id, so
@@ -279,13 +287,18 @@ export const agentsPackage = (
           const address = String(handle?.address ?? "")
           const turn = String(handle?.turn ?? "")
           if (address === "" || turn === "") return { error: "agents.continue needs { handle, grant }; the handle comes from a run that is requesting" }
+          // grant accepts a whole count of calls because rounding could deny a request the parent
+          // tried to grant (spawn.test.ts, "a fractional grant").
+          const grant = a?.grant
+          if (typeof grant !== "number" || !Number.isInteger(grant)) {
+            return { error: `agents.continue takes grant as a whole number of tool calls; got ${JSON.stringify(grant)}` }
+          }
           // The contract comes from the child's own brief, like `result`, so a rewritten handle
           // cannot make an answer structured that never was.
           const target = parseActorAddress(address)
           const declared = yield* declaredRun(source, target, turn)
           if ("error" in declared) return declared
-          const want = typeof a?.grant === "number" ? Math.floor(a.grant) : 0
-          const granted = want > 0 ? yield* Effect.promise(() => reserve(ctx.callId, want)) : 0
+          const granted = grant > 0 ? yield* Effect.promise(() => reserve(ctx.callId, grant)) : 0
           const decision = granted > 0 ? { amount: granted } : { amount: 0, reason: "the parent declined the request" }
           const answer = yield* router.resume(linkOf(source, target), turn, decision)
           return shape(answer, address, turn, declared.contract)

--- a/packages/code/src/execute.test.ts
+++ b/packages/code/src/execute.test.ts
@@ -232,6 +232,72 @@ describe("the spill bound", () => {
   })
 })
 
+describe("the pointer's note", () => {
+  // The note is policy (store.ts, SpillPolicy): every bounded result tells the model how to read
+  // the value back, so the words must name a call the mounted scope answers.
+  const drive = (log: Event[], reactor: typeof codeReactor) =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        yield* settleActor({ reactors: [reactor], keyOf: composeKeys(messageKeys, codeKeys) })
+        return yield* Effect.flatMap(EventLog, (l) => l.read)
+      }).pipe(Effect.provide(Layer.mergeAll(memoryLog(log), jsSandbox, KeyValueStore.layerMemory))) as Effect.Effect<
+        ReadonlyArray<Event>
+      >
+    )
+  const bigLog = (): Event[] => [
+    { type: "MessageReceived", id: "t1", text: "go", at: 1 },
+    { type: "CodeDispatched", execId: "e1", code: 'return "q".repeat(60)', turn: "t1", at: 2 }
+  ]
+
+  test("a scope with no workspace package gets a note with no verb", async () => {
+    const events = await drive(bigLog(), codeReactorFor({ spill: { spillBytes: 10, previewChars: 4 } }, []))
+    const settle = events.find((e) => e.type === "CodeSettled") as { note?: string }
+    expect(settle.note).toContain("ref 'e1.result'")
+    expect(settle.note).not.toContain("workspace.read")
+  })
+
+  test("a stated note overrides the derived one", async () => {
+    const events = await drive(
+      bigLog(),
+      codeReactorFor({ spill: { spillBytes: 10, previewChars: 4, note: (ref) => `files.open({ref: '${ref}'})` } }, [])
+    )
+    const settle = events.find((e) => e.type === "CodeSettled") as { note?: string }
+    expect(settle.note).toBe("files.open({ref: 'e1.result'})")
+  })
+
+  test("a workspace whose read takes no ref refuses at construction", () => {
+    const shadow: Package = definePackage({
+      name: "workspace",
+      description: "a path-only reader standing where the spill reader is expected",
+      docs: {
+        read: {
+          description: "reads a file",
+          input: { type: "object", properties: { path: { type: "string" } }, required: ["path"] }
+        }
+      },
+      methods: { read: () => Effect.succeed({ ok: true }) }
+    })
+    expect(() => codeReactorFor({}, [shadow])).toThrow(/spill pointer/)
+    // A stated note lifts the refusal: the consumer then owns the words.
+    expect(() => codeReactorFor({ spill: { note: (ref) => ref } }, [shadow])).not.toThrow()
+  })
+
+  test("a workspace without the advertised grep refuses at construction", () => {
+    const shadow: Package = definePackage({
+      name: "workspace",
+      description: "a reader without search",
+      docs: {
+        read: {
+          description: "reads a ref",
+          input: { type: "object", properties: { ref: { type: "string" } }, required: ["ref"] }
+        }
+      },
+      methods: { read: () => Effect.succeed({ ok: true }) }
+    })
+    expect(() => codeReactorFor({}, [shadow])).toThrow(/workspace\.grep/)
+  })
+})
+
 describe("a package's requirements ride its type", () => {
   // A package that reaches for a service names it in its type, and the reactor that runs the
   // package declares the same requirement, so the environment that drives the lane must provide

--- a/packages/code/src/execute.ts
+++ b/packages/code/src/execute.ts
@@ -8,7 +8,15 @@ import { annotationsOf, type Package, type PackageRequirements } from "./package
 import { checkInput, renderSignature } from "./contract"
 import { Sandbox, type Bindings } from "./sandbox"
 import { turnHead, turnOf } from "./turns"
-import { hydrate, spill as spillTo, spillPointer, spillPolicyOf, type SpillPolicy } from "./store"
+import {
+  BARE_SPILL_NOTE,
+  hydrate,
+  spill as spillTo,
+  spillPointer,
+  spillPolicyOf,
+  WORKSPACE_SPILL_NOTE,
+  type SpillPolicy
+} from "./store"
 import { callId as callIdOf } from "./ids"
 import { blockedOn, codeSettled, packageCalled, packageReturned } from "./events"
 
@@ -196,7 +204,7 @@ const executeRecorded = <R = never>(
                 yield* log.append([
                   packageReturned({
                     callId,
-                    ...spillPointer(callId, json.length, json.slice(0, spill.previewChars)),
+                    ...spillPointer(callId, json.length, json.slice(0, spill.previewChars), spill.note),
                     ...stamp,
                     at: answeredAt
                   })
@@ -265,7 +273,13 @@ const executeRecorded = <R = never>(
         const ref = `${execId}.result`
         yield* Effect.orDie(spillTo(ref, json))
         return [
-          codeSettled({ execId, ...spillPointer(ref, json.length, json.slice(0, spill.previewChars)), ...logs, ...stamp, at })
+          codeSettled({
+            execId,
+            ...spillPointer(ref, json.length, json.slice(0, spill.previewChars), spill.note),
+            ...logs,
+            ...stamp,
+            at
+          })
         ]
       }
       return [codeSettled({ execId, result: outcome.result, ...logs, ...stamp, at })]
@@ -302,9 +316,29 @@ export const codeReactorFor = <const P extends ReadonlyArray<Package<never>> | R
     if (named.has(pkg.name)) throw new Error(`package "${pkg.name}" declared twice`)
     named.add(pkg.name)
   }
+  // codeReactorFor refuses a default pointer note unless the workspace package answers every
+  // advertised call. A scope with no workspace package gets the bare note. A stated note is the
+  // consumer's contract (execute.test.ts, "the pointer's note").
+  const workspace = (packages as ReadonlyArray<Package<unknown>>).find((pkg) => pkg.name === "workspace")
+  if (policy.spill?.note === undefined && workspace !== undefined) {
+    const answers = (method: string, fields: ReadonlyArray<string>): boolean => {
+      const properties = (workspace.docs?.[method]?.input as
+        | { properties?: Readonly<Record<string, unknown>> }
+        | undefined)?.properties
+      return typeof workspace.methods[method] === "function" && (properties === undefined || fields.every((field) => properties[field] !== undefined))
+    }
+    if (!answers("read", ["ref"]) || !answers("grep", ["pattern", "ref"])) {
+      throw new Error(
+        'package "workspace" cannot answer the spill pointer: a bounded result tells the model `workspace.read({ref})` and `workspace.grep({pattern, ref})`. Provide both methods with matching input contracts, mount the package under another name, or state the pointer through the spill policy note (CodePolicy.spill.note).'
+      )
+    }
+  }
   type R = PackageRequirements<P[number]>
   const mounted = packages as unknown as ReadonlyArray<Package<R>>
-  const spill = spillPolicyOf(policy.spill)
+  const spill = spillPolicyOf({
+    ...policy.spill,
+    note: policy.spill?.note ?? (workspace === undefined ? BARE_SPILL_NOTE : WORKSPACE_SPILL_NOTE)
+  })
   return (events) => {
     const owed = workOwed(events)
     if (owed === undefined) return []

--- a/packages/code/src/store.ts
+++ b/packages/code/src/store.ts
@@ -65,27 +65,41 @@ export const refs = (): Effect.Effect<
 > => Effect.map(Effect.flatMap(KeyValueStore.KeyValueStore, (store) => store.get(WORKSPACE_REFS)), decodeRefs)
 
 // SpillPolicy is the bound and what a bounded value shows: a JSON value longer than `spillBytes`
-// goes to the store and the event keeps a pointer with the first `previewChars` of it. The reactor
-// that applies it takes an override (execute.ts, codeReactorFor), because the right bound is the
-// consumer's context window and storage, not this module's guess.
+// goes to the store and the event keeps a pointer with the first `previewChars` of it. `note`
+// renders the pointer's call to action. The reactor that applies the policy takes an override
+// (execute.ts, codeReactorFor), because the consumer owns the context window, storage, and verbs
+// in scope (execute.test.ts, "the pointer's note").
 export interface SpillPolicy {
   readonly spillBytes: number
   readonly previewChars: number
+  readonly note: (ref: string) => string
 }
 
-export const DEFAULT_SPILL_POLICY: SpillPolicy = { spillBytes: 8_192, previewChars: 500 }
+// WORKSPACE_SPILL_NOTE names the workspace package's read and grep verbs (workspace.ts).
+// codeReactorFor refuses a scope where this note would lie
+// (execute.ts; workspace.test.ts, "the default pointer note names verbs this package answers").
+export const WORKSPACE_SPILL_NOTE = (ref: string): string =>
+  `full value: workspace.read({ref: '${ref}'}), search it: workspace.grep({pattern, ref: '${ref}'})`
+
+// BARE_SPILL_NOTE states the ref and no verb, for a scope that mounts no workspace package: a
+// pointer must never name a call the scope cannot answer (execute.test.ts, "the pointer's note").
+export const BARE_SPILL_NOTE = (ref: string): string =>
+  `full value stored under ref '${ref}'; this scope mounts no reader for it, so work from the preview`
+
+export const DEFAULT_SPILL_POLICY: SpillPolicy = { spillBytes: 8_192, previewChars: 500, note: WORKSPACE_SPILL_NOTE }
 
 export const spillPolicyOf = (policy: Partial<SpillPolicy> = {}): SpillPolicy => ({
   spillBytes: policy.spillBytes ?? DEFAULT_SPILL_POLICY.spillBytes,
-  previewChars: policy.previewChars ?? DEFAULT_SPILL_POLICY.previewChars
+  previewChars: policy.previewChars ?? DEFAULT_SPILL_POLICY.previewChars,
+  note: policy.note ?? DEFAULT_SPILL_POLICY.note
 })
 
 // spillPointer is the pointer a bounded value leaves behind. `size` is the whole value's length, so
 // the reader sees how much the preview left out. The field is named `tmp` because it is the
 // recorded event's own shape, which replay and every consumer read by that name.
-export const spillPointer = (ref: string, size: number, preview: string) => ({
+export const spillPointer = (ref: string, size: number, preview: string, note: (ref: string) => string = WORKSPACE_SPILL_NOTE) => ({
   tmp: ref,
   size,
   preview,
-  note: `full value: workspace.read({ref: '${ref}'}), search it: workspace.grep({pattern, ref: '${ref}'})`
+  note: note(ref)
 })

--- a/packages/code/src/workspace.test.ts
+++ b/packages/code/src/workspace.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { KeyValueStore } from "effect/unstable/persistence"
-import { spill } from "./store"
+import { spill, WORKSPACE_SPILL_NOTE } from "./store"
 import { DEFAULT_WORKSPACE_POLICY, WORKSPACE_SQL_DESCRIPTION, workspacePackage, type SqlRunner } from "./workspace"
 
 // The model's view of the store: a bounded slice of one value, a search across all of them, and a
@@ -154,5 +154,21 @@ describe("backend independence", () => {
     for (const args of [{ pattern: "NEEDLE" }, { pattern: '"note":"wideé"' }]) {
       expect(await call(pkg, "grep", args, other)).toEqual(await call(pkg, "grep", args, memory))
     }
+  })
+})
+
+describe("the pointer's pairing", () => {
+  test("the default pointer note names verbs this package answers", () => {
+    // The note every bounded result carries (store.ts, WORKSPACE_SPILL_NOTE) names this
+    // package's own verbs by ref; a drift between the two sends the model to a call the scope
+    // cannot answer (execute.ts, codeReactorFor).
+    const note = WORKSPACE_SPILL_NOTE("e1.result")
+    const pkg = workspacePackage()
+    expect(note).toContain("workspace.read({ref: 'e1.result'})")
+    expect(note).toContain("workspace.grep(")
+    expect(typeof pkg.methods["read"]).toBe("function")
+    expect(typeof pkg.methods["grep"]).toBe("function")
+    const declared = (pkg.docs?.["read"]?.input as { properties?: Record<string, unknown> } | undefined)?.properties
+    expect(declared?.["ref"]).toBeDefined()
   })
 })

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -1033,3 +1033,19 @@ describe("declared limits", () => {
     expect(timeout).toBe(600_000)
   })
 })
+
+describe("stream bounds", () => {
+  test("an invalid bound refuses at construction", () => {
+    // A value outside Bun's timer range would clamp to 1ms and read as provider trouble
+    // (model.ts, infer).
+    expect(() =>
+      infer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "m", stream: { totalMs: Infinity } })
+    ).toThrow(/finite positive/)
+    expect(() =>
+      infer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "m", stream: { idleMs: 0 } })
+    ).toThrow(/finite positive/)
+    expect(() =>
+      infer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "m", stream: { firstChunkMs: 2_147_483_648 } })
+    ).toThrow(/2147483647/)
+  })
+})

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -78,6 +78,10 @@ export const DEFAULT_STREAM_BOUNDS: StreamBounds = {
   totalMs: 300_000
 }
 
+// MAX_TIMER_DELAY_MS is the largest delay Bun accepts without clamping it to 1ms
+// (model.test.ts, "stream bounds").
+export const MAX_TIMER_DELAY_MS = 2_147_483_647
+
 const bounded = (stream: AsyncIterable<StreamChunk>, bounds: StreamBounds): AsyncIterable<StreamChunk> => ({
   async *[Symbol.asyncIterator]() {
     const startedAt = Date.now()
@@ -623,6 +627,13 @@ export const infer = <const C extends ModelConfig>(config: C): Layer.Layer<Infer
     firstChunkMs: config.stream?.firstChunkMs ?? DEFAULT_STREAM_BOUNDS.firstChunkMs,
     idleMs: config.stream?.idleMs ?? DEFAULT_STREAM_BOUNDS.idleMs,
     totalMs: config.stream?.totalMs ?? DEFAULT_STREAM_BOUNDS.totalMs
+  }
+  // bounds rejects values Bun would clamp to 1ms, which would report healthy providers as timed
+  // out (model.test.ts, "stream bounds").
+  for (const [name, ms] of Object.entries(bounds)) {
+    if (!Number.isFinite(ms) || ms <= 0 || ms > MAX_TIMER_DELAY_MS) {
+      throw new Error(`stream ${name} must be a finite positive count of milliseconds no greater than ${MAX_TIMER_DELAY_MS}; got ${ms}`)
+    }
   }
   const throttleDelays = config.throttleRetryDelaysMs ?? DEFAULT_THROTTLE_RETRY_DELAYS_MS
   const retryAfterJitterMs = config.retryAfterJitterMs ?? DEFAULT_RETRY_AFTER_JITTER_MS


### PR DESCRIPTION
Runtime policy inputs could send the model toward unavailable workspace methods, turn fractional tool-call budgets into zero, or collapse oversized stream timers to one millisecond. This change validates those boundaries before they can waste a run and makes the spill pointer's instruction configurable for each package scope.

- Export and apply an overridable spill-note policy, derive a bare note for scopes without workspace tools, and reject incompatible workspace packages at construction.
- Require whole-number spawn budgets and continuation grants, with errors that name the tool-call unit.
- Reject non-positive, non-finite, and out-of-range stream bounds before constructing the model layer.

Verified with `bun run gate` (41 tasks).

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b2e946ff-e769-4f83-82f2-ada782b08023)
