### PR TITLE
feat(host): settle lanes concurrently

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Tardigrade is a framework for building durable, modular agents that can run at the edge. It is inspired by [React](https://react.dev/)'s declarative approach to building user interfaces.
 
-### A declarative way to build agents
+### Agents that can self-improve
 As models get increasingly smart, they will be capable of writing their own harnesses to improve themselves ([Meta-Harness](https://arxiv.org/abs/2603.28052)). A harness that is too rigid and complex is a bottleneck to this. We need something more composable, and easy to author.
 
 We took inspiration from React. React derives its component tree and declared effects from state (`{ UI, effects } = f(state)`). Tardigrade derives a view and state transitions from the event log, an idea with roots in [Harel's statecharts](https://www.sciencedirect.com/science/article/pii/0167642387900359).

--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -163,6 +163,7 @@ describe("parsing", () => {
     expect(devHelp).toContain("--open")
     expect(devHelp).toContain("--no-open")
     expect(devHelp).toContain("--min-port")
+    expect(devHelp).toContain("--max-concurrent-lanes")
     const pushHelp = (await drive(["push", "--help"])).lines.join("\n")
     expect(pushHelp).toContain("--target")
     expect(pushHelp).toContain("local")

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -276,6 +276,10 @@ export const devCommand = Command.make("dev", {
     Flag.withDescription("The directory holding pushed actor databases. Defaults to TARDIGRADE_ACTOR_DATA."),
     Flag.optional
   ),
+  maxConcurrentLanes: Flag.integer("max-concurrent-lanes").pipe(
+    Flag.withDescription("The maximum actor lanes settled at once. Defaults to TARDIGRADE_MAX_CONCURRENT_LANES."),
+    Flag.optional
+  ),
   actorRefreshMillis: Flag.integer("actor-refresh-ms").pipe(
     Flag.withDescription("Milliseconds to wait after a local actor change before refreshing the registry."),
     Flag.withDefault(DEFAULT_ACTOR_REFRESH_MILLIS)
@@ -297,7 +301,8 @@ export const devCommand = Command.make("dev", {
         port: Option.getOrUndefined(flags.port),
         db: stated(flags.db),
         actors: stated(flags.actors),
-        actorData: stated(flags.actorData)
+        actorData: stated(flags.actorData),
+        maxConcurrentLanes: Option.getOrUndefined(flags.maxConcurrentLanes)
       }, cli.env, file),
       catch: userErrorOf
     })
@@ -320,7 +325,8 @@ export const devCommand = Command.make("dev", {
             port: Option.getOrUndefined(flags.port),
             db: stated(flags.db),
             actors: stated(flags.actors),
-            actorData: stated(flags.actorData)
+            actorData: stated(flags.actorData),
+            maxConcurrentLanes: Option.getOrUndefined(flags.maxConcurrentLanes)
           }, cli.env, written),
           catch: userErrorOf
         })

--- a/apps/cli/src/config.test.ts
+++ b/apps/cli/src/config.test.ts
@@ -5,7 +5,13 @@ import { join } from "node:path"
 import { Effect } from "effect"
 import { BunFileSystem } from "@effect/platform-bun"
 import { DEFAULT_BASE_URL } from "@clavia/tardigrade-client"
-import { DEFAULT_ACTORS, DEFAULT_ACTOR_DATA, DEFAULT_DB, DEFAULT_PORT } from "@clavia/tardigrade-server/config"
+import {
+  DEFAULT_ACTORS,
+  DEFAULT_ACTOR_DATA,
+  DEFAULT_DB,
+  DEFAULT_MAX_CONCURRENT_LANES,
+  DEFAULT_PORT
+} from "@clavia/tardigrade-server/config"
 
 import { configPathIn, parseFileConfig, readFileConfig, resolve, resolveRemote, resolveServer } from "./config"
 
@@ -45,6 +51,7 @@ describe("resolveServer", () => {
     expect(config.db).toBe(DEFAULT_DB)
     expect(config.actors).toBe(DEFAULT_ACTORS)
     expect(config.actorData).toBe(DEFAULT_ACTOR_DATA)
+    expect(config.maxConcurrentLanes).toBe(DEFAULT_MAX_CONCURRENT_LANES)
     expect(config.token).toBeUndefined()
   })
 
@@ -52,22 +59,25 @@ describe("resolveServer", () => {
     const config = resolveServer({}, {
       PORT: "8080",
       TARDIGRADE_DB: "runs.sqlite",
+      TARDIGRADE_MAX_CONCURRENT_LANES: "6",
       MODEL_BASE_URL: "https://api.example.com",
       MODEL_API_KEY: "key",
       MODEL_ID: "a-model"
     })
     expect(config.port).toBe(8080)
     expect(config.db).toBe("runs.sqlite")
+    expect(config.maxConcurrentLanes).toBe(6)
     expect(config.model.id).toBe("a-model")
   })
 
   test("a flag beats the environment", () => {
     const config = resolveServer(
-      { port: 9000, db: "other.sqlite" },
-      { PORT: "8080", TARDIGRADE_DB: "runs.sqlite" }
+      { port: 9000, db: "other.sqlite", maxConcurrentLanes: 3 },
+      { PORT: "8080", TARDIGRADE_DB: "runs.sqlite", TARDIGRADE_MAX_CONCURRENT_LANES: "2" }
     )
     expect(config.port).toBe(9000)
     expect(config.db).toBe("other.sqlite")
+    expect(config.maxConcurrentLanes).toBe(3)
   })
 
   // `tdg dev` is the local command and binds loopback (dev.ts, DEV_HOST), so the token the server
@@ -80,6 +90,10 @@ describe("resolveServer", () => {
   // The reader is the server's own, so a value it refuses is a value this command refuses.
   test("a PORT that is not a port refuses to resolve", () => {
     expect(() => resolveServer({}, { PORT: "http" })).toThrow()
+  })
+
+  test("a concurrency flag that cannot schedule a lane refuses to resolve", () => {
+    expect(() => resolveServer({ maxConcurrentLanes: 0 }, {})).toThrow("positive integer")
   })
 })
 

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -1,7 +1,13 @@
 import { Effect } from "effect"
 import { FileSystem } from "effect/FileSystem"
 import { DEFAULT_BASE_URL } from "@clavia/tardigrade-client"
-import { outputCapabilityOf, readConfig, type Env, type ServerConfigValue } from "@clavia/tardigrade-server/config"
+import {
+  maxConcurrentLanesOf,
+  outputCapabilityOf,
+  readConfig,
+  type Env,
+  type ServerConfigValue
+} from "@clavia/tardigrade-server/config"
 
 // Where a value comes from, decided once. Three sources in one order, everywhere: a flag stated on
 // the command line, then the environment, then the file `tdg setup` wrote, then the exported
@@ -125,6 +131,7 @@ export interface ServerFlags {
   readonly db?: string | undefined
   readonly actors?: string | undefined
   readonly actorData?: string | undefined
+  readonly maxConcurrentLanes?: number | undefined
 }
 
 // resolveServer answers what `tdg dev` boots on. It starts from the server's own reader, so a
@@ -147,6 +154,7 @@ export const resolveServer = (flags: ServerFlags, env: Env, file: FileConfig = {
     db: text(flags.db) ?? base.db,
     actors: text(flags.actors) ?? base.actors,
     actorData: text(flags.actorData) ?? base.actorData,
+    maxConcurrentLanes: maxConcurrentLanesOf(flags.maxConcurrentLanes ?? base.maxConcurrentLanes),
     token: undefined,
     model: {
       baseUrl: resolve(undefined, base.model.baseUrl, model.baseUrl),

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -1,4 +1,10 @@
 import { Context, Layer } from "effect"
+import {
+  DEFAULT_MAX_CONCURRENT_LANES,
+  driverPolicyOf
+} from "@clavia/tardigrade-host/driver"
+
+export { DEFAULT_MAX_CONCURRENT_LANES } from "@clavia/tardigrade-host/driver"
 
 // The server's configuration is the environment and nothing else (apps-server-spec.md,
 // "Conventions"). One operator, one store, one process, so there is no config file to reconcile
@@ -46,6 +52,7 @@ export interface ServerConfigValue {
   readonly db: string
   readonly actors: string
   readonly actorData: string
+  readonly maxConcurrentLanes: number
   // Absent leaves the API open, which is why the process is meant to bind to localhost. Present
   // makes a bearer token required on every route except /healthz (http.ts).
   readonly token: string | undefined
@@ -102,12 +109,28 @@ const port = (env: Env): number => {
   return value
 }
 
+// maxConcurrentLanesOf validates the host-wide count used by configuration flags and environment
+// resolution.
+export const maxConcurrentLanesOf = (value: number): number =>
+  driverPolicyOf({ maxConcurrentLanes: value }).maxConcurrentLanes
+
+const maxConcurrentLanes = (env: Env): number => {
+  const raw = text(env, "TARDIGRADE_MAX_CONCURRENT_LANES")
+  if (raw === undefined) return DEFAULT_MAX_CONCURRENT_LANES
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`TARDIGRADE_MAX_CONCURRENT_LANES must be a positive integer, got ${JSON.stringify(raw)}`)
+  }
+  return maxConcurrentLanesOf(value)
+}
+
 // readConfig resolves the environment into the value the process runs on.
 export const readConfig = (env: Env): ServerConfigValue => ({
   port: port(env),
   db: text(env, "TARDIGRADE_DB") ?? DEFAULT_DB,
   actors: text(env, "TARDIGRADE_ACTORS") ?? DEFAULT_ACTORS,
   actorData: text(env, "TARDIGRADE_ACTOR_DATA") ?? DEFAULT_ACTOR_DATA,
+  maxConcurrentLanes: maxConcurrentLanes(env),
   token: text(env, "TARDIGRADE_TOKEN"),
   model: {
     baseUrl: text(env, "MODEL_BASE_URL"),

--- a/apps/server/src/host.test.ts
+++ b/apps/server/src/host.test.ts
@@ -8,7 +8,7 @@ import { RESERVED_ACTOR } from "@clavia/tardigrade-client/contract"
 import { Infer, type InferRequest } from "tardie"
 import type { Action } from "tardie/events"
 
-import { layerConfig, readConfig } from "./config"
+import { layerConfig, readConfig, ServerConfig } from "./config"
 import { Threads, layerThreads } from "./host"
 import { DriverGauge } from "./http"
 
@@ -49,16 +49,20 @@ const config = layerConfig(readConfig({
 // The body runs with both services the layer provides: the threads it drives, and the gauge
 // /healthz reads over the same driver (http.ts, DriverGauge).
 const running = <A, E>(
-  body: (threads: Context.Service.Shape<typeof Threads>) => Effect.Effect<A, E, DriverGauge | Ingress>
+  body: (threads: Context.Service.Shape<typeof Threads>) => Effect.Effect<A, E, DriverGauge | Ingress>,
+  options: {
+    readonly infer?: Layer.Layer<Infer>
+    readonly config?: Layer.Layer<ServerConfig>
+  } = {}
 ): Promise<A> =>
   Effect.gen(function*() {
     const threads = yield* Threads
     return yield* body(threads)
   }).pipe(
     Effect.provide(Layer.provide(layerThreads({
-      infer: layerScripted,
+      infer: options.infer ?? layerScripted,
       providers: [{ name: "test", send: () => Effect.void }]
-    }), config)),
+    }), options.config ?? config)),
     Effect.scoped,
     Effect.runPromise
   ) as Promise<A>
@@ -68,6 +72,51 @@ const running = <A, E>(
 const brief = (id: string, text = "hello") => ({ type: "MessageReceived", id, text })
 
 describe("the threads service", () => {
+  test("the configured lane capacity runs model calls concurrently", async () => {
+    let release!: () => void
+    const released = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    let twoStarted!: () => void
+    const started = new Promise<void>((resolve) => {
+      twoStarted = resolve
+    })
+    let active = 0
+    let peak = 0
+    let calls = 0
+    const concurrent = Layer.succeed(Infer)({
+      react: () => Effect.promise(async () => {
+        active += 1
+        peak = Math.max(peak, active)
+        calls += 1
+        if (calls === 2) twoStarted()
+        await released
+        active -= 1
+        return { kind: "complete", output: "done" } as Action
+      })
+    })
+    const concurrentConfig = layerConfig(readConfig({
+      TARDIGRADE_DB: ":memory:",
+      TARDIGRADE_ACTORS: `/tmp/tardigrade-host-concurrent-${process.pid}`,
+      TARDIGRADE_MAX_CONCURRENT_LANES: "2"
+    }))
+
+    await running(
+      (threads) => Effect.gen(function*() {
+        yield* Effect.all([
+          threads.append("alpha", brief("a")),
+          threads.append("beta", brief("b"))
+        ], { concurrency: "unbounded" })
+        yield* Effect.promise(() => started)
+        expect(active).toBe(2)
+        release()
+        yield* threads.settled
+        expect(peak).toBe(2)
+      }),
+      { infer: concurrent, config: concurrentConfig }
+    )
+  })
+
   test("ingress commits a deduplicated batch before any actor is driven", async () => {
     const result = await running((threads) =>
       Effect.gen(function*() {
@@ -117,7 +166,7 @@ describe("the threads service", () => {
 
     expect(result.committed.alpha.map((event) => event.type)).toEqual(["ThreadCreated", "MessageReceived"])
     expect(result.committed.beta.map((event) => event.type)).toEqual(["ThreadCreated", "MessageReceived"])
-    expect(result.committed.dirty).toBe(0)
+    expect(result.committed.dirty).toBe(2)
     expect(result.committed.resting).toBe(false)
     expect(result.settled.alpha.some((event) => event.type === "TurnCompleted")).toBe(true)
     expect(result.settled.beta.some((event) => event.type === "TurnCompleted")).toBe(true)

--- a/apps/server/src/host.ts
+++ b/apps/server/src/host.ts
@@ -172,7 +172,8 @@ const runtimeOf = async (
   actor: Actor<ServerR>,
   log: string,
   lane: ReturnType<typeof layerLane>,
-  providers: ReadonlyArray<Provider>
+  providers: ReadonlyArray<Provider>,
+  maxConcurrentLanes: number
 ): Promise<ActorRuntime> => {
   const host: BunHost = await createBunHost<ServerR>({
     log,
@@ -180,6 +181,7 @@ const runtimeOf = async (
     actorFor: (candidate) => (idOf(candidate) === undefined ? undefined : actor),
     layersFor: () => lane,
     providers,
+    driver: { maxConcurrentLanes },
     keyOf: (event) => actor.keyOf?.(event)
   })
   let driving: Promise<void> | undefined
@@ -264,7 +266,7 @@ const runtimeOf = async (
       request()
     }),
     resting: () => host.resting(),
-    dirty: () => (driving === undefined ? 0 : follow ? 2 : 1),
+    dirty: host.work,
     close: async () => {
       await Effect.runPromise(settled)
       await host.close()
@@ -304,7 +306,14 @@ const make = (options: ThreadsOptions) =>
       return result
     }
     const open = async (summary: ActorSummary, actor: Actor<ServerR>, log: string): Promise<ActorRuntime> => {
-      const runtime = await runtimeOf(summary, actor, log, lane, options.providers ?? [])
+      const runtime = await runtimeOf(
+        summary,
+        actor,
+        log,
+        lane,
+        options.providers ?? [],
+        config.maxConcurrentLanes
+      )
       runtimes.set(summary.name, runtime)
       return runtime
     }

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -3,7 +3,16 @@ import { Effect, Layer } from "effect"
 import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { BunHttpServer } from "@effect/platform-bun"
 
-import { DEFAULT_ACTORS, DEFAULT_ACTOR_DATA, DEFAULT_DB, DEFAULT_PORT, layerConfig, readConfig, type ServerConfigValue } from "./config"
+import {
+  DEFAULT_ACTORS,
+  DEFAULT_ACTOR_DATA,
+  DEFAULT_DB,
+  DEFAULT_MAX_CONCURRENT_LANES,
+  DEFAULT_PORT,
+  layerConfig,
+  readConfig,
+  type ServerConfigValue
+} from "./config"
 import { Threads } from "./host"
 import { ALLOWED_HEADERS, layerGaugeResting, serve, PROBLEM_CONTENT_TYPE, DriverGauge, type Health } from "./http"
 
@@ -63,6 +72,7 @@ describe("config", () => {
     expect(config.db).toBe(DEFAULT_DB)
     expect(config.actors).toBe(DEFAULT_ACTORS)
     expect(config.actorData).toBe(DEFAULT_ACTOR_DATA)
+    expect(config.maxConcurrentLanes).toBe(DEFAULT_MAX_CONCURRENT_LANES)
     expect(config.token).toBeUndefined()
     expect(config.model).toEqual({
       baseUrl: undefined,
@@ -79,6 +89,7 @@ describe("config", () => {
       TARDIGRADE_DB: "/var/lib/agents.sqlite",
       TARDIGRADE_ACTORS: "/var/lib/actors",
       TARDIGRADE_ACTOR_DATA: "/var/lib/actor-data",
+      TARDIGRADE_MAX_CONCURRENT_LANES: "7",
       TARDIGRADE_TOKEN: "secret",
       MODEL_BASE_URL: "https://api.example.com",
       MODEL_API_KEY: "key",
@@ -89,6 +100,7 @@ describe("config", () => {
     expect(config.db).toBe("/var/lib/agents.sqlite")
     expect(config.actors).toBe("/var/lib/actors")
     expect(config.actorData).toBe("/var/lib/actor-data")
+    expect(config.maxConcurrentLanes).toBe(7)
     expect(config.token).toBe("secret")
     expect(config.model.baseUrl).toBe("https://api.example.com")
     expect(config.model.provider).toBe("openai")
@@ -98,6 +110,11 @@ describe("config", () => {
   test("a PORT that is not a port refuses to resolve", () => {
     expect(() => readConfig({ PORT: "http" })).toThrow()
     expect(() => readConfig({ PORT: "70000" })).toThrow()
+  })
+
+  test("a concurrency cap that cannot schedule a lane refuses to resolve", () => {
+    expect(() => readConfig({ TARDIGRADE_MAX_CONCURRENT_LANES: "0" })).toThrow("positive integer")
+    expect(() => readConfig({ TARDIGRADE_MAX_CONCURRENT_LANES: "many" })).toThrow("positive integer")
   })
 })
 

--- a/docs/how-to/cli.md
+++ b/docs/how-to/cli.md
@@ -44,6 +44,7 @@ A flag beats an environment variable, which beats `~/.tardigrade/config.json`, w
 | Bearer token | `--token` | `TARDIGRADE_TOKEN` | none |
 | Port for `dev` | `--port` | `PORT` | `4242`, then lower if occupied |
 | Store for `dev` | `--db` | `TARDIGRADE_DB` | `.tardigrade/agents.sqlite` |
+| Concurrent lanes for `dev` | `--max-concurrent-lanes` | `TARDIGRADE_MAX_CONCURRENT_LANES` | `4` |
 | Model | | `MODEL_BASE_URL`, `MODEL_API_KEY`, `MODEL_ID`, `MODEL_PROVIDER`, `MODEL_OUTPUT_GUARANTEE`, `MODEL_OUTPUT_WITH_TOOLS` | what `tdg setup` saved |
 
 `tdg setup` writes the file at mode 0600 and never prints the key back. With no model configured the server still boots and still serves every read; it says so at boot and turns fail naming what is missing.
@@ -69,4 +70,5 @@ tdg push ./actors/reviewer.ts --target local
 tdg ls --url https://tardigrade.example.com --token "$TOKEN"
 tdg events root --types TurnFailed
 tdg dev --port 8080 --db runs.sqlite
+tdg dev --max-concurrent-lanes 5
 ```

--- a/docs/how-to/server.md
+++ b/docs/how-to/server.md
@@ -55,6 +55,7 @@ Every failure is `application/problem+json`.
 | --- | --- |
 | `PORT` | `4242` |
 | `TARDIGRADE_DB` | `.tardigrade/agents.sqlite` |
+| `TARDIGRADE_MAX_CONCURRENT_LANES` | Maximum actor lanes settled at once. Defaults to `4` |
 | `TARDIGRADE_TOKEN` | Unset. When set, every route but `/healthz`, `/openapi.json`, and `/docs` needs `Authorization: Bearer` |
 | `MODEL_BASE_URL` `MODEL_API_KEY` `MODEL_ID` `MODEL_PROVIDER` | The model you supply. `tdg setup` writes these to a file instead |
 | `MODEL_OUTPUT_GUARANTEE` `MODEL_OUTPUT_WITH_TOOLS` | What this endpoint and this model promise about a declared output contract: `native` with `true` or `false` for whether the schema rides beside a tool list, or `none`. A provider name proves nothing here, so an undeclared endpoint serves a contract only through a mounted fallback ([structured output](../output.md)) |

--- a/packages/host/src/driver.test.ts
+++ b/packages/host/src/driver.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test"
+import {
+  createLaneDriver,
+  DEFAULT_MAX_CONCURRENT_LANES,
+  driverPolicyOf
+} from "./driver"
+
+const gate = (): { readonly promise: Promise<void>; readonly open: () => void } => {
+  let open!: () => void
+  const promise = new Promise<void>((resolve) => {
+    open = resolve
+  })
+  return { promise, open }
+}
+
+describe("lane driver", () => {
+  test("the exported default is the resolved capacity", () => {
+    expect(driverPolicyOf()).toEqual({ maxConcurrentLanes: DEFAULT_MAX_CONCURRENT_LANES })
+  })
+
+  test("rejects a capacity that cannot schedule a lane", () => {
+    expect(() => driverPolicyOf({ maxConcurrentLanes: 0 })).toThrow("positive integer")
+    expect(() => driverPolicyOf({ maxConcurrentLanes: 1.5 })).toThrow("positive integer")
+  })
+
+  test("fills the configured capacity with distinct lanes", async () => {
+    const release = gate()
+    const twoStarted = gate()
+    let active = 0
+    let peak = 0
+    let started = 0
+    const served: string[] = []
+    const driver = createLaneDriver({
+      policy: { maxConcurrentLanes: 2 },
+      serve: async (lane) => {
+        active += 1
+        peak = Math.max(peak, active)
+        started += 1
+        served.push(lane)
+        if (started === 2) twoStarted.open()
+        await release.promise
+        active -= 1
+      }
+    })
+    for (const lane of ["a", "b", "c"]) driver.mark(lane)
+
+    const draining = driver.drain()
+    await twoStarted.promise
+    expect(active).toBe(2)
+    expect(driver.work()).toBe(3)
+    expect(driver.resting()).toBe(false)
+    release.open()
+    await draining
+
+    expect(peak).toBe(2)
+    expect(new Set(served)).toEqual(new Set(["a", "b", "c"]))
+    expect(driver.work()).toBe(0)
+    expect(driver.resting()).toBe(true)
+  })
+
+  test("a delivery to an active lane waits for its next pass", async () => {
+    const release = gate()
+    const firstStarted = gate()
+    let calls = 0
+    let active = 0
+    let peak = 0
+    const driver = createLaneDriver({
+      policy: { maxConcurrentLanes: 4 },
+      serve: async () => {
+        calls += 1
+        active += 1
+        peak = Math.max(peak, active)
+        if (calls === 1) {
+          firstStarted.open()
+          await release.promise
+        }
+        active -= 1
+      }
+    })
+    driver.mark("same")
+
+    const draining = driver.drain()
+    await firstStarted.promise
+    driver.mark("same")
+    release.open()
+    await draining
+
+    expect(calls).toBe(2)
+    expect(peak).toBe(1)
+  })
+
+  test("a newly dirty lane fills idle capacity before the first lane finishes", async () => {
+    const release = gate()
+    const firstStarted = gate()
+    const secondStarted = gate()
+    let active = 0
+    const driver = createLaneDriver({
+      policy: { maxConcurrentLanes: 2 },
+      serve: async (lane) => {
+        active += 1
+        if (lane === "a") firstStarted.open()
+        if (lane === "b") secondStarted.open()
+        await release.promise
+        active -= 1
+      }
+    })
+    driver.mark("a")
+
+    const draining = driver.drain()
+    await firstStarted.promise
+    driver.mark("b")
+    await secondStarted.promise
+    expect(active).toBe(2)
+    release.open()
+    await draining
+  })
+
+  test("a failed lane keeps its debt for the next drive", async () => {
+    let attempts = 0
+    const driver = createLaneDriver({
+      serve: async () => {
+        attempts += 1
+        if (attempts === 1) throw new Error("crash")
+      }
+    })
+    driver.mark("a")
+
+    await expect(driver.drain()).rejects.toThrow("crash")
+    await driver.drain()
+    expect(attempts).toBe(2)
+    expect(driver.resting()).toBe(true)
+  })
+})

--- a/packages/host/src/driver.ts
+++ b/packages/host/src/driver.ts
@@ -1,0 +1,126 @@
+// DriverPolicy controls graph-wide lane scheduling. The cap counts live lane settlements; each
+// lane still admits one settlement at a time (tla/runtime/ConcurrentDriver.tla,
+// ConcurrencyBound and LaneExclusive).
+export interface DriverPolicy {
+  readonly maxConcurrentLanes: number
+}
+
+// DEFAULT_MAX_CONCURRENT_LANES is the host's visible settlement capacity when none is stated.
+export const DEFAULT_MAX_CONCURRENT_LANES = 4
+
+// DEFAULT_DRIVER_POLICY is the complete default scheduling policy.
+export const DEFAULT_DRIVER_POLICY: DriverPolicy = {
+  maxConcurrentLanes: DEFAULT_MAX_CONCURRENT_LANES
+}
+
+// driverPolicyOf resolves and validates the policy where a host is constructed.
+export const driverPolicyOf = (policy: Partial<DriverPolicy> = {}): DriverPolicy => {
+  const maxConcurrentLanes = policy.maxConcurrentLanes ?? DEFAULT_DRIVER_POLICY.maxConcurrentLanes
+  if (!Number.isSafeInteger(maxConcurrentLanes) || maxConcurrentLanes <= 0) {
+    throw new Error(`driver maxConcurrentLanes must be a positive integer, got ${JSON.stringify(maxConcurrentLanes)}`)
+  }
+  return { maxConcurrentLanes }
+}
+
+export interface LaneDriver {
+  // mark records that a lane owes a settlement pass.
+  readonly mark: (lane: string) => void
+  // drain settles every owed lane while respecting the configured capacity.
+  readonly drain: () => Promise<void>
+  // resting reports scheduler quiescence across durable debt and live settlements.
+  readonly resting: () => boolean
+  // work counts lanes that are dirty, live, or both.
+  readonly work: () => number
+}
+
+interface LaneDriverOptions {
+  readonly serve: (lane: string) => Promise<void>
+  readonly pick?: (dirty: ReadonlySet<string>) => string
+  readonly policy?: Partial<DriverPolicy>
+}
+
+// createLaneDriver schedules distinct lanes concurrently and keeps an active lane dirty when a
+// delivery reaches it mid-settlement. A failed settlement releases its slot and restores the
+// lane's durable debt (tla/runtime/ConcurrentDriver.tla, ConcurrencyBound and Accounting).
+export const createLaneDriver = (options: LaneDriverOptions): LaneDriver => {
+  const policy = driverPolicyOf(options.policy)
+  const dirty = new Set<string>()
+  const inFlight = new Set<string>()
+  const pulse = (): { readonly promise: Promise<void>; readonly send: () => void } => {
+    let send!: () => void
+    const promise = new Promise<void>((resolve) => {
+      send = resolve
+    })
+    return { promise, send }
+  }
+  let changed = pulse()
+
+  const mark = (lane: string): void => {
+    if (dirty.has(lane)) return
+    dirty.add(lane)
+    const previous = changed
+    changed = pulse()
+    previous.send()
+  }
+
+  const work = (): number => new Set([...dirty, ...inFlight]).size
+  const eligible = (): Set<string> => new Set([...dirty].filter((lane) => !inFlight.has(lane)))
+
+  const drain = async (): Promise<void> => {
+    const active = new Map<string, Promise<void>>()
+    let failure: { readonly cause: unknown } | undefined
+
+    const launch = (lane: string): void => {
+      dirty.delete(lane)
+      inFlight.add(lane)
+      const task = Promise.resolve()
+        .then(() => options.serve(lane))
+        .catch((cause: unknown) => {
+          dirty.add(lane)
+          failure ??= { cause }
+        })
+        .finally(() => {
+          inFlight.delete(lane)
+          active.delete(lane)
+        })
+      active.set(lane, task)
+    }
+
+    for (;;) {
+      while (failure === undefined && active.size < policy.maxConcurrentLanes) {
+        const candidates = eligible()
+        if (candidates.size === 0) break
+        let lane: string
+        try {
+          lane = options.pick?.(candidates) ?? (candidates.values().next().value as string)
+          if (!candidates.has(lane)) {
+            throw new Error(`driver pick returned ineligible lane ${JSON.stringify(lane)}`)
+          }
+        } catch (cause) {
+          failure = { cause }
+          break
+        }
+        launch(lane)
+      }
+
+      if (active.size === 0) break
+      const completions = [...active.values()]
+      if (failure === undefined && active.size < policy.maxConcurrentLanes) {
+        const notification = changed.promise
+        if (eligible().size > 0) continue
+        await Promise.race([...completions, notification])
+      } else {
+        await Promise.race(completions)
+      }
+    }
+
+    if (failure !== undefined) throw failure.cause
+  }
+
+  return {
+    mark,
+    drain,
+    resting: () => dirty.size === 0 && inFlight.size === 0,
+    work
+  }
+}

--- a/packages/host/src/host.test.ts
+++ b/packages/host/src/host.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { Router } from "@clavia/tardigrade-core/router"
-import { transition, type Reactor } from "@clavia/tardigrade-core/actor"
+import { transition, type Actor, type Reactor } from "@clavia/tardigrade-core/actor"
 import { Facets } from "@clavia/tardigrade-core/facets"
 import { createHost } from "./host"
 import { parseActorId } from "@clavia/tardigrade-core/communication/endpoint"
@@ -18,6 +18,14 @@ import { threadCreated } from "@clavia/tardigrade-core/thread"
 const RALLY = 6
 
 const str = (v: unknown): string => String(v ?? "")
+
+const signal = (): { readonly promise: Promise<void>; readonly send: () => void } => {
+  let send!: () => void
+  const promise = new Promise<void>((resolve) => {
+    send = resolve
+  })
+  return { promise, send }
+}
 
 // The rally's key table: the inbound by id (msg:), the answer by the inbound it answers (an:).
 const rallyKeys = (e: Event): string | undefined => {
@@ -69,6 +77,56 @@ const rally = () => {
 }
 
 describe("the host", () => {
+  test("settles distinct lanes up to the configured capacity", async () => {
+    const release = signal()
+    const twoStarted = signal()
+    let active = 0
+    let peak = 0
+    let started = 0
+    const actor: Actor = {
+      keyOf: (event) => event.type === "Done" ? `done:${str((event as { id?: unknown }).id)}` : undefined,
+      reactors: [(events) =>
+        events
+          .filter((event) => event.type === "MessageReceived")
+          .map((event) => {
+            const id = str((event as { id?: unknown }).id)
+            return transition({
+              key: `done:${id}`,
+              input: id,
+              act: (input: string) => Effect.promise(async () => {
+                active += 1
+                peak = Math.max(peak, active)
+                started += 1
+                if (started === 2) twoStarted.send()
+                await release.promise
+                active -= 1
+                return [{ type: "Done", id: input, at: 1 } as Event]
+              })
+            })
+          })]
+    }
+    const host = createHost({
+      actorFor: () => actor,
+      driver: { maxConcurrentLanes: 2 },
+      keyOf: actor.keyOf
+    })
+    for (const lane of ["a", "b", "c"]) {
+      host.commitRoot(`mem:${lane}`, { type: "MessageReceived", id: lane, at: 0 } as Event)
+    }
+
+    const driving = host.drive()
+    await twoStarted.promise
+    expect(active).toBe(2)
+    expect(host.resting()).toBe(false)
+    release.send()
+    await driving
+
+    expect(peak).toBe(2)
+    expect(host.resting()).toBe(true)
+    expect(["a", "b", "c"].map((lane) => host.read(lane).some((event) => event.type === "Done")))
+      .toEqual([true, true, true])
+  })
+
   test("one serve drives the whole rally to quiescence", async () => {
     const host = rally()
     host.commitRoot("mem:a", { type: "MessageReceived", id: "serve", n: 0, at: 0 } as Event)

--- a/packages/host/src/host.ts
+++ b/packages/host/src/host.ts
@@ -23,6 +23,7 @@ import { Self, restingActor, settleActor, type Actor } from "@clavia/tardigrade-
 import { Facets } from "@clavia/tardigrade-core/facets"
 import { deadlocks, victimOf, type EdgesOf } from "./deadlock"
 import { providerTransportFrom, type Provider } from "./communication/provider"
+import { createLaneDriver, type DriverPolicy } from "./driver"
 import {
   sameActorId,
   sameThreadLineage,
@@ -67,9 +68,11 @@ export type HostOptions<R> = {
   // cycle rests forever (packages/core/tla/communication/Delivery.tla,
   // DeliveryDeadlock).
   readonly edgesOf?: EdgesOf
-  // pick chooses which dirty lane the driver serves next; the default
-  // is insertion order. Service order must not change any outcome: the
-  // confluence property test shuffles this seam.
+  // driver states the graph-wide settlement capacity.
+  readonly driver?: Partial<DriverPolicy>
+  // pick chooses which eligible dirty lane the driver serves next; the default is insertion
+  // order. Service order must not change any outcome: the confluence property test shuffles this
+  // seam.
   readonly pick?: (dirty: ReadonlySet<string>) => string
   // keyOf is the composed dedup-key derivation (composeKeys). When
   // given, the host enforces the membrane: it refuses an unkeyed
@@ -124,7 +127,6 @@ const eventAt = (event: Event): number => {
 export const createHost = <R = never>(options: HostOptions<R>): Host => {
   const principal = options.principal ?? "mem"
   const lanes = new Map<string, ReadonlyArray<Event>>()
-  const dirty = new Set<string>()
   const providerTransport = providerTransportFrom(options.providers ?? [])
   const storeKeyOf = (event: Event): string | undefined => threadKeys.keyOf(event) ?? options.keyOf?.(event)
 
@@ -200,7 +202,7 @@ export const createHost = <R = never>(options: HostOptions<R>): Host => {
       : event
     if (seen(current, landed)) return
     append(lane, created === undefined ? [threadCreated(target, lineage, eventAt(event)), landed] : [landed])
-    dirty.add(lane)
+    driver.mark(lane)
   }
 
   const commit = (envelope: Envelope<unknown, Event, ActorId>): void =>
@@ -260,17 +262,19 @@ export const createHost = <R = never>(options: HostOptions<R>): Host => {
     return extra.pipe(Layer.provideMerge(portsOf(lane))) as Layer.Layer<R | EventLog>
   }
 
-  const drain = async (): Promise<void> => {
-    while (dirty.size > 0) {
-      const lane = options.pick?.(dirty) ?? (dirty.values().next().value as string)
-      dirty.delete(lane)
+  const driver = createLaneDriver({
+    ...(options.driver === undefined ? {} : { policy: options.driver }),
+    ...(options.pick === undefined ? {} : { pick: options.pick }),
+    serve: async (lane) => {
       const actor = options.actorFor(lane)
-      if (actor === undefined) continue
+      if (actor === undefined) return
       await Effect.runPromise(settleActor(actor).pipe(Effect.provide(layersOf(lane))))
     }
-  }
+  })
 
-  const drive = async (): Promise<void> => {
+  const drain = (): Promise<void> => driver.drain()
+
+  const driveGraph = async (): Promise<void> => {
     await drain()
     if (options.edgesOf === undefined) return
     // A quiet graph may still be knotted: the sentinel fails one
@@ -292,16 +296,23 @@ export const createHost = <R = never>(options: HostOptions<R>): Host => {
     }
   }
 
+  let driveTail: Promise<void> = Promise.resolve()
+  const drive = (): Promise<void> => {
+    const next = driveTail.then(driveGraph)
+    driveTail = next.then(() => undefined, () => undefined)
+    return next
+  }
+
   const resting = (): boolean => {
     for (const [lane, events] of lanes) {
       const actor = options.actorFor(lane)
       if (actor !== undefined && !restingActor(actor, events)) return false
     }
-    return dirty.size === 0
+    return driver.resting()
   }
 
   const wake = (lane: string): Promise<void> => {
-    dirty.add(lane)
+    driver.mark(lane)
     return drive()
   }
 

--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -60,6 +60,14 @@ const freshPath = (): string => join(dir, `host-${n++}.sqlite`)
 
 const created = (lane: string, at = 0): Event => threadCreated({ actor: "bun", thread: lane }, undefined, at)
 
+const signal = (): { readonly promise: Promise<void>; readonly send: () => void } => {
+  let send!: () => void
+  const promise = new Promise<void>((resolve) => {
+    send = resolve
+  })
+  return { promise, send }
+}
+
 const options = (path: string): BunHostOptions<never> => ({
   log: path,
   actorFor: (lane) => (lane === "echo" ? echo : undefined),
@@ -67,6 +75,58 @@ const options = (path: string): BunHostOptions<never> => ({
 })
 
 describe("the bun host", () => {
+  test("settles distinct lanes up to the configured capacity", async () => {
+    const release = signal()
+    const twoStarted = signal()
+    let active = 0
+    let peak = 0
+    let started = 0
+    const actor: Actor = {
+      keyOf,
+      reactors: [(events) =>
+        events
+          .filter((event) => event.type === "MessageReceived")
+          .map((event) => {
+            const id = String((event as { id?: unknown }).id)
+            return transition({
+              key: `dn:${id}`,
+              input: id,
+              act: (input: string) => Effect.promise(async () => {
+                active += 1
+                peak = Math.max(peak, active)
+                started += 1
+                if (started === 2) twoStarted.send()
+                await release.promise
+                active -= 1
+                return [{ type: "Done", id: input, at: 1 } as Event]
+              })
+            })
+          })]
+    }
+    const h = await createBunHost({
+      log: freshPath(),
+      actorFor: () => actor,
+      keyOf,
+      driver: { maxConcurrentLanes: 2 }
+    })
+    for (const lane of ["a", "b", "c"]) {
+      await h.commitRoot(`bun:${lane}`, { type: "MessageReceived", id: lane, at: 0 } as Event)
+    }
+
+    const driving = h.drive()
+    await twoStarted.promise
+    expect(active).toBe(2)
+    expect(h.work()).toBe(3)
+    expect(await h.resting()).toBe(false)
+    release.send()
+    await driving
+
+    expect(peak).toBe(2)
+    expect(h.work()).toBe(0)
+    expect(await h.resting()).toBe(true)
+    await h.close()
+  })
+
   test("creates the directory for a nested log path", async () => {
     const path = join(dir, `nested-${n++}`, "agents.sqlite")
     const h = await createBunHost(options(path))

--- a/platform/bun/src/host.ts
+++ b/platform/bun/src/host.ts
@@ -30,6 +30,7 @@ import { Facets } from "@clavia/tardigrade-core/facets"
 import { deadlocks, victimOf, type EdgesOf } from "@clavia/tardigrade-host/deadlock"
 import type { HostPorts } from "@clavia/tardigrade-host/host"
 import { providerTransportFrom, type Provider } from "@clavia/tardigrade-host/communication/provider"
+import { createLaneDriver, type DriverPolicy } from "@clavia/tardigrade-host/driver"
 import { traceparentOf } from "@clavia/tardigrade-core/trace"
 import {
   sameActorId,
@@ -86,6 +87,7 @@ export type BunHostOptions<R> = {
   readonly providers?: ReadonlyArray<Provider>
   readonly routes?: ReadonlyArray<TransportRoute>
   readonly edgesOf?: EdgesOf
+  readonly driver?: Partial<DriverPolicy>
   readonly pick?: (dirty: ReadonlySet<string>) => string
   readonly keyOf?: (e: Event) => string | undefined
 } & LayersFor<R>
@@ -105,6 +107,8 @@ export interface BunHost {
   // process runs at start, so work interrupted by a death settles from the surviving log.
   readonly recover: () => Promise<void>
   readonly resting: () => Promise<boolean>
+  // work counts lanes that are dirty, live, or both.
+  readonly work: () => number
   readonly self: (lane: string) => string
   readonly close: () => Promise<void>
 }
@@ -154,7 +158,6 @@ export const createBunHost = async <R = never>(options: BunHostOptions<R>): Prom
     )
   )
 
-  const dirty = new Set<string>()
   const providerTransport = providerTransportFrom(options.providers ?? [])
   const storeKeyOf = (event: Event): string | undefined => threadKeys.keyOf(event) ?? options.keyOf?.(event)
 
@@ -266,7 +269,7 @@ export const createBunHost = async <R = never>(options: BunHostOptions<R>): Prom
           return true
         })
       ).pipe(Effect.orDie)
-      if (appended) dirty.add(lane)
+      if (appended) driver.mark(lane)
     }).pipe(Effect.withSpan("commit", { kind: "producer", attributes: { to: address, type: event.type } }))
   }
 
@@ -323,15 +326,17 @@ export const createBunHost = async <R = never>(options: BunHostOptions<R>): Prom
     return extra.pipe(Layer.provideMerge(portsOf(lane))) as Layer.Layer<R | EventLog>
   }
 
-  const drain = async (): Promise<void> => {
-    while (dirty.size > 0) {
-      const lane = options.pick?.(dirty) ?? (dirty.values().next().value as string)
-      dirty.delete(lane)
+  const driver = createLaneDriver({
+    ...(options.driver === undefined ? {} : { policy: options.driver }),
+    ...(options.pick === undefined ? {} : { pick: options.pick }),
+    serve: async (lane) => {
       const actor = options.actorFor(lane)
-      if (actor === undefined) continue
+      if (actor === undefined) return
       await runtime.runPromise(settleActor(actor).pipe(Effect.provide(layersOf(lane))))
     }
-  }
+  })
+
+  const drain = (): Promise<void> => driver.drain()
 
   const lanesEffect: Effect.Effect<ReadonlyArray<string>, never> = sql<{
     lane: string
@@ -347,7 +352,7 @@ export const createBunHost = async <R = never>(options: BunHostOptions<R>): Prom
     return map
   }
 
-  const drive = async (): Promise<void> => {
+  const driveGraph = async (): Promise<void> => {
     await drain()
     if (options.edgesOf === undefined) return
     for (;;) {
@@ -369,17 +374,24 @@ export const createBunHost = async <R = never>(options: BunHostOptions<R>): Prom
     }
   }
 
+  let driveTail: Promise<void> = Promise.resolve()
+  const drive = (): Promise<void> => {
+    const next = driveTail.then(driveGraph)
+    driveTail = next.then(() => undefined, () => undefined)
+    return next
+  }
+
   const resting = async (): Promise<boolean> => {
     for (const [lane, events] of await lanesMap()) {
       const actor = options.actorFor(lane)
       if (actor !== undefined && !restingActor(actor, events)) return false
     }
-    return dirty.size === 0
+    return driver.resting()
   }
 
   const recover = async (): Promise<void> => {
     for (const lane of (await lanesMap()).keys()) {
-      if (options.actorFor(lane) !== undefined) dirty.add(lane)
+      if (options.actorFor(lane) !== undefined) driver.mark(lane)
     }
     await drive()
   }
@@ -391,12 +403,13 @@ export const createBunHost = async <R = never>(options: BunHostOptions<R>): Prom
     lanes: () => runtime.runPromise(lanesEffect),
     commitRoot: (address, event) => runtime.runPromise(commitRootEffect(address, event)),
     wake: (lane) => {
-      dirty.add(lane)
+      driver.mark(lane)
       return drive()
     },
     drive,
     recover,
     resting,
+    work: driver.work,
     self,
     close: () => runtime.dispose()
   }


### PR DESCRIPTION
## Summary

Settles distinct actor lanes concurrently through one shared driver while keeping each lane exclusive. Exposes the capacity through the host policy, `TARDIGRADE_MAX_CONCURRENT_LANES`, and `tdg dev --max-concurrent-lanes`. Updates the health gauge to count actual owed or live lanes. Frames the README section around agents that can self-improve.

## Why

An agent that spawns several children should allow their independent model calls to overlap. The scheduler preserves keyed per-lane commits, crash debt, durable parking, and graph-wide quiescence while using idle capacity as new lanes become dirty. The README heading now matches the section argument about self-authored harnesses.

## Verification

- `bun run gate`
- `bun run tla ConcurrentDriver`
- End-to-end server test proves two `Infer.react` calls overlap under a capacity of two
- `bun run gate --only=lint:docs`