### PR TITLE
feat(agent): preserve usage evidence

### DIFF
--- a/docs/how-to/migrate.md
+++ b/docs/how-to/migrate.md
@@ -159,7 +159,9 @@ Validate the import before cutover:
 
 Run the same representative task once with Tardigrade. Use the same model, settings, input, data, and timer boundary as the baseline. Check semantic output parity before comparing efficiency.
 
-Use `usageIn(events, turn)` or the recorded attempt usage to total Tardigrade input and output tokens. Report cost only when the provider reports it or the application supplies an explicit price table. Measure latency from request delivery through the terminal event.
+Use `usageIn(events, turn)` or the recorded attempt usage to total Tardigrade input and output tokens. Each usage stamp keeps normalized cache-read, cache-write, and reasoning counts when the provider supplies them. Each `providerReports` entry keeps one physical request's unconventional fields unchanged under `providerSpecific`, including reports from retried requests. The field contains the provider object directly when the request produced one report and an array when it produced several. `reportedCostUsd` keeps the provider figure, and `estimatedCostUsd` keeps an independent projection from the configured price table. `costUsd` remains the provider figure when available and otherwise uses the table estimate. Measure latency from request delivery through the terminal event.
+
+A price table needs `cachedPromptUsdPerToken` or `cacheWritePromptUsdPerToken` when the matching usage bucket is greater than zero. Tardigrade leaves the estimate unknown when a reported cache bucket has no declared rate. Calling `priced` with a complete new table recomputes `estimatedCostUsd`; a table that cannot price the usage preserves a recorded estimate.
 
 For each numeric measure, report `change = Tardigrade - existing` and `percent = change / existing * 100`. A negative token, cost, latency, line, or dependency change is a reduction. Leave the percentage unavailable when the existing value is zero or either value is missing.
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -85,6 +85,7 @@ export {
   sumUsage,
   ZERO_USAGE,
   type Usage,
+  type ProviderUsageReport,
   type CostSource,
   type ModelPricing
 } from "./usage"

--- a/packages/agent/src/usage.test.ts
+++ b/packages/agent/src/usage.test.ts
@@ -5,37 +5,161 @@ import { costNumber, priced, sumUsage, usageFrom, usageIn, usageOf, ZERO_USAGE }
 const table = { promptUsdPerToken: 0.001, completionUsdPerToken: 0.002 }
 
 describe("priced and usageFrom", () => {
-  test("a reported cost keeps its source, including zero, and a price table fills an omitted cost", () => {
-    const billed = usageFrom({ promptTokens: 10, completionTokens: 4, cost: 0 }, table, {
-      provider: "vercel-ai-gateway",
-      model: "anthropic/claude-sonnet-4.6"
-    })
+  test("a provider bill and a table estimate coexist", () => {
+    const raw = {
+      prompt_tokens: 10,
+      completion_tokens: 4,
+      total_tokens: 14,
+      prompt_tokens_details: { cached_tokens: 4 },
+      completion_tokens_details: { reasoning_tokens: 2 },
+      cost: 0
+    }
+    const billed = usageFrom(
+      raw,
+      { ...table, cachedPromptUsdPerToken: 0.0001 },
+      {
+        provider: "vercel-ai-gateway",
+        model: "anthropic/claude-sonnet-4.6"
+      }
+    )
     expect(billed).toEqual({
       promptTokens: 10,
       completionTokens: 4,
+      totalTokens: 14,
+      cachedPromptTokens: 4,
+      reasoningTokens: 2,
       costUsd: 0,
       costSource: "provider",
+      reportedCostUsd: 0,
+      estimatedCostUsd: 6 * 0.001 + 4 * 0.0001 + 4 * 0.002,
       provider: "vercel-ai-gateway",
-      model: "anthropic/claude-sonnet-4.6"
+      model: "anthropic/claude-sonnet-4.6",
+      providerReports: [
+        { provider: "vercel-ai-gateway", model: "anthropic/claude-sonnet-4.6", providerSpecific: raw }
+      ]
     })
-    const filled = usageFrom({ prompt_tokens: 10, completion_tokens: 4 }, table, { provider: "openai", model: "test" })
+
+    const filledRaw = { prompt_tokens: 10, completion_tokens: 4 }
+    const filled = usageFrom(filledRaw, table, { provider: "openai", model: "test" })
     expect(filled).toEqual({
       promptTokens: 10,
       completionTokens: 4,
       costUsd: 10 * 0.001 + 4 * 0.002,
       costSource: "table",
+      estimatedCostUsd: 10 * 0.001 + 4 * 0.002,
       provider: "openai",
-      model: "test"
+      model: "test",
+      providerReports: [{ provider: "openai", model: "test", providerSpecific: filledRaw }]
     })
-    const unknown = usageFrom({ promptTokens: 10, completionTokens: 4 })
-    expect(unknown).toEqual({ promptTokens: 10, completionTokens: 4 })
+    const unknownRaw = { promptTokens: 10, completionTokens: 4 }
+    const unknown = usageFrom(unknownRaw)
+    expect(unknown).toEqual({
+      promptTokens: 10,
+      completionTokens: 4,
+      providerReports: [{ providerSpecific: unknownRaw }]
+    })
+    const futureRaw = { future_billable_units: 3 }
+    expect(usageFrom(futureRaw, table, { provider: "future", model: "m" })).toEqual({
+      promptTokens: 0,
+      completionTokens: 0,
+      provider: "future",
+      model: "m",
+      providerReports: [{ provider: "future", model: "m", providerSpecific: futureRaw }]
+    })
     expect(usageFrom(undefined)).toBeUndefined()
   })
 
-  test("priced does not relabel a figure that already has a cost", () => {
+  test("priced retains a provider figure and recomputes the table projection", () => {
     const reported = { promptTokens: 1, completionTokens: 1, costUsd: 9, costSource: "provider" as const }
-    expect(priced(reported, table)).toEqual(reported)
-    expect(priced({ promptTokens: 10, completionTokens: 4 }, table).costSource).toBe("table")
+    expect(priced(reported, table)).toEqual({
+      ...reported,
+      reportedCostUsd: 9,
+      estimatedCostUsd: 0.003
+    })
+    expect(priced({ promptTokens: 10, completionTokens: 4 }, table)).toMatchObject({
+      costUsd: 10 * 0.001 + 4 * 0.002,
+      costSource: "table",
+      estimatedCostUsd: 10 * 0.001 + 4 * 0.002
+    })
+    expect(priced({ promptTokens: 1, completionTokens: 1, costUsd: 9 }, table)).toEqual({
+      promptTokens: 1,
+      completionTokens: 1,
+      costUsd: 9,
+      estimatedCostUsd: 0.003
+    })
+    expect(
+      priced({ promptTokens: 1, completionTokens: 1, costUsd: 9, estimatedCostUsd: 8 }, table)
+    ).toEqual({
+      promptTokens: 1,
+      completionTokens: 1,
+      costUsd: 9,
+      estimatedCostUsd: 0.003
+    })
+    const recordedTable = {
+      promptTokens: 10,
+      completionTokens: 4,
+      cachedPromptTokens: 5,
+      costUsd: 0.7,
+      costSource: "table" as const
+    }
+    expect(priced(recordedTable, table)).toEqual(recordedTable)
+  })
+
+  test("cache buckets require declared rates", () => {
+    const usage = { promptTokens: 10, completionTokens: 4, cachedPromptTokens: 5 }
+    expect(priced(usage, table)).toEqual(usage)
+    expect(
+      priced(usage, { ...table, cachedPromptUsdPerToken: 0.0002 })
+    ).toMatchObject({ estimatedCostUsd: 5 * 0.001 + 5 * 0.0002 + 4 * 0.002 })
+    expect(
+      priced(
+        { promptTokens: 10, completionTokens: 4, cachedPromptTokens: 4, cacheWritePromptTokens: 2 },
+        { ...table, cachedPromptUsdPerToken: 0.0002, cacheWritePromptUsdPerToken: 0.00125 }
+      )
+    ).toMatchObject({ estimatedCostUsd: 4 * 0.001 + 4 * 0.0002 + 2 * 0.00125 + 4 * 0.002 })
+  })
+
+  test("a normalized adapter view fills details the raw report omits", () => {
+    const raw = { prompt_tokens: 10, completion_tokens: 4, cost: 0 }
+    expect(
+      usageFrom(
+        [
+          raw,
+          {
+            promptTokens: 10,
+            completionTokens: 4,
+            totalTokens: 15,
+            promptTokensDetails: { cachedTokens: 4, cacheWriteTokens: 2 },
+            completionTokensDetails: { reasoningTokens: 2 }
+          }
+        ],
+        { ...table, cachedPromptUsdPerToken: 0.0002, cacheWritePromptUsdPerToken: 0.00125 }
+      )
+    ).toMatchObject({
+      totalTokens: 15,
+      cachedPromptTokens: 4,
+      cacheWritePromptTokens: 2,
+      reasoningTokens: 2,
+      reportedCostUsd: 0,
+      providerReports: [{ providerSpecific: raw }]
+    })
+
+    const converse = { inputTokens: 10, outputTokens: 2, totalTokens: 12, cacheReadInputTokens: 4 }
+    expect(
+      usageFrom(
+        [converse, { promptTokens: 10, completionTokens: 2, totalTokens: 12 }],
+        { ...table, cachedPromptUsdPerToken: 0.0002 },
+        { provider: "bedrock", model: "m" },
+        converse
+      )
+    ).toMatchObject({
+      promptTokens: 14,
+      completionTokens: 2,
+      totalTokens: 16,
+      cachedPromptTokens: 4,
+      estimatedCostUsd: 10 * 0.001 + 4 * 0.0002 + 2 * 0.002
+    })
+    expect(usageFrom({ promptTokens: 3, completionTokens: 2, totalTokens: 0 })).not.toHaveProperty("totalTokens")
   })
 
   test("costNumber reads the seats a gateway actually writes", () => {
@@ -48,20 +172,66 @@ describe("priced and usageFrom", () => {
 
 describe("sumUsage", () => {
   test("unknown is sticky, and mixed sources take the weaker label", () => {
-    const billed = { promptTokens: 1, completionTokens: 1, costUsd: 0.25, costSource: "provider" as const, provider: "a", model: "m" }
-    const filled = { promptTokens: 2, completionTokens: 2, costUsd: 0.5, costSource: "table" as const, provider: "a", model: "m" }
+    const billed = {
+      promptTokens: 1,
+      completionTokens: 1,
+      costUsd: 0.25,
+      costSource: "provider" as const,
+      reportedCostUsd: 0.25,
+      estimatedCostUsd: 0.4,
+      provider: "a",
+      model: "m"
+    }
+    const filled = {
+      promptTokens: 2,
+      completionTokens: 2,
+      costUsd: 0.5,
+      costSource: "table" as const,
+      estimatedCostUsd: 0.5,
+      provider: "a",
+      model: "m"
+    }
     const mixed = sumUsage([billed, filled])
     expect(mixed).toEqual({
       promptTokens: 3,
       completionTokens: 3,
       costUsd: 0.75,
       costSource: "table",
+      estimatedCostUsd: 0.9,
       provider: "a",
       model: "m"
     })
     expect(sumUsage([billed, { promptTokens: 1, completionTokens: 0 }]).costUsd).toBeUndefined()
     expect(sumUsage([billed, { ...billed, provider: "b" }]).provider).toBeUndefined()
     expect(sumUsage([])).toEqual(ZERO_USAGE)
+  })
+
+  test("raw provider metrics survive normalization and aggregation", () => {
+    const first = usageFrom(
+      { inputTokens: 10, outputTokens: 2, totalTokens: 12, cacheReadInputTokens: 4 },
+      undefined,
+      { provider: "bedrock", model: "m" }
+    )!
+    const second = usageFrom(
+      { inputTokens: 12, outputTokens: 3, totalTokens: 15, cacheReadInputTokens: 5 },
+      undefined,
+      { provider: "bedrock", model: "m" }
+    )!
+    expect(
+      priced(first, { ...table, cachedPromptUsdPerToken: 0.0002 })
+    ).toMatchObject({ estimatedCostUsd: 10 * 0.001 + 4 * 0.0002 + 2 * 0.002 })
+    const summed = sumUsage([first, second])
+    expect(summed).toMatchObject({
+      promptTokens: 31,
+      completionTokens: 5,
+      totalTokens: 36,
+      cachedPromptTokens: 9,
+      providerReports: [
+        { provider: "bedrock", model: "m", providerSpecific: first.providerReports![0]!.providerSpecific },
+        { provider: "bedrock", model: "m", providerSpecific: second.providerReports![0]!.providerSpecific }
+      ]
+    })
+    expect(usageOf(JSON.parse(JSON.stringify(summed)))).toEqual(summed)
   })
 })
 
@@ -132,5 +302,9 @@ describe("usageIn", () => {
       costSource: "provider"
     })
     expect(usageOf({ promptTokens: 1, completionTokens: 0, costSource: "table" }).costSource).toBeUndefined()
+    expect(
+      sumUsage([usageOf({ promptTokens: 3, completionTokens: 1, costUsd: 0.4, costSource: "table" })])
+        .estimatedCostUsd
+    ).toBeUndefined()
   })
 })

--- a/packages/agent/src/usage.ts
+++ b/packages/agent/src/usage.ts
@@ -1,28 +1,47 @@
 import type { Event } from "@clavia/tardigrade-core/event"
 import { turnOf } from "@clavia/tardigrade-code/turns"
 
-// Usage is what one model attempt spent. costUsd is present when the figure is known.
-// costSource is how that figure was obtained: the provider billed it, or a price table
-// filled it from token counts. A reported zero is free. Absence of costUsd is unknown.
-// provider and model name who was called, so a later switch cannot rewrite the stamp
-// (usage.test.ts, "a reported cost keeps its source").
+// Usage is what one model attempt spent. The normalized fields support projections, while
+// providerReports preserve the metrics each provider returned for later normalization and
+// repricing (usage.test.ts, "raw provider metrics survive normalization and aggregation").
 
 export type CostSource = "provider" | "table"
+
+// ProviderUsageReport keeps one physical request's provider metrics and serving coordinates.
+export interface ProviderUsageReport {
+  readonly provider?: string
+  readonly model?: string
+  readonly providerSpecific: unknown
+}
 
 export interface Usage {
   readonly promptTokens: number
   readonly completionTokens: number
+  readonly totalTokens?: number
+  readonly cachedPromptTokens?: number
+  readonly cacheWritePromptTokens?: number
+  readonly reasoningTokens?: number
+  // costUsd is the compatibility projection: a provider report wins, then a table estimate.
+  // The two evidence fields remain independent when both exist (usage.test.ts, "a provider bill
+  // and a table estimate coexist").
   readonly costUsd?: number
   readonly costSource?: CostSource
+  readonly reportedCostUsd?: number
+  readonly estimatedCostUsd?: number
   readonly provider?: string
   readonly model?: string
+  readonly providerReports?: ReadonlyArray<ProviderUsageReport>
 }
 
+// ModelPricing states the rates used for an independent cost projection.
 export interface ModelPricing {
-  // Per-token rates for a table fill. Cached prompt tokens have no cheaper seat here, so a
-  // fill prices them at the full input rate (usage.test.ts, "a price table fills an omitted cost").
   readonly promptUsdPerToken: number
   readonly completionUsdPerToken: number
+  // cachedPromptUsdPerToken and cacheWritePromptUsdPerToken price reported cache buckets. A
+  // table that omits a rate cannot estimate a usage stamp with tokens in that bucket
+  // (usage.test.ts, "cache buckets require declared rates").
+  readonly cachedPromptUsdPerToken?: number
+  readonly cacheWritePromptUsdPerToken?: number
 }
 
 export const ZERO_USAGE: Usage = { promptTokens: 0, completionTokens: 0 }
@@ -47,6 +66,19 @@ const firstNumber = (rec: Record<string, unknown>, keys: ReadonlyArray<string>):
   return undefined
 }
 
+const nestedNumber = (
+  rec: Record<string, unknown>,
+  seats: ReadonlyArray<readonly [container: string, keys: ReadonlyArray<string>]>
+): number | undefined => {
+  for (const [container, keys] of seats) {
+    const nested = asRecord(rec[container])
+    if (nested === undefined) continue
+    const found = firstNumber(nested, keys)
+    if (found !== undefined) return found
+  }
+  return undefined
+}
+
 // costNumber reads a provider-billed dollar amount from a usage object. Gateways disagree on
 // the field name, so every common seat is checked; a table fill never writes these keys.
 export const costNumber = (value: unknown): number | undefined => {
@@ -57,62 +89,215 @@ export const costNumber = (value: unknown): number | undefined => {
   return costNumber(rec.gateway)
 }
 
-const tokensOf = (value: unknown): { readonly promptTokens: number; readonly completionTokens: number } | undefined => {
+interface TokenMetrics {
+  readonly promptTokens: number
+  readonly completionTokens: number
+  readonly totalTokens?: number
+  readonly cachedPromptTokens?: number
+  readonly cacheWritePromptTokens?: number
+  readonly reasoningTokens?: number
+  readonly cacheBucketsWereExclusive?: true
+}
+
+const tokensOf = (value: unknown): TokenMetrics | undefined => {
   const rec = asRecord(value)
   if (rec === undefined) return undefined
   const prompt = firstNumber(rec, ["promptTokens", "prompt_tokens", "inputTokens", "input_tokens"])
   const completion = firstNumber(rec, ["completionTokens", "completion_tokens", "outputTokens", "output_tokens"])
   if (prompt === undefined && completion === undefined) return undefined
-  return { promptTokens: prompt ?? 0, completionTokens: completion ?? 0 }
+  const total = firstNumber(rec, ["totalTokens", "total_tokens"])
+  const exclusiveCached = firstNumber(rec, ["cacheReadInputTokens", "cache_read_input_tokens"])
+  const cached =
+    exclusiveCached ??
+    firstNumber(rec, ["cachedPromptTokens", "cached_prompt_tokens", "cachedTokens", "cached_tokens"]) ??
+    nestedNumber(rec, [
+      ["promptTokensDetails", ["cachedTokens", "cached_tokens"]],
+      ["prompt_tokens_details", ["cachedTokens", "cached_tokens"]],
+      ["input_tokens_details", ["cachedTokens", "cached_tokens"]]
+    ])
+  const exclusiveCacheWrite = firstNumber(rec, [
+    "cacheWriteInputTokens",
+    "cache_write_input_tokens",
+    "cacheCreationInputTokens",
+    "cache_creation_input_tokens"
+  ])
+  const cacheWrite =
+    exclusiveCacheWrite ??
+    firstNumber(rec, ["cacheWritePromptTokens", "cache_write_prompt_tokens"]) ??
+    nestedNumber(rec, [
+      ["promptTokensDetails", ["cacheWriteTokens", "cache_write_tokens"]],
+      ["prompt_tokens_details", ["cacheWriteTokens", "cache_write_tokens"]],
+      ["input_tokens_details", ["cacheWriteTokens", "cache_write_tokens"]]
+    ])
+  const reasoning =
+    firstNumber(rec, ["reasoningTokens", "reasoning_tokens"]) ??
+    nestedNumber(rec, [
+      ["completionTokensDetails", ["reasoningTokens", "reasoning_tokens"]],
+      ["completion_tokens_details", ["reasoningTokens", "reasoning_tokens"]],
+      ["output_tokens_details", ["reasoningTokens", "reasoning_tokens"]]
+    ])
+  const cacheBucketsWereExclusive = exclusiveCached !== undefined || exclusiveCacheWrite !== undefined
+  const exclusivePromptTokens = (exclusiveCached ?? 0) + (exclusiveCacheWrite ?? 0)
+  const normalizedTotal =
+    total === undefined || (total === 0 && (prompt ?? 0) + (completion ?? 0) > 0)
+      ? undefined
+      : total + exclusivePromptTokens
+  return {
+    promptTokens: (prompt ?? 0) + exclusivePromptTokens,
+    completionTokens: completion ?? 0,
+    ...(normalizedTotal === undefined ? {} : { totalTokens: normalizedTotal }),
+    ...(cached === undefined ? {} : { cachedPromptTokens: cached }),
+    ...(cacheWrite === undefined ? {} : { cacheWritePromptTokens: cacheWrite }),
+    ...(reasoning === undefined ? {} : { reasoningTokens: reasoning }),
+    ...(cacheBucketsWereExclusive ? { cacheBucketsWereExclusive: true as const } : {})
+  }
 }
 
 export const costOf = (
   pricing: ModelPricing | undefined,
   promptTokens: number,
-  completionTokens: number
-): number | undefined =>
-  pricing === undefined
-    ? undefined
-    : promptTokens * pricing.promptUsdPerToken + completionTokens * pricing.completionUsdPerToken
-
-// priced keeps a cost that is already present, including zero, and fills from the table only
-// when nobody billed a figure. The fill is labeled table so a later reader can tell it from a
-// provider bill (usage.test.ts, "a price table fills an omitted cost").
-export const priced = (usage: Usage, pricing?: ModelPricing): Usage => {
-  if (usage.costUsd !== undefined) return usage
-  const costUsd = costOf(pricing, usage.promptTokens, usage.completionTokens)
-  return costUsd === undefined ? usage : { ...usage, costUsd, costSource: "table" }
+  completionTokens: number,
+  cachedPromptTokens: number = 0,
+  cacheWritePromptTokens: number = 0
+): number | undefined => {
+  if (pricing === undefined) return undefined
+  if (cachedPromptTokens > 0 && pricing.cachedPromptUsdPerToken === undefined) return undefined
+  if (cacheWritePromptTokens > 0 && pricing.cacheWritePromptUsdPerToken === undefined) return undefined
+  const uncachedPromptTokens = promptTokens - cachedPromptTokens - cacheWritePromptTokens
+  if (uncachedPromptTokens < 0) return undefined
+  return (
+    uncachedPromptTokens * pricing.promptUsdPerToken +
+    cachedPromptTokens * (pricing.cachedPromptUsdPerToken ?? 0) +
+    cacheWritePromptTokens * (pricing.cacheWritePromptUsdPerToken ?? 0) +
+    completionTokens * pricing.completionUsdPerToken
+  )
 }
 
-// usageFrom builds spend from a provider reply. A billed dollar, including zero, is provider.
-// Token counts with no bill are filled from the table when one exists, and left without a
-// cost when none does. Nothing at all (no tokens, no bill) is undefined: unknown, not zero.
-// Later parts win on tokens, so the adapter's counts (held last) beat the raw SSE object.
+// priced projects a table independently from the reported bill. costUsd keeps its compatibility
+// precedence, including a provider-reported zero (usage.test.ts, "a provider bill and a table
+// estimate coexist").
+export const priced = (usage: Usage, pricing?: ModelPricing): Usage => {
+  const {
+    costUsd: previousCostUsd,
+    costSource: previousCostSource,
+    reportedCostUsd: recordedReportedCostUsd,
+    estimatedCostUsd: recordedEstimatedCostUsd,
+    ...metrics
+  } = usage
+  const reportedCostUsd =
+    recordedReportedCostUsd ?? (previousCostSource === "provider" ? previousCostUsd : undefined)
+  const estimatedCostUsd =
+    costOf(
+      pricing,
+      usage.promptTokens,
+      usage.completionTokens,
+      usage.cachedPromptTokens,
+      usage.cacheWritePromptTokens
+    ) ?? recordedEstimatedCostUsd
+  const costUsd = previousCostUsd ?? reportedCostUsd ?? estimatedCostUsd
+  const previousSource = previousCostSource === "provider" || previousCostSource === "table" ? previousCostSource : undefined
+  const costSource =
+    previousCostUsd !== undefined
+      ? previousSource
+      : reportedCostUsd !== undefined
+        ? "provider"
+        : estimatedCostUsd !== undefined
+          ? "table"
+          : undefined
+  return {
+    ...metrics,
+    ...(costUsd === undefined ? {} : { costUsd }),
+    ...(costSource === undefined ? {} : { costSource }),
+    ...(reportedCostUsd === undefined ? {} : { reportedCostUsd }),
+    ...(estimatedCostUsd === undefined ? {} : { estimatedCostUsd })
+  }
+}
+
+// usageFrom builds spend from one provider reply. The first reported part is retained verbatim;
+// later normalized parts refine fields without replacing details that only the wire exposed.
 export const usageFrom = (
   reported: unknown,
   pricing?: ModelPricing,
-  stamp?: { readonly provider?: string; readonly model?: string }
+  stamp?: { readonly provider?: string; readonly model?: string },
+  providerMetrics?: unknown
 ): Usage | undefined => {
   const parts = Array.isArray(reported) ? reported : [reported]
-  let tokens: { readonly promptTokens: number; readonly completionTokens: number } | undefined
+  let tokens: TokenMetrics | undefined
   let billed: number | undefined
+  let raw: unknown = providerMetrics
   for (const part of parts) {
+    if (raw === undefined && part !== undefined && part !== null) raw = part
     const next = tokensOf(part)
-    if (next !== undefined) tokens = next
+    if (next !== undefined) {
+      const keepExclusiveFold =
+        tokens?.cacheBucketsWereExclusive === true &&
+        next.cacheBucketsWereExclusive !== true &&
+        next.cachedPromptTokens === undefined &&
+        next.cacheWritePromptTokens === undefined
+      const totalTokens = keepExclusiveFold ? tokens?.totalTokens : (next.totalTokens ?? tokens?.totalTokens)
+      const cachedPromptTokens = next.cachedPromptTokens ?? tokens?.cachedPromptTokens
+      const cacheWritePromptTokens = next.cacheWritePromptTokens ?? tokens?.cacheWritePromptTokens
+      const reasoningTokens = next.reasoningTokens ?? tokens?.reasoningTokens
+      tokens =
+        tokens === undefined
+          ? next
+          : {
+              promptTokens: keepExclusiveFold ? tokens.promptTokens : next.promptTokens,
+              completionTokens: next.completionTokens,
+              ...(totalTokens === undefined ? {} : { totalTokens }),
+              ...(cachedPromptTokens === undefined ? {} : { cachedPromptTokens }),
+              ...(cacheWritePromptTokens === undefined ? {} : { cacheWritePromptTokens }),
+              ...(reasoningTokens === undefined ? {} : { reasoningTokens }),
+              ...(tokens.cacheBucketsWereExclusive === true || next.cacheBucketsWereExclusive === true
+                ? { cacheBucketsWereExclusive: true as const }
+                : {})
+            }
+    }
     const cost = costNumber(part)
     if (cost !== undefined) billed = cost
   }
-  if (tokens === undefined && billed === undefined) return undefined
-  return priced(
-    {
-      promptTokens: tokens?.promptTokens ?? 0,
-      completionTokens: tokens?.completionTokens ?? 0,
-      ...(stamp?.provider === undefined ? {} : { provider: stamp.provider }),
-      ...(stamp?.model === undefined ? {} : { model: stamp.model }),
-      ...(billed === undefined ? {} : { costUsd: billed, costSource: "provider" as const })
-    },
-    pricing
-  )
+  if (tokens === undefined && billed === undefined && raw === undefined) return undefined
+  const usage: Usage = {
+    promptTokens: tokens?.promptTokens ?? 0,
+    completionTokens: tokens?.completionTokens ?? 0,
+    ...(tokens?.totalTokens === undefined ? {} : { totalTokens: tokens.totalTokens }),
+    ...(tokens?.cachedPromptTokens === undefined ? {} : { cachedPromptTokens: tokens.cachedPromptTokens }),
+    ...(tokens?.cacheWritePromptTokens === undefined ? {} : { cacheWritePromptTokens: tokens.cacheWritePromptTokens }),
+    ...(tokens?.reasoningTokens === undefined ? {} : { reasoningTokens: tokens.reasoningTokens }),
+    ...(stamp?.provider === undefined ? {} : { provider: stamp.provider }),
+    ...(stamp?.model === undefined ? {} : { model: stamp.model }),
+    ...(billed === undefined ? {} : { costUsd: billed, costSource: "provider" as const, reportedCostUsd: billed }),
+    ...(raw === undefined
+      ? {}
+      : {
+          providerReports: [
+            {
+              ...(stamp?.provider === undefined ? {} : { provider: stamp.provider }),
+              ...(stamp?.model === undefined ? {} : { model: stamp.model }),
+              providerSpecific: raw
+            }
+          ]
+        })
+  }
+  return tokens === undefined ? usage : priced(usage, pricing)
+}
+
+const reportsOf = (value: unknown): ReadonlyArray<ProviderUsageReport> | undefined => {
+  if (!Array.isArray(value)) return undefined
+  const reports = value.flatMap((candidate): ReadonlyArray<ProviderUsageReport> => {
+    const rec = asRecord(candidate)
+    if (rec === undefined || !("providerSpecific" in rec)) return []
+    const provider = rec.provider
+    const model = rec.model
+    return [
+      {
+        ...(typeof provider === "string" && provider !== "" ? { provider } : {}),
+        ...(typeof model === "string" && model !== "" ? { model } : {}),
+        providerSpecific: rec.providerSpecific
+      }
+    ]
+  })
+  return reports.length === 0 ? undefined : reports
 }
 
 export const usageOf = (value: unknown): Usage => {
@@ -121,13 +306,27 @@ export const usageOf = (value: unknown): Usage => {
   const source = carried?.costSource
   const provider = carried?.provider
   const model = carried?.model
+  const reportedCostUsd = numberOf(carried?.reportedCostUsd)
+  const estimatedCostUsd = numberOf(carried?.estimatedCostUsd)
+  const totalTokens = numberOf(carried?.totalTokens)
+  const cachedPromptTokens = numberOf(carried?.cachedPromptTokens)
+  const cacheWritePromptTokens = numberOf(carried?.cacheWritePromptTokens)
+  const reasoningTokens = numberOf(carried?.reasoningTokens)
+  const providerReports = reportsOf(carried?.providerReports)
   return {
     promptTokens: numberOf(carried?.promptTokens) ?? 0,
     completionTokens: numberOf(carried?.completionTokens) ?? 0,
+    ...(totalTokens === undefined ? {} : { totalTokens }),
+    ...(cachedPromptTokens === undefined ? {} : { cachedPromptTokens }),
+    ...(cacheWritePromptTokens === undefined ? {} : { cacheWritePromptTokens }),
+    ...(reasoningTokens === undefined ? {} : { reasoningTokens }),
     ...(costUsd === undefined ? {} : { costUsd }),
     ...(costUsd !== undefined && (source === "provider" || source === "table") ? { costSource: source } : {}),
+    ...(reportedCostUsd === undefined ? {} : { reportedCostUsd }),
+    ...(estimatedCostUsd === undefined ? {} : { estimatedCostUsd }),
     ...(typeof provider === "string" && provider !== "" ? { provider } : {}),
-    ...(typeof model === "string" && model !== "" ? { model } : {})
+    ...(typeof model === "string" && model !== "" ? { model } : {}),
+    ...(providerReports === undefined ? {} : { providerReports })
   }
 }
 
@@ -148,10 +347,12 @@ export const sumUsage = (parts: ReadonlyArray<Usage>): Usage => {
   let source: CostSource | undefined
   let provider: string | undefined
   let model: string | undefined
+  const providerReports: ProviderUsageReport[] = []
   let first = true
   for (const part of parts) {
     promptTokens += part.promptTokens
     completionTokens += part.completionTokens
+    providerReports.push(...(part.providerReports ?? []))
     if (part.costUsd === undefined) known = false
     else costUsd += part.costUsd
     if (first) {
@@ -165,12 +366,34 @@ export const sumUsage = (parts: ReadonlyArray<Usage>): Usage => {
       model = same(model, part.model)
     }
   }
+  const sumKnown = (read: (part: Usage) => number | undefined): number | undefined => {
+    let total = 0
+    for (const part of parts) {
+      const value = read(part)
+      if (value === undefined) return undefined
+      total += value
+    }
+    return total
+  }
+  const totalTokens = sumKnown((part) => part.totalTokens)
+  const cachedPromptTokens = sumKnown((part) => part.cachedPromptTokens)
+  const cacheWritePromptTokens = sumKnown((part) => part.cacheWritePromptTokens)
+  const reasoningTokens = sumKnown((part) => part.reasoningTokens)
+  const reportedCostUsd = sumKnown((part) => part.reportedCostUsd)
+  const estimatedCostUsd = sumKnown((part) => part.estimatedCostUsd)
   return {
     promptTokens,
     completionTokens,
+    ...(totalTokens === undefined ? {} : { totalTokens }),
+    ...(cachedPromptTokens === undefined ? {} : { cachedPromptTokens }),
+    ...(cacheWritePromptTokens === undefined ? {} : { cacheWritePromptTokens }),
+    ...(reasoningTokens === undefined ? {} : { reasoningTokens }),
     ...(known ? { costUsd, ...(source === undefined ? {} : { costSource: source }) } : {}),
+    ...(reportedCostUsd === undefined ? {} : { reportedCostUsd }),
+    ...(estimatedCostUsd === undefined ? {} : { estimatedCostUsd }),
     ...(provider === undefined ? {} : { provider }),
-    ...(model === undefined ? {} : { model })
+    ...(model === undefined ? {} : { model }),
+    ...(providerReports.length === 0 ? {} : { providerReports })
   }
 }
 

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -26,6 +26,7 @@ import {
   modelIdOf,
   infer,
   retryAfterMsOf,
+  tapConverseUsage,
   tapStopReason,
   throttleDelayMs
 } from "./model"
@@ -219,6 +220,27 @@ describe("the Converse output surface", () => {
     for await (const event of tapStopReason(events, stops)) seen.push(event)
     expect(seen).toHaveLength(2)
     expect(stops.stopReason).toBe("guardrail_intervened")
+  })
+
+  test("the Converse usage tap keeps the raw provider metrics", async () => {
+    const metrics = {
+      inputTokens: 40,
+      outputTokens: 8,
+      totalTokens: 48,
+      cacheReadInputTokens: 24,
+      cacheWriteInputTokens: 4
+    }
+    const reported: { usage?: unknown } = {}
+    const events = {
+      async *[Symbol.asyncIterator]() {
+        yield { messageStart: { role: "assistant" } }
+        yield { metadata: { usage: metrics } }
+      }
+    }
+    const seen: Array<unknown> = []
+    for await (const event of tapConverseUsage(events, reported)) seen.push(event)
+    expect(seen).toHaveLength(2)
+    expect(reported.usage).toEqual(metrics)
   })
 })
 
@@ -522,6 +544,14 @@ describe("infer: cost provenance", () => {
   const table = { promptUsdPerToken: 0.001, completionUsdPerToken: 0.002 }
 
   test("a billed cost is provider, an omitted cost is table or unknown", async () => {
+    const rawUsage = {
+      prompt_tokens: 10,
+      completion_tokens: 4,
+      total_tokens: 14,
+      prompt_tokens_details: { cached_tokens: 4 },
+      completion_tokens_details: { reasoning_tokens: 2 },
+      cost: 0
+    }
     const billed = await Effect.runPromise(
       Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
         Effect.provide(
@@ -530,8 +560,9 @@ describe("infer: cost provenance", () => {
             apiKey: "k",
             model: "test-model",
             provider: "openai",
-            pricing: table,
-            fetch: (async () => sse([...okText, usageChunk({ prompt_tokens: 10, completion_tokens: 4, cost: 0 })])) as unknown as typeof globalThis.fetch
+            pricing: { ...table, cachedPromptUsdPerToken: 0.0001 },
+            fetch: (async () =>
+              sse([{ ...okText[0], usage: null }, okText[1], usageChunk(rawUsage)])) as unknown as typeof globalThis.fetch
           })
         )
       ) as Effect.Effect<Action>
@@ -542,10 +573,16 @@ describe("infer: cost provenance", () => {
       usage: {
         promptTokens: 10,
         completionTokens: 4,
+        totalTokens: 14,
+        cachedPromptTokens: 4,
+        reasoningTokens: 2,
         costUsd: 0,
         costSource: "provider",
+        reportedCostUsd: 0,
+        estimatedCostUsd: 6 * 0.001 + 4 * 0.0001 + 4 * 0.002,
         provider: "openai",
-        model: "test-model"
+        model: "test-model",
+        providerReports: [{ provider: "openai", model: "test-model", providerSpecific: rawUsage }]
       }
     })
 
@@ -568,8 +605,16 @@ describe("infer: cost provenance", () => {
       completionTokens: 4,
       costUsd: 10 * 0.001 + 4 * 0.002,
       costSource: "table",
+      estimatedCostUsd: 10 * 0.001 + 4 * 0.002,
       provider: "openai",
-      model: "test-model"
+      model: "test-model",
+      providerReports: [
+        {
+          provider: "openai",
+          model: "test-model",
+          providerSpecific: { prompt_tokens: 10, completion_tokens: 4 }
+        }
+      ]
     })
 
     const unknown = await Effect.runPromise(
@@ -585,6 +630,41 @@ describe("infer: cost provenance", () => {
       ) as Effect.Effect<Action>
     )
     expect(unknown).toMatchObject({ kind: "complete", output: "ok" })
+  })
+
+  test("multiple wire usage objects remain one lossless physical report", async () => {
+    const detailed = {
+      prompt_tokens: 10,
+      completion_tokens: 4,
+      total_tokens: 14,
+      prompt_tokens_details: { cached_tokens: 4 },
+      completion_tokens_details: { reasoning_tokens: 2 }
+    }
+    const billed = { prompt_tokens: 10, completion_tokens: 4, total_tokens: 14, cost: 0 }
+    const action = await Effect.runPromise(
+      Effect.flatMap(Infer, (model) =>
+        model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))
+      ).pipe(
+        Effect.provide(
+          infer({
+            baseUrl: "https://model.test/v1",
+            apiKey: "k",
+            model: "test-model",
+            provider: "openai",
+            pricing: { ...table, cachedPromptUsdPerToken: 0.0001 },
+            fetch: (async () =>
+              sse([...okText, usageChunk(detailed), usageChunk(billed)])) as unknown as typeof globalThis.fetch
+          })
+        )
+      ) as Effect.Effect<Action>
+    )
+    expect(action.usage).toMatchObject({
+      cachedPromptTokens: 4,
+      reasoningTokens: 2,
+      reportedCostUsd: 0,
+      estimatedCostUsd: 6 * 0.001 + 4 * 0.0001 + 4 * 0.002,
+      providerReports: [{ provider: "openai", model: "test-model", providerSpecific: [detailed, billed] }]
+    })
   })
 })
 
@@ -907,7 +987,25 @@ describe("truncation", () => {
     expect(action).toMatchObject({
       kind: "complete",
       output: "the whole answer",
-      usage: { promptTokens: 20, completionTokens: 32772, costUsd: 6, costSource: "provider" }
+      usage: {
+        promptTokens: 20,
+        completionTokens: 32772,
+        costUsd: 6,
+        costSource: "provider",
+        reportedCostUsd: 6,
+        providerReports: [
+          {
+            provider: "openai",
+            model: "m",
+            providerSpecific: { prompt_tokens: 10, completion_tokens: 32768, cost: 5 }
+          },
+          {
+            provider: "openai",
+            model: "m",
+            providerSpecific: { prompt_tokens: 10, completion_tokens: 4, cost: 1 }
+          }
+        ]
+      }
     })
   })
 

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -1,5 +1,13 @@
 import { Clock, Effect, Layer, Random } from "effect"
-import { StreamProcessor, type ModelMessage, type ProcessorResult, type StreamChunk, type Tool, type ToolCall } from "@tanstack/ai"
+import {
+  StreamProcessor,
+  type ModelMessage,
+  type ProcessorResult,
+  type StreamChunk,
+  type TokenUsage,
+  type Tool,
+  type ToolCall
+} from "@tanstack/ai"
 import { openaiCompatibleText } from "@tanstack/ai-openai/compatible"
 import * as BedrockRuntime from "@aws-sdk/client-bedrock-runtime"
 import { FetchHttpHandler } from "@smithy/fetch-http-handler"
@@ -214,9 +222,8 @@ export interface ModelConfig {
   // promise: a turn that declares a contract fails before spend unless its assembly provides a
   // fallback. A provider name never supplies this value (src/output.ts, capabilityOf).
   readonly output?: OutputCapability
-  // What the model costs, when a catalog or a caller has said. A billed figure from the
-  // provider is preferred; this table fills only a cost the provider omitted
-  // (packages/agent/src/usage.ts, priced). Cached prompt tokens price at the full input rate.
+  // pricing projects an estimate beside any provider-reported bill. Reported cache buckets
+  // require their own stated rates (packages/agent/src/usage.ts, priced).
   readonly pricing?: ModelPricing
   // In-act backoff bases for throttle-shaped failures. Length is the retry count.
   readonly throttleRetryDelaysMs?: ReadonlyArray<number>
@@ -388,7 +395,8 @@ export const bedrockAdapter = (
   bounds: StreamBounds,
   output?: OutputRequest,
   mode: OutputMode = NATIVE_MODE,
-  stops: { stopReason?: string } = {}
+  stops: { stopReason?: string } = {},
+  reported: { usage?: unknown } = {}
 ) => {
   const handler = bedrockHandler(config, bounds)
   const region = config.baseUrl.split("/").filter((s) => s !== "").at(-1) ?? "us-east-1"
@@ -416,7 +424,8 @@ export const bedrockAdapter = (
       return input
     }
     protected override async sendStream(input: BedrockRuntime.ConverseStreamCommandInput) {
-      return tapStopReason(await super.sendStream(input), stops)
+      const stream = await super.sendStream(input)
+      return tapStopReason(tapConverseUsage(stream, reported), stops)
     }
   })({ apiKey: "byok", region, baseURL: config.baseUrl }, config.model as (typeof BEDROCK_CONVERSE_MODELS)[number])
 }
@@ -462,6 +471,7 @@ type BodyReader = {
 // configured stamp: it is observed, never declared.
 interface Wire {
   readonly usage?: unknown
+  readonly usageReports?: ReadonlyArray<unknown>
   readonly provider?: string
   readonly model?: string
   // A structured-output refusal arrives as `choices[].delta.refusal` with an ordinary `stop`
@@ -495,7 +505,7 @@ const captureWire = async (reader: BodyReader): Promise<Wire | undefined> => {
   const wireOf = (parsed: { usage?: unknown; provider?: unknown; model?: unknown }): Wire => {
     const refusal = refusalOf(parsed as never)
     return {
-      ...(parsed.usage === undefined ? {} : { usage: parsed.usage }),
+      ...(parsed.usage === undefined || parsed.usage === null ? {} : { usage: parsed.usage }),
       ...(typeof parsed.provider === "string" ? { provider: parsed.provider } : {}),
       ...(typeof parsed.model === "string" ? { model: parsed.model } : {}),
       ...(refusal === undefined ? {} : { refusal })
@@ -507,10 +517,13 @@ const captureWire = async (reader: BodyReader): Promise<Wire | undefined> => {
     if (payload === "" || payload === "[DONE]") continue
     try {
       const next = wireOf(JSON.parse(payload) as never)
+      const usageReports =
+        next.usage === undefined ? last.usageReports : [...(last.usageReports ?? []), next.usage]
       // Refusal deltas arrive in pieces, like content: each chunk carries the next fragment.
       last = {
         ...last,
         ...next,
+        ...(usageReports === undefined ? {} : { usageReports }),
         ...(next.refusal === undefined ? {} : { refusal: `${last.refusal ?? ""}${next.refusal}` })
       }
     } catch {
@@ -520,7 +533,8 @@ const captureWire = async (reader: BodyReader): Promise<Wire | undefined> => {
   if (Object.keys(last).length > 0) return last
   try {
     const wire = wireOf(JSON.parse(text) as never)
-    return Object.keys(wire).length > 0 ? wire : undefined
+    if (Object.keys(wire).length === 0) return undefined
+    return wire.usage === undefined ? wire : { ...wire, usageReports: [wire.usage] }
   } catch {
     return undefined
   }
@@ -547,11 +561,11 @@ const withCapture = (
 
 const tapTokens = (
   stream: AsyncIterable<StreamChunk>,
-  into: { tokens?: { readonly promptTokens: number; readonly completionTokens: number; readonly cost?: number } }
+  into: { tokens?: TokenUsage }
 ): AsyncIterable<StreamChunk> => ({
   async *[Symbol.asyncIterator]() {
     for await (const chunk of stream) {
-      const tokens = (chunk as { usage?: { promptTokens: number; completionTokens: number; cost?: number } }).usage
+      const tokens = (chunk as { usage?: TokenUsage }).usage
       if (tokens !== undefined) into.tokens = tokens
       yield chunk
     }
@@ -594,6 +608,21 @@ export const tapStopReason = <T>(
   }
 })
 
+// tapConverseUsage preserves the SDK's provider metrics before the shared adapter drops cache
+// details (model.test.ts, "the Converse usage tap keeps the raw provider metrics").
+export const tapConverseUsage = <T>(
+  stream: AsyncIterable<T>,
+  into: { usage?: unknown }
+): AsyncIterable<T> => ({
+  async *[Symbol.asyncIterator]() {
+    for await (const event of stream) {
+      const usage = (event as { metadata?: { usage?: unknown } }).metadata?.usage
+      if (usage !== undefined) into.usage = usage
+      yield event
+    }
+  }
+})
+
 const usageOn = (e: unknown): Usage | undefined =>
   e !== null && typeof e === "object" && "usage" in e ? (e as { usage?: Usage }).usage : undefined
 
@@ -614,8 +643,15 @@ const spentOf = (parts: ReadonlyArray<Usage>, missed: boolean): Usage | undefine
   return {
     promptTokens: summed.promptTokens,
     completionTokens: summed.completionTokens,
+    ...(summed.totalTokens === undefined ? {} : { totalTokens: summed.totalTokens }),
+    ...(summed.cachedPromptTokens === undefined ? {} : { cachedPromptTokens: summed.cachedPromptTokens }),
+    ...(summed.cacheWritePromptTokens === undefined
+      ? {}
+      : { cacheWritePromptTokens: summed.cacheWritePromptTokens }),
+    ...(summed.reasoningTokens === undefined ? {} : { reasoningTokens: summed.reasoningTokens }),
     ...(summed.provider === undefined ? {} : { provider: summed.provider }),
-    ...(summed.model === undefined ? {} : { model: summed.model })
+    ...(summed.model === undefined ? {} : { model: summed.model }),
+    ...(summed.providerReports === undefined ? {} : { providerReports: summed.providerReports })
   }
 }
 
@@ -658,12 +694,13 @@ export const infer = <const C extends ModelConfig>(config: C): Layer.Layer<Infer
     const sink: { promise: Promise<Wire | undefined>; reader?: BodyReader } = {
       promise: Promise.resolve(undefined)
     }
-    const held: { tokens?: { readonly promptTokens: number; readonly completionTokens: number; readonly cost?: number } } = {}
+    const reported: { usage?: unknown } = {}
+    const held: { tokens?: TokenUsage } = {}
     const fetcher = withCapture(config.fetch, keyForRung, bounds.totalMs, sink)
     const stops: { stopReason?: string } = {}
     const adapter =
       config.provider === "bedrock"
-        ? bedrockAdapter(config, maxTokens, bounds, req.output, mode, stops)
+        ? bedrockAdapter(config, maxTokens, bounds, req.output, mode, stops, reported)
         : openaiCompatibleText(config.model, {
             name: "tardigrade",
             baseURL: config.baseUrl,
@@ -703,11 +740,21 @@ export const infer = <const C extends ModelConfig>(config: C): Layer.Layer<Infer
       const wire = await sink.promise
       // Wire-reported provenance wins: a router that names the upstream it served from records
       // the true split; the configured stamp covers a wire that stays silent.
-      const usage = usageFrom([wire?.usage, held.tokens], config.pricing, {
-        ...stampOf(config),
-        ...(wire?.provider === undefined ? {} : { provider: wire.provider }),
-        ...(wire?.model === undefined ? {} : { model: wire.model })
-      })
+      const providerMetrics = wire?.usageReports ?? (reported.usage === undefined ? [] : [reported.usage])
+      const usage = usageFrom(
+        [...providerMetrics, held.tokens],
+        config.pricing,
+        {
+          ...stampOf(config),
+          ...(wire?.provider === undefined ? {} : { provider: wire.provider }),
+          ...(wire?.model === undefined ? {} : { model: wire.model })
+        },
+        providerMetrics.length === 0
+          ? undefined
+          : providerMetrics.length === 1
+            ? providerMetrics[0]
+            : providerMetrics
+      )
       return { usage, endpoint: endpointOf(config, wire), wire }
     }
     try {
@@ -882,11 +929,26 @@ export const infer = <const C extends ModelConfig>(config: C): Layer.Layer<Infer
         }
         yield* Effect.annotateCurrentSpan("gen_ai.usage.input_tokens", action.usage.promptTokens)
         yield* Effect.annotateCurrentSpan("gen_ai.usage.output_tokens", action.usage.completionTokens)
+        if (action.usage.cachedPromptTokens !== undefined) {
+          yield* Effect.annotateCurrentSpan("gen_ai.usage.cache_read.input_tokens", action.usage.cachedPromptTokens)
+        }
+        if (action.usage.cacheWritePromptTokens !== undefined) {
+          yield* Effect.annotateCurrentSpan("gen_ai.usage.cache_creation.input_tokens", action.usage.cacheWritePromptTokens)
+        }
+        if (action.usage.reasoningTokens !== undefined) {
+          yield* Effect.annotateCurrentSpan("gen_ai.usage.reasoning.output_tokens", action.usage.reasoningTokens)
+        }
         if (action.usage.costUsd !== undefined) {
           yield* Effect.annotateCurrentSpan("gen_ai.usage.cost", action.usage.costUsd)
           if (action.usage.costSource !== undefined) {
             yield* Effect.annotateCurrentSpan("gen_ai.usage.cost_source", action.usage.costSource)
           }
+        }
+        if (action.usage.reportedCostUsd !== undefined) {
+          yield* Effect.annotateCurrentSpan("tardigrade.usage.reported_cost", action.usage.reportedCostUsd)
+        }
+        if (action.usage.estimatedCostUsd !== undefined) {
+          yield* Effect.annotateCurrentSpan("tardigrade.usage.estimated_cost", action.usage.estimatedCostUsd)
         }
       }
       return action


### PR DESCRIPTION
Provider credits and cache accounting make a single computed cost insufficient for durable benchmarking. This change records provider evidence alongside a normalized, provider-neutral usage schema so costs can be compared now and recomputed later.

- Normalize prompt, completion, total, cache-read, cache-write, and reasoning tokens across OpenAI-compatible and Bedrock transports.
- Retain every physical request's provider report under `providerSpecific`, including multiple usage messages and output-ceiling retries.
- Expose provider-reported and price-table costs independently while preserving the existing `costUsd` projection.
- Add cache-specific pricing rates and normalized usage telemetry.
- Document the durable schema and repricing behavior.

## Review and verification

- Fable 5 reviewed the implementation twice. Its accepted findings are fixed.
- `bun run gate`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/67869c6e-297e-4fb9-9fc2-4aa5a38ac1fa)
