### PR TITLE
refactor(code): finalize package calls

### DIFF
--- a/packages/code/src/execute.ts
+++ b/packages/code/src/execute.ts
@@ -74,9 +74,9 @@ const executeRecorded = <R = never>(
     // (no method table; the raiser carries `awaiting` on Park).
     const blocked: Array<{ readonly callId: string; readonly awaiting?: string }> = []
     const parkGate = yield* Deferred.make<void>()
-    // finishCall releases a mixed attempt after every host-side call has completed. Every
-    // completion path uses it because the last call may return or park (tla/runtime/Execution.tla,
-    // ParkedAttemptReleases).
+    // finishCall releases a mixed attempt after every host-side call has completed. The call
+    // scope guarantees it as a finalizer because the last call may return or park
+    // (tla/runtime/Execution.tla, ParkedAttemptReleases).
     const finishCall = Effect.gen(function* () {
       inFlight--
       if (parked && inFlight === 0) yield* Deferred.succeed(parkGate, undefined)
@@ -121,7 +121,6 @@ const executeRecorded = <R = never>(
               )
               if (recorded) {
                 const r = recorded as { result?: unknown; tmp?: unknown }
-                yield* finishCall
                 if (r.tmp !== undefined) {
                   // A store that cannot answer is a defect, never a different answer: replaying a
                   // spilled pair with the preview in place of the value would hand the body an
@@ -157,7 +156,6 @@ const executeRecorded = <R = never>(
                 const result = { error: `shadow run: ${pkg.name}.${method} is an open-world write and does not execute in a shadow run` }
                 const answeredAt = yield* Clock.currentTimeMillis
                 yield* log.append([packageReturned({ callId, result, ...stamp, at: answeredAt })])
-                yield* finishCall
                 return { parked: false, result }
               }
               // The contract gate: a declared input schema is checked at this funnel, after the
@@ -176,7 +174,6 @@ const executeRecorded = <R = never>(
                   }
                   const answeredAt = yield* Clock.currentTimeMillis
                   yield* log.append([packageReturned({ callId, result, ...stamp, at: answeredAt })])
-                  yield* finishCall
                   return { parked: false, result }
                 }
               }
@@ -192,7 +189,6 @@ const executeRecorded = <R = never>(
                 Effect.gen(function* () {
                   parked = true
                   blocked.push({ callId, ...(awaiting === undefined ? {} : { awaiting }) })
-                  yield* finishCall
                   return { parked: true }
                 })
               const attempt = yield* fn(args, { callId }).pipe(
@@ -218,9 +214,11 @@ const executeRecorded = <R = never>(
               } else {
                 yield* log.append([packageReturned({ callId, result: attempt.result, ...stamp, at: answeredAt })])
               }
-              yield* finishCall
               return attempt
-            }).pipe(Effect.withSpan("package.call", { attributes: { name: `${pkg.name}.${method}`, callId } }))
+            }).pipe(
+              Effect.ensuring(finishCall),
+              Effect.withSpan("package.call", { attributes: { name: `${pkg.name}.${method}`, callId } })
+            )
           ).then((outcome) => (outcome.parked ? new Promise<unknown>(() => {}) : outcome.result))
         }
       }


### PR DESCRIPTION
## Summary

Package-call completion accounting now runs through one `Effect.ensuring` finalizer around the complete call scope. Replay, refusal, contract validation, live return, and park paths no longer decrement the attempt barrier individually.

## Reason

The mixed-attempt fix depends on every host-side completion decrementing `inFlight` and checking the park gate. Manual calls made each future exit path responsible for remembering that invariant. A scoped finalizer makes completion accounting part of the package-call lifecycle and preserves the `Execution.tla` `ParkedAttemptReleases` contract.

## Verification

- Full 41-task repository gate
- TLA+ Execution pass and expected ExecutionReadyLeak counterexample
- 100 fast-check mixed completion order runs
- Focused replay, projection, TypeScript, and Effect diagnostics