### PR TITLE
feat(cloudflare): add durable actor host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ coverage/
 .cache/
 .turbo/
 .vite/
+.wrangler/
 .eslintcache
 .oxlintcache
 packages/core/tla/states/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![npm version](https://img.shields.io/npm/v/tardie.svg)](https://www.npmjs.com/package/tardie)
 
-Tardigrade is a framework for building durable, modular agents that can run at the edge. It is inspired by [React](https://react.dev/)'s declarative approach to building user interfaces.
+Tardigrade is a typescript framework for building durable, modular agents that can run at the edge. It is inspired by [React](https://react.dev/)'s declarative approach to building user interfaces.
 
 ### Agents that can self-improve
 As models get increasingly smart, they will be capable of writing their own harnesses to improve themselves ([Meta-Harness](https://arxiv.org/abs/2603.28052)). A harness that is too rigid and complex is a bottleneck to this. We need something more composable, and easy to author.

--- a/bun.lock
+++ b/bun.lock
@@ -140,6 +140,24 @@
         "effect": "4.0.0-rc.110",
       },
     },
+    "platform/cloudflare": {
+      "name": "@clavia/tardigrade-cloudflare",
+      "version": "0.0.1",
+      "dependencies": {
+        "@clavia/tardigrade-core": "workspace:*",
+        "@clavia/tardigrade-host": "workspace:*",
+        "@clavia/tardigrade-model": "workspace:*",
+        "@effect/sql-sqlite-do": "4.0.0-rc.110",
+        "effect": "4.0.0-rc.110",
+        "tardie": "workspace:*",
+      },
+      "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.20.1",
+        "@cloudflare/workers-types": "^5.20260804.1",
+        "vitest": "^4.1.10",
+        "wrangler": "^4.119.0",
+      },
+    },
     "platform/model": {
       "name": "@clavia/tardigrade-model",
       "version": "0.0.1",
@@ -221,6 +239,8 @@
 
     "@clavia/tardigrade-client": ["@clavia/tardigrade-client@workspace:packages/client"],
 
+    "@clavia/tardigrade-cloudflare": ["@clavia/tardigrade-cloudflare@workspace:platform/cloudflare"],
+
     "@clavia/tardigrade-code": ["@clavia/tardigrade-code@workspace:packages/code"],
 
     "@clavia/tardigrade-core": ["@clavia/tardigrade-core@workspace:packages/core"],
@@ -233,11 +253,33 @@
 
     "@clavia/tardigrade-voyager": ["@clavia/tardigrade-voyager@workspace:apps/voyager"],
 
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
+
+    "@cloudflare/vitest-pool-workers": ["@cloudflare/vitest-pool-workers@0.20.3", "", { "dependencies": { "cjs-module-lexer": "1.2.3", "esbuild": "0.28.1", "miniflare": "5.20260801.1-alpha", "wrangler": "4.120.0", "zod": "4.4.3" }, "peerDependencies": { "@vitest/runner": "^4.1.0", "@vitest/snapshot": "^4.1.0", "vitest": "^4.1.0" } }, "sha512-aCMvM5zQ3MTz8SorSZB6ZxjVK2Gof6UhIc2Z1z9zbX/obucSYwDUkx8A0MUOod4I7clfB0QLarKBjRdIczK3vg=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260820.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260820.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260820.1", "", { "os": "linux", "cpu": "x64" }, "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260820.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260820.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260823.1", "", {}, "sha512-HdBVDR/gecQ5QwB+DZ9kB5yjNZLS85fe8bMB2K/k0xmCvaoMlAFrQQGLaCBYR00j+i9aTkQzwfrPInVZwlMPwQ=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
     "@effect/platform-bun": ["@effect/platform-bun@4.0.0-rc.110", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-rc.110" }, "peerDependencies": { "effect": "^4.0.0-rc.110" } }, "sha512-f4AcFTWVwGby9RvSitqAcG/McN8OCDy7LW8PYRG4NIOO2eYphlW73S5Z7jm3UDP+FmIwwzjfgfIfBYkfPR+YfA=="],
 
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-rc.110", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-rc.110" } }, "sha512-P8EZloxS7RtCOSL3VSBPyqSenUm93xLbXf9jkWoy67cibZ2wgZ9nAou9iN8f1i4vzgxUsWtDuy6BEmg67np6Zw=="],
 
     "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@4.0.0-rc.110", "", { "peerDependencies": { "effect": "^4.0.0-rc.110" } }, "sha512-Lam3gY1xszjQS/cebdLbWbtR21FtQI4ke7QHqbBQ6AyVJF0CGUtS/ePL9zNq6wHNmJ95FUDGS6W+Qx/l6RPSzA=="],
+
+    "@effect/sql-sqlite-do": ["@effect/sql-sqlite-do@4.0.0-rc.110", "", { "peerDependencies": { "effect": "^4.0.0-rc.110" } }, "sha512-i9+ZssM/n1KONpg3jhXhiSaevNGjLyBu3im2rdHGEfK+E7m56Astvuwevy8YSvHfkjRqjP64eGckSAagkGVKRA=="],
 
     "@effect/tsgo": ["@effect/tsgo@0.36.5", "", { "optionalDependencies": { "@effect/tsgo-darwin-arm64": "0.36.5", "@effect/tsgo-darwin-x64": "0.36.5", "@effect/tsgo-linux-arm": "0.36.5", "@effect/tsgo-linux-arm64": "0.36.5", "@effect/tsgo-linux-x64": "0.36.5", "@effect/tsgo-win32-arm64": "0.36.5", "@effect/tsgo-win32-x64": "0.36.5" }, "bin": { "effect-tsgo": "dist/effect-tsgo.cjs" } }, "sha512-BHxVjeRK1/XlqYHWXkbT4W9JpOrT3sNA2wrfwQPBTojD5OSyxI2TUIltobYhWudyfuCrn770qP6uOpDjdrmghA=="],
 
@@ -261,6 +303,58 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
     "@floating-ui/core": ["@floating-ui/core@1.8.0", "", { "dependencies": { "@floating-ui/utils": "^0.2.12" } }, "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ=="],
 
     "@floating-ui/dom": ["@floating-ui/dom@1.8.0", "", { "dependencies": { "@floating-ui/core": "^1.8.0", "@floating-ui/utils": "^0.2.12" } }, "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg=="],
@@ -268,6 +362,66 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.9", "", { "dependencies": { "@floating-ui/dom": "^1.8.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.1" }, "os": "darwin", "cpu": "arm64" }, "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.1" }, "os": "darwin", "cpu": "x64" }, "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw=="],
+
+    "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.2", "", { "dependencies": { "@img/sharp-wasm32": "0.35.2" }, "os": "freebsd" }, "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.1", "", { "os": "linux", "cpu": "arm" }, "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.1", "", { "os": "linux", "cpu": "none" }, "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.1" }, "os": "linux", "cpu": "arm" }, "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.1" }, "os": "linux", "cpu": "ppc64" }, "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.1" }, "os": "linux", "cpu": "none" }, "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.1" }, "os": "linux", "cpu": "s390x" }, "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.2", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw=="],
+
+    "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.2", "", { "dependencies": { "@img/sharp-wasm32": "0.35.2" }, "cpu": "none" }, "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.2", "", { "os": "win32", "cpu": "x64" }, "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
@@ -401,6 +555,12 @@
 
     "@phosphor-icons/react": ["@phosphor-icons/react@2.1.10", "", { "peerDependencies": { "react": ">= 16.8", "react-dom": ">= 16.8" } }, "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA=="],
 
+    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
+
     "@rolldown/binding-android-arm-eabi": ["@rolldown/binding-android-arm-eabi@1.2.5", "", { "os": "android", "cpu": "arm" }, "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.5", "", { "os": "android", "cpu": "arm64" }, "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig=="],
@@ -433,6 +593,8 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
+    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
     "@smithy/core": ["@smithy/core@3.33.2", "", { "dependencies": { "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w=="],
 
     "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.5.2", "", { "dependencies": { "@smithy/core": "^3.33.2", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg=="],
@@ -450,6 +612,8 @@
     "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
     "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.24", "", {}, "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -470,6 +634,12 @@
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
 
@@ -521,11 +691,37 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.1.0", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "oxc-transform-react": "^0.145.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler", "oxc-transform-react"] }, "sha512-qd2BzUBehkov86WFhg0JkEFEYyCLG9uPCe6qWTY/kRlss9OvJrOF2UbIWT7p+8IzZHkEu0DNGHc4HSv+JdDLsw=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.11", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.11", "", { "dependencies": { "@vitest/spy": "4.1.11", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.11", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.11", "", { "dependencies": { "@vitest/utils": "4.1.11", "pathe": "^2.0.3" } }, "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.11", "", { "dependencies": { "@vitest/pretty-format": "4.1.11", "@vitest/utils": "4.1.11", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.11", "", {}, "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.11", "", { "dependencies": { "@vitest/pretty-format": "4.1.11", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "beautiful-mermaid": ["beautiful-mermaid@1.1.3", "", { "dependencies": { "elkjs": "^0.11.0", "entities": "^7.0.1" } }, "sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg=="],
+
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@1.2.3", "", {}, "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -536,6 +732,16 @@
     "elkjs": ["elkjs@0.11.1", "", {}, "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg=="],
 
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
+
+    "es-module-lexer": ["es-module-lexer@2.3.2", "", {}, "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw=="],
+
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
@@ -550,6 +756,8 @@
     "get-tsconfig": ["get-tsconfig@4.14.1", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A=="],
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "knip": ["knip@6.32.2", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.1", "jiti": "^2.7.0", "oxc-parser": "^0.143.0", "oxc-resolver": "11.24.2", "picomatch": "^4.0.5", "smol-toml": "^1.7.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.17", "unbash": "^4.0.9", "yaml": "^2.9.0", "zod": "^4.4.3" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-WXTXbmocrw7gqm1A1TQvFN0OgJ7hUSU6E1g6SPRIzzHFogUBhXByc7cYeOFVtJ2uODg7DP4VbESYBYnfbtBYsg=="],
 
@@ -577,6 +785,10 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
 
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "miniflare": ["miniflare@5.20260801.1-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260801.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-BHPVzIDA6mbx7LefxpvkXW7DHx9FKB9GorZatbnrrFTt3CVMU8zuUpbgyCuebwDKcTTOZos43ta8GQ0eMVEpxA=="],
+
     "msgpackr": ["msgpackr@2.0.5", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA=="],
 
     "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
@@ -584,6 +796,8 @@
     "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
+
+    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
 
     "openai": ["openai@6.49.0", "", { "peerDependencies": { "@aws-sdk/credential-provider-node": ">=3.972.0 <4", "@smithy/hash-node": ">=4.3.0 <5", "@smithy/signature-v4": ">=5.4.0 <6", "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@aws-sdk/credential-provider-node", "@smithy/hash-node", "@smithy/signature-v4", "ws", "zod"] }, "sha512-aYCc0C6L864eR6WSYIwQGyXriw/nIyZx0ObvhzOEVuk0zoBDpynjSbrionWI7q65B5H8jJX0DXR9snEzM6bfPg=="],
 
@@ -594,6 +808,10 @@
     "oxlint": ["oxlint@1.78.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.78.0", "@oxlint/binding-android-arm64": "1.78.0", "@oxlint/binding-darwin-arm64": "1.78.0", "@oxlint/binding-darwin-x64": "1.78.0", "@oxlint/binding-freebsd-x64": "1.78.0", "@oxlint/binding-linux-arm-gnueabihf": "1.78.0", "@oxlint/binding-linux-arm-musleabihf": "1.78.0", "@oxlint/binding-linux-arm64-gnu": "1.78.0", "@oxlint/binding-linux-arm64-musl": "1.78.0", "@oxlint/binding-linux-ppc64-gnu": "1.78.0", "@oxlint/binding-linux-riscv64-gnu": "1.78.0", "@oxlint/binding-linux-riscv64-musl": "1.78.0", "@oxlint/binding-linux-s390x-gnu": "1.78.0", "@oxlint/binding-linux-x64-gnu": "1.78.0", "@oxlint/binding-linux-x64-musl": "1.78.0", "@oxlint/binding-openharmony-arm64": "1.78.0", "@oxlint/binding-win32-arm64-msvc": "1.78.0", "@oxlint/binding-win32-ia32-msvc": "1.78.0", "@oxlint/binding-win32-x64-msvc": "1.78.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-QgQePuxIqKOzo1KSjG2EnITEeWvWnKAm77eq8nrMtf6AGoA+zyGc4PFYtDNJSD25g/ibOwfQ851hZ4/SPkMVoA=="],
 
     "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
+
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -615,17 +833,35 @@
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "sharp": ["sharp@0.35.2", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.4" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.2", "@img/sharp-darwin-x64": "0.35.2", "@img/sharp-freebsd-wasm32": "0.35.2", "@img/sharp-libvips-darwin-arm64": "1.3.1", "@img/sharp-libvips-darwin-x64": "1.3.1", "@img/sharp-libvips-linux-arm": "1.3.1", "@img/sharp-libvips-linux-arm64": "1.3.1", "@img/sharp-libvips-linux-ppc64": "1.3.1", "@img/sharp-libvips-linux-riscv64": "1.3.1", "@img/sharp-libvips-linux-s390x": "1.3.1", "@img/sharp-libvips-linux-x64": "1.3.1", "@img/sharp-libvips-linuxmusl-arm64": "1.3.1", "@img/sharp-libvips-linuxmusl-x64": "1.3.1", "@img/sharp-linux-arm": "0.35.2", "@img/sharp-linux-arm64": "0.35.2", "@img/sharp-linux-ppc64": "0.35.2", "@img/sharp-linux-riscv64": "0.35.2", "@img/sharp-linux-s390x": "0.35.2", "@img/sharp-linux-x64": "0.35.2", "@img/sharp-linuxmusl-arm64": "0.35.2", "@img/sharp-linuxmusl-x64": "0.35.2", "@img/sharp-webcontainers-wasm32": "0.35.2", "@img/sharp-win32-arm64": "0.35.2", "@img/sharp-win32-ia32": "0.35.2", "@img/sharp-win32-x64": "0.35.2" } }, "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "smol-toml": ["smol-toml@1.8.0", "", {}, "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
+
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
+
+    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
     "tabbable": ["tabbable@6.5.0", "", {}, "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA=="],
 
     "tardie": ["tardie@workspace:packages/agent"],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.3.0", "", {}, "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ=="],
+
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -633,24 +869,72 @@
 
     "unbash": ["unbash@4.0.10", "", {}, "sha512-b7zoBQvpWp0vuN5q2vK2RRBR2SvuruQAs50DApdDveBSn3eSYd84IaHodFqQIMlvY9K2VnyBUEXgwOBuGU9GBg=="],
 
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "vite": ["vite@8.2.2", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.26", "rolldown": "~1.2.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0 || ^0.5.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q=="],
 
+    "vitest": ["vitest@4.1.11", "", { "dependencies": { "@vitest/expect": "4.1.11", "@vitest/mocker": "4.1.11", "@vitest/pretty-format": "4.1.11", "@vitest/runner": "4.1.11", "@vitest/snapshot": "4.1.11", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.11", "@vitest/browser-preview": "4.1.11", "@vitest/browser-webdriverio": "4.1.11", "@vitest/coverage-istanbul": "4.1.11", "@vitest/coverage-v8": "4.1.11", "@vitest/ui": "4.1.11", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw=="],
+
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "workerd": ["workerd@1.20260820.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260820.1", "@cloudflare/workerd-darwin-arm64": "1.20260820.1", "@cloudflare/workerd-linux-64": "1.20260820.1", "@cloudflare/workerd-linux-arm64": "1.20260820.1", "@cloudflare/workerd-windows-64": "1.20260820.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w=="],
+
+    "wrangler": ["wrangler@4.125.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260820.0-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260820.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260820.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg=="],
 
     "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
+    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
+
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1111.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.8", "@aws-sdk/nested-clients": "^3.997.43", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A=="],
 
+    "@cloudflare/vitest-pool-workers/wrangler": ["wrangler@4.120.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260801.1-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260801.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260801.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-cBmu/MeaB/fPacC0JpATs4duTOCagBxrZo+vBzuTX06tLzwSyAHE1drlHUZ8rP0VqVz1fy3ReGYTiHdKkoHltg=="],
+
     "@effect/platform-bun/@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-rc.111", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.3" }, "peerDependencies": { "effect": "^4.0.0-rc.111" } }, "sha512-iES0Q9vmjhaUKqeW9ceonuD45MUg/Ouk08LzRSptZ+B5qB0w9WlRjDmUz5TJmY2betNop5FRI5k4AD4mtQt3Bw=="],
 
+    "miniflare/workerd": ["workerd@1.20260801.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260801.1", "@cloudflare/workerd-darwin-arm64": "1.20260801.1", "@cloudflare/workerd-linux-64": "1.20260801.1", "@cloudflare/workerd-linux-arm64": "1.20260801.1", "@cloudflare/workerd-windows-64": "1.20260801.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-/g9JGTyqnHtoIscpBHqKD8swE2V4StBs2i69PmLiOhH45OP95jCFICl4F1hKlgN57rqfni5LiCitttoX5OOkVA=="],
+
+    "miniflare/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
     "rolldown/@oxc-project/types": ["@oxc-project/types@0.146.0", "", {}, "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA=="],
+
+    "wrangler/miniflare": ["miniflare@5.20260820.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260820.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd": ["workerd@1.20260801.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260801.1", "@cloudflare/workerd-darwin-arm64": "1.20260801.1", "@cloudflare/workerd-linux-64": "1.20260801.1", "@cloudflare/workerd-linux-arm64": "1.20260801.1", "@cloudflare/workerd-windows-64": "1.20260801.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-/g9JGTyqnHtoIscpBHqKD8swE2V4StBs2i69PmLiOhH45OP95jCFICl4F1hKlgN57rqfni5LiCitttoX5OOkVA=="],
+
+    "miniflare/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260801.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-wuJWbXpKvncJi1P0GKS+iYpN5tHdb7JPJJ/+6ZQe8zzovHHVMkLJPNBsgWpqeUhpM3g9qTwEKd2rglNKejuh5A=="],
+
+    "miniflare/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260801.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kwoZiTpnhNrF3+APx84Q/oAqvJ3sU9yefGagwm/ASaH/2W19x0vghkW/r4qCoHCK0WW7EPugZ+aXjgPMRtlq1Q=="],
+
+    "miniflare/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260801.1", "", { "os": "linux", "cpu": "x64" }, "sha512-r0vAxCZH+Jih9Unm1yoyiByPNWNgawcKciOHDm5Q37ZVGOkKLsT9AtLe3yLSaul76WrKqtf+JP2n0WW32VBLJg=="],
+
+    "miniflare/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260801.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-zWgpdZtSozvIgzQNmQiDSF8yEOQJUkRAWNsDXXzAAoy+fCn8YUoSibj3mpFSbZRvbUldeBEaW6SCdC2VEMkhNQ=="],
+
+    "miniflare/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260801.1", "", { "os": "win32", "cpu": "x64" }, "sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg=="],
+
+    "wrangler/miniflare/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260801.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-wuJWbXpKvncJi1P0GKS+iYpN5tHdb7JPJJ/+6ZQe8zzovHHVMkLJPNBsgWpqeUhpM3g9qTwEKd2rglNKejuh5A=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260801.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kwoZiTpnhNrF3+APx84Q/oAqvJ3sU9yefGagwm/ASaH/2W19x0vghkW/r4qCoHCK0WW7EPugZ+aXjgPMRtlq1Q=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260801.1", "", { "os": "linux", "cpu": "x64" }, "sha512-r0vAxCZH+Jih9Unm1yoyiByPNWNgawcKciOHDm5Q37ZVGOkKLsT9AtLe3yLSaul76WrKqtf+JP2n0WW32VBLJg=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260801.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-zWgpdZtSozvIgzQNmQiDSF8yEOQJUkRAWNsDXXzAAoy+fCn8YUoSibj3mpFSbZRvbUldeBEaW6SCdC2VEMkhNQ=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260801.1", "", { "os": "win32", "cpu": "x64" }, "sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg=="],
   }
 }

--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
+  "ignoreDependencies": [
+    "cloudflare"
+  ],
   "workspaces": {
     ".": {
       "ignoreDependencies": [

--- a/packages/core/tla/runtime/DriverAlarmRace.cfg
+++ b/packages/core/tla/runtime/DriverAlarmRace.cfg
@@ -1,0 +1,12 @@
+\* The answers-only re-arm loses an alarm scheduled after a lane's visit.
+\* Expected to FAIL without using a crash: Arrive, Fire, VisitOk,
+\* Arrive during the open pass, then ReArmDrop clears the new arm.
+SPECIFICATION DropSpec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  Lanes = {lane}
+  MaxCrashes = 0
+  Poisoned = {}
+  GiveUpLimit = 2
+INVARIANT TypeOK
+INVARIANT Accounting

--- a/platform/README.md
+++ b/platform/README.md
@@ -1,14 +1,7 @@
 # platform
 
-The packages state contracts and semantics: the log, the reconciler, the code lane, the agent,
-and the ports they leave open (EventLog, Router, Sandbox, Infer). A package depends on effect
-and on other packages, and on nothing else. That invariant is the line between the two trees.
+The packages state contracts and semantics: the log, the reconciler, the code lane, the agent, and the ports they leave open (EventLog, Router, Sandbox, Infer). A package depends on effect and on other packages, and on nothing else. That invariant is the line between the two trees.
 
-A platform binds one port to the world. A binding that delivers events also stamps the sending span's context onto each event it persists (one traceparent string, first stamp wins), or every cross-lane trace it serves arrives fragmented. Storage and delivery on Cloudflare, a model provider
-behind Infer, a Bun process: each binding is one subdirectory here, and it owns its own
-dependencies. `packages/host` stays a package by the same rule: the reference runtime is
-in-memory and dependency-free, and it is the executable contract a platform binding is tested
-against.
+A platform binds one port to the world. A binding that delivers events also stamps the sending span's context onto each event it persists (one traceparent string, first stamp wins), or every cross-lane trace it serves arrives fragmented. Storage and delivery on Cloudflare, a model provider behind Infer, and a Bun process each live in one subdirectory with their own dependencies. `packages/host` stays a package by the same rule: the reference runtime is in-memory and dependency-free, and it is the executable contract a platform binding is tested against.
 
-Nothing lives here yet. `platform/model` (the Infer binding over the AI SDK) is the first
-planned tenant; `platform/bun` binds the log to SQLite through @effect/sql-sqlite-bun, binds the workspace a bounded value spills to (docs/explanations/boundary.md) to a table in that same database, so an event and the value it points at are one file, and binds the workspace's sql verb to a second database beside it, where the model's own tables are durable and the log is out of a wrong statement's reach (docs/how-to/workspace.md); `platform/cloudflare` arrives with the v6 extraction.
+`platform/model` binds Infer through the AI SDK. `platform/bun` binds the log to SQLite through @effect/sql-sqlite-bun, binds the workspace a bounded value spills to ([boundary](../docs/explanations/boundary.md)) to a table in that database, and binds the workspace SQL verb to a second database where model queries cannot alter the log ([workspace](../docs/how-to/workspace.md)). [`platform/cloudflare`](cloudflare/README.md) binds one actor graph to a SQLite Durable Object and drives its lanes through one alarm.

--- a/platform/cloudflare/README.md
+++ b/platform/cloudflare/README.md
@@ -1,0 +1,79 @@
+# Cloudflare platform
+
+This binding runs one actor graph in one SQLite Durable Object. `@effect/sql-sqlite-do` binds the object's full storage handle to Effect SQL, and `effect/unstable/http` serves the Worker routes. Every thread is a lane in the object's event table. One alarm drives ready lanes with the configured concurrency limit, and an alarm scheduled during an active pass remains armed after that pass.
+
+## Verify and deploy
+
+```bash
+bun run --cwd platform/cloudflare typecheck
+bun run --cwd platform/cloudflare test
+bun run --cwd platform/cloudflare test:workers
+bun run --cwd platform/cloudflare bundle
+bun run --cwd platform/cloudflare deploy
+```
+
+Set authentication before using the event API:
+
+```bash
+cd platform/cloudflare
+bunx wrangler secret put TARDIGRADE_TOKEN
+```
+
+Set `MODEL_BASE_URL`, `MODEL_API_KEY`, and `MODEL_ID` to run model turns. `MODEL_API_KEY` should be a Wrangler secret. A host without model configuration records a failed turn that names the missing configuration.
+
+## HTTP shapes
+
+`GET /healthz` is public.
+
+```json
+{ "status": "resting", "dirty": 0 }
+```
+
+Every other endpoint requires `Authorization: Bearer <TARDIGRADE_TOKEN>`. A host without `TARDIGRADE_TOKEN` returns status `503` with `{ "error": "authentication is not configured" }`. An incorrect token returns status `401` with `{ "error": "unauthorized" }`.
+
+`GET /v1/actors` has no input body and returns the actors served by this Worker.
+
+```json
+[{ "name": "default", "builtIn": true }]
+```
+
+`GET /v1/actors/default/threads` has no input body and returns each durable thread with its event count.
+
+```json
+[{ "id": "root", "events": 5 }]
+```
+
+`POST /v1/actors/default/threads/{thread}/events` accepts an event object. A root message has this shape:
+
+```json
+{ "type": "MessageReceived", "id": "m1", "text": "Research sauna safety." }
+```
+
+The response has status `202` and identifies the accepted destination.
+
+```json
+{ "actor": "default", "thread": "root" }
+```
+
+`GET /v1/actors/default/threads/{thread}/events` accepts `after`, `limit`, and comma-separated `types` query parameters. It returns sequence numbers beside the stored events.
+
+```json
+[
+  { "seq": 1, "event": { "type": "ThreadCreated", "thread": "root", "depth": 0 } },
+  { "seq": 2, "event": { "type": "MessageReceived", "id": "m1", "text": "Research sauna safety." } }
+]
+```
+
+## Configuration
+
+| Name | Default | Effect |
+| --- | --- | --- |
+| `TARDIGRADE_TOKEN` | unset | Protects every endpoint except `/healthz`; an unset value closes the event API |
+| `TARDIGRADE_MAX_CONCURRENT_LANES` | `4` | Limits lanes settled concurrently inside one actor object |
+| `TARDIGRADE_ALARM_DELAY_MILLIS` | `0` | Delays a newly armed actor alarm |
+| `MODEL_BASE_URL` | unset | Selects the model API endpoint |
+| `MODEL_API_KEY` | unset | Authenticates the model API request |
+| `MODEL_ID` | unset | Selects the model |
+| `MODEL_PROVIDER` | unset | Supplies an optional provider hint |
+
+`wrangler.jsonc` also makes the Worker CPU limit and Durable Object migration visible. Change those values in the deployment configuration when the account or workload requires a different policy.

--- a/platform/cloudflare/package.json
+++ b/platform/cloudflare/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@clavia/tardigrade-cloudflare",
+  "version": "0.0.1",
+  "private": true,
+  "license": "MIT",
+  "author": "Clavia, Inc.",
+  "description": "Cloudflare Durable Object host binding for tardigrade.",
+  "homepage": "https://github.com/clavia-labs/tardigrade#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/clavia-labs/tardigrade.git",
+    "directory": "platform/cloudflare"
+  },
+  "bugs": {
+    "url": "https://github.com/clavia-labs/tardigrade/issues"
+  },
+  "type": "module",
+  "exports": {
+    "./*": "./src/*.ts"
+  },
+  "dependencies": {
+    "tardie": "workspace:*",
+    "@clavia/tardigrade-core": "workspace:*",
+    "@clavia/tardigrade-host": "workspace:*",
+    "@clavia/tardigrade-model": "workspace:*",
+    "@effect/sql-sqlite-do": "4.0.0-rc.110",
+    "effect": "4.0.0-rc.110"
+  },
+  "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.20.1",
+    "@cloudflare/workers-types": "^5.20260804.1",
+    "vitest": "^4.1.10",
+    "wrangler": "^4.119.0"
+  },
+  "scripts": {
+    "bundle": "wrangler deploy --dry-run --outdir .wrangler/bundle",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "test:workers": "vitest run --config vitest.config.ts"
+  }
+}

--- a/platform/cloudflare/src/alarm.test.ts
+++ b/platform/cloudflare/src/alarm.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test"
+import { alarmPolicyOf, armAt, nextAlarm } from "./alarm"
+
+describe("actor alarm", () => {
+  test("an alarm scheduled during a pass survives quiet stale answers", () => {
+    expect(nextAlarm(101, false, 100)).toBe(101)
+  })
+
+  test("durable debt arms a quiet slot", () => {
+    expect(nextAlarm(null, true, 100, { delayMillis: 7 })).toBe(107)
+  })
+
+  test("a quiet pass with no concurrent arm clears", () => {
+    expect(nextAlarm(null, false, 100)).toBeNull()
+  })
+
+  test("a due alarm cannot block a new arm", () => {
+    expect(armAt(100, 100, 5)).toBe(105)
+  })
+
+  test("policy rejects invalid delays", () => {
+    expect(() => alarmPolicyOf({ delayMillis: -1 })).toThrow("non-negative integer")
+  })
+})

--- a/platform/cloudflare/src/alarm.ts
+++ b/platform/cloudflare/src/alarm.ts
@@ -1,0 +1,36 @@
+// DEFAULT_ALARM_DELAY_MILLIS is the delay for newly committed work.
+export const DEFAULT_ALARM_DELAY_MILLIS = 0
+
+export interface AlarmPolicy {
+  readonly delayMillis: number
+}
+
+export const DEFAULT_ALARM_POLICY: AlarmPolicy = {
+  delayMillis: DEFAULT_ALARM_DELAY_MILLIS
+}
+
+// alarmPolicyOf resolves and validates the actor alarm policy.
+export const alarmPolicyOf = (policy: Partial<AlarmPolicy> = {}): AlarmPolicy => {
+  const delayMillis = policy.delayMillis ?? DEFAULT_ALARM_POLICY.delayMillis
+  if (!Number.isSafeInteger(delayMillis) || delayMillis < 0) {
+    throw new Error(`alarm delayMillis must be a non-negative integer, got ${JSON.stringify(delayMillis)}`)
+  }
+  return { delayMillis }
+}
+
+// armAt returns a replacement alarm time when the standing alarm does not cover new work.
+export const armAt = (due: number | null, now: number, delayMillis: number): number | null => {
+  const at = now + delayMillis
+  return due === null || due <= now || due > at ? at : null
+}
+
+// nextAlarm preserves an alarm scheduled during the active pass and folds in remaining debt.
+export const nextAlarm = (
+  armedDuringPass: number | null,
+  owed: boolean,
+  now: number,
+  policy: AlarmPolicy = DEFAULT_ALARM_POLICY
+): number | null => {
+  if (armedDuringPass !== null) return armedDuringPass
+  return owed ? now + policy.delayMillis : null
+}

--- a/platform/cloudflare/src/host.ts
+++ b/platform/cloudflare/src/host.ts
@@ -1,0 +1,191 @@
+import { Effect, Layer, ManagedRuntime } from "effect"
+import { KeyValueStore } from "effect/unstable/persistence"
+import { SqliteClient } from "@effect/sql-sqlite-do"
+import type { Event } from "@clavia/tardigrade-core/event"
+import { EventLog } from "@clavia/tardigrade-core/event-log"
+import { mappedDirectory } from "@clavia/tardigrade-core/communication/directory"
+import { Router, directoryRoute, sendThrough, type TransportRoute } from "@clavia/tardigrade-core/communication/router"
+import type { Transport } from "@clavia/tardigrade-core/communication/transport"
+import { isActorEnvelope, isProviderEnvelope, linkedEventOf, type ActorEnvelope, type Envelope } from "@clavia/tardigrade-core/communication/envelope"
+import { formatActorId, isActorId, parseActorId, type ActorId, type ProviderEndpoint } from "@clavia/tardigrade-core/communication/endpoint"
+import type { Link } from "@clavia/tardigrade-core/communication/link"
+import { Self, restingActor, settleActor, type Actor } from "@clavia/tardigrade-core/actor"
+import { Facets } from "@clavia/tardigrade-core/facets"
+import { traceparentOf } from "@clavia/tardigrade-core/trace"
+import { sameActorId, sameThreadLineage, threadCreated, threadCreatedOf, threadKeys, type ThreadLineage } from "@clavia/tardigrade-core/thread"
+import { providerTransportFrom, type Provider } from "@clavia/tardigrade-host/communication/provider"
+import { createLaneDriver, type DriverPolicy } from "@clavia/tardigrade-host/driver"
+import type { HostPorts } from "@clavia/tardigrade-host/host"
+import { CloudflareEventStore, layerWorkspace } from "./storage"
+
+type CloudflarePorts = HostPorts | KeyValueStore.KeyValueStore
+type CloudflareLaneEnv<R> = Layer.Layer<Exclude<R, CloudflarePorts>, never, CloudflarePorts>
+
+type LayersFor<R> = [Exclude<R, CloudflarePorts>] extends [never]
+  ? { readonly layersFor?: (lane: string) => CloudflareLaneEnv<R> }
+  : { readonly layersFor: (lane: string) => CloudflareLaneEnv<R> }
+
+export type CloudflareHostOptions<R> = {
+  readonly storage: DurableObjectStorage
+  readonly principal: string
+  readonly actorFor: (lane: string) => Actor<R> | undefined
+  readonly providers?: ReadonlyArray<Provider>
+  readonly routes?: ReadonlyArray<TransportRoute>
+  readonly driver?: Partial<DriverPolicy>
+  readonly pick?: (dirty: ReadonlySet<string>) => string
+  readonly keyOf?: (event: Event) => string | undefined
+} & LayersFor<R>
+
+export interface CloudflareHost {
+  readonly read: (lane: string) => Promise<ReadonlyArray<Event>>
+  readonly lanes: () => Promise<ReadonlyArray<string>>
+  readonly commit: (envelope: Envelope<unknown, Event, ActorId>) => Promise<void>
+  readonly commitRoot: (address: string, event: Event) => Promise<void>
+  readonly drive: () => Promise<void>
+  readonly recover: () => Promise<void>
+  readonly resting: () => Promise<boolean>
+  readonly work: () => number
+  readonly self: (lane: string) => string
+  readonly close: () => Promise<void>
+}
+
+const laneOf = (address: string): string => {
+  const separator = address.indexOf(":")
+  return separator === -1 ? address : address.slice(separator + 1)
+}
+
+// createCloudflareHost binds one actor graph to Effect SQL over its Durable Object storage.
+export const createCloudflareHost = async <R = never>(options: CloudflareHostOptions<R>): Promise<CloudflareHost> => {
+  const database = ManagedRuntime.make(SqliteClient.layer({ storage: options.storage }))
+  const sql = await database.runPromise(SqliteClient.SqliteClient)
+  const workspaceRuntime = ManagedRuntime.make(layerWorkspace(sql))
+  const workspaceStore = await workspaceRuntime.runPromise(KeyValueStore.KeyValueStore)
+  const workspace = Layer.succeed(KeyValueStore.KeyValueStore, workspaceStore)
+  const providerTransport = providerTransportFrom(options.providers ?? [])
+  const storeKeyOf = (event: Event): string | undefined => threadKeys.keyOf(event) ?? options.keyOf?.(event)
+  const events = new CloudflareEventStore(sql, storeKeyOf)
+  await Effect.runPromise(events.initialize())
+  const readEffect = (lane: string): Effect.Effect<ReadonlyArray<Event>> => events.read(lane)
+  const sync = Effect.promise(() => options.storage.sync())
+
+  const commitEffect = (
+    target: ActorId,
+    event: Event,
+    lineage: ThreadLineage | undefined,
+    link?: Link<unknown, ActorId>
+  ): Effect.Effect<void> => {
+    const address = formatActorId(target)
+    return Effect.gen(function* () {
+      if (options.keyOf !== undefined && options.keyOf(event) === undefined && event.type !== "MessageReceived") {
+        return yield* Effect.die(
+          new Error(`unkeyed cross-lane event "${event.type}" to ${address}: every delivered event names its occurrence in its package's key fragment`)
+        )
+      }
+      const lane = laneOf(address)
+      const currentSpan = yield* Effect.currentSpan.pipe(Effect.option)
+      const stamped =
+        currentSpan._tag === "Some" && (event as { readonly traceparent?: unknown }).traceparent === undefined
+          ? ({ ...event, traceparent: traceparentOf(currentSpan.value) } as Event)
+          : event
+      const current = yield* readEffect(lane)
+      const created = threadCreatedOf(current)
+      if (current.length > 0 && created === undefined) return yield* Effect.die(new Error(`thread ${address} has no ThreadCreated first event`))
+      if (created !== undefined && !sameActorId(created.address, target)) {
+        return yield* Effect.die(new Error(`thread ${address} creation address does not match its target`))
+      }
+      if (lineage !== undefined) {
+        if (lineage.depth <= 0 || sameActorId(lineage.parent, target)) {
+          return yield* Effect.die(new Error(`thread ${address} has invalid child lineage`))
+        }
+        if (link === undefined || !isActorId(link.source) || !sameActorId(lineage.parent, link.source)) {
+          return yield* Effect.die(new Error(`thread ${address} lineage parent does not match its delivery source`))
+        }
+        if (created !== undefined && !sameThreadLineage(created, lineage)) {
+          return yield* Effect.die(new Error(`thread ${address} already has different lineage`))
+        }
+      } else if (created === undefined && link !== undefined && isActorId(link.source)) {
+        return yield* Effect.die(new Error(`initial actor delivery to ${address} must carry lineage`))
+      }
+      const landed = link !== undefined && stamped.type === "MessageReceived" ? linkedEventOf({ link, event: stamped }) : stamped
+      const at = (event as { readonly at?: unknown }).at
+      if (created === undefined && (typeof at !== "number" || !Number.isFinite(at))) {
+        return yield* Effect.die(new Error(`first thread event "${event.type}" must carry a finite at`))
+      }
+      const appended = yield* events.append(
+        lane,
+        created === undefined ? [threadCreated(target, lineage, at as number), landed] : [landed]
+      )
+      if (appended > 0) driver.mark(lane)
+      yield* sync
+    }).pipe(Effect.withSpan("commit", { kind: "producer", attributes: { to: address, type: event.type } }))
+  }
+
+  const localTransport: Transport<ActorId, ActorEnvelope> = {
+    name: "local",
+    send: (_destination, envelope) => commitEffect(envelope.link.target, envelope.event, envelope.lineage, envelope.link)
+  }
+  const routes = [
+    directoryRoute(localTransport, mappedDirectory((id: ActorId) => id.actor === options.principal ? id : undefined), isActorEnvelope, (envelope) => envelope.link.target),
+    directoryRoute(providerTransport, mappedDirectory<ProviderEndpoint, ProviderEndpoint>((endpoint) => endpoint), isProviderEnvelope, (envelope) => envelope.link.target),
+    ...(options.routes ?? [])
+  ]
+  const router = Layer.succeed(Router, { send: (envelope) => sendThrough(routes, envelope) })
+  const self = (lane: string): string => `${options.principal}:${lane}`
+  const portsOf = (lane: string) => Layer.mergeAll(
+    Layer.succeed(EventLog, {
+      append: (batch) => events.append(lane, batch).pipe(Effect.andThen(sync), Effect.asVoid),
+      read: readEffect(lane),
+      head: events.head(lane),
+      readFrom: (mark) => events.readFrom(lane, mark)
+    }),
+    router,
+    workspace,
+    Layer.succeed(Self, parseActorId(self(lane))),
+    Layer.succeed(Facets, { read: readEffect })
+  )
+  const layersOf = (lane: string): Layer.Layer<R | EventLog> => {
+    const extra = (options.layersFor ?? (() => Layer.empty as unknown as CloudflareLaneEnv<R>))(lane)
+    return extra.pipe(Layer.provideMerge(portsOf(lane))) as Layer.Layer<R | EventLog>
+  }
+  const driver = createLaneDriver({
+    ...(options.driver === undefined ? {} : { policy: options.driver }),
+    ...(options.pick === undefined ? {} : { pick: options.pick }),
+    serve: async (lane) => {
+      const actor = options.actorFor(lane)
+      if (actor !== undefined) await Effect.runPromise(settleActor(actor).pipe(Effect.provide(layersOf(lane))))
+    }
+  })
+  let tail: Promise<void> = Promise.resolve()
+  const drive = (): Promise<void> => {
+    const next = tail.then(() => driver.drain())
+    tail = next.then(() => undefined, () => undefined)
+    return next
+  }
+  const lanes = (): Promise<ReadonlyArray<string>> => Effect.runPromise(events.lanes())
+  const recover = async (): Promise<void> => {
+    for (const lane of await lanes()) if (options.actorFor(lane) !== undefined) driver.mark(lane)
+    await drive()
+  }
+  const resting = async (): Promise<boolean> => {
+    for (const lane of await lanes()) {
+      const actor = options.actorFor(lane)
+      if (actor !== undefined && !restingActor(actor, await Effect.runPromise(readEffect(lane)))) return false
+    }
+    return driver.resting()
+  }
+  return {
+    read: (lane) => Effect.runPromise(readEffect(lane)),
+    lanes,
+    commit: (envelope) => Effect.runPromise(commitEffect(envelope.link.target, envelope.event, envelope.lineage, envelope.link)),
+    commitRoot: (address, event) => Effect.runPromise(commitEffect(parseActorId(address), event, undefined)),
+    drive,
+    recover,
+    resting,
+    work: driver.work,
+    self,
+    close: async () => {
+      await workspaceRuntime.dispose()
+      await database.dispose()
+    }
+  }
+}

--- a/platform/cloudflare/src/storage.ts
+++ b/platform/cloudflare/src/storage.ts
@@ -1,0 +1,150 @@
+import { Effect, Encoding, Layer } from "effect"
+import { KeyValueStore } from "effect/unstable/persistence"
+import { SqlClient } from "effect/unstable/sql"
+import type { Event } from "@clavia/tardigrade-core/event"
+
+export interface EventRow {
+  readonly seq: number
+  readonly event: Event
+}
+
+// CloudflareEventStore binds the event-log guarantees to an Effect SQL client over one Durable Object database.
+export class CloudflareEventStore {
+  readonly sql: SqlClient.SqlClient
+  readonly keyOf: (event: Event) => string | undefined
+
+  constructor(sql: SqlClient.SqlClient, keyOf: (event: Event) => string | undefined) {
+    this.sql = sql
+    this.keyOf = keyOf
+  }
+
+  initialize(): Effect.Effect<void> {
+    const sql = this.sql
+    return Effect.gen(function* () {
+      yield* sql.unsafe(
+        `CREATE TABLE IF NOT EXISTS events (
+          lane TEXT NOT NULL,
+          seq INTEGER NOT NULL,
+          key TEXT,
+          event TEXT NOT NULL,
+          PRIMARY KEY (lane, seq)
+        ) WITHOUT ROWID`
+      )
+      yield* sql.unsafe("CREATE UNIQUE INDEX IF NOT EXISTS events_lane_key ON events (lane, key) WHERE key IS NOT NULL")
+    }).pipe(Effect.orDie)
+  }
+
+  read(lane: string): Effect.Effect<ReadonlyArray<Event>> {
+    return this.sql
+      .unsafe<{ readonly event: string }>("SELECT event FROM events WHERE lane = ? ORDER BY seq", [lane])
+      .pipe(
+        Effect.map((rows) => rows.map((row) => JSON.parse(row.event) as Event)),
+        Effect.orDie
+      )
+  }
+
+  readFrom(lane: string, mark: number): Effect.Effect<ReadonlyArray<Event>> {
+    return this.sql
+      .unsafe<{ readonly event: string }>("SELECT event FROM events WHERE lane = ? AND seq > ? ORDER BY seq", [lane, mark])
+      .pipe(
+        Effect.map((rows) => rows.map((row) => JSON.parse(row.event) as Event)),
+        Effect.orDie
+      )
+  }
+
+  head(lane: string): Effect.Effect<number> {
+    return this.sql
+      .unsafe<{ readonly head: number }>("SELECT COALESCE(MAX(seq), 0) AS head FROM events WHERE lane = ?", [lane])
+      .pipe(
+        Effect.map((rows) => Number(rows[0]?.head ?? 0)),
+        Effect.orDie
+      )
+  }
+
+  lanes(): Effect.Effect<ReadonlyArray<string>> {
+    return this.sql
+      .unsafe<{ readonly lane: string }>("SELECT DISTINCT lane FROM events ORDER BY lane")
+      .pipe(
+        Effect.map((rows) => rows.map((row) => row.lane)),
+        Effect.orDie
+      )
+  }
+
+  append(lane: string, events: ReadonlyArray<Event>): Effect.Effect<number> {
+    if (events.length === 0) return Effect.succeed(0)
+    const sql = this.sql
+    const keyOf = this.keyOf
+    return sql.withTransaction(
+      Effect.gen(function* () {
+        const heads = yield* sql.unsafe<{ readonly head: number }>(
+          "SELECT COALESCE(MAX(seq), 0) AS head FROM events WHERE lane = ?",
+          [lane]
+        )
+        let seq = Number(heads[0]?.head ?? 0) + 1
+        let appended = 0
+        for (const event of events) {
+          const key = keyOf(event)
+          if (key !== undefined) {
+            const present = yield* sql.unsafe<{ readonly present: number }>(
+              "SELECT 1 AS present FROM events WHERE lane = ? AND key = ?",
+              [lane, key]
+            )
+            if (present.length > 0) continue
+          }
+          yield* sql.unsafe(
+            "INSERT INTO events (lane, seq, key, event) VALUES (?, ?, ?, ?)",
+            [lane, seq, key ?? null, JSON.stringify(event)]
+          )
+          seq += 1
+          appended += 1
+        }
+        return appended
+      })
+    ).pipe(Effect.orDie)
+  }
+}
+
+// layerWorkspace binds Effect's workspace store to the actor database through Effect SQL.
+export const layerWorkspace = (sql: SqlClient.SqlClient): Layer.Layer<KeyValueStore.KeyValueStore> => {
+  const get = (key: string): Effect.Effect<string | undefined> =>
+    sql.unsafe<{ readonly value: string }>("SELECT value FROM workspace WHERE key = ?", [key]).pipe(
+      Effect.map((rows) => rows[0]?.value),
+      Effect.orDie
+    )
+  const set = (key: string, value: string): Effect.Effect<void> =>
+    sql.unsafe(
+      "INSERT INTO workspace (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+      [key, value]
+    ).pipe(Effect.asVoid, Effect.orDie)
+  const initialize = sql.unsafe(
+    `CREATE TABLE IF NOT EXISTS workspace (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    ) WITHOUT ROWID`
+  ).pipe(Effect.asVoid, Effect.orDie)
+  const store = KeyValueStore.make({
+    get,
+    getUint8Array: (key) => get(key).pipe(Effect.map((value) => {
+      if (value === undefined) return undefined
+      const decoded = Encoding.decodeBase64(value)
+      return decoded._tag === "Success" ? decoded.success : new TextEncoder().encode(value)
+    })),
+    set: (key, value) => set(key, typeof value === "string" ? value : Encoding.encodeBase64(value)),
+    remove: (key) => sql.unsafe("DELETE FROM workspace WHERE key = ?", [key]).pipe(Effect.asVoid, Effect.orDie),
+    clear: sql.unsafe("DELETE FROM workspace").pipe(Effect.asVoid, Effect.orDie),
+    size: sql.unsafe<{ readonly count: number }>("SELECT COUNT(*) AS count FROM workspace").pipe(
+      Effect.map((rows) => Number(rows[0]?.count ?? 0)),
+      Effect.orDie
+    ),
+    modify: (key, f) => sql.withTransaction(
+      Effect.gen(function* () {
+        const current = yield* get(key)
+        if (current === undefined) return undefined
+        const next = f(current)
+        yield* set(key, next)
+        return next
+      })
+    ).pipe(Effect.orDie)
+  })
+  return Layer.effect(KeyValueStore.KeyValueStore, Effect.as(initialize, store))
+}

--- a/platform/cloudflare/src/worker.ts
+++ b/platform/cloudflare/src/worker.ts
@@ -1,0 +1,284 @@
+import { DurableObject } from "cloudflare:workers"
+import { Context, Effect, Layer } from "effect"
+import { FetchHttpClient, HttpEffect, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { actor, agentsPackage, budget, codeMode, compaction, fetchPackage, Infer, infer as inferAgent, outputValidateOnce, reply, workspacePackage } from "tardie"
+import type { Action } from "tardie/events"
+import { infer } from "@clavia/tardigrade-model/model"
+import type { Event } from "@clavia/tardigrade-core/event"
+import { traceparentOf } from "@clavia/tardigrade-core/trace"
+import { mappedDirectory } from "@clavia/tardigrade-core/communication/directory"
+import { directoryRoute } from "@clavia/tardigrade-core/communication/router"
+import type { Transport } from "@clavia/tardigrade-core/communication/transport"
+import { isActorEnvelope, type ActorEnvelope } from "@clavia/tardigrade-core/communication/envelope"
+import type { ActorId } from "@clavia/tardigrade-core/communication/endpoint"
+import { DEFAULT_MAX_CONCURRENT_LANES, driverPolicyOf } from "@clavia/tardigrade-host/driver"
+import { alarmPolicyOf, armAt, nextAlarm, type AlarmPolicy } from "./alarm"
+import { createCloudflareHost, type CloudflareHost } from "./host"
+
+export interface Env {
+  readonly ACTORS: DurableObjectNamespace<ActorHost>
+  readonly MODEL_BASE_URL?: string
+  readonly MODEL_API_KEY?: string
+  readonly MODEL_ID?: string
+  readonly MODEL_PROVIDER?: string
+  readonly TARDIGRADE_TOKEN?: string
+  readonly TARDIGRADE_MAX_CONCURRENT_LANES?: string
+  readonly TARDIGRADE_ALARM_DELAY_MILLIS?: string
+}
+
+const LANE_PREFIX = "ag."
+const laneOf = (thread: string): string => `${LANE_PREFIX}${thread}`
+const threadOf = (lane: string): string | undefined => lane.startsWith(LANE_PREFIX) ? lane.slice(LANE_PREFIX.length) : undefined
+
+const assembly = actor(inferAgent([
+  codeMode([agentsPackage(), workspacePackage(), fetchPackage()]),
+  reply,
+  budget,
+  compaction,
+  outputValidateOnce
+]))
+
+const modelLayer = (env: Env) => {
+  if (env.MODEL_BASE_URL === undefined || env.MODEL_API_KEY === undefined || env.MODEL_ID === undefined) {
+    const failed: Action = { kind: "fail", error: "no model is configured", failure: { cause: "inference_error", attempts: 1 } }
+    return Layer.succeed(Infer)({ react: () => Effect.succeed(failed) })
+  }
+  return infer({
+    baseUrl: env.MODEL_BASE_URL,
+    apiKey: env.MODEL_API_KEY,
+    model: env.MODEL_ID,
+    ...(env.MODEL_PROVIDER === undefined ? {} : { provider: env.MODEL_PROVIDER })
+  })
+}
+
+const positiveInteger = (raw: string | undefined, fallback: number, name: string): number => {
+  if (raw === undefined) return fallback
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value) || value <= 0) throw new Error(`${name} must be a positive integer, got ${JSON.stringify(raw)}`)
+  return value
+}
+
+const nonNegativeInteger = (raw: string | undefined, fallback: number, name: string): number => {
+  if (raw === undefined) return fallback
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error(`${name} must be a non-negative integer, got ${JSON.stringify(raw)}`)
+  return value
+}
+
+// ActorHost runs one actor graph over one SQLite-backed Durable Object.
+export class ActorHost extends DurableObject<Env> {
+  private runtime: Promise<CloudflareHost> | undefined
+  private principal: string | undefined
+  private readonly alarmPolicy: AlarmPolicy
+
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env)
+    ctx.storage.sql.exec("CREATE TABLE IF NOT EXISTS actor_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+    this.alarmPolicy = alarmPolicyOf({
+      delayMillis: nonNegativeInteger(env.TARDIGRADE_ALARM_DELAY_MILLIS, 0, "TARDIGRADE_ALARM_DELAY_MILLIS")
+    })
+  }
+
+  async init(principal: string): Promise<void> {
+    this.ctx.storage.sql.exec("INSERT OR IGNORE INTO actor_meta (key, value) VALUES ('principal', ?)", principal)
+    const stored = this.ctx.storage.sql.exec<{ value: string }>("SELECT value FROM actor_meta WHERE key = 'principal'").one().value
+    if (stored !== principal) throw new Error("actor host principal does not match its durable identity")
+    this.principal ??= stored
+  }
+
+  private name(): string {
+    if (this.principal !== undefined) return this.principal
+    const row = this.ctx.storage.sql.exec<{ value: string }>("SELECT value FROM actor_meta WHERE key = 'principal'").toArray()[0]
+    if (row === undefined) throw new Error("actor host has not been initialized")
+    return this.principal = row.value
+  }
+
+  private host(): Promise<CloudflareHost> {
+    if (this.runtime !== undefined) return this.runtime
+    const principal = this.name()
+    const remoteTransport: Transport<ActorId, ActorEnvelope> = {
+      name: "durable-object",
+      send: (destination, envelope) => Effect.currentSpan.pipe(
+        Effect.option,
+        Effect.flatMap((current) => {
+          const event = current._tag === "Some" && (envelope.event as { readonly traceparent?: unknown }).traceparent === undefined
+            ? ({ ...envelope.event, traceparent: traceparentOf(current.value) } as Event)
+            : envelope.event
+          return Effect.promise(async () => {
+            const stub = this.env.ACTORS.getByName(destination.actor)
+            await stub.init(destination.actor)
+            await stub.deliver({ ...envelope, event })
+          })
+        })
+      )
+    }
+    const remoteRoute = directoryRoute(
+      remoteTransport,
+      mappedDirectory((id: ActorId) => id.actor === principal ? undefined : id),
+      isActorEnvelope,
+      (envelope) => envelope.link.target
+    )
+    this.runtime = createCloudflareHost({
+      storage: this.ctx.storage,
+      principal,
+      actorFor: (lane) => threadOf(lane) === undefined ? undefined : assembly,
+      layersFor: () => Layer.mergeAll(modelLayer(this.env), FetchHttpClient.layer),
+      routes: [remoteRoute],
+      driver: driverPolicyOf({
+        maxConcurrentLanes: positiveInteger(
+          this.env.TARDIGRADE_MAX_CONCURRENT_LANES,
+          DEFAULT_MAX_CONCURRENT_LANES,
+          "TARDIGRADE_MAX_CONCURRENT_LANES"
+        )
+      }),
+      keyOf: assembly.keyOf
+    })
+    return this.runtime
+  }
+
+  private async arm(): Promise<void> {
+    const at = armAt(await this.ctx.storage.getAlarm(), Date.now(), this.alarmPolicy.delayMillis)
+    if (at !== null) await this.ctx.storage.setAlarm(at)
+  }
+
+  async append(thread: string, event: Event): Promise<void> {
+    const stamped = event.at === undefined ? { ...event, at: Date.now() } : event
+    const host = await this.host()
+    await host.commitRoot(host.self(laneOf(thread)), stamped)
+    await this.arm()
+  }
+
+  async deliver(envelope: ActorEnvelope): Promise<void> {
+    if (envelope.link.target.actor !== this.name()) throw new Error("delivery target does not match actor host")
+    await (await this.host()).commit(envelope)
+    await this.arm()
+  }
+
+  async events(thread: string): Promise<ReadonlyArray<Event>> {
+    return (await this.host()).read(laneOf(thread))
+  }
+
+  async threads(): Promise<ReadonlyArray<{ readonly id: string; readonly events: number }>> {
+    const host = await this.host()
+    const summaries: Array<{ readonly id: string; readonly events: number }> = []
+    for (const lane of await host.lanes()) {
+      const id = threadOf(lane)
+      if (id !== undefined) summaries.push({ id, events: (await host.read(lane)).length })
+    }
+    return summaries
+  }
+
+  async status(): Promise<{ readonly status: "resting" | "driving"; readonly dirty: number }> {
+    const host = await this.host()
+    return { status: await host.resting() ? "resting" : "driving", dirty: host.work() }
+  }
+
+  async alarm(): Promise<void> {
+    const host = await this.host()
+    await host.recover()
+    const armedDuringPass = await this.ctx.storage.getAlarm()
+    const next = nextAlarm(armedDuringPass, !host.resting(), Date.now(), this.alarmPolicy)
+    if (next === null) await this.ctx.storage.deleteAlarm()
+    else await this.ctx.storage.setAlarm(next)
+  }
+}
+
+const actorStub = async (env: Env, name: string): Promise<DurableObjectStub<ActorHost>> => {
+  const stub = env.ACTORS.getByName(name)
+  await stub.init(name)
+  return stub
+}
+
+class WorkerEnv extends Context.Service<WorkerEnv, Env>()("tardigrade/cloudflare/WorkerEnv") {}
+
+const json = (body: unknown, status = 200) => HttpServerResponse.jsonUnsafe(body, { status })
+
+const authorized = (request: HttpServerRequest.HttpServerRequest, env: Env): boolean =>
+  env.TARDIGRADE_TOKEN !== undefined && request.headers.authorization === `Bearer ${env.TARDIGRADE_TOKEN}`
+
+const guard = (request: HttpServerRequest.HttpServerRequest, env: Env) => {
+  if (env.TARDIGRADE_TOKEN === undefined) return json({ error: "authentication is not configured" }, 503)
+  if (!authorized(request, env)) return json({ error: "unauthorized" }, 401)
+  return undefined
+}
+
+const protectedRoute = <E, R>(
+  f: (
+    request: HttpServerRequest.HttpServerRequest,
+    env: Env
+  ) => Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>
+) => Effect.gen(function* () {
+  const request = yield* HttpServerRequest.HttpServerRequest
+  const env = yield* WorkerEnv
+  const refused = guard(request, env)
+  return refused ?? (yield* f(request, env))
+})
+
+const routes = [
+  HttpRouter.route("GET", "/healthz", Effect.gen(function* () {
+    const env = yield* WorkerEnv
+    return json(yield* Effect.promise(async () => (await actorStub(env, "default")).status()))
+  })),
+  HttpRouter.route("GET", "/v1/actors", protectedRoute((_request, _env) =>
+    Effect.succeed(json([{ name: "default", builtIn: true }]))
+  )),
+  HttpRouter.route("GET", "/v1/actors/:actor/threads", protectedRoute((_request, env) =>
+    Effect.gen(function* () {
+      const params = yield* HttpRouter.params
+      const actor = decodeURIComponent(params.actor ?? "")
+      if (actor !== "default") return json({ error: "unknown actor" }, 404)
+      return json(yield* Effect.promise(async () => (await actorStub(env, actor)).threads()))
+    })
+  )),
+  HttpRouter.route("POST", "/v1/actors/:actor/threads/:thread/events", protectedRoute((request, env) =>
+    Effect.gen(function* () {
+      const params = yield* HttpRouter.params
+      const actor = decodeURIComponent(params.actor ?? "")
+      const thread = decodeURIComponent(params.thread ?? "")
+      if (actor !== "default") return json({ error: "unknown actor" }, 404)
+      const event = (yield* request.json.pipe(Effect.orElseSucceed(() => undefined))) as Event | undefined
+      if (typeof event !== "object" || event === null || typeof event.type !== "string" || event.type === "") {
+        return json({ error: "event type is required" }, 400)
+      }
+      yield* Effect.promise(async () => (await actorStub(env, actor)).append(thread, event))
+      return json({ actor, thread }, 202)
+    })
+  )),
+  HttpRouter.route("GET", "/v1/actors/:actor/threads/:thread/events", protectedRoute((request, env) =>
+    Effect.gen(function* () {
+      const params = yield* HttpRouter.params
+      const actor = decodeURIComponent(params.actor ?? "")
+      const thread = decodeURIComponent(params.thread ?? "")
+      if (actor !== "default") return json({ error: "unknown actor" }, 404)
+      const url = new URL(request.url, "http://worker")
+      const after = Number(url.searchParams.get("after") ?? 0)
+      const limit = Number(url.searchParams.get("limit") ?? 200)
+      const types = url.searchParams.get("types")?.split(",")
+      return yield* Effect.tryPromise({
+        try: async (): Promise<ReadonlyArray<Event>> => (await actorStub(env, actor)).events(thread),
+        catch: (cause) => cause instanceof Error ? cause.message : String(cause)
+      }).pipe(Effect.match({
+        onFailure: (error) => json({ error }, 500),
+        onSuccess: (events) => json(events.map((event, index) => ({ seq: index + 1, event }))
+          .filter((row) => row.seq > after && (types === undefined || types.includes(row.event.type)))
+          .slice(0, limit))
+      }))
+    })
+  )),
+  HttpRouter.route("*", "/*", json({ error: "not found" }, 404))
+] as const
+
+const router = Effect.runSync(HttpRouter.make)
+// routes carry request requirements as registration markers; addAll records them without running a handler (effect/unstable/http/HttpRouter.ts, addAll).
+// @effect-diagnostics-next-line unsafeEffectTypeAssertion:off
+Effect.runSync(router.addAll(routes) as Effect.Effect<void>)
+// httpApp handles the router's opaque internal failure at the web boundary.
+// @effect-diagnostics-next-line anyUnknownInErrorContext:off
+const httpApp = router.asHttpEffect().pipe(Effect.orElseSucceed(() => json({ error: "internal server error" }, 500)))
+const webHandler = HttpEffect.toWebHandler(httpApp)
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    return webHandler(request, Context.make(WorkerEnv, env) as Context.Context<never>)
+  }
+} satisfies ExportedHandler<Env>

--- a/platform/cloudflare/test/actor.workers.ts
+++ b/platform/cloudflare/test/actor.workers.ts
@@ -1,0 +1,46 @@
+import { SELF } from "cloudflare:test"
+import { describe, expect, test } from "vitest"
+
+const authorization = { authorization: "Bearer workers-test-token" }
+
+const trajectory = async (): Promise<ReadonlyArray<{ readonly seq: number; readonly event: { readonly type: string } }>> => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const response = await SELF.fetch("http://test/v1/actors/default/threads/root/events", { headers: authorization })
+    const body = await response.text()
+    if (!response.ok) throw new Error(`event read returned ${response.status}: ${body}`)
+    const events = JSON.parse(body) as ReadonlyArray<{ readonly seq: number; readonly event: { readonly type: string } }>
+    if (events.some((row) => row.event.type === "TurnFailed")) return events
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  return []
+}
+
+describe("cloudflare actor", () => {
+  test("an alarm settles a durable root message", async () => {
+    const refused = await SELF.fetch("http://test/v1/actors")
+    expect(refused.status).toBe(401)
+    const accepted = await SELF.fetch("http://test/v1/actors/default/threads/root/events", {
+      method: "POST",
+      headers: { ...authorization, "content-type": "application/json" },
+      body: JSON.stringify({ type: "MessageReceived", id: "workers-smoke", text: "Run in workerd." })
+    })
+    expect(accepted.status).toBe(202)
+    const events = await trajectory()
+    expect(events.map((row) => row.event.type)).toEqual([
+      "ThreadCreated",
+      "MessageReceived",
+      "ModelCalled",
+      "TurnFailed",
+      "ReplyDelivered"
+    ])
+    const redelivered = await SELF.fetch("http://test/v1/actors/default/threads/root/events", {
+      method: "POST",
+      headers: { ...authorization, "content-type": "application/json" },
+      body: JSON.stringify({ type: "MessageReceived", id: "workers-smoke", text: "Run in workerd." })
+    })
+    expect(redelivered.status).toBe(202)
+    expect((await trajectory()).map((row) => row.event.type)).toEqual(events.map((row) => row.event.type))
+    const health = await SELF.fetch("http://test/healthz")
+    expect(await health.json()).toEqual({ status: "resting", dirty: 0 })
+  })
+})

--- a/platform/cloudflare/tsconfig.json
+++ b/platform/cloudflare/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["esnext", "dom"],
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/platform/cloudflare/tsconfig.test.json
+++ b/platform/cloudflare/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.test.ts", "src/alarm.ts"]
+}

--- a/platform/cloudflare/vitest.config.ts
+++ b/platform/cloudflare/vitest.config.ts
@@ -1,0 +1,10 @@
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers"
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  plugins: [cloudflareTest({
+    wrangler: { configPath: "./wrangler.jsonc" },
+    miniflare: { bindings: { TARDIGRADE_TOKEN: "workers-test-token" } }
+  })],
+  test: { include: ["test/**/*.workers.ts"] }
+})

--- a/platform/cloudflare/wrangler.jsonc
+++ b/platform/cloudflare/wrangler.jsonc
@@ -1,0 +1,16 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "tardigrade",
+  "main": "src/worker.ts",
+  "compatibility_date": "2026-08-08",
+  "compatibility_flags": ["nodejs_compat"],
+  "durable_objects": {
+    "bindings": [{ "name": "ACTORS", "class_name": "ActorHost" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ActorHost"] }],
+  "observability": { "enabled": true },
+  "limits": { "cpu_ms": 300000 },
+  "vars": {
+    "TARDIGRADE_MAX_CONCURRENT_LANES": "4"
+  }
+}

--- a/tools/gate.ts
+++ b/tools/gate.ts
@@ -12,7 +12,7 @@ const root = fileURLToPath(new URL("../", import.meta.url))
 const pkg = (name: string) => `${root}packages/${name}`
 const packages = ["core", "code", "agent", "host", "channels", "client"]
 const platformPkg = (name: string) => `${root}platform/${name}`
-const platforms = ["model", "bun"]
+const platforms = ["model", "bun", "cloudflare"]
 const appPkg = (name: string) => `${root}apps/${name}`
 const apps = ["cli", "server", "voyager"]
 // Apps that ship a bundle. A typecheck proves the sources agree; only a build proves the bundler
@@ -66,7 +66,9 @@ const tasks: ReadonlyArray<Task> = [
   ...apps.map((name) => ({ id: `typecheck:app-${name}`, cwd: appPkg(name), cmd: ["bun", "run", "typecheck"] })),
   ...packages.map((name) => ({ id: `test:${name}`, cwd: pkg(name), cmd: ["bun", "test"] })),
   ...platforms.map((name) => ({ id: `test:platform-${name}`, cwd: platformPkg(name), cmd: ["bun", "test"] })),
+  { id: "test:platform-cloudflare:workers", cwd: platformPkg("cloudflare"), cmd: ["bun", "run", "test:workers"] },
   ...apps.map((name) => ({ id: `test:app-${name}`, cwd: appPkg(name), cmd: ["bun", "test"] })),
+  { id: "bundle:platform-cloudflare", cwd: platformPkg("cloudflare"), cmd: ["bun", "run", "bundle"] },
   ...bundled.map((name) => ({ id: `build:app-${name}`, cwd: appPkg(name), cmd: ["bun", "run", "build"] })),
   { id: "knip", cmd: ["bun", "--bun", "node_modules/.bin/knip"] }
 ]

--- a/tools/tla.ts
+++ b/tools/tla.ts
@@ -57,6 +57,7 @@ export const checks: ReadonlyArray<Check> = [
   pass("runtime", "Driver", "DriverLive.cfg"),
   pass("runtime", "Driver", "DriverIsolate.cfg"),
   pass("runtime", "Driver", "DriverPoisoned.cfg"),
+  counterexample("runtime", "Driver", "DriverAlarmRace.cfg", "Invariant Accounting is violated"),
   counterexample("runtime", "Driver", "DriverDrop.cfg", "Invariant Accounting is violated"),
   pass("runtime", "Execution", "Execution.cfg"),
   counterexample("runtime", "Execution", "ExecutionReadyLeak.cfg", "Invariant ParkedAttemptReleases is violated"),


### PR DESCRIPTION
Adds a Cloudflare platform that hosts each actor graph in a named SQLite Durable Object. Lane logs and workspace values use the official Effect Durable Object SQL adapter, Worker routes use Effect HTTP, and the actor driver settles configured lane concurrency through one alarm.

The alarm finalizer preserves work scheduled during an active alarm pass. A focused TLA configuration pins the lost-wakeup counterexample, unit tests cover the scheduling policy, and a workerd integration test covers authenticated ingress, SQLite settlement, redelivery, and resting health.

The full 47-task gate passes. The Worker bundle deploys to Cloudflare and the live health and fail-closed authentication checks pass.