### PR TITLE
feat(cloudflare): run durable agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,27 @@ const releaseAnalyst = actor(infer([
   deploys,     // recent_deploys and its paired handler
   codeMode(),  // durable JavaScript execution over an empty package scope
   budget,      // a per-turn code budget
-  compaction,  // bounded model context
+  compaction(), // bounded model context
   reply,       // results for parent agents
   outputValidateOnce // validates one structured result without correction
 ]))
 ```
 
 `infer` composes its children, preserves their transitions, and adds inference and tool routing over their final view. `actor` adapts the root component to reconciliation and carries its service requirements into the host type. System fragments join in component order, so the model sees the release instructions beside `recent_deploys` and `execute` in one request. Policy components derive work from the same log.
+
+`compaction(policy?)` takes a model-window resolver and hysteresis ratios. The default fires at 80 percent of a 128,000-token window and keeps a 50 percent tail. A platform that serves several models should state each window from the same model catalog that inference uses:
+
+```ts
+const windows = { default: 1_000_000, sonnet: 200_000 } as const
+
+const boundedContext = compaction({
+  contextWindowTokens: (model) => windows[model === "sonnet" ? "sonnet" : "default"],
+  fireRatio: 0.8,
+  keepRatio: 0.5
+})
+```
+
+When the guard fires, the component appends the resolved policy with its checkpoint. The output shape is `{ type: "CompactionCompleted", keepFrom: string, summary: string, contextWindowTokens: number, fireTokens: number, keepTokens: number, at: number }`.
 
 `codeMode([...components])` applies the same structure to the code surface. Each package factory returns a leaf `CodeComponent`. Code mode composes their package views and transitions, then exposes the combined scope through one `execute` tool. Use `definePackage({...})` for a custom leaf. Use `composeComponents(name, CODE_VIEW_ALGEBRA, children)` when one code component groups other code components.
 

--- a/apps/server/src/actor.ts
+++ b/apps/server/src/actor.ts
@@ -41,7 +41,7 @@ export const assemblyOf = () =>
     codeMode([agentsPackage(), workspacePackage(), filesPackage(), fetchPackage()]),
     reply,
     budget,
-    compaction,
+    compaction(),
     outputValidateOnce
   ]))
 

--- a/apps/voyager/src/narrative.ts
+++ b/apps/voyager/src/narrative.ts
@@ -233,7 +233,7 @@ const ORDER: Readonly<Record<string, ReadonlyArray<string>>> = {
   BudgetRequested: ["callId", "amount", "reason", ...STAMP],
   BudgetGranted: ["callId", "amount", ...STAMP],
   BudgetDenied: ["callId", "reason", ...STAMP],
-  CompactionCompleted: ["keepFrom", ...STAMP, "summary"]
+  CompactionCompleted: ["keepFrom", "contextWindowTokens", "fireTokens", "keepTokens", ...STAMP, "summary"]
 }
 
 // TIME_FIELDS are the fields whose number is an instant rather than a quantity. The lanes stamp

--- a/bun.lock
+++ b/bun.lock
@@ -144,6 +144,7 @@
       "name": "@clavia/tardigrade-cloudflare",
       "version": "0.0.1",
       "dependencies": {
+        "@clavia/tardigrade-code": "workspace:*",
         "@clavia/tardigrade-core": "workspace:*",
         "@clavia/tardigrade-host": "workspace:*",
         "@clavia/tardigrade-model": "workspace:*",

--- a/docs/how-to/migrate.md
+++ b/docs/how-to/migrate.md
@@ -54,7 +54,7 @@ Move related tools to code packages only when the decision rule above applies. M
 
 ### Policies and output
 
-State every policy that affects behavior. `budgetFor({ defaultToolBudget })` limits `execute` calls, so it is not a direct replacement for a model-step limit that counts completions and native tools. Express a custom stop condition as a component over the log. Pass `giveUpAfter` through the second argument to `infer`, and use `compactionFor(...)` when the application needs context thresholds that differ from `DEFAULT_CONTEXT_POLICY`.
+State every policy that affects behavior. `budgetFor({ defaultToolBudget })` limits `execute` calls, so it is not a direct replacement for a model-step limit that counts completions and native tools. Express a custom stop condition as a component over the log. Pass `giveUpAfter` through the second argument to `infer`, and use `compaction(...)` when the application needs a model-window resolver or hysteresis ratios that differ from `DEFAULT_COMPACTION_POLICY`.
 
 Convert each structured result to `output({ name, schema })`. Send that contract with the turn and mount one explicit fallback. Use `outputValidateOnce` when one invalid response should end the turn, or `outputRepairFor({ attempts, projectHistory })` when bounded correction is part of the product behavior.
 

--- a/examples/quickstart/actor.ts
+++ b/examples/quickstart/actor.ts
@@ -42,7 +42,7 @@ export default defineActor({
     // budget stops work tools when the turn reaches its tool-call limit.
     budget,
     // compaction summarizes older context when a long turn outgrows its context window.
-    compaction,
+    compaction(),
     // outputValidateOnce validates one structured result when the endpoint supplies no native guarantee.
     outputValidateOnce
   ]))

--- a/examples/rlm-agent.ts
+++ b/examples/rlm-agent.ts
@@ -18,7 +18,7 @@ const rlm = actor(inferAgent([
   codeMode([agentsPackage(), workspacePackage()]),
   reply, // reports each turn's terminal to whoever asked
   budget, // the per-turn code budget, inherited by spawned children
-  compaction, // bounded model context over long investigations
+  compaction(), // bounded model context over long investigations
   outputValidateOnce // handles structured results without adding a retry
 ]))
 

--- a/packages/agent/src/components/budget.test.ts
+++ b/packages/agent/src/components/budget.test.ts
@@ -18,7 +18,7 @@ import { reply } from "./reply"
 import { nativeOutput } from "./native-output"
 import { agentKeys } from "../events"
 
-const rootReactor = actor(infer([codeMode(), reply, budget, compaction, nativeOutput])).reactors[0]!
+const rootReactor = actor(infer([codeMode(), reply, budget, compaction(), nativeOutput])).reactors[0]!
 
 // The rest of the agent's environment, which every reactor's `act` is typed against whether or not
 // it reaches for it. Naming it is what proves the tools gate answers from the log alone: no model

--- a/packages/agent/src/components/compaction.test.ts
+++ b/packages/agent/src/components/compaction.test.ts
@@ -10,10 +10,9 @@ import { agentKeys } from "../events"
 
 const agentActorKeys = composeKeys(messageKeys, agentKeys)
 import {
-  DEFAULT_CONTEXT_POLICY,
   checkpointOf,
   compactionReactor,
-  compactionReactorFor,
+  contextPolicyOf,
   estimateTokens,
   keepFromIndex,
   suffixOf
@@ -25,6 +24,9 @@ import {
 // rendered chars over four.
 
 const head: Event = { type: "MessageReceived", id: "m0", text: "extract the covenants", at: 0 }
+const TEST_POLICY = { contextWindowTokens: 20_000, fireRatio: 0.8, keepRatio: 0.2 }
+const TEST_CONTEXT = contextPolicyOf(TEST_POLICY)
+const reactor = compactionReactor(TEST_POLICY)
 
 // One resolved tool round inside the open turn, sized so a dozen rounds cross the token budget.
 const round = (i: number, turn = "m0"): Event[] => [
@@ -41,15 +43,15 @@ const openTurn = (rounds: number): Event[] => {
 describe("the compaction measure and guard", () => {
   test("the measure counts what a render sends: capped results, skipped lanes", () => {
     const big: Event = { type: "ToolReturned", callId: "c", result: { data: "x".repeat(40_000) }, at: 1 }
-    expect(estimateTokens([big])).toBe(Math.ceil(DEFAULT_CONTEXT_POLICY.resultRenderCap / 4))
+    expect(estimateTokens([big])).toBe(Math.ceil(TEST_CONTEXT.resultRenderCap / 4))
     const lane: Event = { type: "CodeSettled", execId: "c", result: 1, at: 2 } as Event
     expect(estimateTokens([lane])).toBe(0)
   })
 
   test("the guard fires inside an open turn once a resolved round passes FIRE", () => {
-    expect(estimateTokens(suffixOf(openTurn(16)))).toBeGreaterThan(DEFAULT_CONTEXT_POLICY.fireTokens)
-    expect(compactionReactor(openTurn(16))).toHaveLength(1) // no reply anywhere, the turn is live
-    expect(compactionReactor(openTurn(2))).toHaveLength(0) // under FIRE
+    expect(estimateTokens(suffixOf(openTurn(16)))).toBeGreaterThan(TEST_CONTEXT.fireTokens)
+    expect(reactor(openTurn(16))).toHaveLength(1) // no reply anywhere, the turn is live
+    expect(reactor(openTurn(2))).toHaveLength(0) // under FIRE
   })
 
   test("the guard holds while a call is unanswered", () => {
@@ -57,15 +59,28 @@ describe("the compaction measure and guard", () => {
       ...openTurn(16),
       { type: "ToolCalled", callId: "c99", name: "execute", arguments: {}, turn: "m0", at: 99 }
     ]
-    expect(compactionReactor(awaiting)).toHaveLength(0)
+    expect(reactor(awaiting)).toHaveLength(0)
   })
 
   test("the policy is the consumer's: a raised FIRE holds the guard, a lowered one fires early", () => {
-    expect(compactionReactorFor({ fireTokens: 1_000_000 })(openTurn(16))).toHaveLength(0)
-    expect(compactionReactorFor({ fireTokens: 100 })(openTurn(2))).toHaveLength(1)
+    expect(compactionReactor({ contextWindowTokens: 1_250_000 })(openTurn(16))).toHaveLength(0)
+    expect(compactionReactor({ contextWindowTokens: 125 })(openTurn(2))).toHaveLength(1)
     // The measure moves with the render cap, because one policy states both.
     const big: Event = { type: "ToolReturned", callId: "c", result: { data: "x".repeat(40_000) }, at: 1 }
     expect(estimateTokens([big], { resultRenderCap: 40 })).toBe(10)
+  })
+
+  test("the selected model resolves both hysteresis lines from one window", () => {
+    const policy = contextPolicyOf(
+      { contextWindowTokens: (model) => model === "large" ? 1_000_000 : 100_000 },
+      "large"
+    )
+    expect(policy.fireTokens).toBe(800_000)
+    expect(policy.keepTokens).toBe(500_000)
+  })
+
+  test("the keep line must remain below the fire line", () => {
+    expect(() => contextPolicyOf({ keepRatio: 0.9, fireRatio: 0.8 })).toThrow("keepRatio must be less than fireRatio")
   })
 
   test("the guard is pure: the fold runs with the clock and randomness rigged to throw", () => {
@@ -78,7 +93,7 @@ describe("the compaction measure and guard", () => {
       throw new Error("random in the compaction guard")
     }
     try {
-      expect(compactionReactor(openTurn(16))).toHaveLength(1)
+      expect(reactor(openTurn(16))).toHaveLength(1)
     } finally {
       Date.now = realNow
       Math.random = realRandom
@@ -86,7 +101,7 @@ describe("the compaction measure and guard", () => {
   })
 })
 
-const mailbox = actorFromReactors<Infer | EventLog>([compactionReactor], agentActorKeys)
+const mailbox = actorFromReactors<Infer | EventLog>([reactor], agentActorKeys)
 
 describe("the compaction pass", () => {
   const run = async (initial: ReadonlyArray<Event>) => {
@@ -116,11 +131,16 @@ describe("the compaction pass", () => {
   test("a fire summarizes and checkpoints down to a KEEP-token tail, mid-turn", async () => {
     const { log, briefed } = await run(openTurn(16))
     const checkpoint = checkpointOf(log)
+    expect(log.find((event) => event.type === "CompactionCompleted")).toMatchObject({
+      contextWindowTokens: 20_000,
+      fireTokens: 16_000,
+      keepTokens: 4_000
+    })
     expect(checkpoint.summary).toBe("covenants 1 through 13 extracted")
     expect(keepFromIndex(log, checkpoint.keepFrom)).toBeGreaterThan(0)
     // The retained tail fits KEEP plus at most one round of boundary slack.
     const roundTokens = estimateTokens(round(1))
-    expect(estimateTokens(suffixOf(log))).toBeLessThanOrEqual(DEFAULT_CONTEXT_POLICY.keepTokens + 2 * roundTokens)
+    expect(estimateTokens(suffixOf(log))).toBeLessThanOrEqual(TEST_CONTEXT.keepTokens + 2 * roundTokens)
     expect(briefed()).toContain("extract the covenants")
     expect(briefed()).toContain("run 1")
   })
@@ -190,7 +210,7 @@ describe("a projected repair is invisible to compaction as well as to the render
       { type: "ToolReturned", callId: "c2", result: "ok", turn: "m2", at: 7 }
     ]
     const events = await Effect.runPromise(
-      Effect.all(compactionReactor(log).map((t) => t.act(t.input as never))).pipe(
+      Effect.all(reactor(log).map((t) => t.act(t.input as never))).pipe(
         Effect.provide(
           Layer.succeed(Infer, {
             react: ({ trajectory }: { trajectory: ReadonlyArray<Event> }) => {

--- a/packages/agent/src/components/compaction.ts
+++ b/packages/agent/src/components/compaction.ts
@@ -37,6 +37,12 @@ export interface ContextPolicy {
   readonly messageRenderCap: number
   // Chars of one tool result the render sends; past it the result truncates.
   readonly resultRenderCap: number
+  // Selected model context window used to derive the hysteresis lines.
+  readonly contextWindowTokens: number
+  // Fraction of the selected model window that fires compaction.
+  readonly fireRatio: number
+  // Fraction of the selected model window retained verbatim after compaction.
+  readonly keepRatio: number
   // Rendered suffix size, in estimated tokens, that fires a compaction pass.
   readonly fireTokens: number
   // Estimated tokens of the tail a pass keeps verbatim. Below fireTokens, which is the
@@ -46,23 +52,99 @@ export interface ContextPolicy {
   readonly summaryLineCap: number
 }
 
-export const DEFAULT_CONTEXT_POLICY: ContextPolicy = {
+export type ContextWindowTokens = number | ((model: string | undefined) => number)
+
+export interface CompactionPolicy {
+  readonly messageRenderCap: number
+  readonly resultRenderCap: number
+  readonly contextWindowTokens: ContextWindowTokens
+  readonly fireRatio: number
+  readonly keepRatio: number
+  readonly summaryLineCap: number
+}
+
+export const DEFAULT_COMPACTION_POLICY: CompactionPolicy = {
   messageRenderCap: 12_000,
   resultRenderCap: 6_000,
-  fireTokens: 16_000,
-  keepTokens: 4_000,
+  contextWindowTokens: 128_000,
+  fireRatio: 0.8,
+  keepRatio: 0.5,
   summaryLineCap: 200
 }
 
-// contextPolicyOf fills an override with the defaults. Every surface that applies context policy
-// takes `Partial<ContextPolicy>` and resolves it here, so a caller states only what it changes.
-export const contextPolicyOf = (policy: Partial<ContextPolicy> = {}): ContextPolicy => ({
-  messageRenderCap: policy.messageRenderCap ?? DEFAULT_CONTEXT_POLICY.messageRenderCap,
-  resultRenderCap: policy.resultRenderCap ?? DEFAULT_CONTEXT_POLICY.resultRenderCap,
-  fireTokens: policy.fireTokens ?? DEFAULT_CONTEXT_POLICY.fireTokens,
-  keepTokens: policy.keepTokens ?? DEFAULT_CONTEXT_POLICY.keepTokens,
-  summaryLineCap: policy.summaryLineCap ?? DEFAULT_CONTEXT_POLICY.summaryLineCap
-})
+const positive = (value: number, name: string): number => {
+  if (!Number.isFinite(value) || value <= 0) throw new Error(`${name} must be a finite positive number, got ${value}`)
+  return value
+}
+
+const ratio = (value: number, name: string): number => {
+  if (!Number.isFinite(value) || value <= 0 || value >= 1) throw new Error(`${name} must be between 0 and 1, got ${value}`)
+  return value
+}
+
+// modelOf returns the latest model choice recorded for the open thread. The same MessageReceived
+// field selects inference, so a replay resolves the same model window.
+const modelOf = (log: ReadonlyArray<Event>): string | undefined => {
+  let model: string | undefined
+  for (const event of log) {
+    if (event.type !== "MessageReceived") continue
+    const selected = (event as { readonly model?: unknown }).model
+    if (typeof selected === "string" && selected !== "") model = selected
+  }
+  return model
+}
+
+// contextPolicyOf resolves the model-relative policy into the absolute thresholds used by the
+// guard and render. The fire and keep lines form one hysteresis policy, so they are validated
+// together.
+export const contextPolicyOf = (
+  policy: Partial<CompactionPolicy> = {},
+  model?: string
+): ContextPolicy => {
+  const windowSource = policy.contextWindowTokens ?? DEFAULT_COMPACTION_POLICY.contextWindowTokens
+  const contextWindowTokens = positive(
+    typeof windowSource === "function" ? windowSource(model) : windowSource,
+    "contextWindowTokens"
+  )
+  const fireRatio = ratio(policy.fireRatio ?? DEFAULT_COMPACTION_POLICY.fireRatio, "fireRatio")
+  const keepRatio = ratio(policy.keepRatio ?? DEFAULT_COMPACTION_POLICY.keepRatio, "keepRatio")
+  if (keepRatio >= fireRatio) throw new Error(`keepRatio must be less than fireRatio, got ${keepRatio} and ${fireRatio}`)
+  return {
+    messageRenderCap: positive(
+      policy.messageRenderCap ?? DEFAULT_COMPACTION_POLICY.messageRenderCap,
+      "messageRenderCap"
+    ),
+    resultRenderCap: positive(
+      policy.resultRenderCap ?? DEFAULT_COMPACTION_POLICY.resultRenderCap,
+      "resultRenderCap"
+    ),
+    contextWindowTokens,
+    fireRatio,
+    keepRatio,
+    fireTokens: Math.floor(contextWindowTokens * fireRatio),
+    keepTokens: Math.floor(contextWindowTokens * keepRatio),
+    summaryLineCap: positive(
+      policy.summaryLineCap ?? DEFAULT_COMPACTION_POLICY.summaryLineCap,
+      "summaryLineCap"
+    )
+  }
+}
+
+// resolvedContextPolicyOf fills a partial absolute policy at the render boundary. Components
+// normally contribute every field after resolving their model-relative policy.
+export const resolvedContextPolicyOf = (policy: Partial<ContextPolicy> = {}): ContextPolicy => {
+  const defaults = contextPolicyOf()
+  return {
+    messageRenderCap: policy.messageRenderCap ?? defaults.messageRenderCap,
+    resultRenderCap: policy.resultRenderCap ?? defaults.resultRenderCap,
+    contextWindowTokens: policy.contextWindowTokens ?? defaults.contextWindowTokens,
+    fireRatio: policy.fireRatio ?? defaults.fireRatio,
+    keepRatio: policy.keepRatio ?? defaults.keepRatio,
+    fireTokens: policy.fireTokens ?? defaults.fireTokens,
+    keepTokens: policy.keepTokens ?? defaults.keepTokens,
+    summaryLineCap: policy.summaryLineCap ?? defaults.summaryLineCap
+  }
+}
 
 // renderedChars counts the characters a render sends for one event: capped where the render
 // caps, zero for an event the render skips. The guard must measure the request the model sees;
@@ -99,7 +181,7 @@ const renderedChars = (e: Event, policy: ContextPolicy): number => {
 // be a dependency and an impure path, and every budget decision must fold the same on replay, so
 // the estimate is a pure function of the recorded events (compaction.test.ts, "the measure").
 export const estimateTokens = (events: ReadonlyArray<Event>, policy: Partial<ContextPolicy> = {}): number => {
-  const resolved = contextPolicyOf(policy)
+  const resolved = resolvedContextPolicyOf(policy)
   return Math.ceil(projectedOutput(events).reduce((n, e) => n + renderedChars(e, resolved), 0) / 4)
 }
 
@@ -235,7 +317,7 @@ const firedUncovered = (log: ReadonlyArray<Event>): boolean => {
   return fires > passes
 }
 
-// compactionReactorFor derives a pass when the suffix has crossed FIRE at a round boundary, or an
+// compactionReactor derives a pass when the suffix has crossed FIRE at a round boundary, or an
 // explicit `CompactionFired` stands uncovered. The act always advances the checkpoint (the
 // retained tail is bounded by KEEP < FIRE), so a served pass quiets the derivation instead of
 // re-firing. The checkpoint's key is the identity it keeps from: cc:<keepFrom>. Its input is the
@@ -245,8 +327,8 @@ const firedUncovered = (log: ReadonlyArray<Event>): boolean => {
 //
 // The policy this takes must be the one the render takes, or the guard measures a request the
 // model never sees (ContextPolicy above).
-export const compactionReactorFor = (policy: Partial<ContextPolicy> = {}): Reactor<Infer> => (log) => {
-  const resolved = contextPolicyOf(policy)
+export const compactionReactor = (policy: Partial<CompactionPolicy> = {}): Reactor<Infer> => (log) => {
+  const resolved = contextPolicyOf(policy, modelOf(log))
   // The projection runs first, so the guard, the cut, and the brief all read the history the
   // model reads. A corrected exchange the render hides can neither trigger a paid pass nor leak
   // its rejected reply into a summary (src/output.ts, projectedOutput).
@@ -259,13 +341,27 @@ export const compactionReactorFor = (policy: Partial<ContextPolicy> = {}): React
   return [
     transition({
       key: `cc:${cut.keepFrom}`,
-      input: { keepFrom: cut.keepFrom, summary: prior.summary, span },
+      input: {
+        keepFrom: cut.keepFrom,
+        summary: prior.summary,
+        span,
+        contextWindowTokens: resolved.contextWindowTokens,
+        fireTokens: resolved.fireTokens,
+        keepTokens: resolved.keepTokens
+      },
       act: (input) =>
         Effect.gen(function* () {
           const at = yield* Clock.currentTimeMillis
           const lines = input.span.map((e) => lineOf(e, resolved)).filter((l): l is string => l !== null)
           if (lines.length === 0) {
-            return [compactionCompleted({ keepFrom: input.keepFrom, summary: input.summary, at })]
+            return [compactionCompleted({
+              keepFrom: input.keepFrom,
+              summary: input.summary,
+              contextWindowTokens: input.contextWindowTokens,
+              fireTokens: input.fireTokens,
+              keepTokens: input.keepTokens,
+              at
+            })]
           }
           const brief = [
             "Summarize this agent history in a compact paragraph. Keep every fact a future turn could need: names, ids, decisions, unfinished work.",
@@ -282,26 +378,33 @@ export const compactionReactorFor = (policy: Partial<ContextPolicy> = {}): React
             `compact-${input.keepFrom}`
           )
           const summary = action.kind === "complete" ? action.output : input.summary
-          return [compactionCompleted({ keepFrom: input.keepFrom, summary, at })]
+          return [compactionCompleted({
+            keepFrom: input.keepFrom,
+            summary,
+            contextWindowTokens: input.contextWindowTokens,
+            fireTokens: input.fireTokens,
+            keepTokens: input.keepTokens,
+            at
+          })]
         })
     })
   ]
 }
 
-// compactionReactor is that reactor on the default policy. An agent on another policy builds its
-// own with `compactionReactorFor` and hands the same policy to its render.
-export const compactionReactor: Reactor<Infer> = compactionReactorFor()
-
-// compactionFor derives one context contribution and the transitions governed by that policy.
-export const compactionFor = (policy: Partial<ContextPolicy>): AgentComponent<Infer> => {
-  const reactor = compactionReactorFor(policy)
+// compaction derives one resolved context contribution and the transitions governed by the same
+// model-relative policy.
+export const compaction = (policy: Partial<CompactionPolicy> = {}): AgentComponent<Infer> => {
+  const reactor = compactionReactor(policy)
   return {
     name: "compaction",
     derive: (log) => ({
-      view: { system: [], tools: [], context: [{ component: "compaction", policy }], output: [] },
+      view: {
+        system: [],
+        tools: [],
+        context: [{ component: "compaction", policy: contextPolicyOf(policy, modelOf(log)) }],
+        output: []
+      },
       transitions: reactor(log)
     })
   }
 }
-
-export const compaction: AgentComponent<Infer> = compactionFor({})

--- a/packages/agent/src/events.ts
+++ b/packages/agent/src/events.ts
@@ -475,5 +475,12 @@ export const budgetDenied = (
 ): Event => ({ type: "BudgetDenied", ...fields }) as Event
 
 export const compactionCompleted = (
-  fields: { readonly keepFrom: string; readonly summary: string; readonly at: number }
+  fields: {
+    readonly keepFrom: string
+    readonly summary: string
+    readonly contextWindowTokens: number
+    readonly fireTokens: number
+    readonly keepTokens: number
+    readonly at: number
+  }
 ): Event => ({ type: "CompactionCompleted", ...fields }) as Event

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -12,7 +12,7 @@ import { boundaryOf } from "./boundary"
 import { resumeTurn } from "./resume"
 import { agentsPackage } from "./spawn"
 import { threadCreatedOf } from "@clavia/tardigrade-core/thread"
-import { actor, budgetFor, codeMode, compactionFor, infer, nativeOutput, reply, toolList, type AgentComponent } from "./index"
+import { actor, budgetFor, codeMode, compaction, infer, nativeOutput, reply, toolList, type AgentComponent } from "./index"
 import type { RlmR } from "./turn"
 
 const ROOT_LANE = "ag.root"
@@ -77,7 +77,7 @@ const hosted = (assembled: Actor<TestR>, mind: Mind, log: ReadonlyArray<Event> =
 // in-process host. The three policy components are always mounted, so a test that swaps the
 // work surface still runs the same turn loop, budget wall, and answer contract.
 const rlm = (mind: Mind, components: ReadonlyArray<AgentComponent<RlmR>> = [work()], log: ReadonlyArray<Event> = []) =>
-  hosted(actor(infer([...components, reply, budgetFor({}), compactionFor({}), nativeOutput])), mind, log)
+  hosted(actor(infer([...components, reply, budgetFor({}), compaction(), nativeOutput])), mind, log)
 
 const headText = (trajectory: ReadonlyArray<Event>): string => {
   for (let i = trajectory.length - 1; i >= 0; i--) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -73,7 +73,15 @@ export { nativeOutput } from "./components/native-output"
 export { budgetReactorFor, DEFAULT_BUDGET_POLICY, type BudgetPolicy } from "./components/budget"
 export { toolsReactorFrom, type Answer, type PendingCall, type Serve } from "./runtime/tools"
 export { replyReactor } from "./components/reply"
-export { compactionReactorFor, DEFAULT_CONTEXT_POLICY, type ContextPolicy } from "./components/compaction"
+export {
+  compactionReactor,
+  contextPolicyOf,
+  DEFAULT_COMPACTION_POLICY,
+  resolvedContextPolicyOf,
+  type CompactionPolicy,
+  type ContextPolicy,
+  type ContextWindowTokens
+} from "./components/compaction"
 export { agentKeys, outputRetryRequested, TURN_FAILURE_CAUSES, type TurnFailureCause } from "./events"
 export { resumeTurn, type ResumeTurnOptions, type TurnDriver } from "./resume"
 export {
@@ -153,7 +161,7 @@ export { codeMode, CODE_SYSTEM, codeSystemFor, type CodeModeOptions } from "./co
 export { system, type SystemText } from "./components/system"
 export { toolList, type NativeTool } from "./components/tool-list"
 export { budget, budgetFor } from "./components/budget"
-export { compaction, compactionFor } from "./components/compaction"
+export { compaction } from "./components/compaction"
 export { reply } from "./components/reply"
 export {
   actor,

--- a/packages/agent/src/request.ts
+++ b/packages/agent/src/request.ts
@@ -1,6 +1,6 @@
 import type { Event } from "@clavia/tardigrade-core/event"
 import { terminalReportOutcomeOf } from "@clavia/tardigrade-core/communication/message"
-import { checkpointOf, contextPolicyOf, keepFromIndex, type ContextPolicy } from "./components/compaction"
+import { checkpointOf, keepFromIndex, resolvedContextPolicyOf, type ContextPolicy } from "./components/compaction"
 import {
   correctionText,
   declaredOutputOf,
@@ -158,7 +158,7 @@ export const renderMessages = (
   trajectory: ReadonlyArray<Event>,
   policy: Partial<ContextPolicy> = {}
 ): ReadonlyArray<AgentMessage> => {
-  const resolved = contextPolicyOf(policy)
+  const resolved = resolvedContextPolicyOf(policy)
   const messages: AgentMessage[] = []
   const projected = projectedOutput(trajectory)
   const checkpoint = checkpointOf(projected)

--- a/packages/agent/src/runtime/agent.test.ts
+++ b/packages/agent/src/runtime/agent.test.ts
@@ -19,7 +19,7 @@ import { fetchPackage } from "@clavia/tardigrade-code/fetch"
 import { defineOutputFallback, infer, renderOf, type AgentComponent, type AgentView } from "./agent"
 import { CODE_SYSTEM, codeMode, codeSystemFor } from "../components/code"
 import { budget } from "../components/budget"
-import { compaction, compactionFor } from "../components/compaction"
+import { compaction } from "../components/compaction"
 import { reply } from "../components/reply"
 import { toolList } from "../components/tool-list"
 import { nativeOutput } from "../components/native-output"
@@ -104,7 +104,7 @@ describe("infer component", () => {
         )
       }
     })
-    const agent = actor(infer([echoTable, reply, budget, compaction, nativeOutput]))
+    const agent = actor(infer([echoTable, reply, budget, compaction(), nativeOutput]))
     const events = await run(
       Effect.gen(function* () {
         yield* receive(agent, { id: "m1", text: "go" })
@@ -224,9 +224,16 @@ describe("infer component", () => {
     expect(events.find((event) => event.type === "ToolReturned")).toMatchObject({ result: "served" })
   })
 
-  test("compactionFor's context reaches the render, so the guard and the request hold one policy", () => {
-    const render = renderOf([codeMode(), compactionFor({ messageRenderCap: 1234 }), nativeOutput], [])
-    expect(render.context).toEqual({ messageRenderCap: 1234 })
+  test("compaction's context reaches the render, so the guard and the request hold one policy", () => {
+    const render = renderOf([codeMode(), compaction({ messageRenderCap: 1234 }), nativeOutput], [])
+    expect(render.context).toMatchObject({
+      messageRenderCap: 1234,
+      contextWindowTokens: 128_000,
+      fireRatio: 0.8,
+      keepRatio: 0.5,
+      fireTokens: 102_400,
+      keepTokens: 64_000
+    })
   })
 
   test("different values for one context field fail with both component names", () => {

--- a/packages/agent/src/runtime/infer.ts
+++ b/packages/agent/src/runtime/infer.ts
@@ -43,7 +43,7 @@ export interface InferRequest {
   readonly system: string
   readonly tools: ReadonlyArray<import("../request").ToolSpec>
   // What the render truncates and where, stated by the assembly so the binding renders against
-  // the same numbers the compaction guard fires on (components/compaction.ts, compactionFor).
+  // the same numbers the compaction guard fires on (components/compaction.ts, compaction).
   readonly context?: Partial<ContextPolicy>
   // What the turn does when native structured output is unavailable for this call, and the
   // prompt that fallback needs. Absent means the assembly selected native output.

--- a/packages/agent/src/turn.test.ts
+++ b/packages/agent/src/turn.test.ts
@@ -5,7 +5,7 @@ import type { Event } from "@clavia/tardigrade-core/event"
 import { EventLog, withWatermark } from "@clavia/tardigrade-core/event-log"
 import { send, settleActor, transition } from "@clavia/tardigrade-core/actor"
 import { definePackage, type Package } from "@clavia/tardigrade-code/packages"
-import { Sandbox, type Bindings } from "@clavia/tardigrade-code/sandbox"
+import { guestBindings, Sandbox, type Bindings } from "@clavia/tardigrade-code/sandbox"
 import { Router } from "@clavia/tardigrade-core/router"
 import { parseActorId } from "@clavia/tardigrade-core/communication/endpoint"
 import { Facets } from "@clavia/tardigrade-core/facets"
@@ -40,7 +40,7 @@ import {
 // The default assembly over a stated scope. The infer root contains model inference, call routing,
 // and every child transition in one projection.
 const agentWith = (packages: ReadonlyArray<Package>) =>
-  actor(infer([codeMode(packages), reply, budget, compaction, nativeOutput]))
+  actor(infer([codeMode(packages), reply, budget, compaction(), nativeOutput]))
 const rlmAgent = agentWith([])
 const rootReactor = rlmAgent.reactors[0]!
 // The agent end to end: the model writes code, the code calls packages, every call is recorded,
@@ -67,9 +67,10 @@ const jsSandbox = Layer.succeed(Sandbox, {
   run: (code: string, bindings: Bindings) =>
     Effect.promise(async () => {
       try {
-        const names = Object.keys(bindings)
+        const scope = guestBindings(bindings)
+        const names = Object.keys(scope)
         const body = new AsyncFunction(...names, code)
-        return { result: await body(...names.map((name) => bindings[name])) }
+        return { result: await body(...names.map((name) => scope[name])) }
       } catch (e) {
         return { error: String(e) }
       }
@@ -448,7 +449,7 @@ const completedTurns = (log: ReadonlyArray<Event>): ReadonlySet<string> =>
 const REPAIR_TWO = repairFallback({ attempts: 2 })
 
 const repairAgent = (policy: Parameters<typeof outputRepairFor>[0] = {}) =>
-  actor(infer([codeMode(), reply, budget, compaction, outputRepairFor(policy)]))
+  actor(infer([codeMode(), reply, budget, compaction(), outputRepairFor(policy)]))
 
 describe("a turn that declares an output contract", () => {
   test("a conforming response completes the turn, and outputOf reads it back typed", async () => {
@@ -943,7 +944,7 @@ describe("the mind on a native surface", () => {
 })
 
 describe("the validate-once implementation", () => {
-  const validateOnceAgent = actor(infer([codeMode(), reply, budget, compaction, outputValidateOnce]))
+  const validateOnceAgent = actor(infer([codeMode(), reply, budget, compaction(), outputValidateOnce]))
 
   test("a missed response ends the turn with its own cause, and never asks again", async () => {
     let asked = 0

--- a/packages/agent/src/turn.ts
+++ b/packages/agent/src/turn.ts
@@ -8,7 +8,7 @@ import type { Facets } from "@clavia/tardigrade-core/facets"
 import type { Infer, InferPolicy } from "./runtime/infer"
 import type { OutputContract } from "./output"
 import type { BudgetPolicy } from "./components/budget"
-import type { ContextPolicy } from "./components/compaction"
+import type { CompactionPolicy } from "./components/compaction"
 import type { CodePolicy } from "@clavia/tardigrade-code/execute"
 import type { WorkspacePolicy } from "@clavia/tardigrade-code/workspace"
 
@@ -27,11 +27,11 @@ export type RlmR = AgentR
 // and fills from its own exported default (infer.ts, budget.ts, compaction.ts,
 // packages/code/src/execute.ts). `infer` is the root component's policy; `workspace`
 // bounds the workspace package's own read and grep answers (packages/code/src/workspace.ts); the
-// rest ride their components (budgetFor, compactionFor, codeMode).
+// rest ride their components (budgetFor, compaction, codeMode).
 export interface AgentPolicy {
   readonly infer: Partial<InferPolicy>
   readonly budget: Partial<BudgetPolicy>
-  readonly context: Partial<ContextPolicy>
+  readonly context: Partial<CompactionPolicy>
   readonly code: Partial<CodePolicy>
   readonly workspace: Partial<WorkspacePolicy>
 }

--- a/packages/code/src/contract.test.ts
+++ b/packages/code/src/contract.test.ts
@@ -7,7 +7,7 @@ import { settleActor } from "@clavia/tardigrade-core/actor"
 import { messageKeys } from "@clavia/tardigrade-core/message"
 import { checkInput, renderShape, renderSignature } from "./contract"
 import { definePackage, type Package } from "./packages"
-import { Sandbox, type Bindings } from "./sandbox"
+import { guestBindings, Sandbox, type Bindings } from "./sandbox"
 import { codeReactorFor } from "./execute"
 import { codeKeys } from "./events"
 
@@ -139,9 +139,10 @@ const jsSandbox = Layer.succeed(Sandbox, {
   run: (code: string, bindings: Bindings) =>
     Effect.promise(async () => {
       try {
-        const names = Object.keys(bindings)
+        const scope = guestBindings(bindings)
+        const names = Object.keys(scope)
         const body = new AsyncFunction(...names, code)
-        return { result: await body(...names.map((name) => bindings[name])) }
+        return { result: await body(...names.map((name) => scope[name])) }
       } catch (e) {
         return { error: String(e) }
       }

--- a/packages/code/src/defaults.test.ts
+++ b/packages/code/src/defaults.test.ts
@@ -5,7 +5,7 @@ import type { Event } from "@clavia/tardigrade-core/event"
 import { composeKeys, EventLog, withWatermark } from "@clavia/tardigrade-core/event-log"
 import { settleActor } from "@clavia/tardigrade-core/actor"
 import { messageKeys } from "@clavia/tardigrade-core/message"
-import { DEFAULT_SANDBOX_POLICY, Sandbox } from "./sandbox"
+import { DEFAULT_SANDBOX_POLICY, sandboxReturned, Sandbox } from "./sandbox"
 import { jsSandbox, jsSandboxFor } from "./defaults"
 import { codeReactor } from "./execute"
 import { codeKeys } from "./events"
@@ -60,6 +60,30 @@ describe("jsSandbox console capture", () => {
     const total = (outcome.logs ?? []).reduce((n, l) => n + l.length, 0)
     expect(total).toBeLessThanOrEqual(500 + 200)
     expect((outcome.logs ?? []).at(-1)).toContain("cut at 500 bytes")
+  })
+})
+
+describe("sandbox call ordinals", () => {
+  test("stamps concurrent calls before their promises settle", async () => {
+    const seen: number[] = []
+    const outcome = await Effect.runPromise(
+      Effect.gen(function* () {
+        const sandbox = yield* Sandbox
+        return yield* sandbox.run(
+          "return Promise.all([tools.echo(0), tools.echo(1), tools.echo(2)])",
+          {
+            tools: {
+              echo: async (input: unknown, ordinal: number) => {
+                seen.push(ordinal)
+                return sandboxReturned(input)
+              }
+            }
+          }
+        )
+      }).pipe(Effect.provide(jsSandbox))
+    )
+    expect(outcome.result).toEqual([0, 1, 2])
+    expect(seen).toEqual([0, 1, 2])
   })
 })
 

--- a/packages/code/src/execute.properties.test.ts
+++ b/packages/code/src/execute.properties.test.ts
@@ -10,7 +10,7 @@ import { definePackage, type Package } from "./packages"
 import { Park } from "./errors"
 import { codeKeys } from "./events"
 import { codeReactorFor } from "./execute"
-import { Sandbox, type Bindings } from "./sandbox"
+import { guestBindings, Sandbox, type Bindings } from "./sandbox"
 
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as new (
   ...args: ReadonlyArray<string>
@@ -20,9 +20,10 @@ const jsSandbox = Layer.succeed(Sandbox, {
   run: (code: string, bindings: Bindings) =>
     Effect.promise(async () => {
       try {
-        const names = Object.keys(bindings)
+        const scope = guestBindings(bindings)
+        const names = Object.keys(scope)
         const body = new AsyncFunction(...names, code)
-        return { result: await body(...names.map((name) => bindings[name])) }
+        return { result: await body(...names.map((name) => scope[name])) }
       } catch (error) {
         return { error: String(error) }
       }

--- a/packages/code/src/execute.test.ts
+++ b/packages/code/src/execute.test.ts
@@ -6,7 +6,7 @@ import { composeKeys, EventLog, withWatermark } from "@clavia/tardigrade-core/ev
 import { settleActor, type Reactor } from "@clavia/tardigrade-core/actor"
 import { messageKeys } from "@clavia/tardigrade-core/message"
 import { definePackage, type Package } from "./packages"
-import { Sandbox, type Bindings } from "./sandbox"
+import { guestBindings, Sandbox, type Bindings } from "./sandbox"
 import { codeReactor, codeReactorFor } from "./execute"
 import { codeKeys } from "./events"
 
@@ -23,9 +23,10 @@ const jsSandbox = Layer.succeed(Sandbox, {
   run: (code: string, bindings: Bindings) =>
     Effect.promise(async () => {
       try {
-        const names = Object.keys(bindings)
+        const scope = guestBindings(bindings)
+        const names = Object.keys(scope)
         const body = new AsyncFunction(...names, code)
-        return { result: await body(...names.map((name) => bindings[name])) }
+        return { result: await body(...names.map((name) => scope[name])) }
       } catch (e) {
         return { error: String(e) }
       }

--- a/packages/code/src/execute.ts
+++ b/packages/code/src/execute.ts
@@ -6,7 +6,7 @@ import { transition, type Reactor } from "@clavia/tardigrade-core/actor"
 import { workOwed } from "./projections"
 import { annotationsOf, type Package, type PackageRequirements } from "./packages"
 import { checkInput, renderSignature } from "./contract"
-import { Sandbox, type Bindings } from "./sandbox"
+import { Sandbox, sandboxParked, sandboxReturned, type Bindings, type SandboxCall } from "./sandbox"
 import { turnHead, turnOf } from "./turns"
 import {
   BARE_SPILL_NOTE,
@@ -62,7 +62,6 @@ const executeRecorded = <R = never>(
     // which is why the requirement rides the reactor's type (execute.test.ts, "a package method
     // reads its service through the funnel").
     const context = yield* Effect.context<KeyValueStore.KeyValueStore | R>()
-    let n = 0
     // Park bookkeeping. inFlight counts proxy calls from synchronous invoke to committed pair
     // or park; parkGate completes when every open call settled or parked and at least one
     // parked: the cue to stop waiting on the body.
@@ -81,12 +80,12 @@ const executeRecorded = <R = never>(
       inFlight--
       if (parked && inFlight === 0) yield* Deferred.succeed(parkGate, undefined)
     })
-    const bindings: Record<string, Record<string, (args: unknown) => Promise<unknown>>> = {}
+    const bindings: Record<string, Record<string, SandboxCall>> = {}
     for (const pkg of packages) {
-      const methods: Record<string, (args: unknown) => Promise<unknown>> = {}
+      const methods: Record<string, SandboxCall> = {}
       for (const [method, fn] of Object.entries(pkg.methods)) {
-        methods[method] = (args: unknown) => {
-          const callId = callIdOf(execId, n++)
+        methods[method] = (args: unknown, ordinal: number) => {
+          const callId = callIdOf(execId, ordinal)
           inFlight++
           return Effect.runPromiseWith(context)(
             Effect.gen(function* () {
@@ -219,7 +218,7 @@ const executeRecorded = <R = never>(
               Effect.ensuring(finishCall),
               Effect.withSpan("package.call", { attributes: { name: `${pkg.name}.${method}`, callId } })
             )
-          ).then((outcome) => (outcome.parked ? new Promise<unknown>(() => {}) : outcome.result))
+          ).then((outcome) => outcome.parked ? sandboxParked : sandboxReturned(outcome.result))
         }
       }
       bindings[pkg.name] = methods

--- a/packages/code/src/sandbox.ts
+++ b/packages/code/src/sandbox.ts
@@ -12,11 +12,44 @@ export interface SandboxResult {
   readonly logs?: ReadonlyArray<string>
 }
 
-// Bindings is what a code body sees in scope: one object per package, one async function per
-// method. The functions are host-side proxies; the sandbox only wires names into scope. A
-// binding is a package proxy (an object of methods) or a plain value spliced into scope
-// (`brief`, `spec`, `trajectory`).
-export type Bindings = Readonly<Record<string, Readonly<Record<string, (args: unknown) => Promise<unknown>>> | unknown>>
+export type SandboxCallOutcome =
+  | { readonly _tag: "Returned"; readonly result: unknown }
+  | { readonly _tag: "Parked" }
+
+export type SandboxCall = (args: unknown, ordinal: number) => Promise<SandboxCallOutcome>
+
+// Bindings carries host package calls into a sandbox. A returned call carries its value across
+// the platform boundary. A parked call crosses that boundary as a value and becomes pending in
+// the guest, so a remote sandbox does not hold an RPC open while durable work is away.
+export type Bindings = Readonly<Record<string, Readonly<Record<string, SandboxCall>> | unknown>>
+
+export const sandboxReturned = (result: unknown): SandboxCallOutcome => ({ _tag: "Returned", result })
+export const sandboxParked: SandboxCallOutcome = { _tag: "Parked" }
+
+const packageBinding = (binding: Bindings[string]): Readonly<Record<string, SandboxCall>> | undefined => {
+  if (binding === null || typeof binding !== "object" || Array.isArray(binding)) return undefined
+  const entries = Object.entries(binding)
+  if (!entries.every(([, method]) => typeof method === "function")) return undefined
+  return binding as Readonly<Record<string, SandboxCall>>
+}
+
+// guestBindings turns host call outcomes into the promises a code body observes.
+export const guestBindings = (bindings: Bindings): Readonly<Record<string, unknown>> => {
+  let ordinal = 0
+  return Object.fromEntries(Object.entries(bindings).map(([name, binding]) => {
+    const methods = packageBinding(binding)
+    if (methods === undefined) return [name, binding]
+    return [name, Object.fromEntries(Object.entries(methods).map(([method, call]) => [
+      method,
+      async (args: unknown) => {
+        const position = ordinal++
+        const outcome = await call(args, position)
+        if (outcome._tag === "Parked") return new Promise<never>(() => undefined)
+        return outcome.result
+      }
+    ]))]
+  }))
+}
 
 // Ambient pins one execution's clock and randomness to recorded data, so every attempt sees
 // the same values. `at` is the dispatch event's own timestamp (a body is a pure function of
@@ -125,8 +158,8 @@ export const jsSandboxServiceFor = (policy: Partial<SandboxPolicy> = {}): Sandbo
       Effect.promise(async () => {
         const lines: string[] = []
         const logs = () => (lines.length === 0 ? {} : { logs: lines })
-        const scope: Bindings = {
-          ...bindings,
+        const scope: Readonly<Record<string, unknown>> = {
+          ...guestBindings(bindings),
           console: consoleShim(lines, resolved),
           ...(ambient === undefined ? {} : ambientShims(ambient))
         }

--- a/platform/cloudflare/README.md
+++ b/platform/cloudflare/README.md
@@ -1,6 +1,6 @@
 # Cloudflare platform
 
-This binding stores the actor registry in D1 and runs each registered actor graph in its named SQLite Durable Object. `@effect/sql-d1` binds the registry, `@effect/sql-sqlite-do` binds each actor object's storage, and `effect/unstable/http` serves the Worker routes. Every thread is a lane in its actor's event table. One alarm per actor drives ready lanes with the configured concurrency limit, and an alarm scheduled during an active pass remains armed after that pass.
+This binding stores the actor registry in D1 and runs each registered actor graph in its named SQLite Durable Object. `@effect/sql-d1` binds the registry, `@effect/sql-sqlite-do` binds each actor object's storage, and `effect/unstable/http` serves the Worker routes. Every thread is a lane in its actor's event table. One alarm per actor drives ready lanes with the configured concurrency limit, and an alarm scheduled during an active pass remains armed after that pass. Code mode uses the `LOADER` Dynamic Worker binding. Generated code runs in a fresh Worker with direct network access disabled and calls host packages through an RPC capability.
 
 ## Verify and deploy
 
@@ -78,9 +78,21 @@ The response has status `202` and identifies the accepted destination.
 | `TARDIGRADE_TOKEN` | unset | Protects every endpoint except `/healthz`; an unset value closes the event API |
 | `TARDIGRADE_MAX_CONCURRENT_LANES` | `4` | Limits lanes settled concurrently inside one actor object |
 | `TARDIGRADE_ALARM_DELAY_MILLIS` | `0` | Delays a newly armed actor alarm |
+| `TARDIGRADE_COMPACTION_FIRE_RATIO` | `0.8` | Compacts when rendered context crosses this fraction of the selected model window |
+| `TARDIGRADE_COMPACTION_KEEP_RATIO` | `0.5` | Keeps this fraction of the selected model window verbatim after compaction |
+| `TARDIGRADE_SANDBOX_LOG_CAP_BYTES` | `8192` | Limits the captured console output returned to code mode |
+| `TARDIGRADE_SANDBOX_CPU_MILLIS` | Cloudflare default | Sets the Dynamic Worker CPU limit |
+| `TARDIGRADE_SANDBOX_SUBREQUESTS` | Cloudflare default | Sets the Dynamic Worker subrequest limit |
 | `MODEL_BASE_URL` | unset | Selects the model API endpoint |
 | `MODEL_API_KEY` | unset | Authenticates the model API request |
 | `MODEL_ID` | unset | Selects the model |
+| `MODEL_SONNET_ID` | `MODEL_ID` | Selects the model for `sonnet` briefs |
+| `MODEL_OPUS_ID` | `MODEL_ID` | Selects the model for `opus` briefs |
+| `MODEL_HAIKU_ID` | `MODEL_ID` | Selects the model for `haiku` briefs |
 | `MODEL_PROVIDER` | unset | Supplies an optional provider hint |
+| `MODEL_CONTEXT_WINDOW_TOKENS` | `1000000` in `wrangler.jsonc`; framework fallback `128000` | Declares the default model context window used by compaction |
+| `MODEL_SONNET_CONTEXT_WINDOW_TOKENS` | default model window | Declares the `sonnet` model context window |
+| `MODEL_OPUS_CONTEXT_WINDOW_TOKENS` | default model window | Declares the `opus` model context window |
+| `MODEL_HAIKU_CONTEXT_WINDOW_TOKENS` | default model window | Declares the `haiku` model context window |
 
-`wrangler.jsonc` also makes the D1 registry binding, Worker CPU limit, and Durable Object migration visible. Change those values in the deployment configuration when the account or workload requires a different policy.
+`wrangler.jsonc` also makes the D1 registry binding, Dynamic Worker Loader binding, Worker CPU limit, and Durable Object migration visible. Change those values in the deployment configuration when the account or workload requires a different policy. `DEFAULT_CLOUDFLARE_SANDBOX_POLICY` exposes the Dynamic Worker compatibility date, compatibility flags, console cap, and outbound policy. `layerCloudflareSandbox` accepts overrides for each value.

--- a/platform/cloudflare/package.json
+++ b/platform/cloudflare/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "tardie": "workspace:*",
+    "@clavia/tardigrade-code": "workspace:*",
     "@clavia/tardigrade-core": "workspace:*",
     "@clavia/tardigrade-host": "workspace:*",
     "@clavia/tardigrade-model": "workspace:*",

--- a/platform/cloudflare/src/sandbox.test.ts
+++ b/platform/cloudflare/src/sandbox.test.ts
@@ -1,0 +1,93 @@
+import { Effect } from "effect"
+import { describe, expect, test } from "vitest"
+import { sandboxParked, sandboxReturned } from "@clavia/tardigrade-code/sandbox"
+import { cloudflareSandboxServiceFor, type SandboxBridgeBinding } from "./sandbox"
+
+describe("cloudflare sandbox bridge", () => {
+  test("forwards package calls and closes the capability", async () => {
+    let closed = false
+    const loader = {
+      load: (worker: WorkerLoaderWorkerCode) => ({
+        getEntrypoint: () => ({
+          fetch: async () => {
+            const bridge = (worker.env as { readonly BRIDGE: SandboxBridgeBinding }).BRIDGE
+            const input = worker.env as { readonly BRIDGE: SandboxBridgeBinding; readonly INPUT: { readonly execution: string } }
+            const [outcome] = await bridge.sandboxCallBatch(input.INPUT.execution, [{
+              ordinal: 0,
+              packageName: "tools",
+              method: "add",
+              args: { left: 2, right: 3 }
+            }])
+            if (outcome === undefined) return Response.json({ error: "missing outcome" })
+            return Response.json(outcome._tag === "Parked" ? { error: "parked" } : { result: outcome.result })
+          }
+        })
+      })
+    } as unknown as WorkerLoader
+    const sandbox = cloudflareSandboxServiceFor(loader, (call) => ({
+      binding: {
+        sandboxCallBatch: (_execution, calls) => Promise.all(calls.map((entry) =>
+          call(entry.ordinal, entry.packageName, entry.method, entry.args)
+        ))
+      },
+      execution: "test-execution",
+      close: () => {
+        closed = true
+      }
+    }))
+    const result = await Effect.runPromise(sandbox.run("return 0", {
+      tools: {
+        add: async (input) => {
+          const pair = input as { readonly left: number; readonly right: number }
+          return sandboxReturned(pair.left + pair.right)
+        }
+      }
+    }))
+    expect(result).toEqual({ result: 5 })
+    expect(closed).toBe(true)
+  })
+
+  test("returns concurrent parked calls across the bridge", async () => {
+    let calls = 0
+    const observed: Array<{ readonly input: number; readonly ordinal: number }> = []
+    const arrival = [4, 1, 3, 0, 2]
+    const loader = {
+      load: (worker: WorkerLoaderWorkerCode) => ({
+        getEntrypoint: () => ({
+          fetch: async () => {
+            const bridge = (worker.env as { readonly BRIDGE: SandboxBridgeBinding }).BRIDGE
+            const input = worker.env as { readonly INPUT: { readonly execution: string } }
+            const outcomes = await bridge.sandboxCallBatch(input.INPUT.execution, arrival.map((index) => ({
+              ordinal: index,
+              packageName: "agents",
+              method: "run",
+              args: { index }
+            })))
+            return Response.json({ result: outcomes.filter((outcome) => outcome._tag === "Parked").length })
+          }
+        })
+      })
+    } as unknown as WorkerLoader
+    const sandbox = cloudflareSandboxServiceFor(loader, (call) => ({
+      binding: {
+        sandboxCallBatch: (_execution, calls) => Promise.all(calls.map((entry) =>
+          call(entry.ordinal, entry.packageName, entry.method, entry.args)
+        ))
+      },
+      execution: "test-execution",
+      close: () => undefined
+    }))
+    const result = await Effect.runPromise(sandbox.run("return 0", {
+      agents: {
+        run: async (input, ordinal) => {
+          calls++
+          observed.push({ input: (input as { readonly index: number }).index, ordinal })
+          return sandboxParked
+        }
+      }
+    }))
+    expect(result).toEqual({ result: 5 })
+    expect(calls).toBe(5)
+    expect(observed).toEqual(arrival.map((index) => ({ input: index, ordinal: index })))
+  })
+})

--- a/platform/cloudflare/src/sandbox.ts
+++ b/platform/cloudflare/src/sandbox.ts
@@ -1,0 +1,261 @@
+import { Effect, Layer } from "effect"
+import type {
+  Ambient,
+  Bindings,
+  SandboxCallOutcome,
+  SandboxPolicy,
+  SandboxResult,
+  SandboxService
+} from "@clavia/tardigrade-code/sandbox"
+import { DEFAULT_SANDBOX_POLICY, Sandbox } from "@clavia/tardigrade-code/sandbox"
+
+export interface CloudflareSandboxLimits {
+  readonly cpuMs?: number
+  readonly subRequests?: number
+}
+
+export interface CloudflareSandboxPolicy extends SandboxPolicy {
+  readonly compatibilityDate: string
+  readonly compatibilityFlags: ReadonlyArray<string>
+  readonly limits?: CloudflareSandboxLimits
+  readonly globalOutbound: Fetcher | null
+}
+
+export const DEFAULT_CLOUDFLARE_SANDBOX_POLICY: CloudflareSandboxPolicy = {
+  ...DEFAULT_SANDBOX_POLICY,
+  compatibilityDate: "2026-08-08",
+  compatibilityFlags: [],
+  globalOutbound: null
+}
+
+export interface SandboxBridgeBinding {
+  readonly sandboxCallBatch: (
+    execution: string,
+    calls: ReadonlyArray<SandboxBridgeCall>
+  ) => Promise<ReadonlyArray<SandboxCallOutcome>>
+}
+
+export interface SandboxBridgeCall {
+  readonly ordinal: number
+  readonly packageName: string
+  readonly method: string
+  readonly args: unknown
+}
+
+export interface SandboxBridgeLease {
+  readonly binding: SandboxBridgeBinding
+  readonly execution: string
+  readonly close: () => void
+}
+
+export type SandboxBridgeFactory = (
+  call: (ordinal: number, packageName: string, method: string, args: unknown) => Promise<SandboxCallOutcome>
+) => SandboxBridgeLease
+
+const HARNESS_SOURCE = `
+import body from "body.js";
+
+const consoleShim = (lines, cap) => {
+  let bytes = 0;
+  let cut = false;
+  const push = (args) => {
+    if (bytes >= cap) {
+      if (cut) return;
+      cut = true;
+      lines.push(\`…[console output cut at \${cap} bytes; later lines dropped]\`);
+      return;
+    }
+    const line = args.map(String).join(" ");
+    lines.push(line);
+    bytes += line.length;
+  };
+  return {
+    log: (...args) => push(args),
+    warn: (...args) => push(args),
+    error: (...args) => push(args),
+    info: (...args) => push(args),
+    debug: (...args) => push(args)
+  };
+};
+
+const seededRandom = (seed) => {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  let state = h >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const ambientShims = (ambient) => {
+  const PinnedDate = class extends Date {
+    constructor(...args) {
+      if (args.length === 0) super(ambient.at);
+      else super(...args);
+    }
+    static now() {
+      return ambient.at;
+    }
+  };
+  const PinnedMath = Object.create(Math, { random: { value: seededRandom(ambient.seed) } });
+  return { Date: PinnedDate, Math: PinnedMath };
+};
+
+const response = (value) => new Response(JSON.stringify(value), {
+  headers: { "content-type": "application/json" }
+});
+
+export default {
+  async fetch(_request, env) {
+    let ordinal = 0;
+    let scheduled = false;
+    let pending = [];
+    const call = (packageName, method, args) => new Promise((resolve, reject) => {
+      pending.push({ call: { ordinal: ordinal++, packageName, method, args }, resolve, reject });
+      if (scheduled) return;
+      scheduled = true;
+      queueMicrotask(async () => {
+        const batch = pending;
+        pending = [];
+        scheduled = false;
+        try {
+          const outcomes = await env.BRIDGE.sandboxCallBatch(
+            env.INPUT.execution,
+            batch.map((entry) => entry.call)
+          );
+          for (let i = 0; i < batch.length; i++) {
+            const outcome = outcomes[i];
+            if (outcome === undefined) batch[i].reject(new Error("sandbox bridge omitted a call outcome"));
+            else if (outcome._tag === "Returned") batch[i].resolve(outcome.result);
+          }
+        } catch (error) {
+          for (const entry of batch) entry.reject(error);
+        }
+      });
+    });
+    const lines = [];
+    const logs = () => lines.length === 0 ? {} : { logs: lines };
+    const console = consoleShim(lines, env.INPUT.logCapBytes);
+    const ambient = env.INPUT.ambient === undefined ? {} : ambientShims(env.INPUT.ambient);
+    const args = env.INPUT.names.map((name) => {
+      if (name === "console") return console;
+      if (name === "Date" && ambient.Date !== undefined) return ambient.Date;
+      if (name === "Math" && ambient.Math !== undefined) return ambient.Math;
+      const methods = env.INPUT.packages[name];
+      if (methods !== undefined) {
+        return Object.fromEntries(methods.map((method) => [
+          method,
+          (args) => call(name, method, args)
+        ]));
+      }
+      return env.INPUT.values[name];
+    });
+    try {
+      return response({ result: await body(...args), ...logs() });
+    } catch (error) {
+      return response({ error: String(error), ...logs() });
+    }
+  }
+};
+`
+
+const packageMethods = (binding: Bindings[string]): ReadonlyArray<string> | undefined => {
+  if (binding === null || typeof binding !== "object" || Array.isArray(binding)) return undefined
+  const entries = Object.entries(binding)
+  if (!entries.every(([, method]) => typeof method === "function")) return undefined
+  return entries.map(([method]) => method)
+}
+
+const bodySource = (names: ReadonlyArray<string>, code: string): string =>
+  `export default async function(${names.join(",")}) {\n${code}\n}`
+
+const scopeNames = (bindings: Bindings, ambient: Ambient | undefined): ReadonlyArray<string> =>
+  Object.keys({ ...bindings, console: undefined, ...(ambient === undefined ? {} : { Date: undefined, Math: undefined }) })
+
+const sandboxInput = (bindings: Bindings, ambient: Ambient | undefined, policy: CloudflareSandboxPolicy) => {
+  const names = scopeNames(bindings, ambient)
+  const packages: Record<string, ReadonlyArray<string>> = {}
+  const values: Record<string, unknown> = {}
+  for (const name of names) {
+    if (name === "console" || (ambient !== undefined && (name === "Date" || name === "Math"))) continue
+    const methods = packageMethods(bindings[name])
+    if (methods === undefined) values[name] = bindings[name]
+    else packages[name] = methods
+  }
+  return { names, packages, values, logCapBytes: policy.logCapBytes, ...(ambient === undefined ? {} : { ambient }) }
+}
+
+export const cloudflareSandboxServiceFor = (
+  loader: WorkerLoader,
+  bridgeFor: SandboxBridgeFactory,
+  policy: Partial<CloudflareSandboxPolicy> = {}
+): SandboxService => {
+  const resolved: CloudflareSandboxPolicy = {
+    logCapBytes: policy.logCapBytes ?? DEFAULT_CLOUDFLARE_SANDBOX_POLICY.logCapBytes,
+    compatibilityDate: policy.compatibilityDate ?? DEFAULT_CLOUDFLARE_SANDBOX_POLICY.compatibilityDate,
+    compatibilityFlags: policy.compatibilityFlags ?? DEFAULT_CLOUDFLARE_SANDBOX_POLICY.compatibilityFlags,
+    ...(policy.limits === undefined ? {} : { limits: policy.limits }),
+    globalOutbound: policy.globalOutbound === undefined
+      ? DEFAULT_CLOUDFLARE_SANDBOX_POLICY.globalOutbound
+      : policy.globalOutbound
+  }
+  return {
+    run: (code, bindings, ambient) => Effect.promise(async (signal) => {
+      try {
+        const names = scopeNames(bindings, ambient)
+        const call = (ordinal: number, packageName: string, method: string, args: unknown): Promise<SandboxCallOutcome> => {
+          const binding = bindings[packageName]
+          if (binding === null || typeof binding !== "object") {
+            return Promise.reject(new Error(`sandbox package ${JSON.stringify(packageName)} is unavailable`))
+          }
+          const implementation = (binding as Readonly<Record<string, unknown>>)[method]
+          if (typeof implementation !== "function") {
+            return Promise.reject(new Error(`sandbox method ${JSON.stringify(`${packageName}.${method}`)} is unavailable`))
+          }
+          return implementation(args, ordinal)
+        }
+        const bridge = bridgeFor(call)
+        try {
+          const worker = loader.load({
+          compatibilityDate: resolved.compatibilityDate,
+          compatibilityFlags: [...resolved.compatibilityFlags],
+          mainModule: "index.js",
+          modules: {
+            "index.js": HARNESS_SOURCE,
+            "body.js": bodySource(names, code)
+          },
+          env: {
+            BRIDGE: bridge.binding,
+            INPUT: { ...sandboxInput(bindings, ambient, resolved), execution: bridge.execution }
+          },
+          globalOutbound: resolved.globalOutbound,
+          ...(resolved.limits === undefined ? {} : { limits: resolved.limits })
+        })
+          const response = await worker.getEntrypoint().fetch(new Request("https://sandbox.invalid/run", {
+            method: "POST",
+            signal
+          }))
+          if (!response.ok) return { error: `sandbox returned HTTP ${response.status}` }
+          return await response.json() as SandboxResult
+        } finally {
+          bridge.close()
+        }
+      } catch (error) {
+        return { error: String(error) }
+      }
+    })
+  }
+}
+
+export const layerCloudflareSandbox = (
+  loader: WorkerLoader,
+  bridgeFor: SandboxBridgeFactory,
+  policy: Partial<CloudflareSandboxPolicy> = {}
+): Layer.Layer<never> => Layer.succeed(Sandbox)(cloudflareSandboxServiceFor(loader, bridgeFor, policy))

--- a/platform/cloudflare/src/worker.ts
+++ b/platform/cloudflare/src/worker.ts
@@ -3,7 +3,7 @@ import { Context, Effect, Layer, ManagedRuntime } from "effect"
 import { FetchHttpClient, HttpEffect, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { actor, agentsPackage, budget, codeMode, compaction, fetchPackage, Infer, infer as inferAgent, outputValidateOnce, reply, workspacePackage } from "tardie"
 import type { Action } from "tardie/events"
-import { infer } from "@clavia/tardigrade-model/model"
+import { infer, modelAskOf, modelContextWindowTokensOf, modelIdOf } from "@clavia/tardigrade-model/model"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { traceparentOf } from "@clavia/tardigrade-core/trace"
 import { mappedDirectory } from "@clavia/tardigrade-core/communication/directory"
@@ -12,8 +12,15 @@ import type { Transport } from "@clavia/tardigrade-core/communication/transport"
 import { isActorEnvelope, type ActorEnvelope } from "@clavia/tardigrade-core/communication/envelope"
 import type { ActorId } from "@clavia/tardigrade-core/communication/endpoint"
 import { DEFAULT_MAX_CONCURRENT_LANES, driverPolicyOf } from "@clavia/tardigrade-host/driver"
+import type { SandboxCallOutcome } from "@clavia/tardigrade-code/sandbox"
 import { alarmPolicyOf, armAt, nextAlarm, type AlarmPolicy } from "./alarm"
 import { createCloudflareHost, type CloudflareHost } from "./host"
+import {
+  layerCloudflareSandbox,
+  type SandboxBridgeCall,
+  type CloudflareSandboxLimits,
+  type SandboxBridgeLease
+} from "./sandbox"
 import {
   CloudflareActorRegistry,
   layerCloudflareActorRegistry,
@@ -23,26 +30,31 @@ import {
 export interface Env {
   readonly ACTORS: DurableObjectNamespace<ActorHost>
   readonly REGISTRY: D1Database
+  readonly LOADER: WorkerLoader
   readonly MODEL_BASE_URL?: string
   readonly MODEL_API_KEY?: string
   readonly MODEL_ID?: string
+  readonly MODEL_SONNET_ID?: string
+  readonly MODEL_OPUS_ID?: string
+  readonly MODEL_HAIKU_ID?: string
   readonly MODEL_PROVIDER?: string
+  readonly MODEL_CONTEXT_WINDOW_TOKENS?: string
+  readonly MODEL_SONNET_CONTEXT_WINDOW_TOKENS?: string
+  readonly MODEL_OPUS_CONTEXT_WINDOW_TOKENS?: string
+  readonly MODEL_HAIKU_CONTEXT_WINDOW_TOKENS?: string
   readonly TARDIGRADE_TOKEN?: string
   readonly TARDIGRADE_MAX_CONCURRENT_LANES?: string
   readonly TARDIGRADE_ALARM_DELAY_MILLIS?: string
+  readonly TARDIGRADE_COMPACTION_FIRE_RATIO?: string
+  readonly TARDIGRADE_COMPACTION_KEEP_RATIO?: string
+  readonly TARDIGRADE_SANDBOX_LOG_CAP_BYTES?: string
+  readonly TARDIGRADE_SANDBOX_CPU_MILLIS?: string
+  readonly TARDIGRADE_SANDBOX_SUBREQUESTS?: string
 }
 
 const LANE_PREFIX = "ag."
 const laneOf = (thread: string): string => `${LANE_PREFIX}${thread}`
 const threadOf = (lane: string): string | undefined => lane.startsWith(LANE_PREFIX) ? lane.slice(LANE_PREFIX.length) : undefined
-
-const assembly = actor(inferAgent([
-  codeMode([agentsPackage(), workspacePackage(), fetchPackage()]),
-  reply,
-  budget,
-  compaction,
-  outputValidateOnce
-]))
 
 // DEFAULT_ACTOR_REGISTRATION exposes the actor this Worker deploys when no external artifact has been registered.
 export const DEFAULT_ACTOR_REGISTRATION: CloudflareActorRegistration = {
@@ -52,7 +64,7 @@ export const DEFAULT_ACTOR_REGISTRATION: CloudflareActorRegistration = {
   builtIn: true
 }
 
-const assemblies = new Map([[DEFAULT_ACTOR_REGISTRATION.assembly, assembly] as const])
+const assemblies = new Set([DEFAULT_ACTOR_REGISTRATION.assembly])
 const registryRuntimes = new WeakMap<D1Database, ManagedRuntime.ManagedRuntime<CloudflareActorRegistry, never>>()
 
 const actorRegistry = async (env: Env) => {
@@ -73,11 +85,18 @@ const modelLayer = (env: Env) => {
     const failed: Action = { kind: "fail", error: "no model is configured", failure: { cause: "inference_error", attempts: 1 } }
     return Layer.succeed(Infer)({ react: () => Effect.succeed(failed) })
   }
-  return infer({
-    baseUrl: env.MODEL_BASE_URL,
-    apiKey: env.MODEL_API_KEY,
-    model: env.MODEL_ID,
-    ...(env.MODEL_PROVIDER === undefined ? {} : { provider: env.MODEL_PROVIDER })
+  const baseUrl = env.MODEL_BASE_URL
+  const apiKey = env.MODEL_API_KEY
+  return Layer.succeed(Infer, {
+    react: (request, key) => {
+      const selected = infer({
+        baseUrl,
+        apiKey,
+        model: modelIdOf(env, modelAskOf(request.trajectory)),
+        ...(env.MODEL_PROVIDER === undefined ? {} : { provider: env.MODEL_PROVIDER })
+      })
+      return Effect.flatMap(Infer, (model) => model.react(request, key)).pipe(Effect.provide(selected))
+    }
   })
 }
 
@@ -95,11 +114,46 @@ const nonNegativeInteger = (raw: string | undefined, fallback: number, name: str
   return value
 }
 
+const optionalNonNegativeInteger = (raw: string | undefined, name: string): number | undefined => {
+  if (raw === undefined) return undefined
+  return nonNegativeInteger(raw, 0, name)
+}
+
+const optionalRatio = (raw: string | undefined, name: string): number | undefined => {
+  if (raw === undefined) return undefined
+  const value = Number(raw)
+  if (!Number.isFinite(value) || value <= 0 || value >= 1) {
+    throw new Error(`${name} must be between 0 and 1, got ${JSON.stringify(raw)}`)
+  }
+  return value
+}
+
+const assemblyOf = (name: string, env: Env) => {
+  if (!assemblies.has(name)) return undefined
+  const fireRatio = optionalRatio(env.TARDIGRADE_COMPACTION_FIRE_RATIO, "TARDIGRADE_COMPACTION_FIRE_RATIO")
+  const keepRatio = optionalRatio(env.TARDIGRADE_COMPACTION_KEEP_RATIO, "TARDIGRADE_COMPACTION_KEEP_RATIO")
+  return actor(inferAgent([
+    codeMode([agentsPackage(), workspacePackage(), fetchPackage()]),
+    reply,
+    budget,
+    compaction({
+      contextWindowTokens: (model) => modelContextWindowTokensOf(env, model),
+      ...(fireRatio === undefined ? {} : { fireRatio }),
+      ...(keepRatio === undefined ? {} : { keepRatio })
+    }),
+    outputValidateOnce
+  ]))
+}
+
 // ActorHost runs one actor graph over one SQLite-backed Durable Object.
 export class ActorHost extends DurableObject<Env> {
   private runtime: Promise<CloudflareHost> | undefined
   private principal: string | undefined
   private readonly alarmPolicy: AlarmPolicy
+  private readonly sandboxCalls = new Map<
+    string,
+    (ordinal: number, packageName: string, method: string, args: unknown) => Promise<SandboxCallOutcome>
+  >()
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env)
@@ -128,12 +182,52 @@ export class ActorHost extends DurableObject<Env> {
     return this.principal = row.value
   }
 
+  async sandboxCallBatch(
+    execution: string,
+    calls: ReadonlyArray<SandboxBridgeCall>
+  ): Promise<ReadonlyArray<SandboxCallOutcome>> {
+    const call = this.sandboxCalls.get(execution)
+    if (call === undefined) throw new Error(`sandbox execution ${JSON.stringify(execution)} is unavailable`)
+    return Promise.all(calls.map((entry) => call(entry.ordinal, entry.packageName, entry.method, entry.args)))
+  }
+
   private host(): Promise<CloudflareHost> {
     if (this.runtime !== undefined) return this.runtime
     const principal = this.name()
     const assemblyKey = this.ctx.storage.sql.exec<{ value: string }>("SELECT value FROM actor_meta WHERE key = 'assembly'").one().value
-    const selectedAssembly = assemblies.get(assemblyKey)
+    const selectedAssembly = assemblyOf(assemblyKey, this.env)
     if (selectedAssembly === undefined) throw new Error(`actor assembly ${JSON.stringify(assemblyKey)} is not deployed`)
+    const sandboxCpuMs = optionalNonNegativeInteger(this.env.TARDIGRADE_SANDBOX_CPU_MILLIS, "TARDIGRADE_SANDBOX_CPU_MILLIS")
+    const sandboxSubRequests = optionalNonNegativeInteger(
+      this.env.TARDIGRADE_SANDBOX_SUBREQUESTS,
+      "TARDIGRADE_SANDBOX_SUBREQUESTS"
+    )
+    const sandboxLimits: CloudflareSandboxLimits = {
+      ...(sandboxCpuMs === undefined ? {} : { cpuMs: sandboxCpuMs }),
+      ...(sandboxSubRequests === undefined ? {} : { subRequests: sandboxSubRequests })
+    }
+    const actorName = this.ctx.id.name
+    if (actorName === undefined) throw new Error("actor host requires a named durable object")
+    const sandboxLayer = layerCloudflareSandbox(
+      this.env.LOADER,
+      (call): SandboxBridgeLease => {
+        const execution = crypto.randomUUID()
+        this.sandboxCalls.set(execution, call)
+        return {
+          binding: this.env.ACTORS.getByName(actorName),
+          execution,
+          close: () => {
+            this.sandboxCalls.delete(execution)
+          }
+        }
+      },
+      {
+        ...(this.env.TARDIGRADE_SANDBOX_LOG_CAP_BYTES === undefined
+          ? {}
+          : { logCapBytes: nonNegativeInteger(this.env.TARDIGRADE_SANDBOX_LOG_CAP_BYTES, 0, "TARDIGRADE_SANDBOX_LOG_CAP_BYTES") }),
+        ...(Object.keys(sandboxLimits).length === 0 ? {} : { limits: sandboxLimits })
+      }
+    )
     const remoteTransport: Transport<ActorId, ActorEnvelope> = {
       name: "durable-object",
       send: (destination, envelope) => Effect.currentSpan.pipe(
@@ -162,7 +256,7 @@ export class ActorHost extends DurableObject<Env> {
       storage: this.ctx.storage,
       principal,
       actorFor: (lane) => threadOf(lane) === undefined ? undefined : selectedAssembly,
-      layersFor: () => Layer.mergeAll(modelLayer(this.env), FetchHttpClient.layer),
+      layersFor: () => Layer.mergeAll(modelLayer(this.env), FetchHttpClient.layer, sandboxLayer),
       routes: [remoteRoute],
       driver: driverPolicyOf({
         maxConcurrentLanes: positiveInteger(

--- a/platform/cloudflare/test/sandbox.workers.ts
+++ b/platform/cloudflare/test/sandbox.workers.ts
@@ -1,0 +1,59 @@
+import { env } from "cloudflare:test"
+import { Effect } from "effect"
+import { describe, expect, test } from "vitest"
+import type { Env } from "../src/worker"
+import { cloudflareSandboxServiceFor, type SandboxBridgeFactory } from "../src/sandbox"
+
+const bridgeFor: SandboxBridgeFactory = (_call) => ({
+  binding: (env as Env).ACTORS.getByName("sandbox-test"),
+  execution: "unused",
+  close: () => undefined
+})
+
+describe("cloudflare sandbox", () => {
+  test("runs generated code with deterministic ambient values", async () => {
+    const sandbox = cloudflareSandboxServiceFor((env as Env).LOADER, bridgeFor)
+    const result = await Effect.runPromise(sandbox.run(
+      `const [left, right] = await Promise.all([Promise.resolve(5), Promise.resolve(13)])
+      console.log("totals", left, right)
+      return { left, right, now: Date.now(), random: Math.random() }`,
+      {
+        brief: "parallel addition"
+      },
+      { at: 1234, seed: "sandbox-test" }
+    ))
+    expect(result).toEqual({
+      result: { left: 5, right: 13, now: 1234, random: expect.any(Number) },
+      logs: ["totals 5 13"]
+    })
+  })
+
+  test("cuts captured output at the configured cap", async () => {
+    const sandbox = cloudflareSandboxServiceFor((env as Env).LOADER, bridgeFor, { logCapBytes: 3 })
+    const result = await Effect.runPromise(sandbox.run(
+      `console.log("four")
+      console.log("later")
+      return brief`,
+      { brief: "done" }
+    ))
+    expect(result).toEqual({
+      result: "done",
+      logs: ["four", "…[console output cut at 3 bytes; later lines dropped]"]
+    })
+  })
+
+  test("blocks ambient network access", async () => {
+    const sandbox = cloudflareSandboxServiceFor((env as Env).LOADER, bridgeFor)
+    const result = await Effect.runPromise(sandbox.run(
+      `try {
+        await fetch("https://example.com")
+        return "reachable"
+      } catch (_error) {
+        return "blocked"
+      }`,
+      {}
+    ))
+    expect(result).toEqual({ result: "blocked" })
+  })
+
+})

--- a/platform/cloudflare/wrangler.jsonc
+++ b/platform/cloudflare/wrangler.jsonc
@@ -12,10 +12,14 @@
     "database_name": "tardigrade-registry",
     "database_id": "d73ecf80-70a3-4d22-a37c-81e8ce190317"
   }],
+  "worker_loaders": [{ "binding": "LOADER" }],
   "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ActorHost"] }],
   "observability": { "enabled": true },
   "limits": { "cpu_ms": 300000 },
   "vars": {
+    "MODEL_CONTEXT_WINDOW_TOKENS": "1000000",
+    "TARDIGRADE_COMPACTION_FIRE_RATIO": "0.8",
+    "TARDIGRADE_COMPACTION_KEEP_RATIO": "0.5",
     "TARDIGRADE_MAX_CONCURRENT_LANES": "4"
   }
 }

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -23,6 +23,7 @@ import {
   DEFAULT_STREAM_BOUNDS,
   ladderOf,
   modelAskOf,
+  modelContextWindowTokensOf,
   modelIdOf,
   infer,
   retryAfterMsOf,
@@ -879,6 +880,18 @@ describe("model selection", () => {
         { type: "MessageReceived", id: "m2", text: "b", at: 2 } as never
       ])
     ).toBe("opus")
+  })
+  test("context windows follow the same selected-model fallback", () => {
+    const windows = {
+      MODEL_ID: "default-id",
+      MODEL_CONTEXT_WINDOW_TOKENS: "1000000",
+      MODEL_SONNET_CONTEXT_WINDOW_TOKENS: "200000"
+    }
+    expect(modelContextWindowTokensOf(windows, "sonnet")).toBe(200_000)
+    expect(modelContextWindowTokensOf(windows, "opus")).toBe(1_000_000)
+    expect(() => modelContextWindowTokensOf({ MODEL_ID: "m", MODEL_CONTEXT_WINDOW_TOKENS: "many" })).toThrow(
+      "model context window must be a positive integer"
+    )
   })
 })
 

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -42,6 +42,10 @@ export interface ModelEnv {
   readonly MODEL_SONNET_ID?: string
   readonly MODEL_OPUS_ID?: string
   readonly MODEL_HAIKU_ID?: string
+  readonly MODEL_CONTEXT_WINDOW_TOKENS?: string
+  readonly MODEL_SONNET_CONTEXT_WINDOW_TOKENS?: string
+  readonly MODEL_OPUS_CONTEXT_WINDOW_TOKENS?: string
+  readonly MODEL_HAIKU_CONTEXT_WINDOW_TOKENS?: string
   // "bedrock" speaks Converse through the gateway's aws-bedrock route (v5's proven leg);
   // anything else is the OpenAI-compat wire.
   readonly MODEL_PROVIDER?: string
@@ -70,6 +74,30 @@ export const modelAskOf = (trajectory: ReadonlyArray<Event>): string | undefined
     if (typeof v === "string" && v !== "") name = v
   }
   return name
+}
+
+export const DEFAULT_MODEL_CONTEXT_WINDOW_TOKENS = 128_000
+
+const contextWindowValueOf = (env: ModelEnv, name?: string): string | undefined =>
+  name === "opus"
+    ? (env.MODEL_OPUS_CONTEXT_WINDOW_TOKENS ?? env.MODEL_CONTEXT_WINDOW_TOKENS)
+    : name === "sonnet"
+      ? (env.MODEL_SONNET_CONTEXT_WINDOW_TOKENS ?? env.MODEL_CONTEXT_WINDOW_TOKENS)
+      : name === "haiku"
+        ? (env.MODEL_HAIKU_CONTEXT_WINDOW_TOKENS ?? env.MODEL_CONTEXT_WINDOW_TOKENS)
+        : env.MODEL_CONTEXT_WINDOW_TOKENS
+
+// modelContextWindowTokensOf resolves the selected model's declared context window. The model
+// choice and window share the same alias fallback, so inference and compaction cannot select
+// different configured tiers.
+export const modelContextWindowTokensOf = (env: ModelEnv, name?: string): number => {
+  const raw = contextWindowValueOf(env, name)
+  if (raw === undefined) return DEFAULT_MODEL_CONTEXT_WINDOW_TOKENS
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`model context window must be a positive integer, got ${JSON.stringify(raw)}`)
+  }
+  return value
 }
 
 // StreamBounds is time to first chunk, idle between chunks, and the whole stream. Each timeout


### PR DESCRIPTION
## Summary

Adds a Cloudflare platform backed by one SQLite Durable Object per actor, a D1 actor registry, alarms, configurable lane concurrency, and Dynamic Worker code execution. The sandbox forwards package calls through an opaque Durable Object capability, blocks ambient network access, batches concurrent calls, and preserves guest invocation order across replay.

Compaction now resolves an 80 percent fire line and 50 percent keep line from the selected model context window through `compaction(...)`. Cloudflare maps model aliases and their declared windows through the same configuration, and each `CompactionCompleted` event records the resolved thresholds.

## Why

A complete recursive agent run needs durable parent and child communication, parallel model lanes, budget escalation, replay-stable code execution, and bounded model context on Cloudflare. Fixed 16,000-token compaction fired during a five-child synthesis and caused the root to repeat the batch. Model-relative hysteresis keeps the exchange literal until the selected model approaches its declared window.

## Verification

`bun run gate` passes all 47 tasks. A deployed five-agent sauna research run created one root and five depth-1 children, completed every child without a failed turn, exercised a budget request and grant from 6 to 9 calls, completed the root report, and recorded zero compactions under the declared 1,000,000-token window.
