### PR TITLE
feat(model): route named connections

### DIFF
--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -147,7 +147,7 @@ export const setupCommand = Command.make("setup", { json }, (flags) =>
     const home = homeOf(cli.env)
     if (home === undefined) return yield* userErrorOf(HOME_MISSING)
     const file = yield* readFileConfig(cli.env)
-    const answers = yield* Effect.mapError(setupPrompt(file.model === undefined ? {} : { current: file.model }), userErrorOf)
+    const answers = yield* Effect.mapError(setupPrompt(), userErrorOf)
     const path = yield* Effect.mapError(writeSetup(home, answers), userErrorOf)
     yield* Console.log(flags.json ? jsonOf(setupJson(path, answers)) : setupSummary(path, answers))
   })).pipe(
@@ -316,7 +316,7 @@ export const devCommand = Command.make("dev", {
       ? Effect.gen(function*() {
         const home = homeOf(cli.env)
         if (home === undefined) return yield* Effect.as(Console.log(NO_MODEL_NOTICE), config)
-        const answers = yield* Effect.mapError(setupPrompt({ current: config.model }), userErrorOf)
+        const answers = yield* Effect.mapError(setupPrompt(), userErrorOf)
         const path = yield* Effect.mapError(writeSetup(home, answers), userErrorOf)
         yield* Console.log(setupSummary(path, answers))
         const written = yield* readFileConfig(cli.env)

--- a/apps/cli/src/config.test.ts
+++ b/apps/cli/src/config.test.ts
@@ -67,7 +67,7 @@ describe("resolveServer", () => {
     expect(config.port).toBe(8080)
     expect(config.db).toBe("runs.sqlite")
     expect(config.maxConcurrentLanes).toBe(6)
-    expect(config.model.id).toBe("a-model")
+    expect(config.model.default).toEqual({ id: "a-model", connection: "environment" })
   })
 
   test("a flag beats the environment", () => {
@@ -143,8 +143,8 @@ describe("the config file", () => {
   })
 
   test("a key nobody declared is ignored, and the rest still reads", () => {
-    expect(parseFileConfig(JSON.stringify({ model: { id: "a-model", weird: 3 }, later: true }))).toEqual({
-      model: { id: "a-model" }
+    expect(parseFileConfig(JSON.stringify({ model: { default: { id: "a-model", connection: "primary" }, weird: 3 }, later: true }))).toEqual({
+      model: { default: { id: "a-model", connection: "primary" }, connections: {} }
     })
   })
 
@@ -152,15 +152,18 @@ describe("the config file", () => {
   // survives beside a tool list, because a turn that offers tools and declares a contract sends
   // both on one call (platform/model/src/output.ts, outputModeOf).
   test("the output capability resolves in the same order every value does", async () => {
-    await put(JSON.stringify({ model: { output: "native", outputWithTools: "true" } }))
+    await put(JSON.stringify({ model: {
+      default: { id: "m", connection: "primary" },
+      connections: { primary: { models: { m: { output: "native", outputWithTools: "true" } } } }
+    } }))
     const file = await read({ HOME: home })
-    expect(resolveServer({}, {}, file).model.output).toEqual({ guarantee: "native", withTools: true })
-    expect(resolveServer({}, { MODEL_OUTPUT_GUARANTEE: "none" }, file).model.output).toEqual({ guarantee: "none" })
-    expect(resolveServer({}, {}, {}).model.output).toBeUndefined()
+    expect(resolveServer({}, {}, file).model.connections.primary?.models.m?.output).toEqual({ guarantee: "native", withTools: true })
+    expect(resolveServer({}, { MODEL_ID: "env", MODEL_OUTPUT_GUARANTEE: "none" }, file).model.connections.environment?.models.env?.output).toEqual({ guarantee: "none" })
+    expect(resolveServer({}, {}, {}).model.connections).toEqual({})
   })
 
   test("a capability nobody stated whole refuses to resolve, rather than leaving one field guessed", async () => {
-    await put(JSON.stringify({ model: { output: "probably" } }))
+    await put(JSON.stringify({ model: { connections: { primary: { models: { m: { output: "probably" } } } } } }))
     const file = await read({ HOME: home })
     expect(() => resolveServer({}, {}, file)).toThrow("model output guarantee must be one of")
     expect(() => resolveServer({}, { MODEL_OUTPUT_GUARANTEE: "maybe" }, {})).toThrow("model output guarantee must be one of")
@@ -170,19 +173,40 @@ describe("the config file", () => {
   })
 
   test("the file is the third source for the model, and the environment beats it", async () => {
-    await put(JSON.stringify({ model: { baseUrl: "https://file.example.com", apiKey: "file-key", id: "file-model" } }))
+    await put(JSON.stringify({ model: {
+      default: { id: "file-model", connection: "primary" },
+      connections: {
+        primary: {
+          baseUrl: "https://file.example.com",
+          apiKey: "file-key",
+          driver: "openai-responses",
+          models: { "file-model": { contextWindowTokens: 128000 } }
+        }
+      }
+    } }))
     const file = await read({ HOME: home })
     const fromFile = resolveServer({}, {}, file)
     expect(fromFile.model).toEqual({
-      baseUrl: "https://file.example.com",
-      apiKey: "file-key",
-      id: "file-model",
-      provider: undefined,
-      output: undefined
+      default: { id: "file-model", connection: "primary" },
+      connections: {
+        primary: {
+          baseUrl: "https://file.example.com",
+          apiKey: "file-key",
+          driver: "openai-responses",
+          provider: undefined,
+          models: {
+            "file-model": {
+              contextWindowTokens: 128000,
+              maxOutputTokens: undefined,
+              output: undefined
+            }
+          }
+        }
+      }
     })
     const overridden = resolveServer({}, { MODEL_ID: "env-model" }, file)
-    expect(overridden.model.id).toBe("env-model")
-    expect(overridden.model.baseUrl).toBe("https://file.example.com")
+    expect(overridden.model.default).toEqual({ id: "env-model", connection: "environment" })
+    expect(overridden.model.connections.primary?.baseUrl).toBe("https://file.example.com")
   })
 
   test("the file is the third source for the remote, and a flag beats both", async () => {

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -8,6 +8,7 @@ import {
   type Env,
   type ServerConfigValue
 } from "@clavia/tardigrade-server/config"
+import { modelDriverOf, type ModelReference } from "@clavia/tardigrade-model/connection"
 
 // Where a value comes from, decided once. Three sources in one order, everywhere: a flag stated on
 // the command line, then the environment, then the file `tdg setup` wrote, then the exported
@@ -45,14 +46,19 @@ export const configPathIn = (home: string): string => `${home}/${CONFIG_RELATIVE
 // the one value nothing ever prints back (setup.ts).
 export interface FileConfig {
   readonly model?: {
-    readonly baseUrl?: string
-    readonly apiKey?: string
-    readonly id?: string
-    readonly provider?: string
-    // What the endpoint and the model promise about a declared output contract, and whether that
-    // promise survives beside a tool list (apps/server/src/config.ts, ModelConfig).
-    readonly output?: string
-    readonly outputWithTools?: string
+    readonly default?: ModelReference
+    readonly connections?: Readonly<Record<string, {
+      readonly baseUrl?: string
+      readonly apiKey?: string
+      readonly driver?: string
+      readonly provider?: string
+      readonly models?: Readonly<Record<string, {
+        readonly contextWindowTokens?: number
+        readonly maxOutputTokens?: number
+        readonly output?: string
+        readonly outputWithTools?: string
+      }>>
+    }>>
   }
   readonly url?: string
   readonly token?: string
@@ -61,6 +67,54 @@ export interface FileConfig {
 const stringField = (source: Record<string, unknown>, name: string): string | undefined => {
   const value = source[name]
   return typeof value === "string" ? value : undefined
+}
+
+const positiveIntegerField = (source: Record<string, unknown>, name: string): number | undefined => {
+  const value = source[name]
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0 ? value : undefined
+}
+
+const modelReferenceField = (value: unknown): ModelReference | undefined => {
+  if (typeof value === "string" && value.trim().length > 0) return value.trim()
+  if (typeof value !== "object" || value === null) return undefined
+  const source = value as Record<string, unknown>
+  const id = stringField(source, "id")?.trim()
+  const connection = stringField(source, "connection")?.trim()
+  if (id === undefined || id.length === 0) return undefined
+  return connection === undefined || connection.length === 0 ? { id } : { id, connection }
+}
+
+const fileModelsOf = (value: unknown): NonNullable<NonNullable<NonNullable<FileConfig["model"]>["connections"]>[string]["models"]> => {
+  if (typeof value !== "object" || value === null) return {}
+  const models: Record<string, NonNullable<NonNullable<NonNullable<FileConfig["model"]>["connections"]>[string]["models"]>[string]> = {}
+  for (const [id, raw] of Object.entries(value)) {
+    if (typeof raw !== "object" || raw === null) continue
+    const source = raw as Record<string, unknown>
+    models[id] = {
+      ...(positiveIntegerField(source, "contextWindowTokens") === undefined ? {} : { contextWindowTokens: positiveIntegerField(source, "contextWindowTokens")! }),
+      ...(positiveIntegerField(source, "maxOutputTokens") === undefined ? {} : { maxOutputTokens: positiveIntegerField(source, "maxOutputTokens")! }),
+      ...(stringField(source, "output") === undefined ? {} : { output: stringField(source, "output")! }),
+      ...(stringField(source, "outputWithTools") === undefined ? {} : { outputWithTools: stringField(source, "outputWithTools")! })
+    }
+  }
+  return models
+}
+
+const fileConnectionsOf = (value: unknown): NonNullable<NonNullable<FileConfig["model"]>["connections"]> => {
+  if (typeof value !== "object" || value === null) return {}
+  const connections: Record<string, NonNullable<NonNullable<FileConfig["model"]>["connections"]>[string]> = {}
+  for (const [name, raw] of Object.entries(value)) {
+    if (typeof raw !== "object" || raw === null) continue
+    const source = raw as Record<string, unknown>
+    connections[name] = {
+      ...(stringField(source, "baseUrl") === undefined ? {} : { baseUrl: stringField(source, "baseUrl")! }),
+      ...(stringField(source, "apiKey") === undefined ? {} : { apiKey: stringField(source, "apiKey")! }),
+      ...(stringField(source, "driver") === undefined ? {} : { driver: stringField(source, "driver")! }),
+      ...(stringField(source, "provider") === undefined ? {} : { provider: stringField(source, "provider")! }),
+      models: fileModelsOf(source["models"])
+    }
+  }
+  return connections
 }
 
 // parseFileConfig reads what it recognizes and ignores the rest. A file with a key nobody declared
@@ -80,14 +134,8 @@ export const parseFileConfig = (raw: string): FileConfig => {
     : {}
   return {
     model: {
-      ...(stringField(model, "baseUrl") === undefined ? {} : { baseUrl: stringField(model, "baseUrl")! }),
-      ...(stringField(model, "apiKey") === undefined ? {} : { apiKey: stringField(model, "apiKey")! }),
-      ...(stringField(model, "id") === undefined ? {} : { id: stringField(model, "id")! }),
-      ...(stringField(model, "provider") === undefined ? {} : { provider: stringField(model, "provider")! }),
-      ...(stringField(model, "output") === undefined ? {} : { output: stringField(model, "output")! }),
-      ...(stringField(model, "outputWithTools") === undefined
-        ? {}
-        : { outputWithTools: stringField(model, "outputWithTools")! })
+      ...(modelReferenceField(model["default"]) === undefined ? {} : { default: modelReferenceField(model["default"])! }),
+      connections: fileConnectionsOf(model["connections"])
     },
     ...(stringField(source, "url") === undefined ? {} : { url: stringField(source, "url")! }),
     ...(stringField(source, "token") === undefined ? {} : { token: stringField(source, "token")! })
@@ -148,6 +196,23 @@ export interface ServerFlags {
 export const resolveServer = (flags: ServerFlags, env: Env, file: FileConfig = {}): ServerConfigValue => {
   const base = readConfig(env)
   const model = file.model ?? {}
+  const fileConnections = Object.fromEntries(Object.entries(model.connections ?? {}).map(([name, connection]) => [
+    name,
+    {
+      baseUrl: text(connection.baseUrl),
+      apiKey: text(connection.apiKey),
+      driver: text(connection.driver) === undefined ? undefined : modelDriverOf(text(connection.driver)!),
+      provider: text(connection.provider),
+      models: Object.fromEntries(Object.entries(connection.models ?? {}).map(([id, metadata]) => [
+        id,
+        {
+          contextWindowTokens: metadata.contextWindowTokens,
+          maxOutputTokens: metadata.maxOutputTokens,
+          output: outputCapabilityOf(text(metadata.output), text(metadata.outputWithTools))
+        }
+      ]))
+    }
+  ]))
   return {
     ...base,
     port: flags.port ?? base.port,
@@ -157,14 +222,8 @@ export const resolveServer = (flags: ServerFlags, env: Env, file: FileConfig = {
     maxConcurrentLanes: maxConcurrentLanesOf(flags.maxConcurrentLanes ?? base.maxConcurrentLanes),
     token: undefined,
     model: {
-      baseUrl: resolve(undefined, base.model.baseUrl, model.baseUrl),
-      apiKey: resolve(undefined, base.model.apiKey, model.apiKey),
-      id: resolve(undefined, base.model.id, model.id),
-      provider: resolve(undefined, base.model.provider, model.provider),
-      output: outputCapabilityOf(
-        resolve(undefined, env["MODEL_OUTPUT_GUARANTEE"], model.output),
-        resolve(undefined, env["MODEL_OUTPUT_WITH_TOOLS"], model.outputWithTools)
-      )
+      default: base.model.default ?? model.default,
+      connections: { ...fileConnections, ...base.model.connections }
     }
   }
 }

--- a/apps/cli/src/setup.test.ts
+++ b/apps/cli/src/setup.test.ts
@@ -27,9 +27,13 @@ import {
 const KEY = "sk-do-not-print-me"
 
 const answers: SetupAnswers = {
+  connection: "primary",
   baseUrl: "https://api.example.com/v1",
   id: "a-model",
   apiKey: KEY,
+  driver: "openai-responses",
+  contextWindowTokens: 128_000,
+  maxOutputTokens: 16_384,
   output: "native",
   outputWithTools: "true"
 }
@@ -119,12 +123,23 @@ describe("writeSetup", () => {
     const path = await write({ ...answers, provider: "bedrock" })
     const held = parseFileConfig(await readFile(path, "utf8"))
     expect(held.model).toEqual({
-      baseUrl: "https://api.example.com/v1",
-      apiKey: KEY,
-      id: "a-model",
-      provider: "bedrock",
-      output: "native",
-      outputWithTools: "true"
+      default: { id: "a-model", connection: "primary" },
+      connections: {
+        primary: {
+          baseUrl: "https://api.example.com/v1",
+          apiKey: KEY,
+          driver: "openai-responses",
+          provider: "bedrock",
+          models: {
+            "a-model": {
+              contextWindowTokens: 128_000,
+              maxOutputTokens: 16_384,
+              output: "native",
+              outputWithTools: "true"
+            }
+          }
+        }
+      }
     })
   })
 
@@ -137,7 +152,23 @@ describe("writeSetup", () => {
     const held = parseFileConfig(await readFile(path, "utf8"))
     expect(held.url).toBe("https://agents.example.com")
     expect(held.token).toBe("held")
-    expect(held.model?.id).toBe("a-model")
+    expect(held.model?.default).toEqual({ id: "a-model", connection: "primary" })
+  })
+
+  test("a later setup keeps prior connections and changes the default", async () => {
+    await write()
+    const path = await write({
+      ...answers,
+      connection: "secondary",
+      id: "another-model",
+      baseUrl: "https://secondary.example.com/v1",
+      apiKey: "secondary-key"
+    })
+    const held = parseFileConfig(await readFile(path, "utf8"))
+    expect(Object.keys(held.model?.connections ?? {}).sort()).toEqual(["primary", "secondary"])
+    expect(held.model?.default).toEqual({ id: "another-model", connection: "secondary" })
+    expect(held.model?.connections?.primary?.models?.["a-model"]?.contextWindowTokens).toBe(128_000)
+    expect(held.model?.connections?.secondary?.models?.["another-model"]?.contextWindowTokens).toBe(128_000)
   })
 
   // A rerun over a file left readable by everyone must narrow it, and `mode` on a write applies
@@ -154,27 +185,41 @@ describe("writeSetup", () => {
     await write({ ...answers, provider: "bedrock" })
     const file = await Effect.runPromise(Effect.provide(readFileConfig({ HOME: home }), BunFileSystem.layer))
     expect(file.model).toEqual({
-      baseUrl: "https://api.example.com/v1",
-      apiKey: KEY,
-      id: "a-model",
-      provider: "bedrock",
-      output: "native",
-      outputWithTools: "true"
+      default: { id: "a-model", connection: "primary" },
+      connections: {
+        primary: {
+          baseUrl: "https://api.example.com/v1",
+          apiKey: KEY,
+          driver: "openai-responses",
+          provider: "bedrock",
+          models: {
+            "a-model": {
+              contextWindowTokens: 128_000,
+              maxOutputTokens: 16_384,
+              output: "native",
+              outputWithTools: "true"
+            }
+          }
+        }
+      }
     })
   })
 
   test("a setup with no native guarantee writes the whole alternative", async () => {
     const path = await write({
+      connection: answers.connection,
       baseUrl: answers.baseUrl,
       id: answers.id,
       apiKey: answers.apiKey,
+      driver: answers.driver,
+      contextWindowTokens: answers.contextWindowTokens,
+      ...(answers.maxOutputTokens === undefined ? {} : { maxOutputTokens: answers.maxOutputTokens }),
       ...(answers.provider === undefined ? {} : { provider: answers.provider }),
       output: "none"
     })
-    expect(parseFileConfig(await readFile(path, "utf8")).model).toEqual({
-      baseUrl: "https://api.example.com/v1",
-      apiKey: KEY,
-      id: "a-model",
+    expect(parseFileConfig(await readFile(path, "utf8")).model?.connections?.primary?.models?.["a-model"]).toEqual({
+      contextWindowTokens: 128_000,
+      maxOutputTokens: 16_384,
       output: "none"
     })
   })
@@ -194,6 +239,8 @@ describe("what setup prints", () => {
     expect(JSON.stringify(json)).not.toContain(KEY)
     expect(json.apiKey).toBe("stored")
     expect(json.provider).toBe("bedrock")
+    expect(json.driver).toBe("openai-responses")
+    expect(json.contextWindowTokens).toBe(128_000)
     expect(json.output).toBe("native")
     expect(json.outputWithTools).toBe(true)
     expect(summary).toContain("output native (with tools)")

--- a/apps/cli/src/setup.ts
+++ b/apps/cli/src/setup.ts
@@ -2,6 +2,8 @@ import { Console, Effect, Redacted } from "effect"
 import type { PlatformError } from "effect/PlatformError"
 import { FileSystem } from "effect/FileSystem"
 import { Prompt } from "effect/unstable/cli"
+import { MODEL_DRIVERS, type ModelDriver } from "@clavia/tardigrade-model/connection"
+import { discoveredModelsOf, type ModelMetadata } from "@clavia/tardigrade-model/metadata"
 
 import { configPathIn, parseFileConfig, type Env, type FileConfig } from "./config"
 
@@ -36,9 +38,12 @@ export interface Preset {
   readonly description: string
   readonly baseUrl?: string
   readonly provider?: string
+  readonly driver?: ModelDriver
   readonly modelExample?: string
   readonly credential?: string
   readonly modelsUrl?: string
+  readonly modelListUrl?: string
+  readonly credentialHeader?: "authorization" | "x-api-key"
 }
 
 export const PRESETS: ReadonlyArray<Preset> = [
@@ -49,14 +54,29 @@ export const PRESETS: ReadonlyArray<Preset> = [
     // output: that promise belongs to the endpoint and the model together, and an operator
     // states it (platform/model/src/output.ts, capabilityOf).
     provider: "openai",
+    driver: "openai-responses",
     baseUrl: "https://api.openai.com/v1",
     modelExample: "gpt-5.2",
     credential: "OpenAI API key",
     modelsUrl: "https://platform.openai.com/docs/models"
   },
   {
+    title: "Anthropic",
+    description: "Anthropic's Messages protocol",
+    provider: "anthropic",
+    driver: "anthropic-messages",
+    baseUrl: "https://api.anthropic.com",
+    modelExample: "claude-sonnet-4-6",
+    credential: "Anthropic API key",
+    modelsUrl: "https://docs.anthropic.com/en/docs/about-claude/models",
+    modelListUrl: "https://api.anthropic.com/v1/models",
+    credentialHeader: "x-api-key"
+  },
+  {
     title: "OpenRouter",
     description: "One key across many providers, over the same protocol",
+    provider: "openrouter",
+    driver: "openai-chat-completions",
     baseUrl: "https://openrouter.ai/api/v1",
     modelExample: "anthropic/claude-sonnet-latest",
     credential: "OpenRouter API key",
@@ -65,6 +85,8 @@ export const PRESETS: ReadonlyArray<Preset> = [
   {
     title: "Vercel AI Gateway",
     description: "One Vercel key across providers, over the OpenAI-compatible protocol",
+    provider: "vercel-ai-gateway",
+    driver: "openai-responses",
     baseUrl: "https://ai-gateway.vercel.sh/v1",
     modelExample: "anthropic/claude-opus-5",
     credential: "Vercel AI Gateway API key",
@@ -72,20 +94,41 @@ export const PRESETS: ReadonlyArray<Preset> = [
   },
   {
     title: "Cloudflare AI Gateway",
-    description: "Cloudflare's account-scoped OpenAI-compatible endpoint",
-    modelExample: "openai/gpt-4.1",
+    description: "Cloudflare's account-scoped Responses endpoint",
+    provider: "cloudflare-ai-gateway",
+    driver: "openai-responses",
+    modelExample: "openai/gpt-5.6-luna",
     credential: "Cloudflare API token",
     modelsUrl: "https://developers.cloudflare.com/ai-gateway/models/"
+  },
+  {
+    title: "Azure AI",
+    description: "Azure AI's OpenAI Responses endpoint",
+    provider: "azure-ai",
+    driver: "openai-responses",
+    modelExample: "deployment-name",
+    credential: "Azure AI API key",
+    modelsUrl: "https://ai.azure.com/explore/models"
+  },
+  {
+    title: "Google Vertex AI",
+    description: "Vertex AI's OpenAI-compatible endpoint",
+    provider: "google-vertex-ai",
+    driver: "openai-chat-completions",
+    modelExample: "google/gemini-2.5-pro",
+    credential: "Google access token",
+    modelsUrl: "https://console.cloud.google.com/vertex-ai/model-garden"
   },
   {
     title: "Amazon Bedrock",
     description: "Bedrock's own protocol. The base URL is your region's runtime endpoint",
     provider: "bedrock",
+    driver: "bedrock-converse",
     credential: "AI Gateway API key"
   },
   {
     title: "Other",
-    description: "Any other OpenAI-compatible endpoint, including one you run yourself"
+    description: "A model endpoint whose protocol you declare"
   }
 ]
 
@@ -93,9 +136,13 @@ export const PRESETS: ReadonlyArray<Preset> = [
 // A native guarantee includes the tool combination in the type, so neither the prompt nor a
 // programmatic caller can write half a capability (apps/server/src/config.ts, outputCapabilityOf).
 interface SetupCoordinates {
+  readonly connection: string
   readonly baseUrl: string
   readonly id: string
   readonly apiKey: string
+  readonly driver: ModelDriver
+  readonly contextWindowTokens: number
+  readonly maxOutputTokens?: number
   readonly provider?: string | undefined
 }
 
@@ -108,14 +155,25 @@ export type SetupAnswers = SetupCoordinates &
 const nonEmpty = (what: string) => (value: string): Effect.Effect<string, string> =>
   value.trim().length === 0 ? Effect.fail(`${what} cannot be empty`) : Effect.succeed(value.trim())
 
+const positiveIntegerText = (what: string) => (value: string): Effect.Effect<string, string> => {
+  const number = Number(value)
+  return Number.isSafeInteger(number) && number > 0 ? Effect.succeed(String(number)) : Effect.fail(`${what} must be a positive integer`)
+}
+
+const optionalPositiveIntegerText = (what: string) => (value: string): Effect.Effect<string, string> =>
+  value.trim() === "" ? Effect.succeed("") : positiveIntegerText(what)(value)
+
 export interface ListedModel {
   readonly id: string
   readonly name?: string
+  readonly metadata?: ModelMetadata
 }
 
 export interface ModelListOptions {
   readonly fetch?: typeof globalThis.fetch
   readonly timeoutMillis?: number
+  readonly url?: string
+  readonly credentialHeader?: "authorization" | "x-api-key"
 }
 
 // modelListUrl is the OpenAI-compatible discovery route for a configured base URL.
@@ -123,26 +181,12 @@ export const modelListUrl = (baseUrl: string): string => `${baseUrl.replace(/\/+
 
 // listedModels reads the common OpenAI model-list shape. Unknown rows are ignored, duplicate IDs
 // collapse, and the returned order is stable for the picker.
-export const listedModels = (raw: unknown): ReadonlyArray<ListedModel> => {
-  if (typeof raw !== "object" || raw === null) return []
-  const source = raw as Record<string, unknown>
-  const rows = Array.isArray(source["data"]) ? source["data"] : Array.isArray(source["models"]) ? source["models"] : []
-  const found = new Map<string, ListedModel>()
-  for (const row of rows) {
-    if (typeof row === "string") {
-      const id = row.trim()
-      if (id.length > 0) found.set(id, { id })
-      continue
-    }
-    if (typeof row !== "object" || row === null) continue
-    const value = row as Record<string, unknown>
-    if (typeof value["id"] !== "string" || value["id"].trim().length === 0) continue
-    const id = value["id"].trim()
-    const name = typeof value["name"] === "string" && value["name"].trim().length > 0 ? value["name"].trim() : undefined
-    found.set(id, name === undefined ? { id } : { id, name })
-  }
-  return [...found.values()].sort((left, right) => left.id.localeCompare(right.id))
-}
+export const listedModels = (raw: unknown, url: string = "model-list"): ReadonlyArray<ListedModel> =>
+  discoveredModelsOf(raw, { kind: "discovered", url }).map((model) => ({
+    id: model.id,
+    ...(model.name === undefined ? {} : { name: model.name }),
+    ...(Object.keys(model.metadata).length === 0 ? {} : { metadata: model.metadata })
+  }))
 
 // modelsAt asks an OpenAI-compatible endpoint for the models visible to the supplied credential.
 export const modelsAt = async (
@@ -152,20 +196,32 @@ export const modelsAt = async (
 ): Promise<ReadonlyArray<ListedModel>> => {
   const fetcher = options.fetch ?? globalThis.fetch
   const timeoutMillis = options.timeoutMillis ?? DEFAULT_MODEL_LIST_TIMEOUT_MILLIS
-  const response = await fetcher(modelListUrl(baseUrl), {
-    headers: { accept: "application/json", authorization: `Bearer ${apiKey}` },
+  const url = options.url ?? modelListUrl(baseUrl)
+  const credentialHeader = options.credentialHeader ?? "authorization"
+  const response = await fetcher(url, {
+    headers: {
+      accept: "application/json",
+      [credentialHeader]: credentialHeader === "authorization" ? `Bearer ${apiKey}` : apiKey,
+      ...(credentialHeader === "x-api-key" ? { "anthropic-version": "2023-06-01" } : {})
+    },
     signal: AbortSignal.timeout(timeoutMillis)
   })
   if (!response.ok) throw new Error(`model list returned ${response.status}`)
-  return listedModels(await response.json())
+  return listedModels(await response.json(), url)
 }
 
 export interface SetupPromptOptions {
-  readonly current?: { readonly id?: string | undefined }
+  readonly current?: {
+    readonly connection?: string | undefined
+    readonly id?: string | undefined
+    readonly driver?: string | undefined
+    readonly contextWindowTokens?: number | undefined
+    readonly maxOutputTokens?: number | undefined
+  }
   readonly modelList?: ModelListOptions
 }
 
-type ModelPick = { readonly tag: "model"; readonly id: string } | { readonly tag: "manual" }
+type ModelPick = { readonly tag: "model"; readonly model: ListedModel } | { readonly tag: "manual" }
 
 type OutputPick =
   | { readonly output: "native"; readonly outputWithTools: "true" | "false" }
@@ -179,6 +235,15 @@ export const setupPrompt = (options: SetupPromptOptions = {}) => Effect.gen(func
     message: "Which model provider?",
     choices: PRESETS.map((preset) => ({ title: preset.title, value: preset, description: preset.description }))
   })
+  const connection = yield* Prompt.text({
+    message: "Connection name",
+    default: options.current?.connection ?? preset.provider ?? preset.title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, ""),
+    validate: nonEmpty("the connection name")
+  })
+  const driver = preset.driver ?? (yield* Prompt.select<ModelDriver>({
+    message: "Which protocol does this endpoint accept?",
+    choices: MODEL_DRIVERS.map((driver) => ({ title: driver, value: driver }))
+  }))
   const baseUrl = yield* Prompt.text({
     message: preset.provider === "bedrock" ? "Bedrock runtime endpoint" : "Base URL",
     ...(preset.baseUrl === undefined ? {} : { default: preset.baseUrl }),
@@ -188,7 +253,11 @@ export const setupPrompt = (options: SetupPromptOptions = {}) => Effect.gen(func
     message: preset.credential ?? "API key",
     validate: nonEmpty("the API key")
   })
-  const loaded = yield* Effect.tryPromise(() => modelsAt(baseUrl, Redacted.value(apiKey), options.modelList)).pipe(
+  const loaded = yield* Effect.tryPromise(() => modelsAt(baseUrl, Redacted.value(apiKey), {
+    ...options.modelList,
+    ...(preset.modelListUrl === undefined ? {} : { url: preset.modelListUrl }),
+    ...(preset.credentialHeader === undefined ? {} : { credentialHeader: preset.credentialHeader })
+  })).pipe(
     Effect.match({ onFailure: () => undefined, onSuccess: (models) => models })
   )
   const current = options.current?.id?.trim()
@@ -198,10 +267,10 @@ export const setupPrompt = (options: SetupPromptOptions = {}) => Effect.gen(func
     ...(current === undefined || current.length === 0 ? {} : { default: current }),
     validate: nonEmpty("the model ID")
   })
-  let id: string
+  let selected: ListedModel
   if (loaded === undefined || loaded.length === 0) {
-    yield* Console.log(`Could not load a model list from ${modelListUrl(baseUrl)}. Enter a model ID manually.`)
-    id = yield* manual()
+    yield* Console.log(`Could not load a model list from ${preset.modelListUrl ?? modelListUrl(baseUrl)}. Enter a model ID manually.`)
+    selected = { id: yield* manual() }
   } else {
     const models = [...loaded]
     if (current !== undefined && current.length > 0 && !models.some((model) => model.id === current)) {
@@ -214,15 +283,32 @@ export const setupPrompt = (options: SetupPromptOptions = {}) => Effect.gen(func
       choices: [
         ...models.map((model) => ({
           title: model.id,
-          value: { tag: "model", id: model.id } as const,
+          value: { tag: "model", model } as const,
           ...(model.name === undefined || model.name === model.id ? {} : { description: model.name }),
           ...(model.id === current ? { selected: true } : {})
         })),
         { title: "Enter a model ID manually", value: { tag: "manual" } as const }
       ]
     })
-    id = picked.tag === "model" ? picked.id : yield* manual()
+    selected = picked.tag === "model" ? picked.model : { id: yield* manual() }
   }
+  const discoveredContext = selected.metadata?.contextWindowTokens?.value
+  const contextWindowTokens = Number(yield* Prompt.text({
+    message: "Context window tokens",
+    ...((discoveredContext ?? options.current?.contextWindowTokens) === undefined
+      ? {}
+      : { default: String(discoveredContext ?? options.current?.contextWindowTokens) }),
+    validate: positiveIntegerText("the context window")
+  }))
+  const discoveredOutput = selected.metadata?.maxOutputTokens?.value
+  const maxOutput = yield* Prompt.text({
+    message: "Maximum output tokens, blank when the endpoint does not declare one",
+    ...((discoveredOutput ?? options.current?.maxOutputTokens) === undefined
+      ? {}
+      : { default: String(discoveredOutput ?? options.current?.maxOutputTokens) }),
+    validate: optionalPositiveIntegerText("the maximum output")
+  })
+  const maxOutputTokens = maxOutput.trim() === "" ? undefined : Number(maxOutput)
   const output = yield* Prompt.select<OutputPick>({
     message: "What structured output does this endpoint and model guarantee?",
     choices: [
@@ -244,9 +330,13 @@ export const setupPrompt = (options: SetupPromptOptions = {}) => Effect.gen(func
     ]
   })
   return {
+    connection,
     baseUrl,
-    id,
+    id: selected.id,
     apiKey: Redacted.value(apiKey),
+    driver,
+    contextWindowTokens,
+    ...(maxOutputTokens === undefined ? {} : { maxOutputTokens }),
     ...(preset.provider === undefined ? {} : { provider: preset.provider }),
     ...output
   } satisfies SetupAnswers
@@ -279,12 +369,25 @@ export const writeSetup = (
     const next: FileConfig = {
       ...held,
       model: {
-        baseUrl: answers.baseUrl,
-        apiKey: answers.apiKey,
-        id: answers.id,
-        ...(answers.provider === undefined ? {} : { provider: answers.provider }),
-        output: answers.output,
-        ...(answers.outputWithTools === undefined ? {} : { outputWithTools: answers.outputWithTools })
+        default: { id: answers.id, connection: answers.connection },
+        connections: {
+          ...(held.model?.connections ?? {}),
+          [answers.connection]: {
+            baseUrl: answers.baseUrl,
+            apiKey: answers.apiKey,
+            driver: answers.driver,
+            ...(answers.provider === undefined ? {} : { provider: answers.provider }),
+            models: {
+              ...(held.model?.connections?.[answers.connection]?.models ?? {}),
+              [answers.id]: {
+                contextWindowTokens: answers.contextWindowTokens,
+                ...(answers.maxOutputTokens === undefined ? {} : { maxOutputTokens: answers.maxOutputTokens }),
+                output: answers.output,
+                ...(answers.outputWithTools === undefined ? {} : { outputWithTools: answers.outputWithTools })
+              }
+            }
+          }
+        }
       }
     }
     yield* fs.makeDirectory(directory, { recursive: true, mode: CONFIG_DIR_MODE })
@@ -301,22 +404,34 @@ export const setupSummary = (path: string, answers: SetupAnswers): string =>
   [
     `wrote ${path}`,
     `model ${answers.id}`,
+    `via   ${answers.connection}`,
     `at    ${answers.baseUrl}${answers.provider === undefined ? "" : ` (${answers.provider})`}`,
+    `wire  ${answers.driver}`,
+    `input ${answers.contextWindowTokens} tokens`,
+    `limit ${answers.maxOutputTokens === undefined ? "undeclared" : `${answers.maxOutputTokens} output tokens`}`,
     `output ${answers.output === "native" ? `native (${answers.outputWithTools === "true" ? "with tools" : "without tools"})` : "none"}`
   ].join("\n")
 
 export const setupJson = (path: string, answers: SetupAnswers): {
   readonly path: string
   readonly baseUrl: string
+  readonly connection: string
   readonly id: string
+  readonly driver: ModelDriver
+  readonly contextWindowTokens: number
+  readonly maxOutputTokens?: number
   readonly provider?: string
   readonly output: "native" | "none"
   readonly outputWithTools?: boolean
   readonly apiKey: "stored"
 } => ({
   path,
+  connection: answers.connection,
   baseUrl: answers.baseUrl,
   id: answers.id,
+  driver: answers.driver,
+  contextWindowTokens: answers.contextWindowTokens,
+  ...(answers.maxOutputTokens === undefined ? {} : { maxOutputTokens: answers.maxOutputTokens }),
   ...(answers.provider === undefined ? {} : { provider: answers.provider }),
   output: answers.output,
   ...(answers.outputWithTools === undefined ? {} : { outputWithTools: answers.outputWithTools === "true" }),

--- a/apps/server/src/actor.ts
+++ b/apps/server/src/actor.ts
@@ -19,6 +19,7 @@ import { boundaryOf } from "tardie/boundary"
 import { projection, projectionsOf, Seq, TurnView } from "@clavia/tardigrade-client/contract"
 
 import { inboundOf } from "./projections"
+import type { ModelReference } from "tardie"
 
 // The actor this build serves: the reactors it runs, and the projections it declares over the logs
 // they write. Both halves belong together, because a projection is only meaningful to whoever knows
@@ -36,12 +37,16 @@ import { inboundOf } from "./projections"
 // one root directory, the working directory of the process that booted, and `fetch` makes HTTP
 // requests to any host. There is no shell: a shell cannot be scoped the way a root or an origin can,
 // and this build has no place to ask an operator whether one command is allowed.
-export const assemblyOf = () =>
+export interface AssemblyModelPolicy {
+  readonly contextWindowTokens?: number | ((model: ModelReference | undefined) => number)
+}
+
+export const assemblyOf = (models: AssemblyModelPolicy = {}) =>
   actor(infer([
     codeMode([agentsPackage(), workspacePackage(), filesPackage(), fetchPackage()]),
     reply,
     budget,
-    compaction(),
+    compaction(models.contextWindowTokens === undefined ? {} : { contextWindowTokens: models.contextWindowTokens }),
     outputValidateOnce
   ]))
 

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_MAX_CONCURRENT_LANES,
   driverPolicyOf
 } from "@clavia/tardigrade-host/driver"
+import { modelDriverOf, type ModelDriver, type ModelReference } from "@clavia/tardigrade-model/connection"
 
 export { DEFAULT_MAX_CONCURRENT_LANES } from "@clavia/tardigrade-host/driver"
 
@@ -22,18 +23,33 @@ export const DEFAULT_ACTORS = ".tardigrade/actors"
 
 export const DEFAULT_ACTOR_DATA = ".tardigrade/data"
 
-// The model binding's coordinates. Absent values are absent rather than guessed: the model layer
-// decides what it can do without them, and the server does not invent an endpoint.
-export interface ModelConfig {
-  readonly baseUrl: string | undefined
-  readonly apiKey: string | undefined
-  readonly id: string | undefined
-  readonly provider: string | undefined
+export const ENVIRONMENT_MODEL_CONNECTION = "environment"
+
+export interface ConfiguredModel {
+  readonly contextWindowTokens: number | undefined
+  readonly maxOutputTokens: number | undefined
   // What this endpoint and this model promise about a turn's declared output contract. A
   // provider name proves nothing here: structured output is a property of the endpoint AND the
   // model behind it, so an operator states it. Absent, a turn that declares a contract fails
   // before it spends (platform/model/src/output.ts, capabilityOf).
   readonly output: OutputCapabilityValue | undefined
+}
+
+// ModelConnectionConfig is one named route to models. Coordinates may be absent so the server can
+// boot and report an incomplete environment configuration through the ordinary model failure.
+export interface ModelConnectionConfig {
+  readonly baseUrl: string | undefined
+  readonly apiKey: string | undefined
+  readonly driver: ModelDriver | undefined
+  readonly provider: string | undefined
+  readonly models: Readonly<Record<string, ConfiguredModel>>
+}
+
+// ModelConfig holds every configured route and the deployment fallback. A request and an actor may
+// select another model without replacing this configuration.
+export interface ModelConfig {
+  readonly default: ModelReference | undefined
+  readonly connections: Readonly<Record<string, ModelConnectionConfig>>
 }
 
 export const OUTPUT_GUARANTEES = ["native", "none"] as const
@@ -70,6 +86,14 @@ const text = (env: Env, name: string): string | undefined => {
   if (value === undefined) return undefined
   const trimmed = value.trim()
   return trimmed.length === 0 ? undefined : trimmed
+}
+
+const optionalPositiveInteger = (env: Env, name: string): number | undefined => {
+  const raw = text(env, name)
+  if (raw === undefined) return undefined
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value) || value <= 0) throw new Error(`${name} must be a positive integer, got ${JSON.stringify(raw)}`)
+  return value
 }
 
 // MODEL_OUTPUT_GUARANTEE and MODEL_OUTPUT_WITH_TOOLS name a promise the process must be able to
@@ -125,21 +149,42 @@ const maxConcurrentLanes = (env: Env): number => {
 }
 
 // readConfig resolves the environment into the value the process runs on.
-export const readConfig = (env: Env): ServerConfigValue => ({
-  port: port(env),
-  db: text(env, "TARDIGRADE_DB") ?? DEFAULT_DB,
-  actors: text(env, "TARDIGRADE_ACTORS") ?? DEFAULT_ACTORS,
-  actorData: text(env, "TARDIGRADE_ACTOR_DATA") ?? DEFAULT_ACTOR_DATA,
-  maxConcurrentLanes: maxConcurrentLanes(env),
-  token: text(env, "TARDIGRADE_TOKEN"),
-  model: {
-    baseUrl: text(env, "MODEL_BASE_URL"),
-    apiKey: text(env, "MODEL_API_KEY"),
-    id: text(env, "MODEL_ID"),
-    provider: text(env, "MODEL_PROVIDER"),
-    output: outputCapabilityOf(text(env, "MODEL_OUTPUT_GUARANTEE"), text(env, "MODEL_OUTPUT_WITH_TOOLS"))
+export const readConfig = (env: Env): ServerConfigValue => {
+  const id = text(env, "MODEL_ID")
+  const baseUrl = text(env, "MODEL_BASE_URL")
+  const apiKey = text(env, "MODEL_API_KEY")
+  const driverText = text(env, "MODEL_DRIVER")
+  const provider = text(env, "MODEL_PROVIDER")
+  const contextWindowTokens = optionalPositiveInteger(env, "MODEL_CONTEXT_WINDOW_TOKENS")
+  const maxOutputTokens = optionalPositiveInteger(env, "MODEL_MAX_OUTPUT_TOKENS")
+  const output = outputCapabilityOf(text(env, "MODEL_OUTPUT_GUARANTEE"), text(env, "MODEL_OUTPUT_WITH_TOOLS"))
+  const hasEnvironmentModel = [id, baseUrl, apiKey, driverText, provider, contextWindowTokens, maxOutputTokens, output]
+    .some((value) => value !== undefined)
+  return {
+    port: port(env),
+    db: text(env, "TARDIGRADE_DB") ?? DEFAULT_DB,
+    actors: text(env, "TARDIGRADE_ACTORS") ?? DEFAULT_ACTORS,
+    actorData: text(env, "TARDIGRADE_ACTOR_DATA") ?? DEFAULT_ACTOR_DATA,
+    maxConcurrentLanes: maxConcurrentLanes(env),
+    token: text(env, "TARDIGRADE_TOKEN"),
+    model: {
+      default: id === undefined ? undefined : { id, connection: ENVIRONMENT_MODEL_CONNECTION },
+      connections: hasEnvironmentModel
+        ? {
+            [ENVIRONMENT_MODEL_CONNECTION]: {
+              baseUrl,
+              apiKey,
+              driver: driverText === undefined ? undefined : modelDriverOf(driverText),
+              provider,
+              models: id === undefined
+                ? {}
+                : { [id]: { contextWindowTokens, maxOutputTokens, output } }
+            }
+          }
+        : {}
+    }
   }
-})
+}
 
 // layerConfig provides a resolved configuration; layerFromEnv reads one out of an environment.
 export const layerConfig = (value: ServerConfigValue): Layer.Layer<ServerConfig> =>

--- a/apps/server/src/host.ts
+++ b/apps/server/src/host.ts
@@ -16,6 +16,7 @@ import {
   ACTOR_ARTIFACT_VERSION,
   ACTOR_NAME_PATTERN,
   Infer,
+  type ModelReference,
   type ActorArtifactManifest,
   type ActorDefinition
 } from "tardie"
@@ -26,7 +27,7 @@ import { infer } from "@clavia/tardigrade-model/model"
 import { RESERVED_ACTOR, type ActorArtifact, type ActorSummary } from "@clavia/tardigrade-client/contract"
 
 import { assemblyOf, type ServerR } from "./actor"
-import { ServerConfig, type ServerConfigValue } from "./config"
+import { ServerConfig, type ModelConfig, type ServerConfigValue } from "./config"
 import { DriverGauge } from "./http"
 
 // The durable host, the assembly it runs, and the loop that drives it, behind one service. The
@@ -83,27 +84,89 @@ export class Threads extends Context.Service<
 // The model binding the configured coordinates name. Absent coordinates are not an endpoint this
 // server invents: every attempt fails with what is missing, so the process still boots, still
 // answers /healthz, and says why a turn cannot run (config.ts, ModelConfig).
-export const MISSING_MODEL = "no model is configured: run `tdg setup`, or set MODEL_BASE_URL, MODEL_API_KEY, and MODEL_ID"
+export const MISSING_MODEL = "no model is configured: run `tdg setup`, or set MODEL_BASE_URL, MODEL_API_KEY, MODEL_ID, MODEL_DRIVER, and MODEL_CONTEXT_WINDOW_TOKENS"
+
+interface SelectedModel {
+  readonly id: string
+  readonly connection: string
+  readonly baseUrl: string
+  readonly apiKey: string
+  readonly driver: NonNullable<ModelConfig["connections"][string]["driver"]>
+  readonly provider?: string
+  readonly contextWindowTokens: number
+  readonly maxOutputTokens?: number
+  readonly output?: NonNullable<ModelConfig["connections"][string]["models"][string]["output"]>
+}
+
+// selectedModelFrom resolves an actor selection against host connections and their declared metadata.
+export const selectedModelFrom = (config: ModelConfig, reference?: ModelReference): SelectedModel => {
+  const selected = reference ?? config.default
+  if (selected === undefined) throw new Error("no default model is configured")
+  const defaultConnection = typeof config.default === "object" ? config.default.connection : undefined
+  const id = typeof selected === "string" ? selected : selected.id
+  const connectionName = typeof selected === "string" ? defaultConnection : (selected.connection ?? defaultConnection)
+  if (connectionName === undefined) throw new Error(`model ${JSON.stringify(id)} requires a connection`)
+  const connection = config.connections[connectionName]
+  if (connection === undefined) throw new Error(`unknown model connection ${JSON.stringify(connectionName)}`)
+  const metadata = connection.models[id]
+  if (metadata === undefined) throw new Error(`model ${JSON.stringify(id)} has no metadata on connection ${JSON.stringify(connectionName)}`)
+  if (connection.baseUrl === undefined) throw new Error(`model connection ${JSON.stringify(connectionName)} has no base URL`)
+  if (connection.apiKey === undefined) throw new Error(`model connection ${JSON.stringify(connectionName)} has no API key`)
+  if (connection.driver === undefined) throw new Error(`model connection ${JSON.stringify(connectionName)} has no protocol driver`)
+  if (metadata.contextWindowTokens === undefined) throw new Error(`model ${JSON.stringify(id)} has no context window`)
+  return {
+    id,
+    connection: connectionName,
+    baseUrl: connection.baseUrl,
+    apiKey: connection.apiKey,
+    driver: connection.driver,
+    ...(connection.provider === undefined ? {} : { provider: connection.provider }),
+    contextWindowTokens: metadata.contextWindowTokens,
+    ...(metadata.maxOutputTokens === undefined ? {} : { maxOutputTokens: metadata.maxOutputTokens }),
+    ...(metadata.output === undefined ? {} : { output: metadata.output })
+  }
+}
 
 // modelIsConfigured says whether a turn can reach a model at all. The command line reads it to say
 // so once on boot rather than letting every turn be the first news (apps/cli/src/commands.ts).
 export const modelIsConfigured = (config: ServerConfigValue): boolean =>
-  config.model.baseUrl !== undefined && config.model.apiKey !== undefined && config.model.id !== undefined
+  (() => {
+    try {
+      selectedModelFrom(config.model)
+      return true
+    } catch {
+      return false
+    }
+  })()
 
 const layerInferFrom = (config: ServerConfigValue): Layer.Layer<Infer> => {
-  const { apiKey, baseUrl, id, provider, output } = config.model
-  if (!modelIsConfigured(config) || baseUrl === undefined || apiKey === undefined || id === undefined) {
+  if (!modelIsConfigured(config)) {
     const failed: Action = { kind: "fail", error: MISSING_MODEL, failure: { cause: "inference_error", attempts: 1 } }
     return Layer.succeed(Infer)({ react: () => Effect.succeed(failed) })
   }
-  return infer({
-    baseUrl,
-    apiKey,
-    model: id,
-    ...(provider === undefined ? {} : { provider }),
-    // The capability is the operator's whole statement, passed through as declared. Nothing here
-    // fills a field it did not state (platform/model/src/output.ts, capabilityOf).
-    ...(output === undefined ? {} : { output })
+  return Layer.succeed(Infer, {
+    react: (request, key) => Effect.suspend(() => {
+      let selected: SelectedModel
+      try {
+        selected = selectedModelFrom(config.model, request.model)
+      } catch (error) {
+        return Effect.succeed<Action>({
+          kind: "fail",
+          error: error instanceof Error ? error.message : String(error),
+          failure: { cause: "inference_error", attempts: 0 }
+        })
+      }
+      const binding = infer({
+        baseUrl: selected.baseUrl,
+        apiKey: selected.apiKey,
+        model: selected.id,
+        driver: selected.driver,
+        ...(selected.provider === undefined ? {} : { provider: selected.provider }),
+        ...(selected.maxOutputTokens === undefined ? {} : { maxOutputTokens: selected.maxOutputTokens }),
+        ...(selected.output === undefined ? {} : { output: selected.output })
+      })
+      return Effect.flatMap(Infer, (model) => model.react(request, key)).pipe(Effect.provide(binding))
+    })
   })
 }
 
@@ -300,7 +363,9 @@ const make = (options: ThreadsOptions) =>
     const runtimes = new Map<string, ActorRuntime>()
     const registry = yield* openBunActorRegistry<ActorSummary>({ file: config.db })
     const runRegistry = Effect.runPromiseWith(yield* Effect.context<never>())
-    const builtIn = assemblyOf()
+    const builtIn = modelIsConfigured(config)
+      ? assemblyOf({ contextWindowTokens: (model) => selectedModelFrom(config.model, model).contextWindowTokens })
+      : assemblyOf()
     const root = resolve(config.actors)
     let mutations: Promise<void> = Promise.resolve()
     const exclusive = <A>(operation: () => Promise<A>): Promise<A> => {

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -75,11 +75,8 @@ describe("config", () => {
     expect(config.maxConcurrentLanes).toBe(DEFAULT_MAX_CONCURRENT_LANES)
     expect(config.token).toBeUndefined()
     expect(config.model).toEqual({
-      baseUrl: undefined,
-      apiKey: undefined,
-      id: undefined,
-      provider: undefined,
-      output: undefined
+      default: undefined,
+      connections: {}
     })
   })
 
@@ -94,6 +91,9 @@ describe("config", () => {
       MODEL_BASE_URL: "https://api.example.com",
       MODEL_API_KEY: "key",
       MODEL_ID: "a-model",
+      MODEL_DRIVER: "openai-responses",
+      MODEL_CONTEXT_WINDOW_TOKENS: "1050000",
+      MODEL_MAX_OUTPUT_TOKENS: "128000",
       MODEL_PROVIDER: "openai"
     })
     expect(config.port).toBe(8080)
@@ -102,8 +102,13 @@ describe("config", () => {
     expect(config.actorData).toBe("/var/lib/actor-data")
     expect(config.maxConcurrentLanes).toBe(7)
     expect(config.token).toBe("secret")
-    expect(config.model.baseUrl).toBe("https://api.example.com")
-    expect(config.model.provider).toBe("openai")
+    expect(config.model.default).toEqual({ id: "a-model", connection: "environment" })
+    const connection = config.model.connections["environment"]!
+    expect(connection.baseUrl).toBe("https://api.example.com")
+    expect(connection.provider).toBe("openai")
+    expect(connection.driver).toBe("openai-responses")
+    expect(connection.models["a-model"]?.contextWindowTokens).toBe(1_050_000)
+    expect(connection.models["a-model"]?.maxOutputTokens).toBe(128_000)
   })
 
   // Listening somewhere other than where the operator asked is worse than refusing to start.

--- a/bun.lock
+++ b/bun.lock
@@ -169,6 +169,7 @@
         "@smithy/fetch-http-handler": "^5.6.3",
         "@smithy/node-http-handler": "^4.11.2",
         "@tanstack/ai": "0.46.0",
+        "@tanstack/ai-anthropic": "0.16.6",
         "@tanstack/ai-bedrock": "0.2.3",
         "@tanstack/ai-openai": "0.20.0",
         "effect": "4.0.0-rc.110",
@@ -178,6 +179,8 @@
   },
   "packages": {
     "@ag-ui/core": ["@ag-ui/core@0.1.1-canary.beta.0", "", { "peerDependencies": { "zod": "^3.25.18 || ^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-zcP3RH5p3HJTZ0kyQxNOL1blnVFTDpaShitR7UMS/thwFdl48V6CAG+WQBcYEu/dfa8mKonRez88N0Ok+nEI+w=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.97.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-wOf7AUeJPitcVpvKO4UMu63mWH5SaVipkGd7OOQJt/G6VYGlV8D2Gp9dLxOrttDJh/9gqPqdaBwDGcBevumeAg=="],
 
     "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
 
@@ -619,9 +622,13 @@
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.24", "", {}, "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw=="],
 
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@tanstack/ai": ["@tanstack/ai@0.46.0", "", { "dependencies": { "@ag-ui/core": "0.1.1-canary.beta.0", "@standard-schema/spec": "^1.1.0", "@tanstack/ai-event-client": "^0.9.0", "@tanstack/ai-utils": "^0.4.0", "partial-json": "^0.1.7" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-c0L9MssuCEdVTxNlWQ8R39v1sTqvahDA3OsFfUSWIFwtE39fc3SKY5osOElkPs5/UpwsCvhVmMOHDFA2PrdtzQ=="],
+
+    "@tanstack/ai-anthropic": ["@tanstack/ai-anthropic@0.16.6", "", { "dependencies": { "@anthropic-ai/sdk": "^0.97.1", "@tanstack/ai-utils": "^0.4.0" }, "peerDependencies": { "@tanstack/ai": "^0.45.0", "zod": "^4.0.0" } }, "sha512-zAm9dm14J71ZANRYjTnHUJHRxGYjoFwuGiA0HUtMtYQ2bFEiJqmnxe5CcbDpoKZQtf1NteI7eGgI9CTUg4tkLg=="],
 
     "@tanstack/ai-bedrock": ["@tanstack/ai-bedrock@0.2.3", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-sdk/client-bedrock-runtime": "^3.1057.0", "@aws-sdk/credential-providers": "^3.1057.0", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "@tanstack/openai-base": "^0.9.15", "openai": "^6.41.0" }, "peerDependencies": { "@tanstack/ai": "^0.46.0", "zod": "^4.0.0" } }, "sha512-Uhzd3YGWbhfLqyZyFdQ47V4rAP8gAsjpNtew4giL2McCspdi01FE4WbXcELngr+LZxI0UlGQAgzyx5UyMVIMhA=="],
 
@@ -749,6 +756,8 @@
 
     "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
+
     "fd-package-json": ["fd-package-json@2.0.0", "", { "dependencies": { "walk-up-path": "^4.0.0" } }, "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -760,6 +769,8 @@
     "get-tsconfig": ["get-tsconfig@4.14.1", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A=="],
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
@@ -849,6 +860,8 @@
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
     "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
@@ -866,6 +879,8 @@
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/packages/agent/src/components/compaction.ts
+++ b/packages/agent/src/components/compaction.ts
@@ -5,6 +5,7 @@ import type { Event } from "@clavia/tardigrade-core/event"
 import { turnOf, turnView } from "@clavia/tardigrade-code/turns"
 import { projectedOutput } from "../output"
 import { Infer } from "../runtime/infer"
+import type { ModelReference } from "../model"
 import type { AgentComponent } from "../runtime/agent"
 
 // The compaction reactor: a pure observer of the context size, with the hysteresis design. A
@@ -52,7 +53,7 @@ export interface ContextPolicy {
   readonly summaryLineCap: number
 }
 
-export type ContextWindowTokens = number | ((model: string | undefined) => number)
+export type ContextWindowTokens = number | ((model: ModelReference | undefined) => number)
 
 export interface CompactionPolicy {
   readonly messageRenderCap: number
@@ -82,16 +83,24 @@ const ratio = (value: number, name: string): number => {
   return value
 }
 
-// modelOf returns the latest model choice recorded for the open thread. The same MessageReceived
-// field selects inference, so a replay resolves the same model window.
-const modelOf = (log: ReadonlyArray<Event>): string | undefined => {
-  let model: string | undefined
+// modelOf returns the latest model choice recorded by infer for the open thread.
+const modelSelectionOf = (log: ReadonlyArray<Event>): {
+  readonly model: ModelReference | undefined
+  readonly contextWindowTokens: number | undefined
+} => {
+  let model: ModelReference | undefined
+  let contextWindowTokens: number | undefined
   for (const event of log) {
-    if (event.type !== "MessageReceived") continue
+    if (event.type !== "ModelSelected") continue
     const selected = (event as { readonly model?: unknown }).model
     if (typeof selected === "string" && selected !== "") model = selected
+    else if (typeof selected === "object" && selected !== null && typeof (selected as { id?: unknown }).id === "string") {
+      model = selected as { readonly id: string; readonly connection?: string }
+    }
+    const window = (event as { readonly contextWindowTokens?: unknown }).contextWindowTokens
+    if (typeof window === "number") contextWindowTokens = window
   }
-  return model
+  return { model, contextWindowTokens }
 }
 
 // contextPolicyOf resolves the model-relative policy into the absolute thresholds used by the
@@ -99,7 +108,7 @@ const modelOf = (log: ReadonlyArray<Event>): string | undefined => {
 // together.
 export const contextPolicyOf = (
   policy: Partial<CompactionPolicy> = {},
-  model?: string
+  model?: ModelReference
 ): ContextPolicy => {
   const windowSource = policy.contextWindowTokens ?? DEFAULT_COMPACTION_POLICY.contextWindowTokens
   const contextWindowTokens = positive(
@@ -328,7 +337,12 @@ const firedUncovered = (log: ReadonlyArray<Event>): boolean => {
 // The policy this takes must be the one the render takes, or the guard measures a request the
 // model never sees (ContextPolicy above).
 export const compactionReactor = (policy: Partial<CompactionPolicy> = {}): Reactor<Infer> => (log) => {
-  const resolved = contextPolicyOf(policy, modelOf(log))
+  const selection = modelSelectionOf(log)
+  const model = selection.model
+  const resolved = contextPolicyOf(
+    selection.contextWindowTokens === undefined ? policy : { ...policy, contextWindowTokens: selection.contextWindowTokens },
+    model
+  )
   // The projection runs first, so the guard, the cut, and the brief all read the history the
   // model reads. A corrected exchange the render hides can neither trigger a paid pass nor leak
   // its rejected reply into a summary (src/output.ts, projectedOutput).
@@ -372,6 +386,7 @@ export const compactionReactor = (policy: Partial<CompactionPolicy> = {}): React
           const action = yield* (yield* Infer).react(
             {
               trajectory: [{ type: "MessageReceived", id: `compact-${input.keepFrom}`, text: brief, at }],
+              ...(model === undefined ? {} : { model }),
               system: "",
               tools: []
             },
@@ -398,13 +413,22 @@ export const compaction = (policy: Partial<CompactionPolicy> = {}): AgentCompone
   return {
     name: "compaction",
     derive: (log) => ({
+      ...(() => {
+        const selection = modelSelectionOf(log)
+        const resolved = contextPolicyOf(
+          selection.contextWindowTokens === undefined ? policy : { ...policy, contextWindowTokens: selection.contextWindowTokens },
+          selection.model
+        )
+        return {
       view: {
         system: [],
         tools: [],
-        context: [{ component: "compaction", policy: contextPolicyOf(policy, modelOf(log)) }],
+        context: [{ component: "compaction", policy: resolved }],
         output: []
       },
       transitions: reactor(log)
+        }
+      })()
     })
   }
 }

--- a/packages/agent/src/events.ts
+++ b/packages/agent/src/events.ts
@@ -3,6 +3,7 @@ import { MessageReceived } from "@clavia/tardigrade-core/communication/message"
 import type { Event } from "@clavia/tardigrade-core/event"
 import type { KeyFragment } from "@clavia/tardigrade-core/event-log"
 import type { Usage } from "./usage"
+import { ModelReference, type ModelReference as ModelReferenceType } from "./model"
 
 // The agent's domain events. This alphabet belongs to the agent, and core never learns it: core
 // sees only the open envelope. The model responds by acting: its recorded decision is the
@@ -81,6 +82,26 @@ export const ModelCalled = Schema.Struct({
   output: Schema.optional(OutputPolicy),
   epoch: Schema.optional(Schema.Finite),
   turn: Schema.optional(Schema.String),
+  at: Schema.Finite
+})
+
+// ModelSelected records the infer component's model choice for one turn before work uses it.
+export const ModelSelected = Schema.Struct({
+  type: Schema.Literal("ModelSelected"),
+  turn: Schema.String,
+  model: ModelReference,
+  contextWindowTokens: Schema.optional(Schema.Finite),
+  maxOutputTokens: Schema.optional(Schema.Finite),
+  catalogRevision: Schema.optional(Schema.String),
+  at: Schema.Finite
+})
+
+// ModelSelectionFailed records a model reference that the host could not resolve for one turn.
+export const ModelSelectionFailed = Schema.Struct({
+  type: Schema.Literal("ModelSelectionFailed"),
+  turn: Schema.String,
+  requested: ModelReference,
+  error: Schema.String,
   at: Schema.Finite
 })
 
@@ -261,6 +282,8 @@ export const BudgetDenied = Schema.Struct({
 
 export const AgentEvent = Schema.Union([
   MessageReceived,
+  ModelSelected,
+  ModelSelectionFailed,
   ModelCalled,
   TextReturned,
   ToolCalled,
@@ -321,7 +344,7 @@ export type Action =
 const epochSuffix = (epoch: unknown): string => epoch === undefined || Number(epoch) === 0 ? "" : `/${String(epoch)}`
 
 export const agentKeys: KeyFragment = {
-  prefixes: ["tr:", "bdec:", "brr:", "rd:", "tn:", "rs:", "mc:", "bw:", "br:", "cc:", "or:", "oq:"],
+  prefixes: ["tr:", "bdec:", "brr:", "rd:", "tn:", "rs:", "ms:", "mc:", "bw:", "br:", "cc:", "or:", "oq:"],
   keyOf: (e) => {
     const v = e as Record<string, unknown>
     switch (e.type) {
@@ -347,6 +370,9 @@ export const agentKeys: KeyFragment = {
         // repetition that evidences died attempts is preserved. A mark predating the ordinal
         // lands unkeyed, which the folds tolerate.
         return v.ordinal === undefined ? undefined : `mc:${String(v.turn)}/${String(v.ordinal)}`
+      case "ModelSelected":
+      case "ModelSelectionFailed":
+        return `ms:${String(v.turn)}`
       case "BudgetExhausted":
         // The wall's occurrence is the ceiling it fired at: a grant raises it, so a second
         // crossing keys anew.
@@ -398,6 +424,16 @@ export const modelCalled = (
     }
   } & EpochStamp
 ): Event => ({ type: "ModelCalled", ...fields }) as Event
+
+export const modelSelected = (fields: {
+  readonly turn: string
+  readonly model: ModelReferenceType
+  readonly contextWindowTokens?: number
+  readonly maxOutputTokens?: number
+  readonly catalogRevision?: string
+  readonly at: number
+}): Event =>
+  ({ type: "ModelSelected", ...fields }) as Event
 
 export const textReturned = (fields: { readonly text: string } & Stamp): Event =>
   ({ type: "TextReturned", ...fields }) as Event

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -16,8 +16,12 @@ export {
   DEFAULT_INFER_POLICY,
   type InferPolicy,
   type InferRequest,
+  type ModelResolution,
+  type ModelSelectionInput,
+  type ModelSelector,
   type Render
 } from "./runtime/infer"
+export { ModelReference, type ModelReference as ModelReferenceType } from "./model"
 
 // The turn's declared final response: the contract a caller states, the profile a binding can
 // send unchanged, and the implementation that obtains it. `output` is the whole declarative

--- a/packages/agent/src/model.ts
+++ b/packages/agent/src/model.ts
@@ -1,0 +1,12 @@
+import { Schema } from "effect"
+
+// ModelReference identifies a model through a host connection. A string uses the host's default connection.
+export const ModelReference = Schema.Union([
+  Schema.String,
+  Schema.Struct({
+    id: Schema.String,
+    connection: Schema.optional(Schema.String)
+  })
+])
+
+export type ModelReference = typeof ModelReference.Type

--- a/packages/agent/src/runtime/agent.test.ts
+++ b/packages/agent/src/runtime/agent.test.ts
@@ -25,7 +25,7 @@ import { toolList } from "../components/tool-list"
 import { nativeOutput } from "../components/native-output"
 import { system } from "../components/system"
 import { receive } from "../turn"
-import { Infer, NativeOutputSupport, type InferRequest } from "./infer"
+import { Infer, NativeOutputSupport, selectedModelOf, type InferRequest } from "./infer"
 
 // The component assembly end to end: the render the model sees is the composed view, and a call
 // routes through the same derived tool binding.
@@ -75,6 +75,59 @@ const viewComponent = (
 })
 
 describe("infer component", () => {
+  test("the actor owns model selection", () => {
+    const fallback = { id: "openai/gpt-5.6-luna", connection: "cloudflare" } as const
+    const message = {
+      type: "MessageReceived",
+      id: "m1",
+      text: "go",
+      model: { id: "anthropic/claude-sonnet-4-6", connection: "vercel" },
+      at: 1
+    } as Event
+    expect(selectedModelOf(message, [message], fallback)).toEqual(fallback)
+    expect(selectedModelOf(message, [message], ({ requested }) => requested)).toEqual({
+      id: "anthropic/claude-sonnet-4-6",
+      connection: "vercel"
+    })
+  })
+
+  test("the selected model reaches the model binding", async () => {
+    const seen: InferRequest[] = []
+    const mind = Layer.succeed(Infer, {
+      react: (request: InferRequest) => {
+        seen.push(request)
+        return Effect.succeed({ kind: "complete" as const, output: "done" })
+      }
+    })
+    const agent = actor(infer([
+      reply,
+      compaction({
+        contextWindowTokens: (model) =>
+          typeof model === "object" && model.connection === "vercel" ? 200_000 : 100_000
+      }),
+      nativeOutput
+    ], {
+      model: ({ input }) => (input as { readonly model: { readonly id: string; readonly connection: string } }).model
+    }))
+    const events = await run(
+      Effect.gen(function* () {
+        yield* receive(agent, {
+          id: "m1",
+          text: "go",
+          input: { model: { id: "anthropic/claude-sonnet-4-6", connection: "vercel" } }
+        })
+        return yield* readLog
+      }),
+      Layer.mergeAll(memoryLog(), mind, noRouter, KeyValueStore.layerMemory)
+    )
+    expect(seen[0]?.model).toEqual({ id: "anthropic/claude-sonnet-4-6", connection: "vercel" })
+    expect(seen[0]?.context?.contextWindowTokens).toBe(200_000)
+    expect(events.find((event) => event.type === "ModelSelected")).toMatchObject({
+      turn: "m1",
+      model: { id: "anthropic/claude-sonnet-4-6", connection: "vercel" }
+    })
+  })
+
   test("an assembly must declare one output strategy", () => {
     expect(() => actor(infer([echoTable]))).toThrow("must declare one output strategy")
   })

--- a/packages/agent/src/runtime/agent.ts
+++ b/packages/agent/src/runtime/agent.ts
@@ -238,10 +238,12 @@ export const infer = <
     keys: rootKeys(combined.keys),
     derive: (log) => {
       const children = combined.derive(log)
+      const inferred = inference(log)
+      const selectingModel = inferred.some((candidate) => candidate.key.startsWith("ms:"))
       return {
         view: children.view,
-        transitions: [
-          ...inference(log),
+        transitions: selectingModel ? inferred : [
+          ...inferred,
           ...dispatch(log),
           ...children.transitions
         ]

--- a/packages/agent/src/runtime/infer.ts
+++ b/packages/agent/src/runtime/infer.ts
@@ -1,7 +1,7 @@
 import { Cause, Clock, Context, Effect } from "effect"
 import { EventLog } from "@clavia/tardigrade-core/event-log"
 import { transition, type Reactor } from "@clavia/tardigrade-core/actor"
-import { modelCalled, outputRejected, textReturned, turnFailed } from "../events"
+import { modelCalled, modelSelected, outputRejected, textReturned, turnFailed } from "../events"
 import type { Event } from "@clavia/tardigrade-core/event"
 import type { Action } from "../events"
 import { trajectoryOf, turnEpochOf, turnView } from "@clavia/tardigrade-code/turns"
@@ -18,6 +18,7 @@ import {
   type OutputFallback
 } from "../output"
 import type { ContextPolicy } from "../components/compaction"
+import type { ModelReference } from "../model"
 
 // The infer reactor: the model loop, and nothing else. A think is owed when the current turn
 // has no unanswered tool call and no terminal; serving marks the attempt, does inference, then
@@ -30,7 +31,19 @@ import type { ContextPolicy } from "../components/compaction"
 // output implementation the assembly mounts, not here (src/components/repair.ts, RepairPolicy).
 export interface InferPolicy {
   readonly giveUpAfter: number
+  // model selects the binding for this actor. A function may interpret the actor's own input
+  // contract; an absent selection leaves the choice to the host.
+  readonly model?: ModelReference | ModelSelector
 }
+
+export interface ModelSelectionInput {
+  readonly message: Event
+  readonly input: unknown
+  readonly requested: ModelReference | undefined
+  readonly trajectory: ReadonlyArray<Event>
+}
+
+export type ModelSelector = (turn: ModelSelectionInput) => ModelReference | undefined
 
 export const DEFAULT_INFER_POLICY: InferPolicy = { giveUpAfter: 3 }
 
@@ -40,6 +53,7 @@ export const DEFAULT_INFER_POLICY: InferPolicy = { giveUpAfter: 3 }
 // about tools; the actor is the render's one owner.
 export interface InferRequest {
   readonly trajectory: ReadonlyArray<Event>
+  readonly model?: ModelReference
   readonly system: string
   readonly tools: ReadonlyArray<import("../request").ToolSpec>
   // What the render truncates and where, stated by the assembly so the binding renders against
@@ -48,6 +62,49 @@ export interface InferRequest {
   // What the turn does when native structured output is unavailable for this call, and the
   // prompt that fallback needs. Absent means the assembly selected native output.
   readonly output?: { readonly fallback: OutputFallback; readonly system?: string }
+}
+
+export interface ModelResolution {
+  readonly model: ModelReference
+  readonly contextWindowTokens?: number
+  readonly maxOutputTokens?: number
+  readonly catalogRevision?: string
+}
+
+// selectedModelOf applies the visible model-selection order for one turn. The request is durable
+// input, so its selection wins over the actor default recorded in the assembly.
+export const selectedModelOf = (
+  head: Event,
+  trajectory: ReadonlyArray<Event>,
+  policy?: ModelReference | ModelSelector
+): ModelReference | undefined => {
+  const selected = (head as { readonly model?: unknown }).model
+  const requested = typeof selected === "string" && selected !== ""
+    ? selected
+    : (
+    typeof selected === "object" &&
+    selected !== null &&
+    typeof (selected as { readonly id?: unknown }).id === "string" &&
+    (selected as { readonly id: string }).id !== "" &&
+    ((selected as { readonly connection?: unknown }).connection === undefined ||
+      typeof (selected as { readonly connection?: unknown }).connection === "string")
+  )
+      ? selected as { readonly id: string; readonly connection?: string }
+      : undefined
+  if (typeof policy === "function") {
+    return policy({
+      message: head,
+      input: (head as { readonly input?: unknown }).input,
+      requested,
+      trajectory
+    })
+  }
+  return policy ?? requested
+}
+
+const recordedModelOf = (events: ReadonlyArray<Event>): ModelReference | undefined => {
+  const selected = events.find((event) => event.type === "ModelSelected") as { readonly model?: unknown } | undefined
+  return selected?.model as ModelReference | undefined
 }
 
 const epochStamp = (epoch: number): { readonly epoch?: number } =>
@@ -64,7 +121,10 @@ const epochStamp = (epoch: number): { readonly epoch?: number } =>
 // recorded pair and the dispatch dedup absorbs the new work.
 export class Infer extends Context.Service<
   Infer,
-  { readonly react: (request: InferRequest, key?: string) => Effect.Effect<Action> }
+  {
+    readonly react: (request: InferRequest, key?: string) => Effect.Effect<Action>
+    readonly resolve?: (reference: ModelReference) => ModelResolution
+  }
 >()("agent/Infer") {}
 
 // NativeOutputSupport is compile-time evidence that an injected Infer binding declares native structured output beside tools. nativeOutput carries this requirement into the host type (components/native-output.ts).
@@ -277,8 +337,48 @@ export const inferReactorFor = (policy: Partial<InferPolicy>, render: Render): R
   const giveUpAfter = policy.giveUpAfter ?? DEFAULT_INFER_POLICY.giveUpAfter
   const slice = turnView(log)
   if (slice.length === 0 || awaitingTool(slice) || terminated(slice)) return []
-  const head = slice[0] as { id?: unknown }
+  const head = slice[0] as Event & { id?: unknown }
   const turn = String(head.id)
+  const trajectory = trajectoryOf(log)
+  const recordedModel = recordedModelOf(slice)
+  const model = recordedModel ?? selectedModelOf(head, trajectory, policy.model)
+  if (model !== undefined && recordedModel === undefined) {
+    return [
+      transition({
+        key: `ms:${turn}`,
+        input: { turn, model },
+        act: (input) =>
+          Effect.gen(function* () {
+            const at = yield* Clock.currentTimeMillis
+            const binding = yield* Infer
+            try {
+              const resolved = binding.resolve?.(input.model) ?? { model: input.model }
+              return [modelSelected({ turn: input.turn, ...resolved, at })]
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error)
+              return [
+                {
+                  type: "ModelSelectionFailed",
+                  turn: input.turn,
+                  requested: input.model,
+                  error: message,
+                  at
+                } as Event,
+                turnFailed({
+                  error: message,
+                  cause: "inference_error",
+                  attempts: 0,
+                  attemptKey: `${input.turn}/model`,
+                  policy: { model: input.model },
+                  turn: input.turn,
+                  at
+                })
+              ]
+            }
+          })
+      })
+    ]
+  }
   const epoch = turnEpochOf(log, turn)
   const died = diedAttempts(slice, epoch)
   const marks = slice.filter((e) => e.type === "ModelCalled").length
@@ -390,7 +490,8 @@ export const inferReactorFor = (policy: Partial<InferPolicy>, render: Render): R
         epoch,
         attempt,
         ordinal: marks,
-        trajectory: trajectoryOf(log),
+        trajectory,
+        model,
         render: rendered,
         // The declared policy, stamped on the ask: the contract's identity and the fallback the
         // assembly mounted. The mode the attempt actually ran in is the binding's to report, and
@@ -424,7 +525,7 @@ export const inferReactorFor = (policy: Partial<InferPolicy>, render: Render): R
             })
           ])
           const action = yield* (yield* Infer)
-            .react({ trajectory: input.trajectory, ...input.render }, input.attempt)
+            .react({ trajectory: input.trajectory, ...(input.model === undefined ? {} : { model: input.model }), ...input.render }, input.attempt)
             .pipe(
               Effect.catchCause((cause) =>
                 Cause.hasInterruptsOnly(cause)

--- a/packages/agent/src/spawn.ts
+++ b/packages/agent/src/spawn.ts
@@ -117,14 +117,24 @@ export const agentsPackage = (
     },
     docs: {
       run: {
-        description: `Brief a fresh agent. \`output\` makes the result structured and parsed: the name of a declared contract${declared_.length === 0 ? " (this host declares none)" : ` (${declared_.join(", ")})`}, or a JSON schema of your own. \`model\` picks the mind: haiku for quick, cheap work like scouting; sonnet (default) for most work; opus for the hardest judgment. \`budget\` caps the agent's tool calls: at the cap it answers with its best result, so a research agent can not run forever. \`background: true\` returns { callId } at once; result({id: callId}) awaits the reply later. \`escalatable: true\` lets the agent ask for more budget at the cap instead of answering; the run then returns { requesting, reason, amount, handle }, and you decide with continue().`,
+        description: `Brief a fresh agent. \`output\` makes the result structured and parsed: the name of a declared contract${declared_.length === 0 ? " (this host declares none)" : ` (${declared_.join(", ")})`}, or a JSON schema of your own. \`model\` accepts a model id on the default connection, or { id, connection } to select both. \`budget\` caps the agent's tool calls: at the cap it answers with its best result, so a research agent can not run forever. \`background: true\` returns { callId } at once; result({id: callId}) awaits the reply later. \`escalatable: true\` lets the agent ask for more budget at the cap instead of answering; the run then returns { requesting, reason, amount, handle }, and you decide with continue().`,
         input: {
           type: "object",
           properties: {
             text: { type: "string", description: "the brief" },
             background: { type: "boolean", description: "true: return { callId } at once, the reply arrives later via result()" },
             output: { description: "a declared contract's name, or a JSON schema for a structured answer" },
-            model: { type: "string", enum: ["haiku", "sonnet", "opus"], description: "which model runs the agent; default sonnet" },
+            model: {
+              oneOf: [
+                { type: "string" },
+                {
+                  type: "object",
+                  properties: { id: { type: "string" }, connection: { type: "string" } },
+                  required: ["id"]
+                }
+              ],
+              description: "a model id on the default connection, or { id, connection }"
+            },
             budget: { type: "integer", description: "max tool calls before the agent must answer, a whole number of calls; keeps a research agent bounded" },
             escalatable: { type: "boolean", description: "true: at its budget the agent may ask for more instead of answering; the run returns a request you resolve with continue()" }
           },
@@ -195,7 +205,21 @@ export const agentsPackage = (
           const outputDeclaration = output === undefined ? undefined : { name: output.name, schema: output.schema }
           // The model name rides the brief's envelope: the child's log records the choice, so its
           // Infer resolves it from trajectory and replay agrees by construction.
-          const model = a?.model === "haiku" || a?.model === "sonnet" || a?.model === "opus" ? a.model : undefined
+          const model = (() => {
+            if (a?.model === undefined) return undefined
+            if (typeof a.model === "string" && a.model.trim().length > 0) return a.model.trim()
+            if (typeof a.model !== "object" || a.model === null) return undefined
+            const reference = a.model as { readonly id?: unknown; readonly connection?: unknown }
+            if (typeof reference.id !== "string" || reference.id.trim().length === 0) return undefined
+            if (reference.connection !== undefined && (typeof reference.connection !== "string" || reference.connection.trim().length === 0)) return undefined
+            return {
+              id: reference.id.trim(),
+              ...(reference.connection === undefined ? {} : { connection: reference.connection.trim() })
+            }
+          })()
+          if (a?.model !== undefined && model === undefined) {
+            return { error: "agents.run takes model as a non-empty id or { id, connection }" }
+          }
           // asked is the tool-call budget carried on the brief. It accepts a whole positive count
           // because rounding could turn a requested child into an exhausted run (spawn.test.ts,
           // "a fractional budget"). An absent budget takes the per-agent default.

--- a/platform/cloudflare/src/worker.ts
+++ b/platform/cloudflare/src/worker.ts
@@ -3,7 +3,8 @@ import { Context, Effect, Layer, ManagedRuntime } from "effect"
 import { FetchHttpClient, HttpEffect, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { actor, agentsPackage, budget, codeMode, compaction, fetchPackage, Infer, infer as inferAgent, outputValidateOnce, reply, workspacePackage } from "tardie"
 import type { Action } from "tardie/events"
-import { infer, modelAskOf, modelContextWindowTokensOf, modelIdOf } from "@clavia/tardigrade-model/model"
+import { infer, modelContextWindowTokensOf, modelIdOf } from "@clavia/tardigrade-model/model"
+import { modelDriverOf } from "@clavia/tardigrade-model/connection"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { traceparentOf } from "@clavia/tardigrade-core/trace"
 import { mappedDirectory } from "@clavia/tardigrade-core/communication/directory"
@@ -34,6 +35,8 @@ export interface Env {
   readonly MODEL_BASE_URL?: string
   readonly MODEL_API_KEY?: string
   readonly MODEL_ID?: string
+  readonly MODEL_DRIVER?: string
+  readonly MODEL_CONNECTION?: string
   readonly MODEL_SONNET_ID?: string
   readonly MODEL_OPUS_ID?: string
   readonly MODEL_HAIKU_ID?: string
@@ -65,6 +68,7 @@ export const DEFAULT_ACTOR_REGISTRATION: CloudflareActorRegistration = {
 }
 
 const assemblies = new Set([DEFAULT_ACTOR_REGISTRATION.assembly])
+export const DEFAULT_MODEL_CONNECTION = "default"
 const registryRuntimes = new WeakMap<D1Database, ManagedRuntime.ManagedRuntime<CloudflareActorRegistry, never>>()
 
 const actorRegistry = async (env: Env) => {
@@ -81,18 +85,28 @@ const actorRegistry = async (env: Env) => {
 }
 
 const modelLayer = (env: Env) => {
-  if (env.MODEL_BASE_URL === undefined || env.MODEL_API_KEY === undefined || env.MODEL_ID === undefined) {
+  if (env.MODEL_BASE_URL === undefined || env.MODEL_API_KEY === undefined || env.MODEL_ID === undefined || env.MODEL_DRIVER === undefined) {
     const failed: Action = { kind: "fail", error: "no model is configured", failure: { cause: "inference_error", attempts: 1 } }
     return Layer.succeed(Infer)({ react: () => Effect.succeed(failed) })
   }
   const baseUrl = env.MODEL_BASE_URL
   const apiKey = env.MODEL_API_KEY
+  const driver = modelDriverOf(env.MODEL_DRIVER)
   return Layer.succeed(Infer, {
     react: (request, key) => {
+      const asked = request.model
+      if (typeof asked === "object" && asked.connection !== undefined && asked.connection !== (env.MODEL_CONNECTION ?? DEFAULT_MODEL_CONNECTION)) {
+        return Effect.succeed({
+          kind: "fail" as const,
+          error: `unknown model connection ${JSON.stringify(asked.connection)}`,
+          failure: { cause: "inference_error" as const, attempts: 0 }
+        })
+      }
       const selected = infer({
         baseUrl,
         apiKey,
-        model: modelIdOf(env, modelAskOf(request.trajectory)),
+        model: modelIdOf(env, typeof asked === "string" ? asked : asked?.id),
+        driver,
         ...(env.MODEL_PROVIDER === undefined ? {} : { provider: env.MODEL_PROVIDER })
       })
       return Effect.flatMap(Infer, (model) => model.react(request, key)).pipe(Effect.provide(selected))
@@ -137,7 +151,7 @@ const assemblyOf = (name: string, env: Env) => {
     reply,
     budget,
     compaction({
-      contextWindowTokens: (model) => modelContextWindowTokensOf(env, model),
+      contextWindowTokens: (model) => modelContextWindowTokensOf(env, typeof model === "string" ? model : model?.id),
       ...(fireRatio === undefined ? {} : { fireRatio }),
       ...(keepRatio === undefined ? {} : { keepRatio })
     }),

--- a/platform/cloudflare/wrangler.jsonc
+++ b/platform/cloudflare/wrangler.jsonc
@@ -17,7 +17,8 @@
   "observability": { "enabled": true },
   "limits": { "cpu_ms": 300000 },
   "vars": {
-    "MODEL_CONTEXT_WINDOW_TOKENS": "1000000",
+    "MODEL_DRIVER": "openai-responses",
+    "MODEL_CONTEXT_WINDOW_TOKENS": "1050000",
     "TARDIGRADE_COMPACTION_FIRE_RATIO": "0.8",
     "TARDIGRADE_COMPACTION_KEEP_RATIO": "0.5",
     "TARDIGRADE_MAX_CONCURRENT_LANES": "4"

--- a/platform/model/package.json
+++ b/platform/model/package.json
@@ -29,15 +29,16 @@
     "./*": "./src/*.ts"
   },
   "dependencies": {
-    "@clavia/tardigrade-core": "workspace:*",
-    "tardie": "workspace:*",
     "@aws-sdk/client-bedrock-runtime": "^3.1079.0",
+    "@clavia/tardigrade-core": "workspace:*",
     "@smithy/fetch-http-handler": "^5.6.3",
     "@smithy/node-http-handler": "^4.11.2",
     "@tanstack/ai": "0.46.0",
+    "@tanstack/ai-anthropic": "0.16.6",
     "@tanstack/ai-bedrock": "0.2.3",
     "@tanstack/ai-openai": "0.20.0",
-    "effect": "4.0.0-rc.110"
+    "effect": "4.0.0-rc.110",
+    "tardie": "workspace:*"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/platform/model/src/connection.test.ts
+++ b/platform/model/src/connection.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test"
+import {
+  amazonBedrock,
+  anthropic,
+  azureAI,
+  cloudflareAIGateway,
+  googleVertexAI,
+  modelCatalog,
+  modelDriverOf,
+  openAI,
+  openAICompatible,
+  openRouter,
+  vercelAIGateway
+} from "./connection"
+import { declaredModelMetadata } from "./metadata"
+
+describe("model connections", () => {
+  test("each supported service states its protocol driver", () => {
+    expect(vercelAIGateway().driver).toBe("openai-responses")
+    expect(cloudflareAIGateway().driver).toBe("openai-responses")
+    expect(amazonBedrock().driver).toBe("bedrock-converse")
+    expect(azureAI().driver).toBe("openai-responses")
+    expect(googleVertexAI().driver).toBe("openai-chat-completions")
+    expect(openAI().driver).toBe("openai-responses")
+    expect(anthropic().driver).toBe("anthropic-messages")
+    expect(openRouter().driver).toBe("openai-chat-completions")
+    expect(openAICompatible({ baseUrl: "https://models.example/v1" }).driver).toBe("openai-chat-completions")
+  })
+
+  test("a connection can state another protocol the endpoint supports", () => {
+    expect(vercelAIGateway({ driver: "anthropic-messages" }).driver).toBe("anthropic-messages")
+    expect(modelDriverOf("openai-responses")).toBe("openai-responses")
+    expect(() => modelDriverOf("provider-name")).toThrow("model driver must be one of")
+  })
+})
+
+describe("model catalog", () => {
+  const catalog = modelCatalog({
+    revision: "catalog-7",
+    default: { id: "openai/gpt-5.6-luna", connection: "managed" },
+    connections: { managed: cloudflareAIGateway() },
+    models: {
+      default: {
+        id: "openai/gpt-5.6-luna",
+        connection: "managed",
+        metadata: declaredModelMetadata({
+          contextWindowTokens: 1_050_000,
+          maxOutputTokens: 128_000,
+          output: { guarantee: "native", withTools: true }
+        }, "deployment")
+      }
+    }
+  })
+
+  test("a logical name resolves route, limits, capability, and revision together", () => {
+    expect(catalog.resolve("default")).toMatchObject({
+      name: "default",
+      id: "openai/gpt-5.6-luna",
+      connection: "managed",
+      contextWindowTokens: 1_050_000,
+      maxOutputTokens: 128_000,
+      output: { guarantee: "native", withTools: true },
+      catalogRevision: "catalog-7",
+      route: { kind: "cloudflare-ai-gateway", driver: "openai-responses" },
+      metadata: { contextWindowTokens: { source: { kind: "declared", owner: "deployment" } } }
+    })
+  })
+
+  test("an explicit id and connection still requires catalog metadata", () => {
+    expect(catalog.resolve()).toMatchObject({ id: "openai/gpt-5.6-luna", connection: "managed" })
+    expect(catalog.resolve("openai/gpt-5.6-luna")).toMatchObject({ connection: "managed" })
+    expect(catalog.resolve({ id: "openai/gpt-5.6-luna", connection: "managed" }).name).toBe("default")
+    expect(() => catalog.resolve({ id: "unknown", connection: "managed" })).toThrow("has no declared metadata")
+    expect(() => catalog.resolve("unknown")).toThrow("has no declared metadata")
+  })
+
+  test("construction rejects incomplete coordinates and policy", () => {
+    expect(() => modelCatalog({
+      revision: "",
+      connections: {},
+      models: {}
+    })).toThrow("revision cannot be empty")
+    expect(() => modelCatalog({
+      revision: "r1",
+      connections: {},
+      models: {
+        broken: {
+          id: "m",
+          connection: "missing",
+          metadata: declaredModelMetadata({ contextWindowTokens: 1 }, "test")
+        }
+      }
+    })).toThrow("unknown connection")
+  })
+})

--- a/platform/model/src/connection.ts
+++ b/platform/model/src/connection.ts
@@ -1,0 +1,193 @@
+import type { OutputCapability } from "./output"
+import type { ModelMetadata, MetadataValue } from "./metadata"
+import type { ModelReference } from "tardie"
+
+export type { ModelReference } from "tardie"
+
+export const MODEL_DRIVERS = [
+  "openai-responses",
+  "openai-chat-completions",
+  "anthropic-messages",
+  "bedrock-converse"
+] as const
+
+export type ModelDriver = (typeof MODEL_DRIVERS)[number]
+
+export const modelDriverOf = (value: string): ModelDriver => {
+  if ((MODEL_DRIVERS as ReadonlyArray<string>).includes(value)) return value as ModelDriver
+  throw new Error(`model driver must be one of ${MODEL_DRIVERS.join(", ")}, got ${JSON.stringify(value)}`)
+}
+
+export const MODEL_CONNECTION_KINDS = [
+  "vercel-ai-gateway",
+  "cloudflare-ai-gateway",
+  "amazon-bedrock",
+  "azure-ai",
+  "google-vertex-ai",
+  "openai",
+  "anthropic",
+  "openrouter",
+  "openai-compatible"
+] as const
+
+export type ModelConnectionKind = (typeof MODEL_CONNECTION_KINDS)[number]
+
+export interface ModelConnection {
+  readonly kind: ModelConnectionKind
+  readonly driver: ModelDriver
+  readonly baseUrl?: string
+  readonly provider?: string
+  readonly modelListUrl?: string
+  readonly credential: string
+}
+
+export interface ModelConnectionOptions {
+  readonly baseUrl?: string
+  readonly driver?: ModelDriver
+}
+
+const connection = (
+  kind: ModelConnectionKind,
+  driver: ModelDriver,
+  credential: string,
+  options: ModelConnectionOptions = {},
+  defaults: { readonly baseUrl?: string; readonly provider?: string; readonly modelListUrl?: string } = {}
+): ModelConnection => ({
+  kind,
+  driver: options.driver ?? driver,
+  credential,
+  ...((options.baseUrl ?? defaults.baseUrl) === undefined ? {} : { baseUrl: options.baseUrl ?? defaults.baseUrl }),
+  ...(defaults.provider === undefined ? {} : { provider: defaults.provider }),
+  ...(defaults.modelListUrl === undefined ? {} : { modelListUrl: defaults.modelListUrl })
+})
+
+export const vercelAIGateway = (options: ModelConnectionOptions = {}): ModelConnection =>
+  connection("vercel-ai-gateway", "openai-responses", "Vercel AI Gateway API key", options, {
+    baseUrl: "https://ai-gateway.vercel.sh/v1",
+    provider: "vercel-ai-gateway",
+    modelListUrl: "https://ai-gateway.vercel.sh/v1/models"
+  })
+
+export const cloudflareAIGateway = (options: ModelConnectionOptions = {}): ModelConnection =>
+  connection("cloudflare-ai-gateway", "openai-responses", "Cloudflare API token", options, {
+    provider: "cloudflare-ai-gateway"
+  })
+
+export const amazonBedrock = (options: ModelConnectionOptions = {}): ModelConnection =>
+  connection("amazon-bedrock", "bedrock-converse", "AWS or AI Gateway credential", options, { provider: "bedrock" })
+
+export const azureAI = (options: ModelConnectionOptions = {}): ModelConnection =>
+  connection("azure-ai", "openai-responses", "Azure AI API key or token", options, { provider: "azure-ai" })
+
+export const googleVertexAI = (options: ModelConnectionOptions = {}): ModelConnection =>
+  connection("google-vertex-ai", "openai-chat-completions", "Google access token", options, { provider: "google-vertex-ai" })
+
+export const openAI = (options: ModelConnectionOptions = {}): ModelConnection =>
+  connection("openai", "openai-responses", "OpenAI API key", options, {
+    baseUrl: "https://api.openai.com/v1",
+    provider: "openai",
+    modelListUrl: "https://api.openai.com/v1/models"
+  })
+
+export const anthropic = (options: ModelConnectionOptions = {}): ModelConnection =>
+  connection("anthropic", "anthropic-messages", "Anthropic API key", options, {
+    baseUrl: "https://api.anthropic.com",
+    provider: "anthropic",
+    modelListUrl: "https://api.anthropic.com/v1/models"
+  })
+
+export const openRouter = (options: ModelConnectionOptions = {}): ModelConnection =>
+  connection("openrouter", "openai-chat-completions", "OpenRouter API key", options, {
+    baseUrl: "https://openrouter.ai/api/v1",
+    provider: "openrouter",
+    modelListUrl: "https://openrouter.ai/api/v1/models"
+  })
+
+export const openAICompatible = (
+  options: ModelConnectionOptions & { readonly baseUrl: string }
+): ModelConnection => connection("openai-compatible", "openai-chat-completions", "API key", options)
+
+export interface ModelDefinition {
+  readonly id: string
+  readonly connection: string
+  readonly metadata: ModelMetadata & { readonly contextWindowTokens: MetadataValue<number> }
+}
+
+export interface ModelCatalogConfig {
+  readonly revision: string
+  readonly default?: ModelReference
+  readonly connections: Readonly<Record<string, ModelConnection>>
+  readonly models: Readonly<Record<string, ModelDefinition>>
+}
+
+export interface ResolvedModel {
+  readonly name: string
+  readonly id: string
+  readonly connection: string
+  readonly route: ModelConnection
+  readonly contextWindowTokens: number
+  readonly maxOutputTokens?: number
+  readonly output?: OutputCapability
+  readonly metadata: ModelMetadata & { readonly contextWindowTokens: MetadataValue<number> }
+  readonly catalogRevision: string
+}
+
+const positiveInteger = (value: number, name: string): number => {
+  if (!Number.isSafeInteger(value) || value <= 0) throw new Error(`${name} must be a positive integer, got ${value}`)
+  return value
+}
+
+export const modelCatalog = (config: ModelCatalogConfig) => {
+  if (config.revision.trim().length === 0) throw new Error("model catalog revision cannot be empty")
+  for (const [name, definition] of Object.entries(config.models)) {
+    if (definition.id.trim().length === 0) throw new Error(`model ${JSON.stringify(name)} has an empty id`)
+    if (config.connections[definition.connection] === undefined) {
+      throw new Error(`model ${JSON.stringify(name)} names unknown connection ${JSON.stringify(definition.connection)}`)
+    }
+    positiveInteger(definition.metadata.contextWindowTokens.value, `model ${JSON.stringify(name)} contextWindowTokens`)
+    if (definition.metadata.maxOutputTokens !== undefined) {
+      positiveInteger(definition.metadata.maxOutputTokens.value, `model ${JSON.stringify(name)} maxOutputTokens`)
+    }
+  }
+  const defaultConnection = (): string | undefined => {
+    if (typeof config.default === "object") return config.default.connection
+    if (typeof config.default === "string") return config.models[config.default]?.connection
+    return undefined
+  }
+  const resolved = (name: string, definition: ModelDefinition): ResolvedModel => ({
+    name,
+    id: definition.id,
+    connection: definition.connection,
+    route: config.connections[definition.connection]!,
+    contextWindowTokens: definition.metadata.contextWindowTokens.value,
+    ...(definition.metadata.maxOutputTokens === undefined ? {} : { maxOutputTokens: definition.metadata.maxOutputTokens.value }),
+    ...(definition.metadata.output === undefined ? {} : { output: definition.metadata.output.value }),
+    metadata: definition.metadata,
+    catalogRevision: config.revision
+  })
+  return {
+    revision: config.revision,
+    list: (): ReadonlyArray<string> => Object.keys(config.models).sort(),
+    resolve: (reference?: ModelReference): ResolvedModel => {
+      const selected = reference ?? config.default
+      if (selected === undefined) throw new Error("no default model is configured")
+      if (typeof selected === "string") {
+        const named = config.models[selected]
+        if (named !== undefined) return resolved(selected, named)
+      }
+      const asked = typeof selected === "string" ? { id: selected } : selected
+      const connection = asked.connection ?? defaultConnection()
+      if (connection === undefined) {
+        throw new Error(`model ${JSON.stringify(asked.id)} requires a connection because no default connection is configured`)
+      }
+      const route = config.connections[connection]
+      if (route === undefined) throw new Error(`unknown model connection ${JSON.stringify(connection)}`)
+      const exact = Object.entries(config.models).find(([, model]) => model.id === asked.id && model.connection === connection)
+      if (exact === undefined) {
+        throw new Error(`model ${JSON.stringify(asked.id)} on connection ${JSON.stringify(connection)} has no declared metadata`)
+      }
+      const [name, definition] = exact
+      return resolved(name, definition)
+    }
+  }
+}

--- a/platform/model/src/metadata.test.ts
+++ b/platform/model/src/metadata.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test"
+import {
+  declaredModelMetadata,
+  discoveredModelsOf,
+  mergeModelMetadata,
+  metadataValue,
+  requireModelMetadata,
+  type ModelMetadataSource
+} from "./metadata"
+
+const source: ModelMetadataSource = {
+  kind: "discovered",
+  url: "https://gateway.example/v1/models",
+  revision: "etag-1"
+}
+
+describe("model metadata", () => {
+  test("rich OpenAI-style model rows preserve values and provenance", () => {
+    expect(discoveredModelsOf({
+      data: [{
+        id: "provider/model",
+        name: "A model",
+        context_length: 200_000,
+        top_provider: { max_completion_tokens: 32_000 },
+        architecture: { input_modalities: ["text", "image"], output_modalities: ["text"] },
+        supported_parameters: ["tools", "structured_outputs"],
+        pricing: { prompt: "0.000003", completion: "0.000015", input_cache_read: "0.0000003" }
+      }]
+    }, source)).toEqual([{
+      id: "provider/model",
+      name: "A model",
+      metadata: {
+        contextWindowTokens: metadataValue(200_000, source),
+        maxOutputTokens: metadataValue(32_000, source),
+        inputModalities: metadataValue(["text", "image"], source),
+        outputModalities: metadataValue(["text"], source),
+        output: metadataValue({ guarantee: "native", withTools: true }, source),
+        pricing: metadataValue({
+          promptUsdPerToken: 0.000003,
+          completionUsdPerToken: 0.000015,
+          cachedPromptUsdPerToken: 0.0000003
+        }, source)
+      }
+    }])
+  })
+
+  test("sparse catalogs remain sparse and require an explicit context declaration", () => {
+    const [model] = discoveredModelsOf({ data: [{ id: "model-only" }] }, source)
+    expect(model).toEqual({ id: "model-only", metadata: {} })
+    expect(() => requireModelMetadata(model!)).toThrow("has no declared context window")
+  })
+
+  test("later metadata layers override individual fields and keep their source", () => {
+    const discovered = discoveredModelsOf({ data: [{ id: "m", context_window: 100_000, max_tokens: 8_000 }] }, source)[0]!
+    const declared = declaredModelMetadata({ contextWindowTokens: 120_000 }, "operator")
+    const merged = mergeModelMetadata(discovered.metadata, declared)
+    expect(merged.contextWindowTokens).toEqual({ value: 120_000, source: { kind: "declared", owner: "operator" } })
+    expect(merged.maxOutputTokens).toEqual({ value: 8_000, source })
+  })
+
+  test("declared policy rejects invalid token limits", () => {
+    expect(() => declaredModelMetadata({ contextWindowTokens: 0 }, "operator")).toThrow("positive integer")
+    expect(() => declaredModelMetadata({ contextWindowTokens: 100, maxOutputTokens: -1 }, "operator")).toThrow("positive integer")
+  })
+})

--- a/platform/model/src/metadata.ts
+++ b/platform/model/src/metadata.ts
@@ -1,0 +1,173 @@
+import type { OutputCapability } from "./output"
+import type { ModelPricing } from "tardie/usage"
+
+export type ModelMetadataSource =
+  | { readonly kind: "declared"; readonly owner: string }
+  | { readonly kind: "discovered"; readonly url: string; readonly revision?: string }
+  | { readonly kind: "managed"; readonly catalog: string; readonly revision: string }
+
+export interface MetadataValue<T> {
+  readonly value: T
+  readonly source: ModelMetadataSource
+}
+
+export interface ModelMetadata {
+  readonly contextWindowTokens?: MetadataValue<number>
+  readonly maxOutputTokens?: MetadataValue<number>
+  readonly pricing?: MetadataValue<ModelPricing>
+  readonly output?: MetadataValue<OutputCapability>
+  readonly inputModalities?: MetadataValue<ReadonlyArray<string>>
+  readonly outputModalities?: MetadataValue<ReadonlyArray<string>>
+}
+
+export interface DiscoveredModel {
+  readonly id: string
+  readonly name?: string
+  readonly metadata: ModelMetadata
+}
+
+export interface DeclaredModelMetadata {
+  readonly contextWindowTokens: number
+  readonly maxOutputTokens?: number
+  readonly pricing?: ModelPricing
+  readonly output?: OutputCapability
+  readonly inputModalities?: ReadonlyArray<string>
+  readonly outputModalities?: ReadonlyArray<string>
+}
+
+export const metadataValue = <T>(value: T, source: ModelMetadataSource): MetadataValue<T> => ({ value, source })
+
+export const declaredModelMetadata = (
+  values: DeclaredModelMetadata,
+  owner: string
+): ModelMetadata & { readonly contextWindowTokens: MetadataValue<number> } => {
+  const source: ModelMetadataSource = { kind: "declared", owner }
+  if (!Number.isSafeInteger(values.contextWindowTokens) || values.contextWindowTokens <= 0) {
+    throw new Error(`contextWindowTokens must be a positive integer, got ${values.contextWindowTokens}`)
+  }
+  if (values.maxOutputTokens !== undefined && (!Number.isSafeInteger(values.maxOutputTokens) || values.maxOutputTokens <= 0)) {
+    throw new Error(`maxOutputTokens must be a positive integer, got ${values.maxOutputTokens}`)
+  }
+  return {
+    contextWindowTokens: metadataValue(values.contextWindowTokens, source),
+    ...(values.maxOutputTokens === undefined ? {} : { maxOutputTokens: metadataValue(values.maxOutputTokens, source) }),
+    ...(values.pricing === undefined ? {} : { pricing: metadataValue(values.pricing, source) }),
+    ...(values.output === undefined ? {} : { output: metadataValue(values.output, source) }),
+    ...(values.inputModalities === undefined ? {} : { inputModalities: metadataValue(values.inputModalities, source) }),
+    ...(values.outputModalities === undefined ? {} : { outputModalities: metadataValue(values.outputModalities, source) })
+  }
+}
+
+export const mergeModelMetadata = (...layers: ReadonlyArray<ModelMetadata>): ModelMetadata => {
+  const merged: ModelMetadata = {}
+  for (const layer of layers) Object.assign(merged, layer)
+  return merged
+}
+
+const recordOf = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === "object" && value !== null ? value as Record<string, unknown> : undefined
+
+const positiveNumber = (value: unknown): number | undefined => {
+  const number = typeof value === "number" ? value : typeof value === "string" && value.trim() !== "" ? Number(value) : NaN
+  return Number.isFinite(number) && number > 0 ? number : undefined
+}
+
+const positiveInteger = (value: unknown): number | undefined => {
+  const number = positiveNumber(value)
+  return number !== undefined && Number.isSafeInteger(number) ? number : undefined
+}
+
+const firstInteger = (record: Record<string, unknown>, names: ReadonlyArray<string>): number | undefined => {
+  for (const name of names) {
+    const value = positiveInteger(record[name])
+    if (value !== undefined) return value
+  }
+  return undefined
+}
+
+const strings = (value: unknown): ReadonlyArray<string> | undefined => {
+  if (!Array.isArray(value)) return undefined
+  const found = value.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0).map((entry) => entry.trim())
+  return found.length === 0 ? undefined : found
+}
+
+const pricingOf = (value: unknown): ModelPricing | undefined => {
+  const record = recordOf(value)
+  if (record === undefined) return undefined
+  const promptUsdPerToken = positiveNumber(record["prompt"] ?? record["input"])
+  const completionUsdPerToken = positiveNumber(record["completion"] ?? record["output"])
+  if (promptUsdPerToken === undefined || completionUsdPerToken === undefined) return undefined
+  const cachedPromptUsdPerToken = positiveNumber(record["input_cache_read"] ?? record["cached_prompt"])
+  const cacheWritePromptUsdPerToken = positiveNumber(record["input_cache_write"] ?? record["cache_write_prompt"])
+  return {
+    promptUsdPerToken,
+    completionUsdPerToken,
+    ...(cachedPromptUsdPerToken === undefined ? {} : { cachedPromptUsdPerToken }),
+    ...(cacheWritePromptUsdPerToken === undefined ? {} : { cacheWritePromptUsdPerToken })
+  }
+}
+
+const outputOf = (value: unknown): OutputCapability | undefined => {
+  const parameters = strings(value)
+  if (parameters === undefined) return undefined
+  if (!parameters.includes("structured_outputs") && !parameters.includes("response_format")) return undefined
+  return { guarantee: "native", withTools: parameters.includes("tools") }
+}
+
+export const discoveredModelOf = (raw: unknown, source: ModelMetadataSource): DiscoveredModel | undefined => {
+  const record = recordOf(raw)
+  if (record === undefined || typeof record["id"] !== "string" || record["id"].trim().length === 0) return undefined
+  const top = recordOf(record["top_provider"])
+  const architecture = recordOf(record["architecture"])
+  const contextWindowTokens = firstInteger(record, ["context_window", "context_length", "context_window_tokens"])
+    ?? (top === undefined ? undefined : firstInteger(top, ["context_length"]))
+  const maxOutputTokens = firstInteger(record, ["max_tokens", "max_output_tokens", "max_completion_tokens"])
+    ?? (top === undefined ? undefined : firstInteger(top, ["max_completion_tokens"]))
+  const pricing = pricingOf(record["pricing"])
+  const output = outputOf(record["supported_parameters"])
+  const inputModalities = strings(record["input_modalities"])
+    ?? (architecture === undefined ? undefined : strings(architecture["input_modalities"]))
+  const outputModalities = strings(record["output_modalities"])
+    ?? (architecture === undefined ? undefined : strings(architecture["output_modalities"]))
+  const name = typeof record["name"] === "string" && record["name"].trim().length > 0 ? record["name"].trim() : undefined
+  return {
+    id: record["id"].trim(),
+    ...(name === undefined ? {} : { name }),
+    metadata: {
+      ...(contextWindowTokens === undefined ? {} : { contextWindowTokens: metadataValue(contextWindowTokens, source) }),
+      ...(maxOutputTokens === undefined ? {} : { maxOutputTokens: metadataValue(maxOutputTokens, source) }),
+      ...(pricing === undefined ? {} : { pricing: metadataValue(pricing, source) }),
+      ...(output === undefined ? {} : { output: metadataValue(output, source) }),
+      ...(inputModalities === undefined ? {} : { inputModalities: metadataValue(inputModalities, source) }),
+      ...(outputModalities === undefined ? {} : { outputModalities: metadataValue(outputModalities, source) })
+    }
+  }
+}
+
+export const discoveredModelsOf = (raw: unknown, source: ModelMetadataSource): ReadonlyArray<DiscoveredModel> => {
+  const record = recordOf(raw)
+  if (record === undefined) return []
+  const rows = Array.isArray(record["data"]) ? record["data"] : Array.isArray(record["models"]) ? record["models"] : []
+  const found = new Map<string, DiscoveredModel>()
+  for (const row of rows) {
+    if (typeof row === "string") {
+      const id = row.trim()
+      if (id.length > 0) found.set(id, { id, metadata: {} })
+      continue
+    }
+    const model = discoveredModelOf(row, source)
+    if (model !== undefined) found.set(model.id, model)
+  }
+  return [...found.values()].sort((left, right) => left.id.localeCompare(right.id))
+}
+
+export const requireModelMetadata = (model: DiscoveredModel): DiscoveredModel & {
+  readonly metadata: ModelMetadata & { readonly contextWindowTokens: MetadataValue<number> }
+} => {
+  if (model.metadata.contextWindowTokens === undefined) {
+    throw new Error(`model ${JSON.stringify(model.id)} has no declared context window`)
+  }
+  return model as DiscoveredModel & {
+    readonly metadata: ModelMetadata & { readonly contextWindowTokens: MetadataValue<number> }
+  }
+}

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -31,6 +31,8 @@ import {
   tapStopReason,
   throttleDelayMs
 } from "./model"
+import type { ModelConfig } from "./model"
+import type { ModelDriver } from "./connection"
 import {
   capabilityOf,
   converseOutputConfig,
@@ -40,6 +42,9 @@ import {
 } from "./output"
 import type { Action } from "tardie/events"
 import type { Event } from "@clavia/tardigrade-core/event"
+
+const testInfer = <const C extends Omit<ModelConfig, "driver"> & { readonly driver?: ModelDriver }>(config: C) =>
+  infer({ driver: "openai-chat-completions", ...config })
 
 // The model binding: the trajectory renders into the provider conversation, the streamed reply
 // decodes into one Action, and the whole loop round-trips through a fake OpenAI-compatible SSE
@@ -176,7 +181,7 @@ describe("the Converse output surface", () => {
   })
 
   test("buildInput sets the native surface, and never a forced tool", () => {
-    const config = { baseUrl: "https://bedrock.test/us-east-1", apiKey: "k", model: "anthropic.claude-sonnet", provider: "bedrock" }
+    const config = { baseUrl: "https://bedrock.test/us-east-1", apiKey: "k", model: "anthropic.claude-sonnet", driver: "bedrock-converse" as const, provider: "bedrock" }
     const options = { model: config.model, messages: [{ role: "user", content: "go" }], systemPrompts: ["be brief"], tools: [] }
     const withContract = bedrockAdapter(config, 4096, DEFAULT_STREAM_BOUNDS, request, NATIVE_MODE).buildInput(options as never)
     expect(withContract.outputConfig).toEqual(converseOutputConfig(request, NATIVE_MODE)!)
@@ -274,7 +279,7 @@ describe("infer end to end", () => {
         { id: "r1", choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] }
       ])
     }) as typeof globalThis.fetch
-    const layer = infer({
+    const layer = testInfer({
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "test-model",
@@ -299,7 +304,7 @@ describe("infer end to end", () => {
         { id: "r2", choices: [{ index: 0, delta: { content: "is 4" } }] },
         { id: "r2", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }
       ])) as unknown as typeof globalThis.fetch
-    const layer = infer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "test-model", fetch: fetchImpl })
+    const layer = testInfer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "test-model", fetch: fetchImpl })
     const action = await Effect.runPromise(
       Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "2+2?", at: 1 }]))).pipe(
         Effect.provide(layer)
@@ -330,7 +335,7 @@ describe("infer end to end", () => {
         { id: "r3", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }
       ])
     }) as typeof globalThis.fetch
-    const layer = infer({
+    const layer = testInfer({
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "gpt-5.2",
@@ -404,7 +409,7 @@ describe("infer end to end", () => {
       return sse([])
     }) as unknown as typeof globalThis.fetch
     // No provider name and no declared capability: the endpoint promises nothing.
-    const layer = infer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "mystery", fetch: fetchImpl })
+    const layer = testInfer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "mystery", fetch: fetchImpl })
     const action = (await Effect.runPromise(
       Effect.flatMap(Infer, (model) => model.react(reqOf(declared()))).pipe(Effect.provide(layer)) as Effect.Effect<unknown>
     )) as Action
@@ -432,7 +437,7 @@ describe("infer end to end", () => {
         { id: "r5", choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 11, completion_tokens: 0 } }
       ])
     }) as unknown as typeof globalThis.fetch
-    const layer = infer({
+    const layer = testInfer({
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "m",
@@ -460,7 +465,7 @@ describe("infer end to end", () => {
         { id: "r6", choices: [{ index: 0, delta: { role: "assistant" } }] },
         { id: "r6", choices: [{ index: 0, delta: {}, finish_reason: "content_filter" }] }
       ])) as unknown as typeof globalThis.fetch
-    const layer = infer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "m", fetch: fetchImpl, sleep: async () => {} })
+    const layer = testInfer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "m", fetch: fetchImpl, sleep: async () => {} })
     const action = (await Effect.runPromise(
       Effect.flatMap(Infer, (model) =>
         model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))
@@ -478,7 +483,7 @@ describe("infer end to end", () => {
         { id: "r7", choices: [{ index: 0, delta: { role: "assistant", content: ANSWER } }] },
         { id: "r7", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }
       ])) as unknown as typeof globalThis.fetch
-    const layer = infer({
+    const layer = testInfer({
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "gpt-5.2",
@@ -499,7 +504,7 @@ describe("infer end to end", () => {
         { id: "r8", provider: "Anthropic", model: "claude-sonnet-4.5", choices: [{ index: 0, delta: { role: "assistant", content: "ok" } }] },
         { id: "r8", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }
       ])) as unknown as typeof globalThis.fetch
-    const layer = infer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "auto", provider: "openrouter", fetch: fetchImpl })
+    const layer = testInfer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "auto", provider: "openrouter", fetch: fetchImpl })
     const action = (await Effect.runPromise(
       Effect.flatMap(Infer, (model) =>
         model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))
@@ -523,7 +528,7 @@ describe("infer end to end", () => {
         { id: "r3", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }
       ])
     }) as typeof globalThis.fetch
-    const layer = infer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "test-model", fetch: fetchImpl })
+    const layer = testInfer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "test-model", fetch: fetchImpl })
     const trajectory = [{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]
     await Effect.runPromise(
       Effect.flatMap(Infer, (model) => model.react(reqOf(trajectory), "m1/infer/0")).pipe(Effect.provide(layer)) as Effect.Effect<unknown>
@@ -556,7 +561,7 @@ describe("infer: cost provenance", () => {
     const billed = await Effect.runPromise(
       Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
         Effect.provide(
-          infer({
+          testInfer({
             baseUrl: "https://model.test/v1",
             apiKey: "k",
             model: "test-model",
@@ -590,7 +595,7 @@ describe("infer: cost provenance", () => {
     const filled = await Effect.runPromise(
       Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
         Effect.provide(
-          infer({
+          testInfer({
             baseUrl: "https://model.test/v1",
             apiKey: "k",
             model: "test-model",
@@ -621,7 +626,7 @@ describe("infer: cost provenance", () => {
     const unknown = await Effect.runPromise(
       Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
         Effect.provide(
-          infer({
+          testInfer({
             baseUrl: "https://model.test/v1",
             apiKey: "k",
             model: "test-model",
@@ -647,7 +652,7 @@ describe("infer: cost provenance", () => {
         model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))
       ).pipe(
         Effect.provide(
-          infer({
+          testInfer({
             baseUrl: "https://model.test/v1",
             apiKey: "k",
             model: "test-model",
@@ -688,7 +693,7 @@ describe("infer: throttle-shaped retry", () => {
     const slept: Array<number> = []
     const seed = "throttle retry"
     const expectedDelay = Effect.runSync(Random.next.pipe(Random.withSeed(seed))) * 2_000
-    const layer = infer({
+    const layer = testInfer({
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "test-model",
@@ -729,7 +734,7 @@ describe("infer: throttle-shaped retry", () => {
     const slept: Array<number> = []
     const seed = "clock retry"
     const expectedDelay = Effect.runSync(Random.next.pipe(Random.withSeed(seed))) * 2_000
-    const layer = infer({
+    const layer = testInfer({
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "test-model",
@@ -766,7 +771,7 @@ describe("infer: throttle-shaped retry", () => {
       return new Response(JSON.stringify({ error: { message: "upstream trouble" } }), { status: 503 })
     }) as unknown as typeof globalThis.fetch
     const slept: Array<number> = []
-    const layer = infer({
+    const layer = testInfer({
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "test-model",
@@ -806,7 +811,7 @@ describe("infer: throttle-shaped retry", () => {
       return new Response(JSON.stringify({ error: { message: "bad request" } }), { status: 400 })
     }) as unknown as typeof globalThis.fetch
     const slept: Array<number> = []
-    const layer = infer({
+    const layer = testInfer({
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "test-model",
@@ -832,7 +837,7 @@ describe("infer: throttle-shaped retry", () => {
 
   test("Bun's timed-out wording enters the bounded retry policy", async () => {
     let calls = 0
-    const layer = infer({
+    const layer = testInfer({
       baseUrl: "https://model.test/v1",
       apiKey: "k",
       model: "test-model",
@@ -962,7 +967,7 @@ describe("truncation", () => {
       keys.push(request.headers.get("Idempotency-Key"))
       return calls++ === 0 ? cut("half an ans") : whole("the whole answer")
     }) as unknown as typeof fetch
-    const layer = infer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", fetch: fetchImpl as never })
+    const layer = testInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", fetch: fetchImpl as never })
     const action = await Effect.runPromise(
       Effect.flatMap(Infer, (i) => i.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]), "t1/infer/0")).pipe(
         Effect.provide(layer)
@@ -984,7 +989,7 @@ describe("truncation", () => {
       calls++ === 0
         ? cut("half an ans", { prompt_tokens: 10, completion_tokens: 32768, cost: 5 })
         : whole("the whole answer", { prompt_tokens: 10, completion_tokens: 4, cost: 1 })) as unknown as typeof fetch
-    const layer = infer({
+    const layer = testInfer({
       provider: "openai",
       model: "m",
       baseUrl: "https://x",
@@ -1024,7 +1029,7 @@ describe("truncation", () => {
 
   test("the top rung still truncating fails the turn loudly, never half an answer", async () => {
     const fetchImpl = (async () => cut("half")) as unknown as typeof fetch
-    const layer = infer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", fetch: fetchImpl as never })
+    const layer = testInfer({ provider: "openai", model: "m", baseUrl: "https://x", apiKey: "k", fetch: fetchImpl as never })
     const action = await Effect.runPromise(
       Effect.flatMap(Infer, (i) => i.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
         Effect.provide(layer)
@@ -1041,7 +1046,7 @@ describe("truncation", () => {
     const routed = await Effect.runPromise(
       Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
         Effect.provide(
-          infer({
+          testInfer({
             baseUrl: "https://model.test/v1",
             apiKey: "k",
             model: "meta-llama/llama-3.1-70b",
@@ -1081,7 +1086,7 @@ describe("truncation", () => {
           }),
           { status: 200, headers: { "content-type": "text/event-stream" } }
         )) as unknown as typeof fetch
-      const layer = infer({
+      const layer = testInfer({
         provider: "openai",
         model: "m",
         baseUrl: "https://x",
@@ -1128,7 +1133,7 @@ describe("declared limits", () => {
         headers: { "content-type": "text/event-stream" }
       })
     }) as unknown as typeof fetch
-    const layer = infer({
+    const layer = testInfer({
       provider: "openai",
       model: "m",
       baseUrl: "https://x",
@@ -1150,13 +1155,13 @@ describe("stream bounds", () => {
     // A value outside Bun's timer range would clamp to 1ms and read as provider trouble
     // (model.ts, infer).
     expect(() =>
-      infer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "m", stream: { totalMs: Infinity } })
+      testInfer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "m", stream: { totalMs: Infinity } })
     ).toThrow(/finite positive/)
     expect(() =>
-      infer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "m", stream: { idleMs: 0 } })
+      testInfer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "m", stream: { idleMs: 0 } })
     ).toThrow(/finite positive/)
     expect(() =>
-      infer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "m", stream: { firstChunkMs: 2_147_483_648 } })
+      testInfer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "m", stream: { firstChunkMs: 2_147_483_648 } })
     ).toThrow(/2147483647/)
   })
 })

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -9,12 +9,14 @@ import {
   type ToolCall
 } from "@tanstack/ai"
 import { openaiCompatibleText } from "@tanstack/ai-openai/compatible"
+import { createAnthropicChat } from "@tanstack/ai-anthropic"
 import * as BedrockRuntime from "@aws-sdk/client-bedrock-runtime"
 import { FetchHttpHandler } from "@smithy/fetch-http-handler"
 import { BedrockConverseTextAdapter, type BEDROCK_CONVERSE_MODELS } from "@tanstack/ai-bedrock"
 import { Infer, NativeOutputSupport, type InferRequest } from "tardie"
 import type { Action, AttemptEndpoint } from "tardie/events"
 import type { Event } from "@clavia/tardigrade-core/event"
+import type { ModelReference } from "tardie"
 import { assertSupportedBun } from "@clavia/tardigrade-core/runtime"
 import { modelRequest, type AgentMessage, type ModelRequest, type OutputRequest, type ToolSpec } from "tardie/request"
 import {
@@ -28,6 +30,8 @@ import {
 } from "./output"
 import { NATIVE_MODE, type OutputMode } from "tardie/output"
 import { sumUsage, usageFrom, type ModelPricing, type Usage } from "tardie/usage"
+import type { ModelDriver } from "./connection"
+import { modelDriverOf } from "./connection"
 
 // The real model binding: one inference per react, streamed through a TanStack adapter and
 // decoded by their StreamProcessor. The reactors never learn this layer exists. Resilience is
@@ -46,13 +50,19 @@ export interface ModelEnv {
   readonly MODEL_SONNET_CONTEXT_WINDOW_TOKENS?: string
   readonly MODEL_OPUS_CONTEXT_WINDOW_TOKENS?: string
   readonly MODEL_HAIKU_CONTEXT_WINDOW_TOKENS?: string
+  readonly MODEL_DRIVER?: string
   // "bedrock" speaks Converse through the gateway's aws-bedrock route (v5's proven leg);
   // anything else is the OpenAI-compat wire.
   readonly MODEL_PROVIDER?: string
 }
 
 export const modelConfigured = (env: ModelEnv): boolean =>
-  env.MODEL_BASE_URL !== undefined && env.MODEL_API_KEY !== undefined && env.MODEL_ID !== undefined
+  env.MODEL_BASE_URL !== undefined && env.MODEL_API_KEY !== undefined && env.MODEL_ID !== undefined && env.MODEL_DRIVER !== undefined
+
+export const modelDriverFrom = (env: ModelEnv): ModelDriver => {
+  if (env.MODEL_DRIVER === undefined) throw new Error("MODEL_DRIVER is required")
+  return modelDriverOf(env.MODEL_DRIVER)
+}
 
 // The model vocabulary agents speak: short names, resolved to provider ids by env. An unknown
 // or absent name is the default. The asked name rides the brief's MessageReceived envelope, so
@@ -66,12 +76,19 @@ export const modelIdOf = (env: ModelEnv, name?: string): string =>
         ? (env.MODEL_HAIKU_ID ?? env.MODEL_ID!)
         : env.MODEL_ID!
 
-export const modelAskOf = (trajectory: ReadonlyArray<Event>): string | undefined => {
-  let name: string | undefined
+export const modelAskOf = (trajectory: ReadonlyArray<Event>): ModelReference | undefined => {
+  let name: ModelReference | undefined
   for (const e of trajectory) {
     if (e.type !== "MessageReceived") continue
     const v = (e as { model?: unknown }).model
     if (typeof v === "string" && v !== "") name = v
+    else if (
+      typeof v === "object" &&
+      v !== null &&
+      typeof (v as { id?: unknown }).id === "string" &&
+      (v as { id: string }).id !== "" &&
+      ((v as { connection?: unknown }).connection === undefined || typeof (v as { connection?: unknown }).connection === "string")
+    ) name = v as { readonly id: string; readonly connection?: string }
   }
   return name
 }
@@ -233,6 +250,7 @@ export interface ModelConfig {
   readonly baseUrl: string
   readonly apiKey: string
   readonly model: string
+  readonly driver: ModelDriver
   readonly provider?: string
   // The model's output ceiling, DECLARED by the operator rather than guessed: no wire this
   // binding speaks publishes limits, so the number that bounds the truncation ladder is stated
@@ -726,14 +744,20 @@ export const infer = <const C extends ModelConfig>(config: C): Layer.Layer<Infer
     const held: { tokens?: TokenUsage } = {}
     const fetcher = withCapture(config.fetch, keyForRung, bounds.totalMs, sink)
     const stops: { stopReason?: string } = {}
-    const adapter =
-      config.provider === "bedrock"
-        ? bedrockAdapter(config, maxTokens, bounds, req.output, mode, stops, reported)
+    const adapter = config.driver === "bedrock-converse"
+      ? bedrockAdapter(config, maxTokens, bounds, req.output, mode, stops, reported)
+      : config.driver === "anthropic-messages"
+        ? createAnthropicChat(config.model as never, config.apiKey, {
+            baseURL: config.baseUrl,
+            maxRetries: 0,
+            fetch: fetcher
+          })
         : openaiCompatibleText(config.model, {
             name: "tardigrade",
             baseURL: config.baseUrl,
             apiKey: config.apiKey,
-            // The openai SDK client retries a throttle-shaped failure on its own schedule by
+            api: config.driver === "openai-responses" ? "responses" : "chat-completions",
+            // The OpenAI client retries a throttle-shaped failure on its own schedule by
             // default (`maxRetries: 2`, real waits it does not expose to us). Turned off here so
             // a 429 or a 5xx surfaces to `react`'s own retry loop once, on our own backoff.
             maxRetries: 0,
@@ -743,7 +767,12 @@ export const infer = <const C extends ModelConfig>(config: C): Layer.Layer<Infer
     // compatible leg's provider-options seam, and `outputConfig` through the Converse leg's
     // buildInput above. Both are absent under an implementation that asked for no guarantee, so
     // no endpoint is handed a schema it never promised to keep.
-    const responseFormat = config.provider === "bedrock" ? undefined : compatibleResponseFormat(req.output, mode)
+    const responseFormat = config.driver === "openai-responses" || config.driver === "openai-chat-completions"
+      ? compatibleResponseFormat(req.output, mode)
+      : undefined
+    const outputSchema = config.driver === "anthropic-messages" && req.output?.kind === "contract" && mode.kind === "native"
+      ? req.output.contract.schema
+      : undefined
     // The fallback's own instruction rides the request and reaches the model only on an attempt
     // running as that fallback, so a native attempt sends exactly the base prompt.
     const fallbackSystem = fallbackSystemFor(req.output, mode)
@@ -759,6 +788,7 @@ export const infer = <const C extends ModelConfig>(config: C): Layer.Layer<Infer
         max_tokens: maxTokens,
         ...(responseFormat === undefined ? {} : { response_format: responseFormat })
       } as never,
+      ...(outputSchema === undefined ? {} : { outputSchema }),
       logger: noopLogger
     } as never)
     // The wire is read once and answers two questions: what the attempt spent, and who served
@@ -816,7 +846,7 @@ export const infer = <const C extends ModelConfig>(config: C): Layer.Layer<Infer
       attributes: {
         "gen_ai.operation.name": "chat",
         "gen_ai.request.model": config.model,
-        "gen_ai.provider.name": config.provider === "bedrock" ? "aws.bedrock" : (config.provider ?? "openai")
+        "gen_ai.provider.name": config.driver === "bedrock-converse" ? "aws.bedrock" : (config.provider ?? config.driver)
       }
     })(function* (request: InferRequest, key?: string) {
       // The retry ladder reads the wall clock to honour a provider's `Retry-After` date, and it

--- a/platform/model/src/output.types.test.ts
+++ b/platform/model/src/output.types.test.ts
@@ -29,6 +29,7 @@ const native = infer({
   baseUrl: "https://model.test",
   apiKey: "test",
   model: "strict",
+  driver: "openai-responses",
   output: { guarantee: "native", withTools: true }
 })
 
@@ -36,6 +37,7 @@ const toolLimited = infer({
   baseUrl: "https://model.test",
   apiKey: "test",
   model: "strict-without-tools",
+  driver: "openai-responses",
   output: { guarantee: "native", withTools: false }
 })
 
@@ -43,6 +45,7 @@ const unproven = infer({
   baseUrl: "https://model.test",
   apiKey: "test",
   model: "unproven",
+  driver: "openai-responses",
   output: { guarantee: "none" }
 })
 


### PR DESCRIPTION
## Summary

Adds named model connections with explicit protocol drivers and field-level metadata provenance. CLI setup can preserve multiple connections and select one deployment default. Each agent may select a connection and model through its infer policy, and the runtime records that selection before inference so compaction uses the same model context window.

This gives self-hosted deployments a common configuration model for OpenAI Responses, OpenAI Chat Completions, Anthropic Messages, and Bedrock Converse while keeping model choice inside agent behavior.

## Verification

- Typechecked core, agent, model, server, CLI, and Cloudflare packages.
- Passed 150 focused agent, model, setup, and compaction tests.

## Remaining

- Add typed actor methods so each actor declares its callable input and output interface.
- Expose the agent message method through that generic actor interface.
- Add generic CLI and HTTP method invocation surfaces.
- Finish documentation and run the full repository gate.