### PR TITLE
feat(agent): declare actor methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ tdg init researcher
 cd researcher
 ```
 
-The `init` command creates `researcher/actor.ts` from the bundled template. Read the [Quickstart guide](docs/quickstart.md) to understand the framework, then edit `actor.ts` to describe the agent. Build and push the result into the local actor registry:
+The `init` command creates `researcher/actor.ts` from the bundled template. The template exports a named actor with `agentMethods`, the typed interface for sending a message and reading its state from the log. Read the [Quickstart guide](docs/quickstart.md) to understand the framework, then edit `actor.ts` to describe the agent. Build and push the result into the local actor registry:
 
 ```bash
 tdg build actor.ts
@@ -112,26 +112,50 @@ The call follows one route:
 Mount the component beside the built-in parts that this task needs:
 
 ```ts
-import { actor, budget, codeMode, compaction, infer, outputValidateOnce, reply, system } from "tardie"
+import {
+  actor,
+  agentMethods,
+  agentsPackage,
+  budget,
+  codeMode,
+  compaction,
+  defineActor,
+  fetchPackage,
+  filesPackage,
+  infer,
+  outputValidateOnce,
+  reply,
+  system,
+  workspacePackage
+} from "tardie"
 
 const instructions = system(
   "You are a release analyst. Identify risky changes and recommend the safest next action."
 )
 
-const releaseAnalyst = actor(infer([
-  instructions, // the agent's system prompt
-  deploys,     // recent_deploys and its paired handler
-  codeMode(),  // durable JavaScript execution over an empty package scope
-  budget,      // a per-turn code budget
-  compaction(), // bounded model context
-  reply,       // results for parent agents
-  outputValidateOnce // validates one structured result without correction
-]))
+const releaseAnalyst = defineActor({
+  name: "release-analyst",
+  methods: agentMethods,
+  actor: actor(infer([
+    instructions, // the agent's system prompt
+    deploys,     // recent_deploys and its paired handler
+    codeMode([
+      filesPackage(),
+      fetchPackage(),
+      agentsPackage(),
+      workspacePackage()
+    ]),
+    budget,      // a per-turn code budget
+    compaction(), // bounded model context
+    reply,       // results for parent agents
+    outputValidateOnce // validates one structured result without correction
+  ]))
+})
 ```
 
-`infer` composes its children, preserves their transitions, and adds inference and tool routing over their final view. `actor` adapts the root component to reconciliation and carries its service requirements into the host type. System fragments join in component order, so the model sees the release instructions beside `recent_deploys` and `execute` in one request. Policy components derive work from the same log.
+`infer` composes the components into an agent loop. `defineActor` gives that loop a stable name and callable interface. `agentMethods` provides a `message` method with `{ text, input? }` input and a string result.
 
-`compaction(policy?)` takes a model-window resolver and hysteresis ratios. The default fires at 80 percent of a 128,000-token window and keeps a 50 percent tail. A platform that serves several models should state each window from the same model catalog that inference uses:
+`compaction(policy?)` bounds model context. Its default uses a 128,000-token window, fires at 80 percent, and keeps a 50 percent tail. A platform that serves several models should supply their windows:
 
 ```ts
 const windows = { default: 1_000_000, sonnet: 200_000 } as const
@@ -143,11 +167,11 @@ const boundedContext = compaction({
 })
 ```
 
-When the guard fires, the component appends the resolved policy with its checkpoint. The output shape is `{ type: "CompactionCompleted", keepFrom: string, summary: string, contextWindowTokens: number, fireTokens: number, keepTokens: number, at: number }`.
+When compaction runs, its checkpoint records the applied policy with the summary.
 
-`codeMode([...components])` applies the same structure to the code surface. Each package factory returns a leaf `CodeComponent`. Code mode composes their package views and transitions, then exposes the combined scope through one `execute` tool. Use `definePackage({...})` for a custom leaf. Use `composeComponents(name, CODE_VIEW_ALGEBRA, children)` when one code component groups other code components.
+`codeMode([...components])` combines code packages behind one `execute` tool. Define a package with `definePackage(...)`. Group packages with `composeComponents(...)`.
 
-This agent can inspect deployments, analyze results with JavaScript, compact a long investigation, and report to a parent agent. Change the list to create another harness.
+This agent can inspect deployments and files, fetch sources, delegate research, and analyze results with JavaScript. Change the package list to create another harness.
 
 A run can follow this path:
 
@@ -165,6 +189,9 @@ Each action and result becomes an event that every component can interpret.
 The three code blocks form one program.
 
 ```ts
+import { Layer } from "effect"
+import { BunFileSystem, BunPath } from "@effect/platform-bun"
+import { FetchHttpClient } from "effect/unstable/http"
 import { infer } from "tardie/model"
 import { createBunHost } from "tardie/bun/host"
 
@@ -174,10 +201,17 @@ const model = infer({
   model: process.env.MODEL_ID!
 })
 
+const platform = Layer.mergeAll(
+  model,
+  BunFileSystem.layer,
+  BunPath.layer,
+  FetchHttpClient.layer
+)
+
 const host = await createBunHost({
   log: "agents.sqlite",
-  actorFor: () => releaseAnalyst,
-  layersFor: () => model
+  actorFor: () => releaseAnalyst.actor,
+  layersFor: () => platform
 })
 
 await host.commitRoot("bun:main", {

--- a/apps/cli/src/build.test.ts
+++ b/apps/cli/src/build.test.ts
@@ -26,6 +26,7 @@ describe("buildActor", () => {
       import { defineActor } from "tardie"
       export default defineActor({
         name: "researcher",
+        methods: {},
         actor: { reactors: [], keyOf: () => "root" }
       })
     `)
@@ -42,11 +43,22 @@ describe("buildActor", () => {
     await expect(buildActor(path, { cwd: root, out: "output" })).rejects.toThrow("name must match")
   })
 
+  test("refuses an actor with no callable interface", async () => {
+    const path = await entry(`
+      export default {
+        name: "researcher",
+        actor: { reactors: [], keyOf: () => "root" }
+      }
+    `)
+    await expect(buildActor(path, { cwd: root, out: "output" })).rejects.toThrow("must declare its methods")
+  })
+
   test("the summary hands the source to local push", async () => {
     const path = await entry(`
       import { defineActor } from "tardie"
       export default defineActor({
         name: "researcher",
+        methods: {},
         actor: { reactors: [], keyOf: () => "root" }
       })
     `)

--- a/apps/cli/src/build.ts
+++ b/apps/cli/src/build.ts
@@ -6,6 +6,8 @@ import { fileURLToPath, pathToFileURL } from "node:url"
 import {
   ACTOR_ARTIFACT_VERSION,
   ACTOR_NAME_PATTERN,
+  actorMethodsOf,
+  type ActorMethods,
   type ActorArtifactManifest,
   type ActorDefinition
 } from "tardie"
@@ -31,7 +33,7 @@ const definitionOf = async (modulePath: string): Promise<ActorDefinition<unknown
   const loaded: unknown = await import(`${pathToFileURL(modulePath).href}?build=${crypto.randomUUID()}`)
   const definition = (loaded as { readonly default?: unknown }).default
   if (typeof definition !== "object" || definition === null) {
-    throw new Error("actor entry must default export defineActor({ name, actor })")
+    throw new Error("actor entry must default export defineActor({ name, methods, actor })")
   }
   const candidate = definition as Partial<ActorDefinition<unknown>>
   if (typeof candidate.name !== "string" || !ACTOR_NAME_PATTERN.test(candidate.name)) {
@@ -45,6 +47,10 @@ const definitionOf = async (modulePath: string): Promise<ActorDefinition<unknown
   ) {
     throw new Error("actor entry must contain an Actor in its actor field")
   }
+  if (typeof candidate.methods !== "object" || candidate.methods === null || Array.isArray(candidate.methods)) {
+    throw new Error("actor entry must declare its methods")
+  }
+  actorMethodsOf(candidate.methods as ActorMethods)
   return candidate as ActorDefinition<unknown>
 }
 

--- a/apps/cli/src/dev.test.ts
+++ b/apps/cli/src/dev.test.ts
@@ -88,7 +88,7 @@ const booted = <A>(
 
 // installActor performs the final atomic directory swap of a local push.
 const installActor = (root: string, name: string, revision: string): string => {
-  const module = `export default { name: ${JSON.stringify(name)}, revision: ${JSON.stringify(revision)}, actor: { reactors: [], keyOf: () => undefined } }\n`
+  const module = `export default { name: ${JSON.stringify(name)}, revision: ${JSON.stringify(revision)}, methods: {}, actor: { reactors: [], keyOf: () => undefined } }\n`
   const digest = `sha256:${createHash("sha256").update(module).digest("hex")}`
   const destination = join(root, name)
   const incoming = `${destination}.incoming`

--- a/apps/cli/src/push.test.ts
+++ b/apps/cli/src/push.test.ts
@@ -16,7 +16,7 @@ const entry = async (): Promise<string> => {
   const path = join(root, "actor.ts")
   await writeFile(path, `
     import { defineActor } from "tardie"
-    export default defineActor({ name: "reviewer", actor: { reactors: [], keyOf: () => "root" } })
+    export default defineActor({ name: "reviewer", methods: {}, actor: { reactors: [], keyOf: () => "root" } })
   `, "utf8")
   return path
 }

--- a/apps/server/src/actor.test.ts
+++ b/apps/server/src/actor.test.ts
@@ -4,7 +4,7 @@ import type { Event } from "@clavia/tardigrade-core/event"
 import { replyId } from "@clavia/tardigrade-core/message"
 import { projection, projectionsOf, RESERVED_PROJECTIONS } from "@clavia/tardigrade-client/contract"
 
-import { agentProjections } from "./actor"
+import { agentProjections, builtInActor } from "./actor"
 
 // The actor's own declaration: what it says a thread can be asked beyond its log, and what the
 // platform refuses to mount. The projections are pure functions of an event array, so the fixtures
@@ -29,6 +29,12 @@ const reply = (id: string, text = "done"): Event =>
   ({ type: "MessageReceived", id: replyId(id), text, outcome: "completed", at: at() }) as Event
 
 const turns = agentProjections.turns
+
+describe("the built-in actor", () => {
+  test("declares the message method", () => {
+    expect(Object.keys(builtInActor().methods)).toEqual(["message"])
+  })
+})
 
 describe("the turns projection", () => {
   test("one entry per inbound message, with its boundary", () => {

--- a/apps/server/src/actor.ts
+++ b/apps/server/src/actor.ts
@@ -3,10 +3,12 @@ import type { Event } from "@clavia/tardigrade-core/event"
 import type { Actor } from "@clavia/tardigrade-core/actor"
 import {
   actor,
+  agentMethods,
   agentsPackage,
   budget,
   codeMode,
   compaction,
+  defineActor,
   fetchPackage,
   filesPackage,
   infer,
@@ -16,7 +18,7 @@ import {
 } from "tardie"
 import { turnEpochOf } from "@clavia/tardigrade-code/turns"
 import { boundaryOf } from "tardie/boundary"
-import { projection, projectionsOf, Seq, TurnView } from "@clavia/tardigrade-client/contract"
+import { projection, projectionsOf, RESERVED_ACTOR, Seq, TurnView } from "@clavia/tardigrade-client/contract"
 
 import { inboundOf } from "./projections"
 
@@ -44,6 +46,13 @@ export const assemblyOf = () =>
     compaction(),
     outputValidateOnce
   ]))
+
+// builtInActor declares the built-in assembly and its callable interface together.
+export const builtInActor = () => defineActor({
+  name: RESERVED_ACTOR,
+  methods: agentMethods,
+  actor: assemblyOf()
+})
 
 // ServerR is what this assembly needs bound. It is read off the assembly rather than restated, so a
 // package added above lands in the host's obligation and a host that binds nothing for it fails to

--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -199,7 +199,7 @@ describe("actors", () => {
       isolatedConfig,
       Layer.provide(layerThreads({ infer: layerScripted }), isolatedConfig)
     ])
-    const module = `export default { name: "reviewer", actor: { reactors: [], keyOf: () => undefined } }\n`
+    const module = `export default { name: "reviewer", methods: {}, actor: { reactors: [], keyOf: () => undefined } }\n`
     const digest = `sha256:${createHash("sha256").update(module).digest("hex")}`
     try {
       const result = await Effect.gen(function*() {
@@ -209,7 +209,7 @@ describe("actors", () => {
         const base = `http://127.0.0.1:${port}`
         return yield* Effect.promise(async () => {
           const pushed = await put(base, "/v1/actors", {
-            manifest: { schema: 1, name: "reviewer", module: "actor.mjs", digest },
+            manifest: { schema: 2, name: "reviewer", module: "actor.mjs", digest },
             module
           })
           const summary = await pushed.json()

--- a/apps/server/src/contract.test.ts
+++ b/apps/server/src/contract.test.ts
@@ -16,6 +16,7 @@ import { layerGaugeResting, PROBLEM_CONTENT_TYPE, serve } from "./http"
 
 // A Threads that owns nothing, so every read is the empty log a 404 is made of.
 const layerThreadsEmpty = Layer.succeed(Threads)({
+  methods: {},
   append: () => Effect.void,
   events: () => Effect.succeed([]),
   list: Effect.succeed([]),

--- a/apps/server/src/host.test.ts
+++ b/apps/server/src/host.test.ts
@@ -72,6 +72,11 @@ const running = <A, E>(
 const brief = (id: string, text = "hello") => ({ type: "MessageReceived", id, text })
 
 describe("the threads service", () => {
+  test("retains the built-in actor methods", async () => {
+    const methods = await running((threads) => Effect.succeed(Object.keys(threads.methods)))
+    expect(methods).toEqual(["message"])
+  })
+
   test("the configured lane capacity runs model calls concurrently", async () => {
     let release!: () => void
     const released = new Promise<void>((resolve) => {

--- a/apps/server/src/host.ts
+++ b/apps/server/src/host.ts
@@ -9,13 +9,14 @@ import { pathToFileURL } from "node:url"
 import type { Event } from "@clavia/tardigrade-core/event"
 import type { Envelope } from "@clavia/tardigrade-core/communication/envelope"
 import type { Directory } from "@clavia/tardigrade-core/communication/directory"
-import type { Actor } from "@clavia/tardigrade-core/actor"
 import { Ingress, ingressFrom } from "@clavia/tardigrade-host/communication/ingress"
 import type { Provider } from "@clavia/tardigrade-host/communication/provider"
 import {
   ACTOR_ARTIFACT_VERSION,
   ACTOR_NAME_PATTERN,
   Infer,
+  actorMethodsOf,
+  type ActorMethods,
   type ActorArtifactManifest,
   type ActorDefinition
 } from "tardie"
@@ -25,7 +26,7 @@ import { openBunActorRegistry } from "@clavia/tardigrade-bun/registry"
 import { infer } from "@clavia/tardigrade-model/model"
 import { RESERVED_ACTOR, type ActorArtifact, type ActorSummary } from "@clavia/tardigrade-client/contract"
 
-import { assemblyOf, type ServerR } from "./actor"
+import { builtInActor, type ServerR } from "./actor"
 import { ServerConfig, type ServerConfigValue } from "./config"
 import { DriverGauge } from "./http"
 
@@ -55,19 +56,19 @@ export class ActorPushRefused extends Data.TaggedError("ActorPushRefused")<{
 }> {}
 
 export interface ActorThreads {
+  readonly methods: ActorMethods
   readonly append: (id: string, event: Event) => Effect.Effect<void>
   readonly events: (id: string) => Effect.Effect<ReadonlyArray<Event>>
   readonly list: Effect.Effect<ReadonlyArray<{ readonly id: string; readonly events: ReadonlyArray<Event> }>>
   readonly settled: Effect.Effect<void>
 }
 
-// The operations the HTTP surface has: append an event, read a log, list what exists. Every one
-// speaks a thread id and none of them reads an event's fields, because what an event means is the
-// actor's knowledge and this service holds the log (actor.ts, agentProjections).
+// Threads exposes the selected actor's method declarations beside its durable thread operations. Method meaning stays with the actor, while the service stores and returns its event log (packages/agent/src/method.ts, ActorMethodDeclaration).
 export class Threads extends Context.Service<
   Threads,
   {
     readonly append: ActorThreads["append"]
+    readonly methods: ActorThreads["methods"]
     readonly events: ActorThreads["events"]
     readonly list: ActorThreads["list"]
     // settled resolves once the drive in flight, and the follow-up it coalesced, has finished. A
@@ -151,7 +152,7 @@ const definitionOf = async (modulePath: string, expected: ActorArtifactManifest)
   const loaded: unknown = await import(`${pathToFileURL(modulePath).href}?digest=${encodeURIComponent(expected.digest)}`)
   const definition = (loaded as { readonly default?: unknown }).default
   if (typeof definition !== "object" || definition === null) {
-    throw new Error("actor artifact must default export defineActor({ name, actor })")
+    throw new Error("actor artifact must default export defineActor({ name, methods, actor })")
   }
   const candidate = definition as Partial<ActorDefinition<ServerR>>
   if (candidate.name !== expected.name || !ACTOR_NAME_PATTERN.test(expected.name)) {
@@ -165,17 +166,22 @@ const definitionOf = async (modulePath: string, expected: ActorArtifactManifest)
   ) {
     throw new Error("actor artifact does not contain an Actor")
   }
+  if (typeof candidate.methods !== "object" || candidate.methods === null || Array.isArray(candidate.methods)) {
+    throw new Error("actor artifact does not declare its methods")
+  }
+  actorMethodsOf(candidate.methods as ActorMethods)
   return candidate as ActorDefinition<ServerR>
 }
 
 const runtimeOf = async (
   summary: ActorSummary,
-  actor: Actor<ServerR>,
+  definition: ActorDefinition<ServerR>,
   log: string,
   lane: ReturnType<typeof layerLane>,
   providers: ReadonlyArray<Provider>,
   maxConcurrentLanes: number
 ): Promise<ActorRuntime> => {
+  const actor = definition.actor
   const host: BunHost = await createBunHost<ServerR>({
     log,
     principal: summary.name,
@@ -243,6 +249,7 @@ const runtimeOf = async (
       yield* Effect.promise(() => host.commit(placed))
     })
   const threads: ActorThreads = {
+    methods: definition.methods,
     append: (id, event) =>
       Effect.gen(function*() {
         yield* commitRoot(id, event)
@@ -300,7 +307,7 @@ const make = (options: ThreadsOptions) =>
     const runtimes = new Map<string, ActorRuntime>()
     const registry = yield* openBunActorRegistry<ActorSummary>({ file: config.db })
     const runRegistry = Effect.runPromiseWith(yield* Effect.context<never>())
-    const builtIn = assemblyOf()
+    const builtIn = builtInActor()
     const root = resolve(config.actors)
     let mutations: Promise<void> = Promise.resolve()
     const exclusive = <A>(operation: () => Promise<A>): Promise<A> => {
@@ -308,10 +315,10 @@ const make = (options: ThreadsOptions) =>
       mutations = result.then(() => undefined, () => undefined)
       return result
     }
-    const open = async (summary: ActorSummary, actor: Actor<ServerR>, log: string): Promise<ActorRuntime> => {
+    const open = async (summary: ActorSummary, definition: ActorDefinition<ServerR>, log: string): Promise<ActorRuntime> => {
       const runtime = await runtimeOf(
         summary,
-        actor,
+        definition,
         log,
         lane,
         options.providers ?? [],
@@ -321,23 +328,23 @@ const make = (options: ThreadsOptions) =>
       await runRegistry(registry.put(summary))
       return runtime
     }
-    const load = async (directory: string): Promise<{ readonly summary: ActorSummary; readonly actor: Actor<ServerR> }> => {
+    const load = async (directory: string): Promise<{ readonly summary: ActorSummary; readonly definition: ActorDefinition<ServerR> }> => {
       const artifact = await manifestOf(directory)
       if (artifact.manifest.name === RESERVED_ACTOR) throw new Error(`${RESERVED_ACTOR} is reserved for the built-in actor`)
       const definition = await definitionOf(join(directory, artifact.manifest.module), artifact.manifest)
       return {
         summary: { name: definition.name, builtIn: false, digest: artifact.manifest.digest },
-        actor: definition.actor
+        definition
       }
     }
-    const replace = async (summary: ActorSummary, actor: Actor<ServerR>): Promise<void> => {
+    const replace = async (summary: ActorSummary, definition: ActorDefinition<ServerR>): Promise<void> => {
       const current = runtimes.get(summary.name)
       if (current?.summary.digest === summary.digest) return
       if (current !== undefined) {
         await current.close()
         runtimes.delete(summary.name)
       }
-      await open(summary, actor, join(resolve(config.actorData), `${summary.name}.sqlite`))
+      await open(summary, definition, join(resolve(config.actorData), `${summary.name}.sqlite`))
     }
     const synchronize = async (): Promise<void> => {
       const entries = await readdir(root, { withFileTypes: true }).catch((error: NodeJS.ErrnoException) => {
@@ -350,7 +357,7 @@ const make = (options: ThreadsOptions) =>
         const loaded = await load(join(root, entry.name))
         if (loaded.summary.name !== entry.name) throw new Error(`actor artifact name does not match directory ${JSON.stringify(entry.name)}`)
         found.add(loaded.summary.name)
-        await replace(loaded.summary, loaded.actor)
+        await replace(loaded.summary, loaded.definition)
       }
       for (const [name, runtime] of runtimes) {
         if (name === RESERVED_ACTOR || found.has(name)) continue
@@ -423,7 +430,7 @@ const make = (options: ThreadsOptions) =>
           }
           const summary: ActorSummary = { name: manifest.name, builtIn: false, digest: manifest.digest }
           try {
-            await open(summary, definition.actor, join(resolve(config.actorData), `${manifest.name}.sqlite`))
+            await open(summary, definition, join(resolve(config.actorData), `${manifest.name}.sqlite`))
             try {
               await rename(destination, previous)
             } catch (error) {

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -30,6 +30,7 @@ setDefaultTimeout(BOOT_MS)
 // The conventions these tests are about hold over any host, so the thread routes get one that owns
 // nothing. The routes themselves are exercised against a real host in api.test.ts.
 const layerThreadsEmpty = Layer.succeed(Threads)({
+  methods: {},
   append: () => Effect.void,
   events: () => Effect.succeed([]),
   list: Effect.succeed([]),

--- a/docs/how-to/migrate.md
+++ b/docs/how-to/migrate.md
@@ -23,7 +23,7 @@ The current Vercel AI SDK agent surface includes [`ToolLoopAgent` and loop contr
 
 | Existing concern | Tardigrade home |
 | --- | --- |
-| `ToolLoopAgent`, `generateText`, `streamText`, or a manual model loop | `defineActor({ name, actor: actor(infer([...])) })` |
+| `ToolLoopAgent`, `generateText`, `streamText`, or a manual model loop | `defineActor({ name, methods, actor: actor(infer([...])) })` |
 | System instructions | `system(...)` |
 | Tool declarations and handlers | Package components mounted through `codeMode`, or fixed tools mounted through `toolList` |
 | `stopWhen`, maximum steps, and retry options | `budgetFor`, `infer` policy, and domain components with explicit policy values |

--- a/examples/quickstart/actor.ts
+++ b/examples/quickstart/actor.ts
@@ -1,5 +1,6 @@
 import {
   actor,
+  agentMethods,
   agentsPackage,
   budget,
   codeMode,
@@ -29,6 +30,8 @@ Return a concise answer with concrete findings.
 
 export default defineActor({
   name: actorName,
+  // methods declares the typed calls this actor accepts.
+  methods: agentMethods,
   // actor carries component and output requirements into the host type.
   actor: actor(infer([
     system(actorInstructions),

--- a/packages/agent/src/artifact.test.ts
+++ b/packages/agent/src/artifact.test.ts
@@ -1,16 +1,27 @@
 import { describe, expect, test } from "bun:test"
 
+import { Schema } from "effect"
+import type { Event } from "@clavia/tardigrade-core/event"
 import { defineActor } from "./artifact"
+import { actorMethod, actorMethodsOf } from "./method"
 
 const actor = { reactors: [], keyOf: () => "root" }
+const methods = actorMethodsOf({
+  inspect: actorMethod({
+    input: Schema.Struct({ value: Schema.String }),
+    output: Schema.String,
+    event: ({ id, input, at }): Event => ({ type: "Inspected", id, value: input.value, at }),
+    state: () => ({ status: "pending" })
+  })
+})
 
 describe("defineActor", () => {
   test("keeps a portable named actor", () => {
-    const definition = defineActor({ name: "release-analyst", actor })
-    expect(definition).toEqual({ name: "release-analyst", actor })
+    const definition = defineActor({ name: "release-analyst", actor, methods })
+    expect(definition).toEqual({ name: "release-analyst", actor, methods })
   })
 
   test("refuses a name that cannot be a path or directory segment", () => {
-    expect(() => defineActor({ name: "Release Analyst", actor })).toThrow("actor name must match")
+    expect(() => defineActor({ name: "Release Analyst", actor, methods })).toThrow("actor name must match")
   })
 })

--- a/packages/agent/src/artifact.ts
+++ b/packages/agent/src/artifact.ts
@@ -1,8 +1,9 @@
 import type { Actor } from "@clavia/tardigrade-core/actor"
+import { actorMethodsOf, type ActorMethods } from "./method"
 
 export const ACTOR_NAME_PATTERN = /^[a-z][a-z0-9-]{0,62}$/u
 
-export const ACTOR_ARTIFACT_VERSION = 1
+export const ACTOR_ARTIFACT_VERSION = 2
 
 export interface ActorArtifactManifest {
   readonly schema: typeof ACTOR_ARTIFACT_VERSION
@@ -11,14 +12,18 @@ export interface ActorArtifactManifest {
   readonly digest: string
 }
 
-export interface ActorDefinition<R = never> {
+export interface ActorDefinition<R = never, Methods extends ActorMethods = ActorMethods> {
   readonly name: string
   readonly actor: Actor<R>
+  readonly methods: Methods
 }
 
-export const defineActor = <R>(definition: ActorDefinition<R>): ActorDefinition<R> => {
+export const defineActor = <R, const Methods extends ActorMethods>(
+  definition: ActorDefinition<R, Methods>
+): ActorDefinition<R, Methods> => {
   if (!ACTOR_NAME_PATTERN.test(definition.name)) {
     throw new Error(`actor name must match ${String(ACTOR_NAME_PATTERN)}, got ${JSON.stringify(definition.name)}`)
   }
+  actorMethodsOf(definition.methods)
   return definition
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -6,6 +6,20 @@ export {
   type ActorArtifactManifest,
   type ActorDefinition
 } from "./artifact"
+export {
+  ACTOR_METHOD_NAME_PATTERN,
+  actorMethod,
+  actorMethodsOf,
+  type ActorMethod,
+  type ActorMethodCall,
+  type ActorMethodDeclaration,
+  type ActorMethodDefinition,
+  type ActorMethodInput,
+  type ActorMethodOutput,
+  type ActorMethods,
+  type ActorMethodState
+} from "./method"
+export { AgentMessageInput, agentMessageMethod, agentMethods, type AgentMessageInput as AgentMessageInputType } from "./message-method"
 
 // The parts a caller lists. An agent is components over one log; the reactors underneath remain
 // reachable for a bespoke assembly.

--- a/packages/agent/src/message-method.test.ts
+++ b/packages/agent/src/message-method.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import type { Event } from "@clavia/tardigrade-core/event"
+import { agentMessageMethod, agentMethods } from "./message-method"
+
+const head = agentMessageMethod.event({
+  id: "m1",
+  input: { text: "review it", input: { pull: 227 } },
+  at: 1
+})
+
+describe("agentMessageMethod", () => {
+  test("turns its typed input into the agent's durable inbound", () => {
+    expect(head).toEqual({
+      type: "MessageReceived",
+      id: "m1",
+      text: "review it",
+      input: { pull: 227 },
+      at: 1
+    })
+    expect(agentMethods).toEqual({ message: agentMessageMethod })
+  })
+
+  test("projects pending, blocked, completed, and failed states", () => {
+    expect(agentMessageMethod.state([], "m1")).toBeUndefined()
+    expect(agentMessageMethod.state([head], "m2")).toBeUndefined()
+    expect(agentMessageMethod.state([head], "m1")).toEqual({ status: "pending" })
+    expect(agentMessageMethod.state([
+      head,
+      { type: "BudgetRequested", turn: "m1", callId: "c1", reason: "one more check", amount: 1, at: 2 } as Event
+    ], "m1")).toEqual({ status: "blocked", reason: "one more check" })
+    expect(agentMessageMethod.state([
+      head,
+      { type: "TurnCompleted", turn: "m1", output: "done", at: 2 } as Event
+    ], "m1")).toEqual({ status: "completed", output: "done" })
+    expect(agentMessageMethod.state([
+      head,
+      { type: "TurnFailed", turn: "m1", error: "provider refused", at: 2 } as Event
+    ], "m1")).toEqual({ status: "failed", error: "provider refused" })
+  })
+})

--- a/packages/agent/src/message-method.ts
+++ b/packages/agent/src/message-method.ts
@@ -1,0 +1,36 @@
+import { Schema } from "effect"
+import { messageReceived } from "@clavia/tardigrade-core/communication/message"
+import { boundaryOf } from "./boundary"
+import { actorMethod, actorMethodsOf } from "./method"
+
+export const AgentMessageInput = Schema.Struct({
+  text: Schema.String,
+  input: Schema.optionalKey(Schema.Unknown)
+}).annotate({ identifier: "AgentMessageInput" })
+
+export type AgentMessageInput = typeof AgentMessageInput.Type
+
+// agentMessageMethod exposes an agent turn as the generic message actor method.
+export const agentMessageMethod = actorMethod({
+  input: AgentMessageInput,
+  output: Schema.String,
+  event: ({ id, input, at }) => messageReceived({
+    id,
+    text: input.text,
+    ...(input.input === undefined ? {} : { input: input.input }),
+    at
+  }),
+  state: (events, id) => {
+    const invoked = events.some((event) =>
+      event.type === "MessageReceived" && (event as { readonly id?: unknown }).id === id
+    )
+    if (!invoked) return undefined
+    const boundary = boundaryOf(events, id)
+    if (boundary === undefined) return { status: "pending" }
+    if (boundary.kind === "completed") return { status: "completed", output: boundary.output }
+    if (boundary.kind === "failed") return { status: "failed", error: boundary.error }
+    return { status: "blocked", reason: boundary.reason }
+  }
+})
+
+export const agentMethods = actorMethodsOf({ message: agentMessageMethod })

--- a/packages/agent/src/method.test.ts
+++ b/packages/agent/src/method.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test"
+import { Schema } from "effect"
+import type { Event } from "@clavia/tardigrade-core/event"
+import {
+  actorMethod,
+  actorMethodsOf,
+  type ActorMethodCall,
+  type ActorMethodInput,
+  type ActorMethodOutput,
+  type ActorMethodState
+} from "./method"
+
+const inspect = actorMethod({
+  input: Schema.Struct({ value: Schema.String }),
+  output: Schema.Struct({ length: Schema.Finite }),
+  event: ({ id, input, at }): Event => ({ type: "Inspected", id, value: input.value, at }),
+  state: (_events, id) => ({ status: "completed", output: { length: id.length } })
+})
+
+describe("actorMethod", () => {
+  test("preserves its decoded input and output types", () => {
+    const call: ActorMethodCall<{ readonly value: string }> = {
+      id: "call-1",
+      input: { value: "hello" },
+      at: 7
+    }
+    const accepted: Parameters<typeof inspect.event>[0] = call
+    const input: ActorMethodInput<typeof inspect> = call.input
+    const output: ActorMethodOutput<typeof inspect> = { length: 6 }
+    const state: ActorMethodState<{ readonly length: number }> | undefined = inspect.state([], call.id)
+    expect(accepted.input).toEqual(input)
+    expect(state).toEqual({ status: "completed", output })
+  })
+
+  test("builds the durable input event and projects its current state", () => {
+    expect(inspect.event({ id: "call-1", input: { value: "hello" }, at: 7 })).toEqual({
+      type: "Inspected",
+      id: "call-1",
+      value: "hello",
+      at: 7
+    })
+    expect(inspect.state([], "call-1")).toEqual({ status: "completed", output: { length: 6 } })
+  })
+
+  test("builds an event from dynamically typed input only after decoding it", () => {
+    expect(inspect.eventOf({ id: "call-1", input: { value: "hello" }, at: 7 })).toEqual({
+      type: "Inspected",
+      id: "call-1",
+      value: "hello",
+      at: 7
+    })
+    expect(() => inspect.eventOf({ id: "call-1", input: { value: 42 }, at: 7 })).toThrow()
+  })
+})
+
+describe("actorMethodsOf", () => {
+  test("keeps a named heterogeneous interface", () => {
+    const methods = actorMethodsOf({ inspect })
+    expect(methods.inspect).toBe(inspect)
+  })
+
+  test("refuses a name that cannot become an invocation surface", () => {
+    expect(() => actorMethodsOf({ "Inspect now": inspect })).toThrow("actor method name must match")
+  })
+
+  test("refuses a method without both schemas", () => {
+    expect(() => actorMethodsOf({
+      broken: { ...inspect, output: {} as Schema.Top }
+    })).toThrow("must declare input and output schemas")
+  })
+
+  test("refuses a method without its event builder and state function", () => {
+    expect(() => actorMethodsOf({
+      broken: { ...inspect, eventOf: undefined as never }
+    })).toThrow("must declare eventOf and state functions")
+  })
+})

--- a/packages/agent/src/method.ts
+++ b/packages/agent/src/method.ts
@@ -1,0 +1,85 @@
+import { Schema } from "effect"
+import type { Event } from "@clavia/tardigrade-core/event"
+
+export const ACTOR_METHOD_NAME_PATTERN = /^[a-z][a-z0-9-]{0,62}$/u
+
+// ActorMethodCall identifies one durable invocation and carries its decoded input.
+export interface ActorMethodCall<Input> {
+  readonly id: string
+  readonly input: Input
+  readonly at: number
+}
+
+// ActorMethodState reports what the actor's log currently says about an invocation that exists.
+export type ActorMethodState<Output> =
+  | { readonly status: "pending" }
+  | { readonly status: "blocked"; readonly reason: string }
+  | { readonly status: "completed"; readonly output: Output }
+  | { readonly status: "failed"; readonly error: string }
+
+// ActorMethodDeclaration is the erased shape a heterogeneous method table preserves. eventOf validates unknown input before constructing the durable event.
+export interface ActorMethodDeclaration {
+  readonly input: Schema.ConstraintDecoder<unknown>
+  readonly output: Schema.Top
+  readonly eventOf: (call: ActorMethodCall<unknown>) => Event
+  readonly state: (events: ReadonlyArray<Event>, id: string) => ActorMethodState<unknown> | undefined
+}
+
+// ActorMethodDefinition declares one typed call as an input event and a result projection.
+export interface ActorMethodDefinition<
+  Input extends Schema.ConstraintDecoder<unknown> = Schema.ConstraintDecoder<unknown>,
+  Output extends Schema.Top = Schema.Top
+> {
+  readonly input: Input
+  readonly output: Output
+  readonly event: (call: ActorMethodCall<Input["Type"]>) => Event
+  readonly state: (events: ReadonlyArray<Event>, id: string) => ActorMethodState<Output["Type"]> | undefined
+}
+
+// ActorMethod carries a typed definition and its dynamically callable event builder.
+export interface ActorMethod<
+  Input extends Schema.ConstraintDecoder<unknown> = Schema.ConstraintDecoder<unknown>,
+  Output extends Schema.Top = Schema.Top
+>
+  extends ActorMethodDefinition<Input, Output>, ActorMethodDeclaration {
+  readonly input: Input
+  readonly output: Output
+  readonly state: (events: ReadonlyArray<Event>, id: string) => ActorMethodState<Output["Type"]> | undefined
+}
+
+export type ActorMethods = Readonly<Record<string, ActorMethodDeclaration>>
+
+export type ActorMethodInput<Method extends ActorMethodDeclaration> = Method["input"]["Type"]
+
+export type ActorMethodOutput<Method extends ActorMethodDeclaration> = Method["output"]["Type"]
+
+// actorMethod preserves the schema types and adds the validated event builder used after dynamic lookup.
+export const actorMethod = <Input extends Schema.ConstraintDecoder<unknown>, Output extends Schema.Top>(
+  definition: ActorMethodDefinition<Input, Output>
+): ActorMethod<Input, Output> => ({
+  ...definition,
+  eventOf: (call) => definition.event({
+    ...call,
+    input: Schema.decodeUnknownSync(definition.input)(call.input)
+  })
+})
+
+// actorMethodsOf validates the names that later invocation surfaces expose.
+export const actorMethodsOf = <const Methods extends ActorMethods>(methods: Methods): Methods => {
+  for (const [name, declaration] of Object.entries(methods)) {
+    if (!ACTOR_METHOD_NAME_PATTERN.test(name)) {
+      throw new Error(`actor method name must match ${String(ACTOR_METHOD_NAME_PATTERN)}, got ${JSON.stringify(name)}`)
+    }
+    if (typeof declaration !== "object" || declaration === null) {
+      throw new Error(`actor method ${JSON.stringify(name)} must be a declaration`)
+    }
+    const candidate = declaration as Partial<ActorMethodDeclaration>
+    if (!Schema.isSchema(candidate.input) || !Schema.isSchema(candidate.output)) {
+      throw new Error(`actor method ${JSON.stringify(name)} must declare input and output schemas`)
+    }
+    if (typeof candidate.eventOf !== "function" || typeof candidate.state !== "function") {
+      throw new Error(`actor method ${JSON.stringify(name)} must declare eventOf and state functions`)
+    }
+  }
+  return methods
+}

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -208,7 +208,7 @@ export type ActorSummary = typeof ActorSummary.Type
 
 export const ActorArtifact = Schema.Struct({
   manifest: Schema.Struct({
-    schema: Schema.Literal(1),
+    schema: Schema.Literal(2),
     name: Schema.String,
     module: Schema.String,
     digest: Schema.String


### PR DESCRIPTION
## Summary

Actor artifacts currently expose an assembly, while callers have no typed declaration for the operations an actor accepts. This change adds actor-owned method declarations with input and output schemas, durable event construction, and log-derived invocation state.

The built-in agent declares a `message` method. Actor definitions, CLI builds, server loading, and hosted runtimes validate and retain method tables. Artifact schema version advances to 2 because actor artifacts now require this callable interface. The quickstart and migration docs show the new definition.

Invocation transport stays outside this change. HTTP routes, CLI method commands, waiting, and model routing can build on the declaration in focused follow-ups.

## Verification

- `bun run gate`
- `bun run gate --only=lint:docs` after README edits