### PR TITLE
style: compact quickstart imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,20 +113,9 @@ Mount the component beside the built-in parts that this task needs:
 
 ```ts
 import {
-  actor,
-  agentMethods,
-  agentsPackage,
-  budget,
-  codeMode,
-  compaction,
-  defineActor,
-  fetchPackage,
-  filesPackage,
-  infer,
-  outputValidateOnce,
-  reply,
-  system,
-  workspacePackage
+  actor, agentMethods, agentsPackage, budget, codeMode,
+  compaction, defineActor, fetchPackage, filesPackage, infer,
+  outputValidateOnce, reply, system, workspacePackage
 } from "tardie"
 
 const instructions = system(

--- a/examples/quickstart/actor.ts
+++ b/examples/quickstart/actor.ts
@@ -1,18 +1,7 @@
 import {
-  actor,
-  agentMethods,
-  agentsPackage,
-  budget,
-  codeMode,
-  compaction,
-  defineActor,
-  fetchPackage,
-  filesPackage,
-  infer,
-  outputValidateOnce,
-  reply,
-  system,
-  workspacePackage
+  actor, agentMethods, agentsPackage, budget, codeMode,
+  compaction, defineActor, fetchPackage, filesPackage, infer,
+  outputValidateOnce, reply, system, workspacePackage
 } from "tardie"
 
 // actorName is the stable name used by build, push, and run.


### PR DESCRIPTION
## Summary

The quickstart actor imports fourteen names from `tardie`. This change keeps one module import and arranges its names across three horizontal rows in the README and bundled quickstart source. The example takes less vertical space while preserving alphabetical order.

## Verification

- `bun run gate --only=lint,lint:docs`