### PR TITLE
feat(api): serve actor methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,21 +42,21 @@ tdg init researcher
 cd researcher
 ```
 
-The `init` command creates `researcher/actor.ts` from the bundled template. The template exports a named actor with `agentMethods`, the typed interface for sending a message and reading its state from the log. Read the [Quickstart guide](docs/quickstart.md) to understand the framework, then edit `actor.ts` to describe the agent. Build and push the result into the local actor registry:
+The `init` command creates `researcher/actor.ts` from the bundled template. The template exports a named actor with `agentMethods`, the typed interface for sending a message and reading its state from the log. Read the [Quickstart guide](docs/quickstart.md) to understand the framework, then edit `actor.ts` to describe the agent. Push builds the actor and writes it to the local actor registry:
 
 ```bash
-tdg build actor.ts
 tdg push actor.ts --target local
 tdg dev
 ```
 
-Keep `tdg dev` running. Start the actor from another shell in the same directory:
+Keep `tdg dev` running. Discover the actor's methods, then call `message` from another shell in the same directory:
 
 ```bash
-tdg run "read this repo and tell me what it does" --actor researcher
+tdg methods --actor researcher
+tdg call message '{"text":"read this repo and tell me what it does"}' --actor researcher
 ```
 
-Voyager opens at [localhost:4242](http://localhost:4242) by default. `tdg run` prints the direct Voyager URL for the new trace.
+Voyager opens at [localhost:4242](http://localhost:4242) by default. `tdg call` prints the direct Voyager URL for the new trace.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/assets/voyager-dark.png">

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -27,8 +27,7 @@
     "@clavia/tardigrade-server": "workspace:*",
     "@effect/platform-bun": "4.0.0-rc.110",
     "@effect/platform-node-shared": "4.0.0-rc.110",
-    "effect": "4.0.0-rc.110",
-    "tardie": "workspace:*"
+    "effect": "4.0.0-rc.110"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -27,14 +27,12 @@
     "@clavia/tardigrade-server": "workspace:*",
     "@effect/platform-bun": "4.0.0-rc.110",
     "@effect/platform-node-shared": "4.0.0-rc.110",
-    "effect": "4.0.0-rc.110"
+    "effect": "4.0.0-rc.110",
+    "tardie": "workspace:*"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "bun test",
     "start": "bun run src/main.ts"
-  },
-  "devDependencies": {
-    "tardie": "workspace:*"
   }
 }

--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, test } from "bun:test"
 import { Cause, Console, Effect, Exit, Layer, Option } from "effect"
 import { CliError, Command } from "effect/unstable/cli"
 import { BunServices } from "@effect/platform-bun"
-import { ProblemError, RESERVED_ACTOR, type Accepted, type ActorSummary, type ThreadSummary, type Client, type EventRow, type TurnView } from "@clavia/tardigrade-client"
+import { ProblemError, RESERVED_ACTOR, type ActorSummary, type ThreadSummary, type Client, type EventRow, type MethodAccepted } from "@clavia/tardigrade-client"
+import type { ActorMethodState } from "tardie"
 
 import { NO_MODEL_NOTICE, problemLine, tdg } from "./commands"
-import { Cli, type CliProjections, type CliServices } from "./services"
+import { Cli, type CliMethods, type CliServices } from "./services"
 
 // The command tree, driven the way a shell drives it: real arguments through the real parser, over
 // a client this file wrote. Nothing here spawns a process, and nothing here reaches a network.
@@ -20,7 +21,7 @@ const events: ReadonlyArray<EventRow> = [
 ]
 
 interface Recorded {
-  readonly appended: Array<{ thread: string; id: string; text: string }>
+  readonly invoked: Array<{ thread: string; id: string; text: string }>
   readonly asked: Array<{ thread: string; options: unknown }>
 }
 
@@ -34,10 +35,10 @@ const clientOf = (
     readonly list?: ReadonlyArray<ThreadSummary>
     readonly actors?: ReadonlyArray<ActorSummary>
     readonly events?: ReadonlyArray<EventRow>
-    readonly turns?: ReadonlyArray<TurnView>
+    readonly states?: ReadonlyArray<ActorMethodState<string>>
     readonly fail?: ProblemError
   }
-): Client<CliProjections> => {
+): Client<{}, CliMethods> => {
   let read = 0
   return {
     baseUrl: "http://localhost:0",
@@ -50,25 +51,28 @@ const clientOf = (
       recorded.asked.push({ thread, options })
       return answers.fail === undefined ? Promise.resolve(answers.events ?? []) : Promise.reject(answers.fail)
     },
-    // The single turn lookup is a query on the actor's declared projection, so the stand-in answers
-    // it the way the server does: the entries that match, narrowed by `turn` when one is stated.
-    projection: ((_thread: string, _name: string, query?: { readonly turn?: string }) => {
-      const views = answers.turns ?? []
-      const view = views[Math.min(read++, views.length - 1)]
-      if (view === undefined) return refuse()
-      const wanted = query?.turn
-      return Promise.resolve(wanted === undefined || view.turn === wanted ? [view] : [])
-    }) as Client<CliProjections>["projection"],
-    append: (thread, event) => {
-      recorded.appended.push({
+    methodState: () => {
+      const states = answers.states ?? []
+      const state = states[Math.min(read++, states.length - 1)]
+      return state === undefined ? refuse() : Promise.resolve(state)
+    },
+    invoke: (thread, _name, invocation) => {
+      recorded.invoked.push({
         thread,
-        id: String(event["id"] ?? ""),
-        text: String(event["text"] ?? "")
+        id: invocation.id,
+        text: invocation.input.text
       })
       return answers.fail === undefined
-        ? Promise.resolve({ actor: RESERVED_ACTOR, thread } satisfies Accepted)
+        ? Promise.resolve({
+          actor: RESERVED_ACTOR,
+          thread,
+          method: "message",
+          call: invocation.id
+        } satisfies MethodAccepted)
         : Promise.reject(answers.fail)
     },
+    append: refuse,
+    projection: refuse as Client<{}, CliMethods>["projection"],
     tree: refuse,
     resume: refuse,
     health: refuse,
@@ -95,7 +99,7 @@ const drive = async (
   } = {}
 ): Promise<Ran> => {
   const lines: Array<string> = []
-  const recorded: Recorded = { appended: [], asked: [] }
+  const recorded: Recorded = { invoked: [], asked: [] }
   const minted = [...(options.ids ?? ["minted-1", "minted-2", "minted-3"])]
   const services: CliServices = {
     env: options.env ?? {},
@@ -267,12 +271,12 @@ describe("send", () => {
   test("the turn handle is printed and nothing is waited on", async () => {
     const ran = await drive(["send", "root", "do the thing"])
     expect(ran.lines[0]).toBe("root minted-1")
-    expect(ran.recorded.appended).toEqual([{ thread: "root", id: "minted-1", text: "do the thing" }])
+    expect(ran.recorded.invoked).toEqual([{ thread: "root", id: "minted-1", text: "do the thing" }])
   })
 
   test("a stated id is the id, so a retry is absorbed", async () => {
     const ran = await drive(["send", "root", "again", "--id", "m1"])
-    expect(ran.recorded.appended[0]?.id).toBe("m1")
+    expect(ran.recorded.invoked[0]?.id).toBe("m1")
   })
 
   test("--json prints the handle verbatim", async () => {
@@ -287,9 +291,9 @@ describe("run", () => {
       ["run", "summarize", "--thread", "root", "--id", "m1", "--poll", "1"],
       {
         answers: {
-          turns: [
-            { turn: "m1", status: "pending", epoch: 0 },
-            { turn: "m1", status: "completed", epoch: 0, output: "the summary" }
+          states: [
+            { status: "pending" },
+            { status: "completed", output: "the summary" }
           ]
         }
       }
@@ -302,22 +306,30 @@ describe("run", () => {
 
   test("a thread nobody named is minted, so a run births its own thread", async () => {
     const ran = await drive(["run", "hello", "--poll", "1"], {
-      answers: { turns: [{ turn: "minted-2", status: "completed", epoch: 0, output: "hi" }] }
+      answers: { states: [{ status: "completed", output: "hi" }] }
     })
-    expect(ran.recorded.appended).toEqual([{ thread: "minted-1", id: "minted-2", text: "hello" }])
+    expect(ran.recorded.invoked).toEqual([{ thread: "minted-1", id: "minted-2", text: "hello" }])
   })
 
   test("a failed turn prints its error and exits non-zero", async () => {
     const ran = await drive(["run", "hello", "--thread", "root", "--id", "m1", "--poll", "1"], {
-      answers: { turns: [{ turn: "m1", status: "failed", epoch: 0, error: "no model is configured" }] }
+      answers: { states: [{ status: "failed", error: "no model is configured" }] }
     })
     expect(ran.lines[0]).toBe("root m1 failed\nno model is configured")
     expect(ran.failed).toBe(true)
   })
 
+  test("a blocked turn prints its reason and exits non-zero", async () => {
+    const ran = await drive(["run", "hello", "--thread", "root", "--id", "m1", "--poll", "1"], {
+      answers: { states: [{ status: "blocked", reason: "budget" }] }
+    })
+    expect(ran.lines[0]).toBe("root m1 blocked\nbudget")
+    expect(ran.failed).toBe(true)
+  })
+
   test("a turn that never settles gives up rather than hanging", async () => {
     const ran = await drive(["run", "hello", "--thread", "root", "--id", "m1", "--poll", "1", "--timeout", "0"], {
-      answers: { turns: [{ turn: "m1", status: "pending", epoch: 0 }] }
+      answers: { states: [{ status: "pending" }] }
     })
     expect(ran.failed).toBe(true)
     expect(failureText(ran)).toContain("still pending")

--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -2,11 +2,10 @@ import { describe, expect, test } from "bun:test"
 import { Cause, Console, Effect, Exit, Layer, Option } from "effect"
 import { CliError, Command } from "effect/unstable/cli"
 import { BunServices } from "@effect/platform-bun"
-import { ProblemError, RESERVED_ACTOR, type ActorSummary, type ThreadSummary, type Client, type EventRow, type MethodAccepted } from "@clavia/tardigrade-client"
-import type { ActorMethodState } from "tardie"
+import { ProblemError, RESERVED_ACTOR, type ActorSummary, type ThreadSummary, type Client, type EventRow, type MethodAccepted, type MethodState, type MethodSummary } from "@clavia/tardigrade-client"
 
 import { NO_MODEL_NOTICE, problemLine, tdg } from "./commands"
-import { Cli, type CliMethods, type CliServices } from "./services"
+import { Cli, type CliServices } from "./services"
 
 // The command tree, driven the way a shell drives it: real arguments through the real parser, over
 // a client this file wrote. Nothing here spawns a process, and nothing here reaches a network.
@@ -21,8 +20,9 @@ const events: ReadonlyArray<EventRow> = [
 ]
 
 interface Recorded {
-  readonly invoked: Array<{ thread: string; id: string; text: string }>
+  readonly invoked: Array<{ thread: string; method: string; id: string; input: unknown }>
   readonly asked: Array<{ thread: string; options: unknown }>
+  methodReads: number
 }
 
 const refuse = () => Promise.reject(new Error("this command should not have called that"))
@@ -35,10 +35,11 @@ const clientOf = (
     readonly list?: ReadonlyArray<ThreadSummary>
     readonly actors?: ReadonlyArray<ActorSummary>
     readonly events?: ReadonlyArray<EventRow>
-    readonly states?: ReadonlyArray<ActorMethodState<string>>
+    readonly methods?: ReadonlyArray<MethodSummary>
+    readonly states?: ReadonlyArray<MethodState>
     readonly fail?: ProblemError
   }
-): Client<{}, CliMethods> => {
+): Client => {
   let read = 0
   return {
     baseUrl: "http://localhost:0",
@@ -47,32 +48,35 @@ const clientOf = (
       ? Promise.resolve(answers.actors ?? [{ name: RESERVED_ACTOR, builtIn: true }])
       : Promise.reject(answers.fail),
     list: () => (answers.fail === undefined ? Promise.resolve(answers.list ?? []) : Promise.reject(answers.fail)),
+    methods: () => answers.fail === undefined ? Promise.resolve(answers.methods ?? []) : Promise.reject(answers.fail),
     events: (thread, options) => {
       recorded.asked.push({ thread, options })
       return answers.fail === undefined ? Promise.resolve(answers.events ?? []) : Promise.reject(answers.fail)
     },
     methodState: () => {
+      recorded.methodReads += 1
       const states = answers.states ?? []
       const state = states[Math.min(read++, states.length - 1)]
       return state === undefined ? refuse() : Promise.resolve(state)
     },
-    invoke: (thread, _name, invocation) => {
+    invoke: (thread, name, invocation) => {
       recorded.invoked.push({
         thread,
+        method: name,
         id: invocation.id,
-        text: invocation.input.text
+        input: invocation.input
       })
       return answers.fail === undefined
         ? Promise.resolve({
           actor: RESERVED_ACTOR,
           thread,
-          method: "message",
+          method: name,
           call: invocation.id
         } satisfies MethodAccepted)
         : Promise.reject(answers.fail)
     },
     append: refuse,
-    projection: refuse as Client<{}, CliMethods>["projection"],
+    projection: refuse as Client["projection"],
     tree: refuse,
     resume: refuse,
     health: refuse,
@@ -99,7 +103,7 @@ const drive = async (
   } = {}
 ): Promise<Ran> => {
   const lines: Array<string> = []
-  const recorded: Recorded = { invoked: [], asked: [] }
+  const recorded: Recorded = { invoked: [], asked: [], methodReads: 0 }
   const minted = [...(options.ids ?? ["minted-1", "minted-2", "minted-3"])]
   const services: CliServices = {
     env: options.env ?? {},
@@ -150,6 +154,10 @@ describe("parsing", () => {
     expect((await drive([])).lines.join("\n")).toContain("build")
     expect((await drive([])).lines.join("\n")).toContain("push")
     expect((await drive([])).lines.join("\n")).toContain("actors")
+    expect((await drive([])).lines.join("\n")).toContain("methods")
+    expect((await drive([])).lines.join("\n")).toContain("call")
+    expect((await drive([])).lines.join("\n")).not.toContain("run ")
+    expect((await drive([])).lines.join("\n")).not.toContain("send")
     const help = (await drive(["setup", "--help"])).lines.join("\n")
     expect(help).toContain("~/.tardigrade/config.json")
     expect(help).toContain("0600")
@@ -267,28 +275,31 @@ describe("events", () => {
   })
 })
 
-describe("send", () => {
-  test("the turn handle is printed and nothing is waited on", async () => {
-    const ran = await drive(["send", "root", "do the thing"])
-    expect(ran.lines[0]).toBe("root minted-1")
-    expect(ran.recorded.invoked).toEqual([{ thread: "root", id: "minted-1", text: "do the thing" }])
+describe("methods", () => {
+  const methods: ReadonlyArray<MethodSummary> = [{
+    name: "message",
+    input: { schema: { type: "object", required: ["text"], properties: { text: { type: "string" } } } },
+    output: { schema: { type: "string" } }
+  }]
+
+  test("the human rendering shows each method and schema", async () => {
+    const ran = await drive(["methods"], { answers: { methods } })
+    expect(ran.failed).toBe(false)
+    expect(ran.lines[0]).toContain("message")
+    expect(ran.lines[0]).toContain("\"required\":[\"text\"]")
+    expect(ran.lines[0]).toContain("output {\"type\":\"string\"}")
   })
 
-  test("a stated id is the id, so a retry is absorbed", async () => {
-    const ran = await drive(["send", "root", "again", "--id", "m1"])
-    expect(ran.recorded.invoked[0]?.id).toBe("m1")
-  })
-
-  test("--json prints the handle verbatim", async () => {
-    const ran = await drive(["send", "root", "again", "--json", "--id", "m1"])
-    expect(JSON.parse(ran.lines[0] ?? "")).toEqual({ actor: RESERVED_ACTOR, thread: "root", turn: "m1" })
+  test("--json prints the method catalog verbatim", async () => {
+    const ran = await drive(["methods", "--json"], { answers: { methods } })
+    expect(JSON.parse(ran.lines[0] ?? "")).toEqual(methods)
   })
 })
 
-describe("run", () => {
-  test("a pending turn is polled until it settles, and the output is printed", async () => {
+describe("call", () => {
+  test("a pending call is polled until it settles, and the output is printed", async () => {
     const ran = await drive(
-      ["run", "summarize", "--thread", "root", "--id", "m1", "--poll", "1"],
+      ["call", "message", "{\"text\":\"summarize\"}", "--thread", "root", "--id", "m1", "--poll", "1"],
       {
         answers: {
           states: [
@@ -302,33 +313,72 @@ describe("run", () => {
     expect(ran.lines[0]).toBe(
       "root m1 completed\nthe summary\n\ntrace\n  http://localhost:0/?actor=default&thread=root"
     )
+    expect(ran.recorded.invoked).toEqual([{
+      thread: "root",
+      method: "message",
+      id: "m1",
+      input: { text: "summarize" }
+    }])
   })
 
-  test("a thread nobody named is minted, so a run births its own thread", async () => {
-    const ran = await drive(["run", "hello", "--poll", "1"], {
-      answers: { states: [{ status: "completed", output: "hi" }] }
+  test("a custom method receives its JSON input", async () => {
+    const ran = await drive(["call", "inspect", "{\"path\":\"README.md\",\"depth\":2}", "--poll", "1"], {
+      answers: { states: [{ status: "completed", output: { findings: 3 } }] }
     })
-    expect(ran.recorded.invoked).toEqual([{ thread: "minted-1", id: "minted-2", text: "hello" }])
+    expect(ran.recorded.invoked).toEqual([{
+      thread: "minted-1",
+      method: "inspect",
+      id: "minted-2",
+      input: { path: "README.md", depth: 2 }
+    }])
+    expect(ran.lines[0]).toContain('{\n  "findings": 3\n}')
   })
 
-  test("a failed turn prints its error and exits non-zero", async () => {
-    const ran = await drive(["run", "hello", "--thread", "root", "--id", "m1", "--poll", "1"], {
+  test("--no-wait prints the durable handle without reading state", async () => {
+    const ran = await drive(["call", "message", "{\"text\":\"again\"}", "--thread", "root", "--id", "m1", "--no-wait"])
+    expect(ran.failed).toBe(false)
+    expect(ran.lines[0]).toBe("root m1 accepted")
+    expect(ran.recorded.methodReads).toBe(0)
+  })
+
+  test("--json includes the handle and terminal state", async () => {
+    const ran = await drive(["call", "message", "{\"text\":\"again\"}", "--thread", "root", "--id", "m1", "--json"], {
+      answers: { states: [{ status: "completed", output: "done" }] }
+    })
+    expect(JSON.parse(ran.lines[0] ?? "")).toEqual({
+      actor: RESERVED_ACTOR,
+      thread: "root",
+      method: "message",
+      call: "m1",
+      state: { status: "completed", output: "done" }
+    })
+  })
+
+  test("malformed JSON is refused before a method is invoked", async () => {
+    const ran = await drive(["call", "message", "hello"])
+    expect(ran.failed).toBe(true)
+    expect(failureText(ran)).toContain("valid JSON")
+    expect(ran.recorded.invoked).toEqual([])
+  })
+
+  test("a failed call prints its error and exits non-zero", async () => {
+    const ran = await drive(["call", "message", "{\"text\":\"hello\"}", "--thread", "root", "--id", "m1", "--poll", "1"], {
       answers: { states: [{ status: "failed", error: "no model is configured" }] }
     })
     expect(ran.lines[0]).toBe("root m1 failed\nno model is configured")
     expect(ran.failed).toBe(true)
   })
 
-  test("a blocked turn prints its reason and exits non-zero", async () => {
-    const ran = await drive(["run", "hello", "--thread", "root", "--id", "m1", "--poll", "1"], {
+  test("a blocked call prints its reason and exits non-zero", async () => {
+    const ran = await drive(["call", "message", "{\"text\":\"hello\"}", "--thread", "root", "--id", "m1", "--poll", "1"], {
       answers: { states: [{ status: "blocked", reason: "budget" }] }
     })
     expect(ran.lines[0]).toBe("root m1 blocked\nbudget")
     expect(ran.failed).toBe(true)
   })
 
-  test("a turn that never settles gives up rather than hanging", async () => {
-    const ran = await drive(["run", "hello", "--thread", "root", "--id", "m1", "--poll", "1", "--timeout", "0"], {
+  test("a call that never settles gives up rather than hanging", async () => {
+    const ran = await drive(["call", "message", "{\"text\":\"hello\"}", "--thread", "root", "--id", "m1", "--poll", "1", "--timeout", "0"], {
       answers: { states: [{ status: "pending" }] }
     })
     expect(ran.failed).toBe(true)

--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -149,15 +149,12 @@ describe("parsing", () => {
   // Every command is a declaration, so a command that exists is a command the help names. `setup`
   // is the first one a person runs, so it is the first one listed (commands.ts, tdg).
   test("the tree names setup, and its help says what it writes", async () => {
-    expect((await drive([])).lines.join("\n")).toContain("setup")
-    expect((await drive([])).lines.join("\n")).toContain("init")
-    expect((await drive([])).lines.join("\n")).toContain("build")
-    expect((await drive([])).lines.join("\n")).toContain("push")
-    expect((await drive([])).lines.join("\n")).toContain("actors")
-    expect((await drive([])).lines.join("\n")).toContain("methods")
-    expect((await drive([])).lines.join("\n")).toContain("call")
-    expect((await drive([])).lines.join("\n")).not.toContain("run ")
-    expect((await drive([])).lines.join("\n")).not.toContain("send")
+    const root = (await drive([])).lines.join("\n")
+    for (const command of ["setup", "init", "build", "push", "actors", "methods", "call"]) {
+      expect(root).toContain(command)
+    }
+    expect(root).not.toContain("run ")
+    expect(root).not.toContain("send")
     const help = (await drive(["setup", "--help"])).lines.join("\n")
     expect(help).toContain("~/.tardigrade/config.json")
     expect(help).toContain("0600")
@@ -350,7 +347,8 @@ describe("call", () => {
       thread: "root",
       method: "message",
       call: "m1",
-      state: { status: "completed", output: "done" }
+      status: "completed",
+      output: "done"
     })
   })
 

--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -278,8 +278,8 @@ describe("events", () => {
 describe("methods", () => {
   const methods: ReadonlyArray<MethodSummary> = [{
     name: "message",
-    input: { schema: { type: "object", required: ["text"], properties: { text: { type: "string" } } } },
-    output: { schema: { type: "string" } }
+    inputSchema: { type: "object", required: ["text"], properties: { text: { type: "string" } } },
+    outputSchema: { type: "string" }
   }]
 
   test("the human rendering shows each method and schema", async () => {

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -1,6 +1,7 @@
 import { Clock, Console, Effect, Layer, Option } from "effect"
 import { Argument, CliError, Command, Flag } from "effect/unstable/cli"
-import { NO_ANSWER, ProblemError, RESERVED_ACTOR, type Client, type TurnView } from "@clavia/tardigrade-client"
+import { NO_ANSWER, ProblemError, RESERVED_ACTOR, type Client } from "@clavia/tardigrade-client"
+import type { ActorMethodState } from "tardie"
 
 import { modelIsConfigured } from "@clavia/tardigrade-server/host"
 
@@ -10,8 +11,8 @@ import { availableDevPort, DEFAULT_ACTOR_REFRESH_MILLIS, DEFAULT_MIN_PORT, DEV_U
 import { initActor, initSummary } from "./init"
 import { DEFAULT_ACTOR_DIRECTORY, pushActor, pushSummary, PUSH_TARGETS } from "./push"
 import { homeOf, HOME_MISSING, setupJson, setupPrompt, setupSummary, writeSetup } from "./setup"
-import { actorsTable, threadsTable, DEFAULT_DETAIL_WIDTH, eventsTable, jsonOf, turnLines } from "./render"
-import { Cli, type CliProjections } from "./services"
+import { actorsTable, threadsTable, DEFAULT_DETAIL_WIDTH, eventsTable, jsonOf, methodLines } from "./render"
+import { Cli, type CliMethods } from "./services"
 import { traceUrlFor } from "./workflow"
 
 // The command tree. Every command is a declaration: its flags, its arguments, and its description
@@ -33,10 +34,8 @@ export const DEFAULT_TIMEOUT_MILLIS = 300_000
 // overrides it for scripts, containers, and remote shells.
 export const DEFAULT_OPEN_BROWSER = true
 
-// The turn status a run is asked for. Everything else, `failed` and `parked` alike, leaves the
-// command with a non-zero exit: a script that ran a turn and got no answer should not read as
-// success (commands.test.ts, "a failed turn prints its error and exits non-zero").
-export const SETTLED: TurnView["status"] = "completed"
+// SETTLED is the method state that makes `tdg run` succeed.
+export const SETTLED: ActorMethodState<string>["status"] = "completed"
 
 // problemLine is the whole of what a failed call prints. The four fields are the server's own words
 // (packages/client/src/problem.ts), and a status of NO_ANSWER means the call never reached a
@@ -106,21 +105,17 @@ const clientOf = (flags: {
 const stated = (option: Option.Option<string>): string | undefined => Option.getOrUndefined(option)
 
 const settle = (
-  client: Client<CliProjections>,
+  client: Client<{}, CliMethods>,
   thread: string,
   turn: string,
   pollMillis: number,
   timeoutMillis: number
-): Effect.Effect<TurnView, CliError.UserError> =>
+): Effect.Effect<ActorMethodState<string>, CliError.UserError> =>
   Effect.gen(function*() {
     const started = yield* Clock.currentTimeMillis
     for (;;) {
-      // The single lookup is a query on the actor's declared projection rather than a route of its
-      // own: `turn` narrows it to one entry, and a turn nobody was asked to serve matches nothing
-      // (apps/server/src/actor.ts, agentProjections).
-      const views = yield* call(() => client.projection(thread, "turns", { turn }))
-      const view = views.find((candidate) => candidate.turn === turn)
-      if (view !== undefined && view.status !== "pending") return view
+      const state = yield* call(() => client.methodState(thread, "message", turn))
+      if (state.status !== "pending") return state
       if ((yield* Clock.currentTimeMillis) - started >= timeoutMillis) {
         return yield* userErrorOf(
           `turn ${turn} on thread ${thread} was still pending after ${timeoutMillis}ms. It is still running: read it with \`tdg events ${thread}\`.`
@@ -385,17 +380,17 @@ export const runCommand = Command.make("run", {
     const client = yield* clientOf(flags)
     const thread = stated(flags.thread) ?? cli.mintId()
     const id = stated(flags.id) ?? cli.mintId()
-    const accepted = yield* call(() => client.append(thread, { type: "MessageReceived", id, text: flags.brief }))
+    const accepted = yield* call(() => client.invoke(thread, "message", { id, input: { text: flags.brief } }))
     const view = yield* settle(client, accepted.thread, id, flags.poll, flags.timeout)
     yield* Console.log(
       flags.json
         ? jsonOf(view)
         : view.status === SETTLED
-        ? `${turnLines(accepted.thread, view)}\n\ntrace\n  ${traceUrlFor(client.baseUrl, client.actor, accepted.thread)}`
-        : turnLines(accepted.thread, view)
+        ? `${methodLines(accepted.thread, id, view)}\n\ntrace\n  ${traceUrlFor(client.baseUrl, client.actor, accepted.thread)}`
+        : methodLines(accepted.thread, id, view)
     )
     if (view.status !== SETTLED) {
-      return yield* userErrorOf(`turn ${view.turn} on thread ${accepted.thread} is ${view.status}`)
+      return yield* userErrorOf(`turn ${id} on thread ${accepted.thread} is ${view.status}`)
     }
   })).pipe(
     Command.withDescription(
@@ -417,10 +412,13 @@ export const sendCommand = Command.make("send", {
     const cli = yield* Cli
     const client = yield* clientOf(flags)
     const id = stated(flags.id) ?? cli.mintId()
-    const accepted = yield* call(() => client.append(flags.thread, { type: "MessageReceived", id, text: flags.brief }))
-    // The turn is the id this invocation minted: the platform echoes the two levels it knows and
-    // nothing turn-shaped, because a turn is the actor's reading of the log (contract.ts, Accepted).
-    yield* Console.log(flags.json ? jsonOf({ ...accepted, turn: id }) : `${accepted.thread} ${id}`)
+    const accepted = yield* call(() => client.invoke(flags.thread, "message", { id, input: { text: flags.brief } }))
+    // The JSON output keeps the command's existing turn handle while the method endpoint returns its richer handle.
+    yield* Console.log(
+      flags.json
+        ? jsonOf({ actor: accepted.actor, thread: accepted.thread, turn: id })
+        : `${accepted.thread} ${id}`
+    )
   })).pipe(
     Command.withDescription(
       "Deliver a brief and print the turn handle without waiting. The turn settles on the server's own loop."

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -1,7 +1,6 @@
 import { Clock, Console, Effect, Layer, Option } from "effect"
 import { Argument, CliError, Command, Flag } from "effect/unstable/cli"
-import { NO_ANSWER, ProblemError, RESERVED_ACTOR, type Client } from "@clavia/tardigrade-client"
-import type { ActorMethodState } from "tardie"
+import { NO_ANSWER, ProblemError, RESERVED_ACTOR, type Client, type MethodState } from "@clavia/tardigrade-client"
 
 import { modelIsConfigured } from "@clavia/tardigrade-server/host"
 
@@ -11,8 +10,8 @@ import { availableDevPort, DEFAULT_ACTOR_REFRESH_MILLIS, DEFAULT_MIN_PORT, DEV_U
 import { initActor, initSummary } from "./init"
 import { DEFAULT_ACTOR_DIRECTORY, pushActor, pushSummary, PUSH_TARGETS } from "./push"
 import { homeOf, HOME_MISSING, setupJson, setupPrompt, setupSummary, writeSetup } from "./setup"
-import { actorsTable, threadsTable, DEFAULT_DETAIL_WIDTH, eventsTable, jsonOf, methodLines } from "./render"
-import { Cli, type CliMethods } from "./services"
+import { actorsTable, threadsTable, DEFAULT_DETAIL_WIDTH, eventsTable, jsonOf, methodLines, methodsLines } from "./render"
+import { Cli } from "./services"
 import { traceUrlFor } from "./workflow"
 
 // The command tree. Every command is a declaration: its flags, its arguments, and its description
@@ -20,22 +19,18 @@ import { traceUrlFor } from "./workflow"
 // the same tree the parser runs (commands.test.ts). A handler is a few lines over the derived
 // client (packages/client) and holds no wire knowledge of its own.
 
-// How often `tdg run` asks whether the turn it delivered has left `pending`. The server answers a
-// delivery with 202 and settles the turn on its own loop, so waiting is polling; this is the delay
-// a person sees between the turn finishing and the command printing.
+// DEFAULT_POLL_MILLIS is how often `tdg call` asks whether a method call has left `pending`.
 export const DEFAULT_POLL_MILLIS = 200
 
-// How long `tdg run` waits before it gives up and says so. A turn that outlives this is still
-// running on the server, and its output is still one `tdg events` away, so the number bounds the
-// command rather than the work.
+// DEFAULT_TIMEOUT_MILLIS bounds how long `tdg call` waits while the server continues the work.
 export const DEFAULT_TIMEOUT_MILLIS = 300_000
 
 // DEFAULT_OPEN_BROWSER is whether `tdg dev` opens the UI after listening. The `--no-open` flag
 // overrides it for scripts, containers, and remote shells.
 export const DEFAULT_OPEN_BROWSER = true
 
-// SETTLED is the method state that makes `tdg run` succeed.
-export const SETTLED: ActorMethodState<string>["status"] = "completed"
+// SETTLED is the method state that makes `tdg call` succeed.
+export const SETTLED: MethodState["status"] = "completed"
 
 // problemLine is the whole of what a failed call prints. The four fields are the server's own words
 // (packages/client/src/problem.ts), and a status of NO_ANSWER means the call never reached a
@@ -79,9 +74,9 @@ const actor = Flag.string("actor").pipe(
   Flag.withDefault(RESERVED_ACTOR)
 )
 
-const messageId = Flag.string("id").pipe(
+const invocationId = Flag.string("id").pipe(
   Flag.withDescription(
-    "The message id, which is also the turn id and the dedup key. A fresh one is minted per invocation, so state it to make a retry absorbed rather than duplicated."
+    "The call id and dedup key. A fresh one is minted per invocation, so state it to make a retry absorbed rather than duplicated."
   ),
   Flag.optional
 )
@@ -104,21 +99,28 @@ const clientOf = (flags: {
 
 const stated = (option: Option.Option<string>): string | undefined => Option.getOrUndefined(option)
 
+const methodInput = (source: string): Effect.Effect<unknown, CliError.UserError> =>
+  Effect.try({
+    try: () => JSON.parse(source) as unknown,
+    catch: () => userErrorOf("method input must be valid JSON")
+  })
+
 const settle = (
-  client: Client<{}, CliMethods>,
+  client: Client,
   thread: string,
-  turn: string,
+  method: string,
+  invocation: string,
   pollMillis: number,
   timeoutMillis: number
-): Effect.Effect<ActorMethodState<string>, CliError.UserError> =>
+): Effect.Effect<MethodState, CliError.UserError> =>
   Effect.gen(function*() {
     const started = yield* Clock.currentTimeMillis
     for (;;) {
-      const state = yield* call(() => client.methodState(thread, "message", turn))
+      const state = yield* call(() => client.methodState(thread, method, invocation))
       if (state.status !== "pending") return state
       if ((yield* Clock.currentTimeMillis) - started >= timeoutMillis) {
         return yield* userErrorOf(
-          `turn ${turn} on thread ${thread} was still pending after ${timeoutMillis}ms. It is still running: read it with \`tdg events ${thread}\`.`
+          `call ${invocation} on thread ${thread} was still pending after ${timeoutMillis}ms. It is still running: read it with \`tdg events ${thread}\`.`
         )
       }
       yield* Effect.sleep(pollMillis)
@@ -358,19 +360,37 @@ export const devCommand = Command.make("dev", {
       ])
     )
 
-export const runCommand = Command.make("run", {
-  brief: Argument.string("brief").pipe(Argument.withDescription("What to ask the actor to do")),
+export const methodsCommand = Command.make("methods", remote, (flags) =>
+  Effect.gen(function*() {
+    const client = yield* clientOf(flags)
+    const methods = yield* call(() => client.methods())
+    yield* Console.log(flags.json ? jsonOf(methods) : methodsLines(methods))
+  })).pipe(
+    Command.withDescription("List the actor's callable methods and their input and output schemas."),
+    Command.withExamples([
+      { command: "tdg methods --actor researcher", description: "Inspect an actor's callable interface" },
+      { command: "tdg methods --actor researcher --json", description: "Print the method catalog as JSON" }
+    ])
+  )
+
+export const callCommand = Command.make("call", {
+  method: Argument.string("method").pipe(Argument.withDescription("The declared method to call")),
+  input: Argument.string("input").pipe(Argument.withDescription("The method input as JSON")),
   thread: Flag.string("thread").pipe(
-    Flag.withDescription("The thread to deliver to. A fresh id is minted per invocation, which births a new thread."),
+    Flag.withDescription("The thread to call. A fresh id is minted when this flag is absent."),
     Flag.optional
   ),
-  id: messageId,
+  id: invocationId,
+  wait: Flag.boolean("wait").pipe(
+    Flag.withDescription("Wait for the method call to leave pending."),
+    Flag.withDefault(true)
+  ),
   poll: Flag.integer("poll").pipe(
-    Flag.withDescription("Milliseconds between turn reads while waiting."),
+    Flag.withDescription("Milliseconds between method state reads while waiting."),
     Flag.withDefault(DEFAULT_POLL_MILLIS)
   ),
   timeout: Flag.integer("timeout").pipe(
-    Flag.withDescription("Milliseconds to wait for the turn to leave pending."),
+    Flag.withDescription("Milliseconds to wait for the method call to leave pending."),
     Flag.withDefault(DEFAULT_TIMEOUT_MILLIS)
   ),
   ...remote
@@ -380,49 +400,32 @@ export const runCommand = Command.make("run", {
     const client = yield* clientOf(flags)
     const thread = stated(flags.thread) ?? cli.mintId()
     const id = stated(flags.id) ?? cli.mintId()
-    const accepted = yield* call(() => client.invoke(thread, "message", { id, input: { text: flags.brief } }))
-    const view = yield* settle(client, accepted.thread, id, flags.poll, flags.timeout)
+    const input = yield* methodInput(flags.input)
+    const accepted = yield* call(() => client.invoke(thread, flags.method, { id, input }))
+    if (!flags.wait) {
+      yield* Console.log(flags.json ? jsonOf(accepted) : `${accepted.thread} ${accepted.call} accepted`)
+      return
+    }
+    const state = yield* settle(client, accepted.thread, accepted.method, accepted.call, flags.poll, flags.timeout)
     yield* Console.log(
       flags.json
-        ? jsonOf(view)
-        : view.status === SETTLED
-        ? `${methodLines(accepted.thread, id, view)}\n\ntrace\n  ${traceUrlFor(client.baseUrl, client.actor, accepted.thread)}`
-        : methodLines(accepted.thread, id, view)
+        ? jsonOf({ ...accepted, state })
+        : state.status === SETTLED
+        ? `${methodLines(accepted.thread, accepted.call, state)}\n\ntrace\n  ${traceUrlFor(client.baseUrl, client.actor, accepted.thread)}`
+        : methodLines(accepted.thread, accepted.call, state)
     )
-    if (view.status !== SETTLED) {
-      return yield* userErrorOf(`turn ${id} on thread ${accepted.thread} is ${view.status}`)
+    if (state.status !== SETTLED) {
+      return yield* userErrorOf(`call ${accepted.call} on thread ${accepted.thread} is ${state.status}`)
     }
   })).pipe(
     Command.withDescription(
-      "Start a thread, wait for its turn to settle, and print what it answered. Exits non-zero unless the turn completed."
+      "Call a declared actor method with JSON input and wait for its durable state. Exits non-zero unless the call completes."
     ),
     Command.withExamples([
-      { command: "tdg run \"summarize the log\"", description: "Brief a new thread and wait for its answer" },
-      { command: "tdg run \"and again\" --thread surveyor", description: "Brief a thread that already exists" }
+      { command: "tdg call message '{\"text\":\"summarize the log\"}'", description: "Call message on a new thread and wait" },
+      { command: "tdg call message '{\"text\":\"and again\"}' --thread surveyor", description: "Call message on an existing thread" },
+      { command: "tdg call inspect '{\"path\":\"README.md\"}' --no-wait", description: "Call a custom method without waiting" }
     ])
-  )
-
-export const sendCommand = Command.make("send", {
-  thread: Argument.string("thread").pipe(Argument.withDescription("The thread to deliver to")),
-  brief: Argument.string("brief").pipe(Argument.withDescription("What to ask the actor to do")),
-  id: messageId,
-  ...remote
-}, (flags) =>
-  Effect.gen(function*() {
-    const cli = yield* Cli
-    const client = yield* clientOf(flags)
-    const id = stated(flags.id) ?? cli.mintId()
-    const accepted = yield* call(() => client.invoke(flags.thread, "message", { id, input: { text: flags.brief } }))
-    // The JSON output keeps the command's existing turn handle while the method endpoint returns its richer handle.
-    yield* Console.log(
-      flags.json
-        ? jsonOf({ actor: accepted.actor, thread: accepted.thread, turn: id })
-        : `${accepted.thread} ${id}`
-    )
-  })).pipe(
-    Command.withDescription(
-      "Deliver a brief and print the turn handle without waiting. The turn settles on the server's own loop."
-    )
   )
 
 export const lsCommand = Command.make("ls", remote, (flags) =>
@@ -431,7 +434,7 @@ export const lsCommand = Command.make("ls", remote, (flags) =>
     const threads = yield* call(() => client.list())
     yield* Console.log(flags.json ? jsonOf(threads) : threadsTable(threads))
   })).pipe(
-    Command.withDescription("List every thread a store holds, parent before child. A spawned child is a thread like any other, so a run that spawned nine lists ten rows."),
+    Command.withDescription("List every thread a store holds, parent before child. An execution that spawned nine children lists ten rows."),
     Command.withAlias("list")
   )
 
@@ -489,5 +492,5 @@ export const tdg = Command.make("tdg").pipe(
   Command.withDescription(
     "The tardigrade command. Every read is a projection of a durable log, and every failure is the server's own problem document."
   ),
-  Command.withSubcommands([setupCommand, initCommand, buildCommand, pushCommand, devCommand, actorsCommand, runCommand, sendCommand, lsCommand, eventsCommand])
+  Command.withSubcommands([setupCommand, initCommand, buildCommand, pushCommand, devCommand, actorsCommand, methodsCommand, callCommand, lsCommand, eventsCommand])
 )

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -29,9 +29,6 @@ export const DEFAULT_TIMEOUT_MILLIS = 300_000
 // overrides it for scripts, containers, and remote shells.
 export const DEFAULT_OPEN_BROWSER = true
 
-// SETTLED is the method state that makes `tdg call` succeed.
-export const SETTLED: MethodState["status"] = "completed"
-
 // problemLine is the whole of what a failed call prints. The four fields are the server's own words
 // (packages/client/src/problem.ts), and a status of NO_ANSWER means the call never reached a
 // response, so there is no status line to quote.
@@ -74,9 +71,9 @@ const actor = Flag.string("actor").pipe(
   Flag.withDefault(RESERVED_ACTOR)
 )
 
-const invocationId = Flag.string("id").pipe(
+const callId = Flag.string("id").pipe(
   Flag.withDescription(
-    "The call id and dedup key. A fresh one is minted per invocation, so state it to make a retry absorbed rather than duplicated."
+    "The call id. A fresh id is minted unless stated; reuse it for an idempotent retry."
   ),
   Flag.optional
 )
@@ -109,18 +106,18 @@ const settle = (
   client: Client,
   thread: string,
   method: string,
-  invocation: string,
+  callId: string,
   pollMillis: number,
   timeoutMillis: number
 ): Effect.Effect<MethodState, CliError.UserError> =>
   Effect.gen(function*() {
     const started = yield* Clock.currentTimeMillis
     for (;;) {
-      const state = yield* call(() => client.methodState(thread, method, invocation))
+      const state = yield* call(() => client.methodState(thread, method, callId))
       if (state.status !== "pending") return state
       if ((yield* Clock.currentTimeMillis) - started >= timeoutMillis) {
         return yield* userErrorOf(
-          `call ${invocation} on thread ${thread} was still pending after ${timeoutMillis}ms. It is still running: read it with \`tdg events ${thread}\`.`
+          `call ${callId} on thread ${thread} was still pending after ${timeoutMillis}ms. It is still running: read it with \`tdg events ${thread}\`.`
         )
       }
       yield* Effect.sleep(pollMillis)
@@ -366,7 +363,7 @@ export const methodsCommand = Command.make("methods", remote, (flags) =>
     const methods = yield* call(() => client.methods())
     yield* Console.log(flags.json ? jsonOf(methods) : methodsLines(methods))
   })).pipe(
-    Command.withDescription("List the actor's callable methods and their input and output schemas."),
+    Command.withDescription("List method names and their input and output schemas."),
     Command.withExamples([
       { command: "tdg methods --actor researcher", description: "Inspect an actor's callable interface" },
       { command: "tdg methods --actor researcher --json", description: "Print the method catalog as JSON" }
@@ -377,10 +374,10 @@ export const callCommand = Command.make("call", {
   method: Argument.string("method").pipe(Argument.withDescription("The declared method to call")),
   input: Argument.string("input").pipe(Argument.withDescription("The method input as JSON")),
   thread: Flag.string("thread").pipe(
-    Flag.withDescription("The thread to call. A fresh id is minted when this flag is absent."),
+    Flag.withDescription("The thread id. A fresh id is minted unless stated."),
     Flag.optional
   ),
-  id: invocationId,
+  id: callId,
   wait: Flag.boolean("wait").pipe(
     Flag.withDescription("Wait for the method call to leave pending."),
     Flag.withDefault(true)
@@ -409,22 +406,19 @@ export const callCommand = Command.make("call", {
     const state = yield* settle(client, accepted.thread, accepted.method, accepted.call, flags.poll, flags.timeout)
     yield* Console.log(
       flags.json
-        ? jsonOf({ ...accepted, state })
-        : state.status === SETTLED
+        ? jsonOf({ ...accepted, ...state })
+        : state.status === "completed"
         ? `${methodLines(accepted.thread, accepted.call, state)}\n\ntrace\n  ${traceUrlFor(client.baseUrl, client.actor, accepted.thread)}`
         : methodLines(accepted.thread, accepted.call, state)
     )
-    if (state.status !== SETTLED) {
+    if (state.status !== "completed") {
       return yield* userErrorOf(`call ${accepted.call} on thread ${accepted.thread} is ${state.status}`)
     }
   })).pipe(
-    Command.withDescription(
-      "Call a declared actor method with JSON input and wait for its durable state. Exits non-zero unless the call completes."
-    ),
+    Command.withDescription("Call an actor method with JSON input. Waits by default and exits non-zero unless completed."),
     Command.withExamples([
       { command: "tdg call message '{\"text\":\"summarize the log\"}'", description: "Call message on a new thread and wait" },
-      { command: "tdg call message '{\"text\":\"and again\"}' --thread surveyor", description: "Call message on an existing thread" },
-      { command: "tdg call inspect '{\"path\":\"README.md\"}' --no-wait", description: "Call a custom method without waiting" }
+      { command: "tdg call message '{\"text\":\"and again\"}' --thread surveyor", description: "Call message on an existing thread" }
     ])
   )
 

--- a/apps/cli/src/dev.test.ts
+++ b/apps/cli/src/dev.test.ts
@@ -246,9 +246,9 @@ describe("tdg dev", () => {
     expect(seen.index).toBe(200)
   })
 
-  test("run drives a brief to a completed turn with no model credentials", async () => {
+  test("call drives a message to completed with no model credentials", async () => {
     const seen = await booted(async (baseUrl) => {
-      const ran = await drive(baseUrl, ["run", "survey the log", "--thread", "root", "--id", "m1", "--poll", "10"])
+      const ran = await drive(baseUrl, ["call", "message", "{\"text\":\"survey the log\"}", "--thread", "root", "--id", "m1", "--poll", "10"])
       const listed = await drive(baseUrl, ["ls", "--json"])
       const logged = await drive(baseUrl, ["events", "root", "--types", "MessageReceived"])
       const ghost = await drive(baseUrl, ["events", "ghost"])

--- a/apps/cli/src/init.test.ts
+++ b/apps/cli/src/init.test.ts
@@ -58,8 +58,9 @@ describe("initSummary", () => {
 
     expect(summary).toContain("created reviewer/actor.ts")
     expect(summary).toContain("cd reviewer")
-    expect(summary).toContain("tdg build actor.ts")
     expect(summary).toContain("tdg push actor.ts --target local")
+    expect(summary).not.toContain("tdg build actor.ts")
+    expect(summary).toContain("tdg call message")
     expect(summary).toContain("tdg dev")
     expect(summary).toContain('--actor reviewer')
   })

--- a/apps/cli/src/init.ts
+++ b/apps/cli/src/init.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises"
 import { dirname, relative, resolve } from "node:path"
 
 import { actorTemplate } from "./template"
-import { runCommandFor, shellWord } from "./workflow"
+import { callCommandFor, shellWord } from "./workflow"
 
 export const DEFAULT_ACTOR_ENTRY = "actor.ts"
 
@@ -55,11 +55,10 @@ export const initSummary = (actor: InitializedActor, cwd: string = process.cwd()
     "",
     "next",
     `  cd ${shellWord(directory)}`,
-    `  tdg build ${shellWord(entry)}`,
     `  tdg push ${shellWord(entry)} --target local`,
     "  tdg dev",
     "",
     "then, in another terminal",
-    `  ${runCommandFor(actor.name)}`
+    `  ${callCommandFor(actor.name)}`
   ].join("\n")
 }

--- a/apps/cli/src/push.ts
+++ b/apps/cli/src/push.ts
@@ -5,7 +5,7 @@ import { join, resolve } from "node:path"
 import type { ActorArtifactManifest } from "tardie"
 
 import { ACTOR_MANIFEST_FILE, ACTOR_MODULE_FILE, buildActor, type BuildActorOptions, type BuiltActor } from "./build"
-import { runCommandFor } from "./workflow"
+import { callCommandFor } from "./workflow"
 
 export const DEFAULT_ACTOR_DIRECTORY = ".tardigrade/actors"
 export const PUSH_PATH = "/v1/actors"
@@ -113,7 +113,7 @@ export const pushSummary = (pushed: PushedActor): string => {
       "  tdg dev",
       "",
       "then, in another terminal",
-      `  ${runCommandFor(pushed.manifest.name)}`
+      `  ${callCommandFor(pushed.manifest.name)}`
     )
   }
   return summary.join("\n")

--- a/apps/cli/src/render.test.ts
+++ b/apps/cli/src/render.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import type { ThreadSummary, EventRow } from "@clavia/tardigrade-client"
 
-import { actorsTable, threadsTable, ABSENT, DEFAULT_DETAIL_WIDTH, ELLIPSIS, eventsTable, methodLines, table } from "./render"
+import { actorsTable, threadsTable, ABSENT, DEFAULT_DETAIL_WIDTH, ELLIPSIS, eventsTable, methodLines, methodsLines, table } from "./render"
 
 // The human rendering. A table is plain aligned text, so these assert on columns rather than on
 // escape sequences, and a value the projection did not carry reads as absent rather than as empty.
@@ -100,5 +100,25 @@ describe("methodLines", () => {
 
   test("a blocked call prints its reason", () => {
     expect(methodLines("root", "m1", { status: "blocked", reason: "budget" })).toBe("root m1 blocked\nbudget")
+  })
+})
+
+describe("methodsLines", () => {
+  test("shows the root schemas for a method", () => {
+    expect(methodsLines([{
+      name: "message",
+      input: {
+        dialect: "draft-2020-12",
+        schema: { $ref: "#/$defs/AgentMessageInput" },
+        definitions: { AgentMessageInput: { type: "object", required: ["text"] } }
+      },
+      output: { dialect: "draft-07", schema: { type: "string" }, definitions: {} }
+    }])).toBe(
+      "message\n  input  {\"type\":\"object\",\"required\":[\"text\"]}\n  output {\"type\":\"string\"}"
+    )
+  })
+
+  test("an actor with no methods says so", () => {
+    expect(methodsLines([])).toBe("no methods")
   })
 })

--- a/apps/cli/src/render.test.ts
+++ b/apps/cli/src/render.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import type { ThreadSummary, EventRow } from "@clavia/tardigrade-client"
 
-import { actorsTable, threadsTable, ABSENT, DEFAULT_DETAIL_WIDTH, ELLIPSIS, eventsTable, table, turnLines } from "./render"
+import { actorsTable, threadsTable, ABSENT, DEFAULT_DETAIL_WIDTH, ELLIPSIS, eventsTable, methodLines, table } from "./render"
 
 // The human rendering. A table is plain aligned text, so these assert on columns rather than on
 // escape sequences, and a value the projection did not carry reads as absent rather than as empty.
@@ -85,16 +85,20 @@ describe("eventsTable", () => {
   })
 })
 
-describe("turnLines", () => {
-  test("a completed turn prints its output under its handle", () => {
-    expect(turnLines("root", { turn: "m1", status: "completed", epoch: 0, output: "ok" })).toBe("root m1 completed\nok")
+describe("methodLines", () => {
+  test("a completed call prints its output under its handle", () => {
+    expect(methodLines("root", "m1", { status: "completed", output: "ok" })).toBe("root m1 completed\nok")
   })
 
-  test("a failed turn prints its error", () => {
-    expect(turnLines("root", { turn: "m1", status: "failed", epoch: 0, error: "no model" })).toBe("root m1 failed\nno model")
+  test("a failed call prints its error", () => {
+    expect(methodLines("root", "m1", { status: "failed", error: "no model" })).toBe("root m1 failed\nno model")
   })
 
-  test("a pending turn is its handle alone", () => {
-    expect(turnLines("root", { turn: "m1", status: "pending", epoch: 0 })).toBe("root m1 pending")
+  test("a pending call is its handle alone", () => {
+    expect(methodLines("root", "m1", { status: "pending" })).toBe("root m1 pending")
+  })
+
+  test("a blocked call prints its reason", () => {
+    expect(methodLines("root", "m1", { status: "blocked", reason: "budget" })).toBe("root m1 blocked\nbudget")
   })
 })

--- a/apps/cli/src/render.test.ts
+++ b/apps/cli/src/render.test.ts
@@ -107,12 +107,8 @@ describe("methodsLines", () => {
   test("shows the root schemas for a method", () => {
     expect(methodsLines([{
       name: "message",
-      input: {
-        dialect: "draft-2020-12",
-        schema: { $ref: "#/$defs/AgentMessageInput" },
-        definitions: { AgentMessageInput: { type: "object", required: ["text"] } }
-      },
-      output: { dialect: "draft-07", schema: { type: "string" }, definitions: {} }
+      inputSchema: { type: "object", required: ["text"] },
+      outputSchema: { type: "string" }
     }])).toBe(
       "message\n  input  {\"type\":\"object\",\"required\":[\"text\"]}\n  output {\"type\":\"string\"}"
     )

--- a/apps/cli/src/render.ts
+++ b/apps/cli/src/render.ts
@@ -1,4 +1,5 @@
-import type { ActorSummary, ThreadSummary, EventRow, TurnView } from "@clavia/tardigrade-client"
+import type { ActorSummary, ThreadSummary, EventRow } from "@clavia/tardigrade-client"
+import type { ActorMethodState } from "tardie"
 
 // What a command puts on stdout. Two renderings of the same value: aligned text for a person and
 // the client's own value for a pipe (`--json`), which is why every function here takes what the
@@ -86,11 +87,11 @@ export const eventsTable = (rows: ReadonlyArray<EventRow>, width = DEFAULT_DETAI
       rows.map((row) => [String(row.seq), row.event.type, truncate(detailOf(row), width)])
     )
 
-// A turn's boundary as a person reads it: the status word, then whichever of output or error the
-// projection carried.
-export const turnLines = (thread: string, view: TurnView): string => {
-  const head = `${thread} ${view.turn} ${view.status}`
-  if (view.output !== undefined) return `${head}\n${view.output}`
-  if (view.error !== undefined) return `${head}\n${view.error}`
+// methodLines renders a call handle, its durable status, and any terminal detail.
+export const methodLines = (thread: string, call: string, state: ActorMethodState<string>): string => {
+  const head = `${thread} ${call} ${state.status}`
+  if (state.status === "completed") return `${head}\n${state.output}`
+  if (state.status === "failed") return `${head}\n${state.error}`
+  if (state.status === "blocked") return `${head}\n${state.reason}`
   return head
 }

--- a/apps/cli/src/render.ts
+++ b/apps/cli/src/render.ts
@@ -98,26 +98,12 @@ export const methodLines = (thread: string, call: string, state: MethodState): s
   return head
 }
 
-const documentSchema = (document: unknown): unknown => {
-  if (typeof document !== "object" || document === null || !("schema" in document)) return document
-  const value = document as { readonly schema: unknown; readonly definitions?: unknown }
-  if (
-    typeof value.schema === "object" && value.schema !== null && "$ref" in value.schema &&
-    typeof value.schema.$ref === "string" && value.schema.$ref.startsWith("#/$defs/") &&
-    typeof value.definitions === "object" && value.definitions !== null
-  ) {
-    const name = value.schema.$ref.slice("#/$defs/".length)
-    return (value.definitions as Record<string, unknown>)[name] ?? value.schema
-  }
-  return value.schema
-}
-
 // methodsLines renders each method with the input and output schemas an author calls against.
 export const methodsLines = (methods: ReadonlyArray<MethodSummary>): string =>
   methods.length === 0
     ? "no methods"
     : methods.map((method) => [
       method.name,
-      `  input  ${JSON.stringify(documentSchema(method.input))}`,
-      `  output ${JSON.stringify(documentSchema(method.output))}`
+      `  input  ${JSON.stringify(method.inputSchema)}`,
+      `  output ${JSON.stringify(method.outputSchema)}`
     ].join("\n")).join("\n\n")

--- a/apps/cli/src/render.ts
+++ b/apps/cli/src/render.ts
@@ -1,5 +1,4 @@
-import type { ActorSummary, ThreadSummary, EventRow } from "@clavia/tardigrade-client"
-import type { ActorMethodState } from "tardie"
+import type { ActorSummary, ThreadSummary, EventRow, MethodState, MethodSummary } from "@clavia/tardigrade-client"
 
 // What a command puts on stdout. Two renderings of the same value: aligned text for a person and
 // the client's own value for a pipe (`--json`), which is why every function here takes what the
@@ -88,10 +87,37 @@ export const eventsTable = (rows: ReadonlyArray<EventRow>, width = DEFAULT_DETAI
     )
 
 // methodLines renders a call handle, its durable status, and any terminal detail.
-export const methodLines = (thread: string, call: string, state: ActorMethodState<string>): string => {
+export const methodLines = (thread: string, call: string, state: MethodState): string => {
   const head = `${thread} ${call} ${state.status}`
-  if (state.status === "completed") return `${head}\n${state.output}`
+  if (state.status === "completed") {
+    const output = typeof state.output === "string" ? state.output : jsonOf(state.output)
+    return `${head}\n${output}`
+  }
   if (state.status === "failed") return `${head}\n${state.error}`
   if (state.status === "blocked") return `${head}\n${state.reason}`
   return head
 }
+
+const documentSchema = (document: unknown): unknown => {
+  if (typeof document !== "object" || document === null || !("schema" in document)) return document
+  const value = document as { readonly schema: unknown; readonly definitions?: unknown }
+  if (
+    typeof value.schema === "object" && value.schema !== null && "$ref" in value.schema &&
+    typeof value.schema.$ref === "string" && value.schema.$ref.startsWith("#/$defs/") &&
+    typeof value.definitions === "object" && value.definitions !== null
+  ) {
+    const name = value.schema.$ref.slice("#/$defs/".length)
+    return (value.definitions as Record<string, unknown>)[name] ?? value.schema
+  }
+  return value.schema
+}
+
+// methodsLines renders each method with the input and output schemas an author calls against.
+export const methodsLines = (methods: ReadonlyArray<MethodSummary>): string =>
+  methods.length === 0
+    ? "no methods"
+    : methods.map((method) => [
+      method.name,
+      `  input  ${JSON.stringify(documentSchema(method.input))}`,
+      `  output ${JSON.stringify(documentSchema(method.output))}`
+    ].join("\n")).join("\n\n")

--- a/apps/cli/src/services.ts
+++ b/apps/cli/src/services.ts
@@ -1,6 +1,6 @@
 import { Context, Layer } from "effect"
 import { makeClient, type Client, type ClientOptions } from "@clavia/tardigrade-client"
-import { agentProjections } from "@clavia/tardigrade-server/actor"
+import { agentMethods } from "tardie"
 
 import type { Env } from "./config"
 
@@ -9,14 +9,11 @@ import type { Env } from "./config"
 // drives a real command tree against a client it wrote, with an environment it stated, and no
 // process to spawn (commands.test.ts).
 
-// The projections the command line reads. They are the served actor's own declaration, imported
-// rather than restated, so `tdg` asks for exactly what the server mounts and gets it typed
-// (apps/server/src/actor.ts, agentProjections).
-export type CliProjections = typeof agentProjections
+export type CliMethods = typeof agentMethods
 
 export interface CliServices {
   readonly env: Env
-  readonly openClient: (options: ClientOptions<CliProjections>) => Client<CliProjections>
+  readonly openClient: (options: ClientOptions<{}, CliMethods>) => Client<{}, CliMethods>
   // Where the invocation's message id comes from. A retried invocation carrying the same id is
   // absorbed by the server rather than started twice (docs/how-to/server.md, "Redelivery is
   // absorbed"), so the id is minted once per delivery and is stated in the help.
@@ -27,6 +24,6 @@ export class Cli extends Context.Service<Cli, CliServices>()("tardigrade/cli/Cli
 
 export const layerCli: Layer.Layer<Cli> = Layer.succeed(Cli)({
   env: process.env,
-  openClient: (options) => makeClient({ ...options, projections: agentProjections }),
+  openClient: (options) => makeClient({ ...options, methods: agentMethods }),
   mintId: () => crypto.randomUUID()
 })

--- a/apps/cli/src/services.ts
+++ b/apps/cli/src/services.ts
@@ -1,6 +1,5 @@
 import { Context, Layer } from "effect"
 import { makeClient, type Client, type ClientOptions } from "@clavia/tardigrade-client"
-import { agentMethods } from "tardie"
 
 import type { Env } from "./config"
 
@@ -9,14 +8,10 @@ import type { Env } from "./config"
 // drives a real command tree against a client it wrote, with an environment it stated, and no
 // process to spawn (commands.test.ts).
 
-export type CliMethods = typeof agentMethods
-
 export interface CliServices {
   readonly env: Env
-  readonly openClient: (options: ClientOptions<{}, CliMethods>) => Client<{}, CliMethods>
-  // Where the invocation's message id comes from. A retried invocation carrying the same id is
-  // absorbed by the server rather than started twice (docs/how-to/server.md, "Redelivery is
-  // absorbed"), so the id is minted once per delivery and is stated in the help.
+  readonly openClient: (options: ClientOptions) => Client
+  // mintId supplies the durable thread and call ids used when a caller states neither.
   readonly mintId: () => string
 }
 
@@ -24,6 +19,6 @@ export class Cli extends Context.Service<Cli, CliServices>()("tardigrade/cli/Cli
 
 export const layerCli: Layer.Layer<Cli> = Layer.succeed(Cli)({
   env: process.env,
-  openClient: (options) => makeClient({ ...options, methods: agentMethods }),
+  openClient: (options) => makeClient(options),
   mintId: () => crypto.randomUUID()
 })

--- a/apps/cli/src/workflow.test.ts
+++ b/apps/cli/src/workflow.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, test } from "bun:test"
 
-import { runCommandFor, shellWord, traceUrlFor } from "./workflow"
+import { callCommandFor, shellWord, traceUrlFor } from "./workflow"
 
 describe("the onboarding workflow", () => {
   test("shell words stay copyable", () => {
     expect(shellWord("actor.ts")).toBe("actor.ts")
     expect(shellWord("my actor.ts")).toBe("'my actor.ts'")
-    expect(runCommandFor("researcher")).toBe(
-      "tdg run 'Read this repository and tell me what it does' --actor researcher"
+    expect(callCommandFor("researcher")).toBe(
+      "tdg call message '{\"text\":\"Read this repository and tell me what it does\"}' --actor researcher"
     )
   })
 
-  test("a run links to its Voyager trace", () => {
+  test("a call links to its Voyager trace", () => {
     expect(traceUrlFor("http://localhost:4242/v1", "research agent", "thread/1")).toBe(
       "http://localhost:4242/?actor=research+agent&thread=thread%2F1"
     )

--- a/apps/cli/src/workflow.ts
+++ b/apps/cli/src/workflow.ts
@@ -1,15 +1,15 @@
-// DEFAULT_ONBOARDING_BRIEF is the first local run suggested after an actor is pushed.
+// DEFAULT_ONBOARDING_BRIEF is the first message suggested after an actor is pushed.
 export const DEFAULT_ONBOARDING_BRIEF = "Read this repository and tell me what it does"
 
 // shellWord quotes a generated shell argument when spaces or shell punctuation make a bare word unsafe (workflow.test.ts).
 export const shellWord = (value: string): string =>
   /^[A-Za-z0-9_./-]+$/u.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`
 
-// runCommandFor renders the local quickstart command with its actor and brief stated.
-export const runCommandFor = (
+// callCommandFor renders the local quickstart command with its actor and method input stated.
+export const callCommandFor = (
   actor: string,
   brief: string = DEFAULT_ONBOARDING_BRIEF
-): string => `tdg run ${shellWord(brief)} --actor ${shellWord(actor)}`
+): string => `tdg call message ${shellWord(JSON.stringify({ text: brief }))} --actor ${shellWord(actor)}`
 
 // traceUrlFor selects the actor and thread in the Voyager served at the API origin (apps/voyager/src/nav.ts, Route).
 export const traceUrlFor = (baseUrl: string, actor: string, thread: string): string => {

--- a/apps/server/src/actor.test.ts
+++ b/apps/server/src/actor.test.ts
@@ -2,13 +2,11 @@ import { describe, expect, test } from "bun:test"
 import { Schema } from "effect"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { replyId } from "@clavia/tardigrade-core/message"
-import { projection, projectionsOf, RESERVED_PROJECTIONS } from "@clavia/tardigrade-client/contract"
+import { projection, projectionsOf } from "@clavia/tardigrade-client/contract"
 
 import { agentProjections, builtInActor } from "./actor"
 
-// The actor's own declaration: what it says a thread can be asked beyond its log, and what the
-// platform refuses to mount. The projections are pure functions of an event array, so the fixtures
-// are event arrays, trimmed to the fields the reading looks at.
+// The actor's own declaration states what a thread can be asked beyond its log. The projections are pure functions of an event array, so the fixtures are event arrays trimmed to the fields the reading looks at.
 
 let clock = 0
 const at = () => ++clock
@@ -103,30 +101,11 @@ describe("reading one turn", () => {
 })
 
 describe("declaring projections", () => {
-  // The log is not a projection of itself, so the two names that read it are refused where the
-  // declaration is written rather than where a request arrives (contract.ts, RESERVED_PROJECTIONS).
-  test("a projection may not claim a reserved name", () => {
-    for (const reserved of RESERVED_PROJECTIONS) {
-      expect(() =>
-        projectionsOf({
-          [reserved]: projection({
-            params: {},
-            result: Schema.Array(Schema.String),
-            run: () => []
-          })
-        })
-      ).toThrow(`a projection may not be named ${JSON.stringify(reserved)}`)
-    }
-  })
-
-  test("a name the log does not own is declared without complaint", () => {
+  test("the projection namespace accepts platform route names", () => {
     const declared = projectionsOf({
-      streams: projection({ params: {}, result: Schema.Array(Schema.String), run: () => [] })
+      events: projection({ params: {}, result: Schema.Array(Schema.String), run: () => [] }),
+      stream: projection({ params: {}, result: Schema.Array(Schema.String), run: () => [] })
     })
-    expect(Object.keys(declared)).toEqual(["streams"])
-  })
-
-  test("the reserved names are the log's own two routes", () => {
-    expect([...RESERVED_PROJECTIONS].sort()).toEqual(["events", "stream"])
+    expect(Object.keys(declared)).toEqual(["events", "stream"])
   })
 })

--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -138,6 +138,69 @@ const birth = async (base: string, id: string, message: { id: string; text: stri
   })
 }
 
+const callMessage = async (base: string, thread: string, call: string, text: string) => {
+  const response = await post(base, `/v1/actors/default/threads/${thread}/methods/message`, {
+    id: call,
+    input: { text }
+  })
+  expect(response.status).toBe(202)
+  expect(await response.json()).toEqual({
+    actor: RESERVED_ACTOR,
+    thread,
+    method: "message",
+    call
+  })
+  return until(`method call ${call} of ${thread}`, async () => {
+    const state = await get(base, `/v1/actors/default/threads/${thread}/methods/message/${call}`)
+    const body = await state.json() as Record<string, unknown>
+    return body["status"] === "pending" ? undefined : body
+  })
+}
+
+describe("actor methods", () => {
+  test("an invocation births a thread and exposes its completed state", async () => {
+    const state = await serving((base) => callMessage(base, "alpha", "m1", "hello"))
+    expect(state).toEqual({ status: "completed", output: "ok: hello" })
+  })
+
+  test("an invalid input is refused before it reaches the log", async () => {
+    const refusal = await serving(async (base) => {
+      const response = await post(base, "/v1/actors/default/threads/alpha/methods/message", {
+        id: "m1",
+        input: {}
+      })
+      return { status: response.status, body: await response.json() as Record<string, unknown> }
+    })
+    expect(refusal.status).toBe(400)
+    expect(refusal.body).toMatchObject({ title: "Invalid Request", status: 400 })
+    expect(String(refusal.body["detail"])).toContain("message")
+    expect(String(refusal.body["detail"])).toContain("text")
+  })
+
+  test("an unknown method names the methods the actor declares", async () => {
+    const refusal = await serving(async (base) => {
+      const response = await post(base, "/v1/actors/default/threads/alpha/methods/missing", {
+        id: "m1",
+        input: {}
+      })
+      return { status: response.status, body: await response.json() as Record<string, unknown> }
+    })
+    expect(refusal.status).toBe(404)
+    expect(refusal.body).toMatchObject({ title: "Unknown Method", status: 404 })
+    expect(String(refusal.body["detail"])).toContain('"message"')
+  })
+
+  test("a call the method cannot derive is its own 404", async () => {
+    const refusal = await serving(async (base) => {
+      await callMessage(base, "alpha", "m1", "hello")
+      const response = await get(base, "/v1/actors/default/threads/alpha/methods/message/missing")
+      return { status: response.status, body: await response.json() as Record<string, unknown> }
+    })
+    expect(refusal.status).toBe(404)
+    expect(refusal.body).toMatchObject({ title: "Unknown Method Call", status: 404 })
+  })
+})
+
 describe("appending", () => {
   test("an appended message births a thread and the server drives its turn to completed", async () => {
     const view = await serving((base) => birth(base, "alpha", { id: "m1", text: "hello" }))

--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -120,7 +120,7 @@ const put = (base: string, path: string, body: unknown) =>
 // agentProjections).
 const turnOf = async (base: string, thread: string, turn: string): Promise<TurnView | undefined> => {
   const views = (await (await fetch(
-    `${base}/v1/actors/default/threads/${thread}/turns?turn=${encodeURIComponent(turn)}`
+    `${base}/v1/actors/default/threads/${thread}/projections/turns?turn=${encodeURIComponent(turn)}`
   )).json()) as ReadonlyArray<TurnView>
   return views[0]
 }
@@ -139,10 +139,11 @@ const birth = async (base: string, id: string, message: { id: string; text: stri
 }
 
 const callMessage = async (base: string, thread: string, call: string, text: string) => {
-  const response = await post(base, `/v1/actors/default/threads/${thread}/methods/message`, {
-    id: call,
-    input: { text }
-  })
+  const response = await put(
+    base,
+    `/v1/actors/default/threads/${thread}/methods/message/calls/${call}`,
+    { text }
+  )
   expect(response.status).toBe(202)
   expect(await response.json()).toEqual({
     actor: RESERVED_ACTOR,
@@ -151,7 +152,7 @@ const callMessage = async (base: string, thread: string, call: string, text: str
     call
   })
   return until(`method call ${call} of ${thread}`, async () => {
-    const state = await get(base, `/v1/actors/default/threads/${thread}/methods/message/${call}`)
+    const state = await get(base, `/v1/actors/default/threads/${thread}/methods/message/calls/${call}`)
     const body = await state.json() as Record<string, unknown>
     return body["status"] === "pending" ? undefined : body
   })
@@ -162,15 +163,16 @@ describe("actor methods", () => {
     const methods = await serving(async (base) =>
       await (await get(base, "/v1/actors/default/methods")).json() as ReadonlyArray<{
         readonly name: string
-        readonly input: { readonly schema?: unknown; readonly definitions?: Record<string, unknown> }
-        readonly output: { readonly schema?: unknown }
+        readonly inputSchema: { readonly $ref?: unknown; readonly $defs?: Record<string, unknown> }
+        readonly outputSchema: { readonly type?: unknown }
       }>)
     expect(methods.map((method) => method.name)).toEqual(["message"])
-    expect(methods[0]?.input.definitions?.["AgentMessageInput"]).toMatchObject({
+    expect(methods[0]?.inputSchema.$ref).toBe("#/$defs/AgentMessageInput")
+    expect(methods[0]?.inputSchema.$defs?.["AgentMessageInput"]).toMatchObject({
       type: "object",
       required: ["text"]
     })
-    expect(methods[0]?.output.schema).toMatchObject({ type: "string" })
+    expect(methods[0]?.outputSchema).toMatchObject({ type: "string" })
   })
 
   test("an invocation births a thread and exposes its completed state", async () => {
@@ -178,12 +180,27 @@ describe("actor methods", () => {
     expect(state).toEqual({ status: "completed", output: "ok: hello" })
   })
 
+  test("putting the same call URL is absorbed", async () => {
+    const read = await serving(async (base) => {
+      await callMessage(base, "alpha", "m1", "hello")
+      const eventsAt = async () => await (await get(base, "/v1/actors/default/threads/alpha/events")).json() as ReadonlyArray<EventRow>
+      const before = await eventsAt()
+      const repeated = await put(base, "/v1/actors/default/threads/alpha/methods/message/calls/m1", { text: "different" })
+      const after = await eventsAt()
+      const state = await get(base, "/v1/actors/default/threads/alpha/methods/message/calls/m1")
+      return { repeated: { status: repeated.status, body: await repeated.json() }, before, after, state: await state.json() }
+    })
+    expect(read.repeated).toEqual({
+      status: 202,
+      body: { actor: RESERVED_ACTOR, thread: "alpha", method: "message", call: "m1" }
+    })
+    expect(read.after).toEqual(read.before)
+    expect(read.state).toEqual({ status: "completed", output: "ok: hello" })
+  })
+
   test("an invalid input is refused before it reaches the log", async () => {
     const refusal = await serving(async (base) => {
-      const response = await post(base, "/v1/actors/default/threads/alpha/methods/message", {
-        id: "m1",
-        input: {}
-      })
+      const response = await put(base, "/v1/actors/default/threads/alpha/methods/message/calls/m1", {})
       return { status: response.status, body: await response.json() as Record<string, unknown> }
     })
     expect(refusal.status).toBe(400)
@@ -194,10 +211,7 @@ describe("actor methods", () => {
 
   test("an unknown method names the methods the actor declares", async () => {
     const refusal = await serving(async (base) => {
-      const response = await post(base, "/v1/actors/default/threads/alpha/methods/missing", {
-        id: "m1",
-        input: {}
-      })
+      const response = await put(base, "/v1/actors/default/threads/alpha/methods/missing/calls/m1", {})
       return { status: response.status, body: await response.json() as Record<string, unknown> }
     })
     expect(refusal.status).toBe(404)
@@ -208,7 +222,7 @@ describe("actor methods", () => {
   test("a call the method cannot derive is its own 404", async () => {
     const refusal = await serving(async (base) => {
       await callMessage(base, "alpha", "m1", "hello")
-      const response = await get(base, "/v1/actors/default/threads/alpha/methods/message/missing")
+      const response = await get(base, "/v1/actors/default/threads/alpha/methods/message/calls/missing")
       return { status: response.status, body: await response.json() as Record<string, unknown> }
     })
     expect(refusal.status).toBe(404)
@@ -475,7 +489,7 @@ describe("the event stream", () => {
   })
 })
 
-// The projections the actor declares are mounted by name under a thread, and this build's actor
+// The projections the actor declares are mounted by name under a thread's projection namespace, and this build's actor
 // declares `turns` (actor.ts, agentProjections). The cases below are about the mounting: that a
 // declared name serves what the actor computes, that its own query reaches `run`, and that any
 // other name says what does exist.
@@ -483,7 +497,7 @@ describe("projections", () => {
   test("a declared projection serves what the actor computes", async () => {
     const read = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
-      const response = await fetch(`${base}/v1/actors/default/threads/alpha/turns`)
+      const response = await fetch(`${base}/v1/actors/default/threads/alpha/projections/turns`)
       return { status: response.status, body: await response.json() as ReadonlyArray<TurnView> }
     })
     expect(read.status).toBe(200)
@@ -501,7 +515,10 @@ describe("projections", () => {
           body: await response.json() as Record<string, unknown>
         }
       }
-      return { ghost: await read("/v1/actors/default/threads/alpha/facts"), actor: await read("/v1/actors/ghost/threads/alpha/facts") }
+      return {
+        ghost: await read("/v1/actors/default/threads/alpha/projections/facts"),
+        actor: await read("/v1/actors/ghost/threads/alpha/projections/facts")
+      }
     })
     expect(answers.ghost.status).toBe(404)
     expect(answers.ghost.type).toContain(PROBLEM_CONTENT_TYPE)
@@ -517,18 +534,13 @@ describe("projections", () => {
     expect(answers.actor.body).toMatchObject({ title: "Unknown Actor" })
   })
 
-  // `events` is the log read back, and the log is not a projection of itself, so a reserved name
-  // keeps serving the platform's own route rather than reaching the projection mount. `stream` is
-  // the same rule for the tail, proven where the tail is exercised ("the event stream", below;
-  // contract.ts, RESERVED_PROJECTIONS).
-  test("a reserved name still serves the log", async () => {
+  test("the event log keeps its platform route", async () => {
     const answers = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
       const events = await fetch(`${base}/v1/actors/default/threads/alpha/events`)
       return { status: events.status, type: events.headers.get("content-type") }
     })
     expect(answers.status).toBe(200)
-    // Not a problem document, which is what reaching the projection mount would have produced.
     expect(answers.type).toContain("application/json")
   })
 
@@ -536,7 +548,10 @@ describe("projections", () => {
     const read = await serving(async (base) => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
       const json = async (path: string) => (await (await fetch(`${base}${path}`)).json()) as ReadonlyArray<TurnView>
-      return { now: await json("/v1/actors/default/threads/alpha/turns"), atTwo: await json("/v1/actors/default/threads/alpha/turns?at=2") }
+      return {
+        now: await json("/v1/actors/default/threads/alpha/projections/turns"),
+        atTwo: await json("/v1/actors/default/threads/alpha/projections/turns?at=2")
+      }
     })
     expect(read.now).toEqual([{ turn: "m1", status: "completed", epoch: 0, output: "ok: hello" }])
     // Creation and the message stand before the cut, with nothing that answered the turn.
@@ -550,8 +565,8 @@ describe("projections", () => {
       await birth(base, "alpha", { id: "m1", text: "hello" })
       const json = async (path: string) => (await (await fetch(`${base}${path}`)).json()) as ReadonlyArray<TurnView>
       return {
-        one: await json("/v1/actors/default/threads/alpha/turns?turn=m1"),
-        ghost: await json("/v1/actors/default/threads/alpha/turns?turn=m9")
+        one: await json("/v1/actors/default/threads/alpha/projections/turns?turn=m1"),
+        ghost: await json("/v1/actors/default/threads/alpha/projections/turns?turn=m9")
       }
     })
     expect(read.one).toEqual([{ turn: "m1", status: "completed", epoch: 0, output: "ok: hello" }])

--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -158,6 +158,21 @@ const callMessage = async (base: string, thread: string, call: string, text: str
 }
 
 describe("actor methods", () => {
+  test("the actor exposes its method schemas", async () => {
+    const methods = await serving(async (base) =>
+      await (await get(base, "/v1/actors/default/methods")).json() as ReadonlyArray<{
+        readonly name: string
+        readonly input: { readonly schema?: unknown; readonly definitions?: Record<string, unknown> }
+        readonly output: { readonly schema?: unknown }
+      }>)
+    expect(methods.map((method) => method.name)).toEqual(["message"])
+    expect(methods[0]?.input.definitions?.["AgentMessageInput"]).toMatchObject({
+      type: "object",
+      required: ["text"]
+    })
+    expect(methods[0]?.output.schema).toMatchObject({ type: "string" })
+  })
+
   test("an invocation births a thread and exposes its completed state", async () => {
     const state = await serving((base) => callMessage(base, "alpha", "m1", "hello"))
     expect(state).toEqual({ status: "completed", output: "ok: hello" })

--- a/apps/server/src/api.ts
+++ b/apps/server/src/api.ts
@@ -1,4 +1,4 @@
-import { Clock, Duration, Effect, Stream } from "effect"
+import { Clock, Duration, Effect, Schema, Stream } from "effect"
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, type HttpApiEndpoint } from "effect/unstable/httpapi"
 import type { Event } from "@clavia/tardigrade-core/event"
@@ -275,6 +275,13 @@ export const ServerApi = apiOf(agentProjections)
 // layerMethodsGroup invokes and reads the method declarations carried by the selected actor runtime.
 export const layerMethodsGroup = HttpApiBuilder.group(ServerApi, "methods", (handlers) =>
   handlers
+    .handle("methods", ({ params }) =>
+      Effect.map(actorOf(params.actor), (threads) =>
+        Object.entries(threads.methods).map(([name, method]) => ({
+          name,
+          input: Schema.toJsonSchemaDocument(method.input),
+          output: Schema.toJsonSchemaDocument(method.output)
+        }))))
     .handle("invoke", ({ params, payload }) =>
       Effect.gen(function*() {
         const threads = yield* actorOf(params.actor)

--- a/apps/server/src/api.ts
+++ b/apps/server/src/api.ts
@@ -272,6 +272,14 @@ export const layerThreadsGroup = (options: ApiOptions = {}) => {
 // ServerApi is the surface this process serves: the platform's log routes, actor methods, and declared projections.
 export const ServerApi = apiOf(agentProjections)
 
+// jsonSchemaOf attaches every generated definition to the root schema that references it.
+const jsonSchemaOf = (schema: Schema.Constraint): unknown => {
+  const document = Schema.toJsonSchemaDocument(schema)
+  return Object.keys(document.definitions).length === 0
+    ? document.schema
+    : { ...document.schema, $defs: document.definitions }
+}
+
 // layerMethodsGroup invokes and reads the method declarations carried by the selected actor runtime.
 export const layerMethodsGroup = HttpApiBuilder.group(ServerApi, "methods", (handlers) =>
   handlers
@@ -279,8 +287,8 @@ export const layerMethodsGroup = HttpApiBuilder.group(ServerApi, "methods", (han
       Effect.map(actorOf(params.actor), (threads) =>
         Object.entries(threads.methods).map(([name, method]) => ({
           name,
-          input: Schema.toJsonSchemaDocument(method.input),
-          output: Schema.toJsonSchemaDocument(method.output)
+          inputSchema: jsonSchemaOf(method.input),
+          outputSchema: jsonSchemaOf(method.output)
         }))))
     .handle("invoke", ({ params, payload }) =>
       Effect.gen(function*() {
@@ -291,13 +299,13 @@ export const layerMethodsGroup = HttpApiBuilder.group(ServerApi, "methods", (han
         }
         const at = yield* Clock.currentTimeMillis
         const event = yield* Effect.try({
-          try: () => method.eventOf({ id: payload.id, input: payload.input, at }),
+          try: () => method.eventOf({ id: params.call, input: payload, at }),
           catch: (failure) => InvalidRequest.of(
             `The input for method ${JSON.stringify(params.method)} is invalid. ${failureMessage(failure)}`
           )
         })
         yield* threads.append(params.id, event)
-        return { actor: params.actor, thread: params.id, method: params.method, call: payload.id }
+        return { actor: params.actor, thread: params.id, method: params.method, call: params.call }
       }))
     .handle("methodState", ({ params }) =>
       Effect.gen(function*() {
@@ -355,10 +363,7 @@ export const layerProjectionsGroup = HttpApiBuilder.group(ServerApi, "projection
   return handlers.handleAll(served)
 })
 
-// The name a request asked for, when the actor never declared it. The declared names are literal
-// paths, and a literal segment beats a parameter in this router, so this route is reached only by a
-// name that matched nothing (api.test.ts, "a name the actor never declared says what does exist").
-// `events` and `stream` never reach here either, for the same reason: they are the log's own routes.
+// The name a request asked for when the actor never declared it.
 const declaredProjections = Object.keys(agentProjections)
 const declaredDetail = declaredProjections.length === 0
   ? "This actor declares no projections."
@@ -366,7 +371,7 @@ const declaredDetail = declaredProjections.length === 0
 
 export const layerUnknownProjection = HttpRouter.add(
   "GET",
-  "/v1/actors/:actor/threads/:id/:name",
+  "/v1/actors/:actor/threads/:id/projections/:name",
   Effect.gen(function*() {
     const params = yield* HttpRouter.params
     const actor = paramOf(params, "actor")

--- a/apps/server/src/api.ts
+++ b/apps/server/src/api.ts
@@ -280,6 +280,13 @@ const jsonSchemaOf = (schema: Schema.Constraint): unknown => {
     : { ...document.schema, $defs: document.definitions }
 }
 
+const methodOf = (threads: ActorThreads, name: string) => {
+  const method = threads.methods[name]
+  return method === undefined
+    ? Effect.fail(UnknownMethod.of(unknownMethodDetail(name, threads.methods)))
+    : Effect.succeed(method)
+}
+
 // layerMethodsGroup invokes and reads the method declarations carried by the selected actor runtime.
 export const layerMethodsGroup = HttpApiBuilder.group(ServerApi, "methods", (handlers) =>
   handlers
@@ -293,10 +300,7 @@ export const layerMethodsGroup = HttpApiBuilder.group(ServerApi, "methods", (han
     .handle("invoke", ({ params, payload }) =>
       Effect.gen(function*() {
         const threads = yield* actorOf(params.actor)
-        const method = threads.methods[params.method]
-        if (method === undefined) {
-          return yield* Effect.fail(UnknownMethod.of(unknownMethodDetail(params.method, threads.methods)))
-        }
+        const method = yield* methodOf(threads, params.method)
         const at = yield* Clock.currentTimeMillis
         const event = yield* Effect.try({
           try: () => method.eventOf({ id: params.call, input: payload, at }),
@@ -310,10 +314,7 @@ export const layerMethodsGroup = HttpApiBuilder.group(ServerApi, "methods", (han
     .handle("methodState", ({ params }) =>
       Effect.gen(function*() {
         const threads = yield* actorOf(params.actor)
-        const method = threads.methods[params.method]
-        if (method === undefined) {
-          return yield* Effect.fail(UnknownMethod.of(unknownMethodDetail(params.method, threads.methods)))
-        }
+        const method = yield* methodOf(threads, params.method)
         const log = yield* logOf(threads.events, params.id)
         const state = method.state(log, params.call)
         if (state === undefined) {

--- a/apps/server/src/api.ts
+++ b/apps/server/src/api.ts
@@ -1,4 +1,4 @@
-import { Duration, Effect, Stream } from "effect"
+import { Clock, Duration, Effect, Stream } from "effect"
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, type HttpApiEndpoint } from "effect/unstable/httpapi"
 import type { Event } from "@clavia/tardigrade-core/event"
@@ -11,6 +11,8 @@ import {
   RESERVED_ACTOR,
   unacceptableField,
   UnknownActor,
+  UnknownMethod,
+  UnknownMethodCall,
   UnknownProjection,
   UnknownThread,
   type ActorSummary,
@@ -65,6 +67,17 @@ const unknownThreadDetail = (id: string) => `No thread named ${JSON.stringify(id
 
 const unknownActorDetail = (actor: string) =>
   `No actor named ${JSON.stringify(actor)} is available on this server.`
+
+const unknownMethodDetail = (name: string, methods: Readonly<Record<string, unknown>>): string => {
+  const declared = Object.keys(methods)
+  const available = declared.length === 0
+    ? "This actor declares no methods."
+    : `This actor declares ${declared.map((method) => JSON.stringify(method)).join(", ")}.`
+  return `No method named ${JSON.stringify(name)} is declared. ${available}`
+}
+
+const failureMessage = (failure: unknown): string =>
+  failure instanceof Error ? failure.message : String(failure)
 
 // actorOf is the guard every declared route runs first. The actor level is a path parameter so the
 // declaration states the shape a deploy will vary (contract.ts, RESERVED_ACTOR), and this build
@@ -256,10 +269,47 @@ export const layerThreadsGroup = (options: ApiOptions = {}) => {
         })))
 }
 
-// ServerApi is the surface this process serves: the platform's log routes plus the projections the
-// actor it mounts declares (actor.ts, agentProjections). The OpenAPI document and the reference
-// page are derived from this value, so a projection appears in both by being declared.
+// ServerApi is the surface this process serves: the platform's log routes, actor methods, and declared projections.
 export const ServerApi = apiOf(agentProjections)
+
+// layerMethodsGroup invokes and reads the method declarations carried by the selected actor runtime.
+export const layerMethodsGroup = HttpApiBuilder.group(ServerApi, "methods", (handlers) =>
+  handlers
+    .handle("invoke", ({ params, payload }) =>
+      Effect.gen(function*() {
+        const threads = yield* actorOf(params.actor)
+        const method = threads.methods[params.method]
+        if (method === undefined) {
+          return yield* Effect.fail(UnknownMethod.of(unknownMethodDetail(params.method, threads.methods)))
+        }
+        const at = yield* Clock.currentTimeMillis
+        const event = yield* Effect.try({
+          try: () => method.eventOf({ id: payload.id, input: payload.input, at }),
+          catch: (failure) => InvalidRequest.of(
+            `The input for method ${JSON.stringify(params.method)} is invalid. ${failureMessage(failure)}`
+          )
+        })
+        yield* threads.append(params.id, event)
+        return { actor: params.actor, thread: params.id, method: params.method, call: payload.id }
+      }))
+    .handle("methodState", ({ params }) =>
+      Effect.gen(function*() {
+        const threads = yield* actorOf(params.actor)
+        const method = threads.methods[params.method]
+        if (method === undefined) {
+          return yield* Effect.fail(UnknownMethod.of(unknownMethodDetail(params.method, threads.methods)))
+        }
+        const log = yield* logOf(threads.events, params.id)
+        const state = method.state(log, params.call)
+        if (state === undefined) {
+          return yield* Effect.fail(
+            UnknownMethodCall.of(
+              `No call named ${JSON.stringify(params.call)} exists for method ${JSON.stringify(params.method)} on this thread.`
+            )
+          )
+        }
+        return state
+      })))
 
 // layerProjectionsGroup implements every declared projection the same way, because there is only
 // one way: read the thread's log, hand it to `run` with the decoded query, and answer what comes

--- a/apps/server/src/contract.test.ts
+++ b/apps/server/src/contract.test.ts
@@ -51,20 +51,17 @@ const BOOT_MS = 20_000
 
 setDefaultTimeout(BOOT_MS)
 
-// Every route the server answers, as method and OpenAPI path. The stream is absent because it is
-// not a declared endpoint (api.ts, layerStream). The first three are the log, which is the whole of
-// what the platform declares; `turns` is there because the actor this build mounts declares it
-// (actor.ts, agentProjections), and it appears in the document by being declared.
+// Every route the server answers, as method and OpenAPI path. The stream is absent because it is not a declared endpoint (api.ts, layerStream). `turns` appears because this build's actor declares it (actor.ts, agentProjections).
 const ROUTES: ReadonlyArray<readonly [string, string]> = [
   ["get", "/v1/actors"],
   ["put", "/v1/actors"],
   ["get", "/v1/actors/{actor}/methods"],
   ["post", "/v1/actors/{actor}/threads/{id}/events"],
-  ["post", "/v1/actors/{actor}/threads/{id}/methods/{method}"],
+  ["put", "/v1/actors/{actor}/threads/{id}/methods/{method}/calls/{call}"],
   ["get", "/v1/actors/{actor}/threads"],
   ["get", "/v1/actors/{actor}/threads/{id}/events"],
-  ["get", "/v1/actors/{actor}/threads/{id}/methods/{method}/{call}"],
-  ["get", "/v1/actors/{actor}/threads/{id}/turns"],
+  ["get", "/v1/actors/{actor}/threads/{id}/methods/{method}/calls/{call}"],
+  ["get", "/v1/actors/{actor}/threads/{id}/projections/turns"],
   ["get", "/v1/actors/{actor}/threads/{id}/tree"],
   ["get", "/healthz"]
 ]
@@ -131,8 +128,8 @@ describe("problem documents", () => {
     const failures = await serving({}, (client) =>
       Effect.gen(function*() {
         const unknownThread = yield* client.get("/v1/actors/default/threads/ghost/events")
-        const unknownProjection = yield* client.get("/v1/actors/default/threads/ghost/facts")
-        const unknownTurn = yield* client.get("/v1/actors/default/threads/ghost/turns?at=1")
+        const unknownProjection = yield* client.get("/v1/actors/default/threads/ghost/projections/facts")
+        const unknownTurn = yield* client.get("/v1/actors/default/threads/ghost/projections/turns?at=1")
         return [
           { status: unknownThread.status, type: unknownThread.headers["content-type"], body: yield* unknownThread.json },
           {
@@ -167,7 +164,7 @@ describe("problem documents", () => {
       Effect.gen(function*() {
         const post = (path: string, body: unknown) =>
           client.post(path, { body: HttpBody.jsonUnsafe(body) })
-        const repeated = yield* client.get("/v1/actors/default/threads/ghost/turns?at=1&at=2")
+        const repeated = yield* client.get("/v1/actors/default/threads/ghost/projections/turns?at=1&at=2")
         const notANumber = yield* client.get("/v1/actors/default/threads/ghost/events?after=soon")
         const negative = yield* client.get("/v1/actors/default/threads/ghost/events?limit=-1")
         const missingField = yield* post("/v1/actors/default/threads/ghost/events", { id: "m1" })

--- a/apps/server/src/contract.test.ts
+++ b/apps/server/src/contract.test.ts
@@ -59,8 +59,10 @@ const ROUTES: ReadonlyArray<readonly [string, string]> = [
   ["get", "/v1/actors"],
   ["put", "/v1/actors"],
   ["post", "/v1/actors/{actor}/threads/{id}/events"],
+  ["post", "/v1/actors/{actor}/threads/{id}/methods/{method}"],
   ["get", "/v1/actors/{actor}/threads"],
   ["get", "/v1/actors/{actor}/threads/{id}/events"],
+  ["get", "/v1/actors/{actor}/threads/{id}/methods/{method}/{call}"],
   ["get", "/v1/actors/{actor}/threads/{id}/turns"],
   ["get", "/v1/actors/{actor}/threads/{id}/tree"],
   ["get", "/healthz"]

--- a/apps/server/src/contract.test.ts
+++ b/apps/server/src/contract.test.ts
@@ -58,6 +58,7 @@ setDefaultTimeout(BOOT_MS)
 const ROUTES: ReadonlyArray<readonly [string, string]> = [
   ["get", "/v1/actors"],
   ["put", "/v1/actors"],
+  ["get", "/v1/actors/{actor}/methods"],
   ["post", "/v1/actors/{actor}/threads/{id}/events"],
   ["post", "/v1/actors/{actor}/threads/{id}/methods/{method}"],
   ["get", "/v1/actors/{actor}/threads"],

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -2,7 +2,7 @@ import { Context, Effect, Layer } from "effect"
 import { Headers, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiScalar } from "effect/unstable/httpapi"
 
-import { layerActorsGroup, layerProjectionsGroup, layerThreadsGroup, layerStream, layerUnknownProjection, ServerApi, type ApiOptions } from "./api"
+import { layerActorsGroup, layerMethodsGroup, layerProjectionsGroup, layerThreadsGroup, layerStream, layerUnknownProjection, ServerApi, type ApiOptions } from "./api"
 import { ServerConfig } from "./config"
 import { Api, DOCS_PATH, OPENAPI_PATH, type Health } from "@clavia/tardigrade-client/contract"
 import { layerRequestProblems } from "./contract"
@@ -163,6 +163,7 @@ export const layerApp = (options: ApiOptions = {}) =>
       Layer.provide(HttpApiBuilder.layer(ServerApi, { openapiPath: OPENAPI_PATH }), [
         layerActorsGroup,
         layerThreadsGroup(options),
+        layerMethodsGroup,
         layerProjectionsGroup,
         layerHealthGroup
       ]),

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -171,9 +171,7 @@ export const layerApp = (options: ApiOptions = {}) =>
     ),
     HttpApiScalar.layer(ServerApi, { path: DOCS_PATH }),
     layerStream(options),
-    // After the declared routes and before the catch-all: a literal segment beats a parameter in
-    // this router, so a projection the actor declared is served and every other name under a thread
-    // is told what does exist (api.ts, layerUnknownProjection).
+    // layerUnknownProjection names the declared projections when a lookup misses.
     layerUnknownProjection,
     layerNotFound,
     layerCors,

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,6 @@
         "@effect/platform-bun": "4.0.0-rc.110",
         "@effect/platform-node-shared": "4.0.0-rc.110",
         "effect": "4.0.0-rc.110",
-        "tardie": "workspace:*",
       },
     },
     "apps/server": {

--- a/bun.lock
+++ b/bun.lock
@@ -26,8 +26,6 @@
         "@effect/platform-bun": "4.0.0-rc.110",
         "@effect/platform-node-shared": "4.0.0-rc.110",
         "effect": "4.0.0-rc.110",
-      },
-      "devDependencies": {
         "tardie": "workspace:*",
       },
     },
@@ -94,6 +92,7 @@
       "dependencies": {
         "@clavia/tardigrade-core": "workspace:*",
         "effect": "4.0.0-rc.110",
+        "tardie": "workspace:*",
       },
     },
     "packages/code": {

--- a/docs/how-to/cli.md
+++ b/docs/how-to/cli.md
@@ -15,7 +15,8 @@ Or run it without installing: `bunx tardie <command>`. Bun 1.4 or later.
 ```bash
 tdg setup                  # provider, model, key
 tdg dev                    # API and UI on http://localhost:4242
-tdg run "read this repo and tell me what it does"
+tdg methods
+tdg call message '{"text":"read this repo and tell me what it does"}'
 ```
 
 ## Commands
@@ -27,12 +28,12 @@ tdg run "read this repo and tell me what it does"
 | `tdg push <entry> --target <local\|hosted>` | Build and push an actor |
 | `tdg dev` | Serve the API and the UI on one port |
 | `tdg actors` | List actors available on the server |
-| `tdg run <brief>` | Start a thread and wait for its answer |
-| `tdg send <thread> <brief>` | Send to a thread, do not wait |
+| `tdg methods` | List an actor's methods and schemas |
+| `tdg call <method> <input>` | Call a method with JSON input and wait for its result |
 | `tdg ls` | List threads |
 | `tdg events <thread>` | Print a thread's log |
 
-Commands that print data take `--json` where their help lists it. Remote commands take `--url` and `--token`. `tdg <command> --help` prints the rest.
+Commands that print data take `--json` where their help lists it. Remote commands take `--url` and `--token`. A call creates a thread unless `--thread` names one. Use `--no-wait` to print its durable handle immediately. `tdg <command> --help` prints the rest.
 
 ## Configuration
 
@@ -63,7 +64,9 @@ No shell: a directory or a host list can be scoped and a shell cannot.
 ## Examples
 
 ```bash
-tdg run "summarize the open PRs" --json
+tdg methods --actor reviewer
+tdg call message '{"text":"summarize the open PRs"}' --actor reviewer --json
+tdg call inspect '{"path":"README.md"}' --actor reviewer --no-wait
 tdg actors
 tdg build ./actors/reviewer.ts
 tdg push ./actors/reviewer.ts --target local

--- a/docs/how-to/migrate.md
+++ b/docs/how-to/migrate.md
@@ -178,7 +178,7 @@ Treat one matched model run as a sample. State any output difference or provider
 
 ## Cut over and report
 
-Prepare the production Tardigrade server, actor push, database path, credentials, health check, and client URL. Keep production deployment as a separate authorized action. The migration itself proves the local actor with `tdg build`, `tdg push --target local`, `tdg dev`, and a representative `tdg run`.
+Prepare the production Tardigrade server, actor push, database path, credentials, health check, and client URL. Keep production deployment as a separate authorized action. The migration itself proves the local actor with `tdg build`, `tdg push --target local`, `tdg dev`, and a representative `tdg call`.
 
 Keep the existing endpoint and store available for rollback. Switch traffic only after tests pass, imported threads settle, a new turn succeeds, and the application renders event progress and terminals. Remove the existing harness dependencies after a repository search finds no remaining imports and the rollback window closes.
 

--- a/docs/how-to/server.md
+++ b/docs/how-to/server.md
@@ -16,24 +16,32 @@ Base path `/v1`. The built-in actor is named `default`.
 
 | | |
 | --- | --- |
+| `GET /v1/actors` | List actors |
+| `PUT /v1/actors` | Push an actor artifact |
+| `GET /v1/actors/{actor}/methods` | List methods with standalone input and output schemas |
 | `GET /v1/actors/{actor}/threads` | List threads |
+| `PUT /v1/actors/{actor}/threads/{id}/methods/{method}/calls/{call}` | Call a method with its input as the body |
+| `GET /v1/actors/{actor}/threads/{id}/methods/{method}/calls/{call}` | Read a method call's derived state |
 | `POST /v1/actors/{actor}/threads/{id}/events` | Append an event, creating the thread if new |
 | `GET /v1/actors/{actor}/threads/{id}/events` | Read the log. `after`, `limit`, `types` |
 | `GET /v1/actors/{actor}/threads/{id}/events/stream` | Follow the log. Server-sent events, resumes from `Last-Event-ID` |
-| `GET /v1/actors/{actor}/threads/{id}/{projection}` | A projection the actor declares. `agent` declares `turns` |
+| `GET /v1/actors/{actor}/threads/{id}/projections/{projection}` | Read a projection the actor declares. `default` declares `turns` |
 | `GET /v1/actors/{actor}/threads/{id}/tree` | The spawn family |
 | `GET /healthz` `GET /openapi.json` `GET /docs` | Unversioned |
 
 ```bash
-curl -X POST localhost:4242/v1/actors/default/threads/inv-81/events \
-  -d '{"id":"m1","type":"MessageReceived","text":"audit the deploy"}'
-# {"actor":"agent","thread":"inv-81"}
+curl -X PUT localhost:4242/v1/actors/default/threads/inv-81/methods/message/calls/m1 \
+  -H 'content-type: application/json' \
+  -d '{"text":"audit the deploy"}'
+# {"actor":"default","thread":"inv-81","method":"message","call":"m1"}
 
-curl localhost:4242/v1/actors/default/threads/inv-81/turns
-# [{"turn":"m1","status":"completed","output":"…","epoch":0}]
+curl localhost:4242/v1/actors/default/threads/inv-81/methods/message/calls/m1
+# {"status":"completed","output":"…"}
 ```
 
-Appending is how a root thread is created, messaged, and intervened in. The host atomically records `ThreadCreated` before the first delivered event. A spawned child records its parent address and depth in that creation event, so the tree survives changes to thread naming. The message id is the dedup key, so sending the same message twice changes nothing.
+Calling a method is the application ingress. The caller chooses the thread and call ids, and the method schema validates the body. Repeating the same call URL is absorbed by the log.
+
+Appending is the lower-level ingress for channels and interventions. The host atomically records `ThreadCreated` before the first delivered event. A spawned child records its parent address and depth in that creation event, so the tree survives changes to thread naming.
 
 Reads are projections of the log, so `?at=<seq>` answers as of that point in history.
 
@@ -67,8 +75,9 @@ The server boots without a model and serves every read; turns fail naming what i
 `tardie/client` is generated from the same declaration this server implements, so `/openapi.json` and the client cannot drift from it.
 
 ```ts
+import { agentMethods } from "tardie"
 import { makeClient } from "tardie/client"
 
-const client = makeClient({ baseUrl: "http://localhost:4242" })
-await client.append("inv-81", { id: "m1", type: "MessageReceived", text: "audit the deploy" })
+const client = makeClient({ baseUrl: "http://localhost:4242", methods: agentMethods })
+await client.invoke("inv-81", "message", { id: "m1", input: { text: "audit the deploy" } })
 ```

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -31,7 +31,8 @@
   },
   "dependencies": {
     "@clavia/tardigrade-core": "workspace:*",
-    "effect": "4.0.0-rc.110"
+    "effect": "4.0.0-rc.110",
+    "tardie": "workspace:*"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test"
 import { Schema } from "effect"
+import { agentMethods, type ActorMethodState } from "tardie"
 
 import { makeClient, SERVER_ERROR_DETAIL, SERVER_ERROR_TITLE, UNEXPECTED_RESPONSE_TITLE } from "./client"
 import { PROBLEM_CONTENT_TYPE, PROBLEM_TYPE_BASE, projection, projectionsOf } from "./contract"
@@ -98,6 +99,33 @@ describe("the token", () => {
   test("no token means no header", async () => {
     await makeClient({ baseUrl: "http://localhost:4111" , fetch: stub }).list()
     expect(calls[0]!.headers["authorization"]).toBeUndefined()
+  })
+})
+
+describe("a declared actor method", () => {
+  test("invokes the selected method with its typed input", async () => {
+    answer = () => new Response(JSON.stringify({
+      actor: "default",
+      thread: "root",
+      method: "message",
+      call: "m1"
+    }), { status: 202, headers: { "content-type": "application/json" } })
+    const client = makeClient({ baseUrl: "http://localhost:4111", fetch: stub, methods: agentMethods })
+    const accepted = await client.invoke("root", "message", { id: "m1", input: { text: "hello" } })
+    expect(accepted.call).toBe("m1")
+    expect(lastUrl().pathname).toBe("/v1/actors/default/threads/root/methods/message")
+    expect(JSON.parse(calls[0]!.body ?? "")).toEqual({ id: "m1", input: { text: "hello" } })
+  })
+
+  test("reads and types completed output from the declaration", async () => {
+    answer = () => new Response(JSON.stringify({ status: "completed", output: "done" }), {
+      status: 200,
+      headers: { "content-type": "application/json" }
+    })
+    const client = makeClient({ baseUrl: "http://localhost:4111", fetch: stub, methods: agentMethods })
+    const state: ActorMethodState<string> = await client.methodState("root", "message", "m1")
+    expect(state).toEqual({ status: "completed", output: "done" })
+    expect(lastUrl().pathname).toBe("/v1/actors/default/threads/root/methods/message/m1")
   })
 })
 

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -103,6 +103,17 @@ describe("the token", () => {
 })
 
 describe("a declared actor method", () => {
+  test("discovers method schemas at the actor", async () => {
+    answer = () => new Response(JSON.stringify([{
+      name: "message",
+      input: { dialect: "draft-2020-12", schema: { type: "object" }, definitions: {} },
+      output: { dialect: "draft-2020-12", schema: { type: "string" }, definitions: {} }
+    }]), { status: 200, headers: { "content-type": "application/json" } })
+    const methods = await makeClient({ baseUrl: "http://localhost:4111", fetch: stub }).methods()
+    expect(methods[0]?.name).toBe("message")
+    expect(lastUrl().pathname).toBe("/v1/actors/default/methods")
+  })
+
   test("invokes the selected method with its typed input", async () => {
     answer = () => new Response(JSON.stringify({
       actor: "default",

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -12,6 +12,7 @@ import { ProblemError } from "./problem"
 
 interface Call {
   readonly url: string
+  readonly method: string
   readonly headers: Record<string, string>
   readonly body: string | undefined
 }
@@ -38,6 +39,7 @@ const stub = ((input: string | URL | Request, init?: RequestInit) => {
   const headers = new Headers(init?.headers ?? {})
   calls.push({
     url: String(input),
+    method: init?.method ?? "GET",
     headers: Object.fromEntries(headers.entries()),
     body: bodyOf(init?.body)
   })
@@ -106,8 +108,8 @@ describe("a declared actor method", () => {
   test("discovers method schemas at the actor", async () => {
     answer = () => new Response(JSON.stringify([{
       name: "message",
-      input: { dialect: "draft-2020-12", schema: { type: "object" }, definitions: {} },
-      output: { dialect: "draft-2020-12", schema: { type: "string" }, definitions: {} }
+      inputSchema: { type: "object" },
+      outputSchema: { type: "string" }
     }]), { status: 200, headers: { "content-type": "application/json" } })
     const methods = await makeClient({ baseUrl: "http://localhost:4111", fetch: stub }).methods()
     expect(methods[0]?.name).toBe("message")
@@ -124,8 +126,9 @@ describe("a declared actor method", () => {
     const client = makeClient({ baseUrl: "http://localhost:4111", fetch: stub, methods: agentMethods })
     const accepted = await client.invoke("root", "message", { id: "m1", input: { text: "hello" } })
     expect(accepted.call).toBe("m1")
-    expect(lastUrl().pathname).toBe("/v1/actors/default/threads/root/methods/message")
-    expect(JSON.parse(calls[0]!.body ?? "")).toEqual({ id: "m1", input: { text: "hello" } })
+    expect(calls[0]?.method).toBe("PUT")
+    expect(lastUrl().pathname).toBe("/v1/actors/default/threads/root/methods/message/calls/m1")
+    expect(JSON.parse(calls[0]!.body ?? "")).toEqual({ text: "hello" })
   })
 
   test("reads and types completed output from the declaration", async () => {
@@ -136,7 +139,7 @@ describe("a declared actor method", () => {
     const client = makeClient({ baseUrl: "http://localhost:4111", fetch: stub, methods: agentMethods })
     const state: ActorMethodState<string> = await client.methodState("root", "message", "m1")
     expect(state).toEqual({ status: "completed", output: "done" })
-    expect(lastUrl().pathname).toBe("/v1/actors/default/threads/root/methods/message/m1")
+    expect(lastUrl().pathname).toBe("/v1/actors/default/threads/root/methods/message/calls/m1")
   })
 })
 
@@ -204,7 +207,7 @@ describe("a declared projection", () => {
   test("serves at the name it was declared under, and carries its own query", async () => {
     const client = makeClient({ baseUrl: "http://localhost:4111", fetch: stub, projections })
     await client.projection("root", "turns", { at: 3 })
-    expect(lastUrl().pathname).toBe("/v1/actors/default/threads/root/turns")
+    expect(lastUrl().pathname).toBe("/v1/actors/default/threads/root/projections/turns")
     expect(lastUrl().searchParams.get("at")).toBe("3")
   })
 
@@ -279,7 +282,7 @@ describe("resuming a turn", () => {
     // Two calls: the projection it read, then the append it made.
     expect(calls).toHaveLength(2)
     const read = new URL(calls[0]!.url)
-    expect(read.pathname).toBe("/v1/actors/default/threads/root/turns")
+    expect(read.pathname).toBe("/v1/actors/default/threads/root/projections/turns")
     expect(read.searchParams.get("turn")).toBe("m1")
     const appended = new URL(calls[1]!.url)
     expect(appended.pathname).toBe("/v1/actors/default/threads/root/events")

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -269,8 +269,8 @@ export const makeClient = <const P extends Projections = {}, const M extends Act
     methods: () => run(api.methods.methods({ params: { actor } })),
     invoke: (thread, name, call) =>
       run(api.methods.invoke({
-        params: { actor, id: thread, method: name },
-        payload: call
+        params: { actor, id: thread, method: name, call: call.id },
+        payload: call.input
       })),
     methodState: (thread, name, call) =>
       run(api.methods.methodState({

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,6 +1,7 @@
 import { Effect, type Schema } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientError, HttpClientRequest } from "effect/unstable/http"
 import { HttpApiClient, type HttpApi } from "effect/unstable/httpapi"
+import type { ActorMethodInput, ActorMethodOutput, ActorMethods, ActorMethodState } from "tardie"
 
 import {
   apiOf,
@@ -13,6 +14,7 @@ import {
   type ThreadSummary,
   type EventRow,
   type Health,
+  type MethodAccepted,
   type Projections,
   type TurnView
 } from "./contract"
@@ -57,7 +59,7 @@ type ProjectionCall = (request: {
   readonly query: unknown
 }) => Effect.Effect<unknown, unknown>
 
-export interface ClientOptions<P extends Projections = {}> {
+export interface ClientOptions<P extends Projections = {}, M extends ActorMethods = ActorMethods> {
   // The server's address. A path on it is kept, so a server mounted under a prefix works.
   readonly baseUrl?: string | undefined
   // The bearer token, sent as an `authorization` header on every request (apps/server/src/http.ts,
@@ -78,6 +80,8 @@ export interface ClientOptions<P extends Projections = {}> {
   // client that reads the log alone states none; one that calls a projection states the same
   // declaration the server mounts (contract.ts, apiOf).
   readonly projections?: P | undefined
+  // methods preserves the selected actor's call types at this client boundary.
+  readonly methods?: M | undefined
 }
 
 export interface EventsOptions {
@@ -98,9 +102,15 @@ export type ProjectionQuery<P extends Projections, Name extends keyof P> = Schem
 
 export type ProjectionResult<P extends Projections, Name extends keyof P> = P[Name]["result"]["Type"]
 
+// MethodCall carries the caller-minted id and the selected declaration's input type.
+export type MethodCall<M extends ActorMethods, Name extends keyof M> = {
+  readonly id: string
+  readonly input: ActorMethodInput<M[Name]>
+}
+
 type SchemaStructType<Fields> = Fields extends Schema.Struct.Fields ? Schema.Struct<Fields>["Type"] : never
 
-export interface Client<P extends Projections = {}> {
+export interface Client<P extends Projections = {}, M extends ActorMethods = ActorMethods> {
   readonly baseUrl: string
   // The actor every call addresses, resolved once at construction (ClientOptions, actor).
   readonly actor: string
@@ -111,6 +121,18 @@ export interface Client<P extends Projections = {}> {
   // Appends one event to a thread's log. A brief is `{ type: "MessageReceived", id, text }`; the
   // platform requires nothing but `type` (contract.ts, Append).
   readonly append: (thread: string, event: Append) => Promise<Accepted>
+  // invoke commits one declared method call and returns its durable handle.
+  readonly invoke: <const Name extends keyof M & string>(
+    thread: string,
+    name: Name,
+    call: MethodCall<M, Name>
+  ) => Promise<MethodAccepted>
+  // methodState reads the selected declaration's typed durable state.
+  readonly methodState: <const Name extends keyof M & string>(
+    thread: string,
+    name: Name,
+    call: string
+  ) => Promise<ActorMethodState<ActorMethodOutput<M[Name]>>>
   // Resumes a failed turn by appending the TurnResumed its reactors already interpret. It is the
   // SDK's convenience rather than a route: the platform has no resume, because a resume is an
   // append like any other (resume, below).
@@ -184,7 +206,9 @@ const eventsQuery = (options: EventsOptions) => {
 
 // makeClient builds the client once. The derivation reads the declaration and compiles an encoder
 // and a decoder per endpoint, so it happens at construction rather than per call.
-export const makeClient = <const P extends Projections = {}>(options: ClientOptions<P> = {}): Client<P> => {
+export const makeClient = <const P extends Projections = {}, const M extends ActorMethods = ActorMethods>(
+  options: ClientOptions<P, M> = {}
+): Client<P, M> => {
   const baseUrl = options.baseUrl ?? DEFAULT_BASE_URL
   const token = options.token
   // The derivation's own requirement is `HttpClient`, which the layer below provides, plus whatever
@@ -239,6 +263,15 @@ export const makeClient = <const P extends Projections = {}>(options: ClientOpti
     events: (thread, events = {}) =>
       run(api.threads.events({ params: { actor, id: thread }, query: eventsQuery(events) })),
     append,
+    invoke: (thread, name, call) =>
+      run(api.methods.invoke({
+        params: { actor, id: thread, method: name },
+        payload: call
+      })),
+    methodState: (thread, name, call) =>
+      run(api.methods.methodState({
+        params: { actor, id: thread, method: name, call }
+      })) as never,
     // A resume is an append, so the platform has no route for it and no guard over it. The check
     // below is advisory: it reads the turns projection to refuse the obvious mistake early and to
     // learn the epoch to stamp. A turn that fails between the read and the append still gets a

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -15,6 +15,7 @@ import {
   type EventRow,
   type Health,
   type MethodAccepted,
+  type MethodSummary,
   type Projections,
   type TurnView
 } from "./contract"
@@ -121,6 +122,8 @@ export interface Client<P extends Projections = {}, M extends ActorMethods = Act
   // Appends one event to a thread's log. A brief is `{ type: "MessageReceived", id, text }`; the
   // platform requires nothing but `type` (contract.ts, Append).
   readonly append: (thread: string, event: Append) => Promise<Accepted>
+  // methods lists the selected actor's callable interface and JSON Schema documents.
+  readonly methods: () => Promise<ReadonlyArray<MethodSummary>>
   // invoke commits one declared method call and returns its durable handle.
   readonly invoke: <const Name extends keyof M & string>(
     thread: string,
@@ -263,6 +266,7 @@ export const makeClient = <const P extends Projections = {}, const M extends Act
     events: (thread, events = {}) =>
       run(api.threads.events({ params: { actor, id: thread }, query: eventsQuery(events) })),
     append,
+    methods: () => run(api.methods.methods({ params: { actor } })),
     invoke: (thread, name, call) =>
       run(api.methods.invoke({
         params: { actor, id: thread, method: name },

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -285,9 +285,7 @@ const ActorParams = { actor: Schema.String }
 
 const ThreadParams = { actor: Schema.String, id: Schema.String }
 
-const MethodParams = { ...ThreadParams, method: Schema.String }
-
-const MethodCallParams = { ...MethodParams, call: Schema.String }
+const MethodCallParams = { ...ThreadParams, method: Schema.String, call: Schema.String }
 
 // threadsGroup declares the platform's raw log operations: list threads, append an event, and read events back.
 export const threadsGroup = HttpApiGroup.make("threads").add(

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -225,6 +225,15 @@ export const MethodState = Schema.Union([
 
 export type MethodState = typeof MethodState.Type
 
+// MethodSummary exposes one declared method and the JSON Schema documents for its input and output.
+export const MethodSummary = Schema.Struct({
+  name: Schema.String,
+  input: Schema.Unknown,
+  output: Schema.Unknown
+}).annotate({ identifier: "MethodSummary" })
+
+export type MethodSummary = typeof MethodSummary.Type
+
 export const Health = Schema.Struct({
   status: Schema.Literals(["resting", "driving"]),
   dirty: Schema.Finite
@@ -319,6 +328,11 @@ export const threadsGroup = HttpApiGroup.make("threads").add(
 
 // methodsGroup turns typed actor input into a durable event and projects each call from the same log.
 export const methodsGroup = HttpApiGroup.make("methods").add(
+  HttpApiEndpoint.get("methods", "/v1/actors/:actor/methods", {
+    params: ActorParams,
+    success: Schema.Array(MethodSummary),
+    error: [UnknownActor.schema]
+  }),
   HttpApiEndpoint.post("invoke", "/v1/actors/:actor/threads/:id/methods/:method", {
     params: MethodParams,
     payload: MethodInvocation,

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -96,6 +96,12 @@ export const UnknownActor = problemKind("unknown-actor", "Unknown Actor", 404)
 // exist (apps/server/src/api.ts, layerProjections).
 export const UnknownProjection = problemKind("unknown-projection", "Unknown Projection", 404)
 
+// UnknownMethod reports a method name the selected actor did not declare.
+export const UnknownMethod = problemKind("unknown-method", "Unknown Method", 404)
+
+// UnknownMethodCall reports a call id the selected method cannot derive from the thread log.
+export const UnknownMethodCall = problemKind("unknown-method-call", "Unknown Method Call", 404)
+
 // A resume refused before it was sent. The platform has no resume route: a resume is an appended
 // TurnResumed like any other event, and the guard that a turn's active epoch must be failed is the
 // SDK's convenience rather than the server's rule (client.ts, resume).
@@ -191,6 +197,34 @@ export const Accepted = Schema.Struct({
 
 export type Accepted = typeof Accepted.Type
 
+// MethodInvocation carries the caller-minted durable id and the selected method's encoded input.
+export const MethodInvocation = Schema.Struct({
+  id: Schema.NonEmptyString,
+  input: Schema.Unknown
+}).annotate({ identifier: "MethodInvocation" })
+
+export type MethodInvocation = typeof MethodInvocation.Type
+
+// MethodAccepted identifies the method call committed for asynchronous reconciliation.
+export const MethodAccepted = Schema.Struct({
+  actor: Schema.String,
+  thread: Schema.String,
+  method: Schema.String,
+  call: Schema.String
+}).annotate({ identifier: "MethodAccepted" }).pipe(HttpApiSchema.status(202))
+
+export type MethodAccepted = typeof MethodAccepted.Type
+
+// MethodState is the durable state any declared actor method can expose on the wire.
+export const MethodState = Schema.Union([
+  Schema.Struct({ status: Schema.Literal("pending") }),
+  Schema.Struct({ status: Schema.Literal("blocked"), reason: Schema.String }),
+  Schema.Struct({ status: Schema.Literal("completed"), output: Schema.Unknown }),
+  Schema.Struct({ status: Schema.Literal("failed"), error: Schema.String })
+]).annotate({ identifier: "MethodState" })
+
+export type MethodState = typeof MethodState.Type
+
 export const Health = Schema.Struct({
   status: Schema.Literals(["resting", "driving"]),
   dirty: Schema.Finite
@@ -250,9 +284,11 @@ const ActorParams = { actor: Schema.String }
 
 const ThreadParams = { actor: Schema.String, id: Schema.String }
 
-// The log, which is the whole of what the platform guarantees: list the threads an actor holds,
-// append an event, read the events back. A tail follows beside this group (stream.ts). Everything
-// else a thread can be asked is a projection its actor declares, mounted by name below.
+const MethodParams = { ...ThreadParams, method: Schema.String }
+
+const MethodCallParams = { ...MethodParams, call: Schema.String }
+
+// threadsGroup declares the platform's raw log operations: list threads, append an event, and read events back.
 export const threadsGroup = HttpApiGroup.make("threads").add(
   // Envelope is an append: a message is an event, and the log is where it lands, so the write side
   // of a thread is the same noun as its read side (docs/how-to/server.md, "Creation is delivery").
@@ -278,6 +314,21 @@ export const threadsGroup = HttpApiGroup.make("threads").add(
     params: ThreadParams,
     success: ThreadNode,
     error: [UnknownActor.schema, UnknownThread.schema]
+  })
+)
+
+// methodsGroup turns typed actor input into a durable event and projects each call from the same log.
+export const methodsGroup = HttpApiGroup.make("methods").add(
+  HttpApiEndpoint.post("invoke", "/v1/actors/:actor/threads/:id/methods/:method", {
+    params: MethodParams,
+    payload: MethodInvocation,
+    success: MethodAccepted,
+    error: [InvalidRequest.schema, UnknownActor.schema, UnknownMethod.schema]
+  }),
+  HttpApiEndpoint.get("methodState", "/v1/actors/:actor/threads/:id/methods/:method/:call", {
+    params: MethodCallParams,
+    success: MethodState,
+    error: [UnknownActor.schema, UnknownThread.schema, UnknownMethod.schema, UnknownMethodCall.schema]
   })
 )
 
@@ -389,18 +440,15 @@ export class RequestProblems extends HttpApiMiddleware.Service<RequestProblems>(
   { error: InvalidRequest.schema }
 ) {}
 
-// apiOf is the whole surface for one actor: the log, the projections that actor declares, and the
-// health probe. It is a function rather than a constant because the projections are not the
-// platform's to know: a server builds the API it serves from the actor it mounts
-// (apps/server/src/api.ts, ServerApi).
+// apiOf combines the actor registry, raw logs, actor methods, declared projections, and health probe.
 export const apiOf = <const P extends Projections>(projections: P) =>
-  HttpApi.make("tardigrade").add(actorsGroup, threadsGroup, projectionsGroupOf(projections), healthGroup)
+  HttpApi.make("tardigrade").add(actorsGroup, threadsGroup, methodsGroup, projectionsGroupOf(projections), healthGroup)
     .middleware(RequestProblems)
     .annotateMerge(
       OpenApi.annotations({
         title: "Tardigrade",
         description:
-          "Actors, threads, turns, and events: the platform holds the log, and every other read is a projection its actor declares. Every failure is an RFC 9457 problem document."
+          "Actors expose durable methods over thread logs. Raw events and declared projections remain available for inspection. Every failure is an RFC 9457 problem document."
       })
     )
 

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -197,14 +197,6 @@ export const Accepted = Schema.Struct({
 
 export type Accepted = typeof Accepted.Type
 
-// MethodInvocation carries the caller-minted durable id and the selected method's encoded input.
-export const MethodInvocation = Schema.Struct({
-  id: Schema.NonEmptyString,
-  input: Schema.Unknown
-}).annotate({ identifier: "MethodInvocation" })
-
-export type MethodInvocation = typeof MethodInvocation.Type
-
 // MethodAccepted identifies the method call committed for asynchronous reconciliation.
 export const MethodAccepted = Schema.Struct({
   actor: Schema.String,
@@ -225,11 +217,11 @@ export const MethodState = Schema.Union([
 
 export type MethodState = typeof MethodState.Type
 
-// MethodSummary exposes one declared method and the JSON Schema documents for its input and output.
+// MethodSummary exposes one declared method and standalone JSON Schemas for its input and output.
 export const MethodSummary = Schema.Struct({
   name: Schema.String,
-  input: Schema.Unknown,
-  output: Schema.Unknown
+  inputSchema: Schema.Unknown,
+  outputSchema: Schema.Unknown
 }).annotate({ identifier: "MethodSummary" })
 
 export type MethodSummary = typeof MethodSummary.Type
@@ -333,13 +325,13 @@ export const methodsGroup = HttpApiGroup.make("methods").add(
     success: Schema.Array(MethodSummary),
     error: [UnknownActor.schema]
   }),
-  HttpApiEndpoint.post("invoke", "/v1/actors/:actor/threads/:id/methods/:method", {
-    params: MethodParams,
-    payload: MethodInvocation,
+  HttpApiEndpoint.put("invoke", "/v1/actors/:actor/threads/:id/methods/:method/calls/:call", {
+    params: MethodCallParams,
+    payload: Schema.Unknown,
     success: MethodAccepted,
     error: [InvalidRequest.schema, UnknownActor.schema, UnknownMethod.schema]
   }),
-  HttpApiEndpoint.get("methodState", "/v1/actors/:actor/threads/:id/methods/:method/:call", {
+  HttpApiEndpoint.get("methodState", "/v1/actors/:actor/threads/:id/methods/:method/calls/:call", {
     params: MethodCallParams,
     success: MethodState,
     error: [UnknownActor.schema, UnknownThread.schema, UnknownMethod.schema, UnknownMethodCall.schema]
@@ -385,27 +377,8 @@ export const projection = <Params extends Schema.Struct.Fields, Result extends S
   }
 ): typeof declaration => declaration
 
-// The two names a projection may not claim. The log is not a projection of itself: `events` is the
-// log read back and `stream` is the same log followed, and both are the platform's own guarantee
-// rather than anything an actor derives (projectionsOf refuses either, the way infer refuses a
-// duplicate tool).
-export const RESERVED_PROJECTIONS: ReadonlyArray<string> = ["events", "stream"]
-
-// projectionsOf is the constructor an actor declares through. It refuses a reserved name where the
-// declaration is written rather than where a request arrives, so a build that would shadow the log
-// never starts (apps/server/src/actor.test.ts, "a projection may not claim a reserved name").
-export const projectionsOf = <const P extends Projections>(projections: P): P => {
-  for (const name of Object.keys(projections)) {
-    if (RESERVED_PROJECTIONS.includes(name)) {
-      throw new Error(
-        `a projection may not be named ${JSON.stringify(name)}: ${
-          RESERVED_PROJECTIONS.map((reserved) => JSON.stringify(reserved)).join(" and ")
-        } are the log itself`
-      )
-    }
-  }
-  return projections
-}
+// projectionsOf preserves the names and schemas used to build the projection routes.
+export const projectionsOf = <const P extends Projections>(projections: P): P => projections
 
 // One endpoint from one declaration. The schemas are type parameters of this function rather than
 // fields reached through one declaration parameter, because inference through an indexed access
@@ -415,7 +388,7 @@ const projectionEndpoint = <
   Params extends Schema.Struct.Fields,
   Result extends Schema.Top
 >(name: Name, params: Params, result: Result) =>
-  HttpApiEndpoint.get(name, `/v1/actors/:actor/threads/:id/${name}` as const, {
+  HttpApiEndpoint.get(name, `/v1/actors/:actor/threads/:id/projections/${name}` as const, {
     params: ThreadParams,
     query: params,
     success: result,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -29,7 +29,6 @@ export type {
   EventRow,
   Health,
   MethodAccepted,
-  MethodInvocation,
   MethodSummary,
   MethodState,
   Problem,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -30,6 +30,7 @@ export type {
   Health,
   MethodAccepted,
   MethodInvocation,
+  MethodSummary,
   MethodState,
   Problem,
   ThreadNode,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -12,7 +12,8 @@ export {
   type Client,
   type ClientOptions,
   type EventsOptions,
-  type FollowOptions
+  type FollowOptions,
+  type MethodCall
 } from "./client"
 export { isProblem, NO_ANSWER, problemOf, ProblemError } from "./problem"
 // The vocabulary's top level, and where the versioned routes live. A consumer that builds a URL by
@@ -24,13 +25,16 @@ export { CLOSED, stream, streamUrl, type EventSourceLike, type Frame, type OpenE
 export type {
   Accepted,
   ActorSummary,
+  Append,
+  EventRow,
+  Health,
+  MethodAccepted,
+  MethodInvocation,
+  MethodState,
+  Problem,
   ThreadNode,
   ThreadStatus,
   ThreadSummary,
-  EventRow,
-  Health,
-  Append,
-  Problem,
   TurnStatus,
   TurnView
 } from "./contract"


### PR DESCRIPTION
## Summary

Actors now expose their declared methods through the HTTP API and typed client. Method discovery returns standalone input and output JSON Schemas. Calls use idempotent `PUT` resources whose body is the method input, and call state is derived from the thread log.

The CLI now discovers methods with `tdg methods` and invokes any declared method with `tdg call`. `--no-wait` returns the durable handle immediately. Generated quickstarts use the method surface and avoid a redundant build before push.

Declared projections now live under `/projections/:name`, which prevents collisions with platform thread routes.

## Why

Actor methods provide a typed application ingress over the durable log. A discoverable schema and a stable call URL let clients validate input, retry safely, and read the same derived state after recovery.

## Verification

`bun run gate` passes all 47 tasks.