### PR TITLE
feat(agent): select model references

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ const instructions = system(
   "You are a release analyst. Identify risky changes and recommend the safest next action."
 )
 
+const releaseModel = { provider: "openai", default_model: "gpt-5.2" } as const
+
 const releaseAnalyst = defineActor({
   name: "release-analyst",
   methods: agentMethods,
@@ -141,11 +143,11 @@ const releaseAnalyst = defineActor({
     compaction(), // bounded model context
     reply,       // results for parent agents
     outputValidateOnce // validates one structured result without correction
-  ]))
+  ], releaseModel))
 })
 ```
 
-`infer` composes the components into an agent loop. `defineActor` gives that loop a stable name and callable interface. `agentMethods` provides a `message` method with `{ text, input? }` input and a string result.
+`infer` composes the components into an agent loop and selects its provider and default model. `defineActor` gives that loop a stable name and callable interface. `agentMethods` provides a `message` method with `{ text, input?, model? }` input and a string result.
 
 `compaction(policy?)` bounds model context. Its default uses a 128,000-token window, fires at 80 percent, and keeps a 50 percent tail. A platform that serves several models should supply their windows:
 

--- a/apps/server/src/actor.ts
+++ b/apps/server/src/actor.ts
@@ -14,7 +14,8 @@ import {
   infer,
   outputValidateOnce,
   reply,
-  workspacePackage
+  workspacePackage,
+  type ModelRefType
 } from "tardie"
 import { turnEpochOf } from "@clavia/tardigrade-code/turns"
 import { boundaryOf } from "tardie/boundary"
@@ -38,20 +39,34 @@ import { inboundOf } from "./projections"
 // one root directory, the working directory of the process that booted, and `fetch` makes HTTP
 // requests to any host. There is no shell: a shell cannot be scoped the way a root or an origin can,
 // and this build has no place to ask an operator whether one command is allowed.
-export const assemblyOf = () =>
+export interface AssemblyModelPolicy {
+  readonly provider: string
+  readonly default_model: string
+  readonly contextWindowTokens?: number | ((model: ModelRefType | undefined) => number)
+}
+
+export const UNCONFIGURED_MODEL: AssemblyModelPolicy = {
+  provider: "unconfigured",
+  default_model: "unconfigured"
+}
+
+export const assemblyOf = (models: AssemblyModelPolicy = UNCONFIGURED_MODEL) =>
   actor(infer([
     codeMode([agentsPackage(), workspacePackage(), filesPackage(), fetchPackage()]),
     reply,
     budget,
-    compaction(),
+    compaction(models.contextWindowTokens === undefined ? {} : { contextWindowTokens: models.contextWindowTokens }),
     outputValidateOnce
-  ]))
+  ], {
+    provider: models.provider,
+    default_model: models.default_model
+  }))
 
 // builtInActor declares the built-in assembly and its callable interface together.
-export const builtInActor = () => defineActor({
+export const builtInActor = (models: AssemblyModelPolicy = UNCONFIGURED_MODEL) => defineActor({
   name: RESERVED_ACTOR,
   methods: agentMethods,
-  actor: assemblyOf()
+  actor: assemblyOf(models)
 })
 
 // ServerR is what this assembly needs bound. It is read off the assembly rather than restated, so a

--- a/docs/how-to/migrate.md
+++ b/docs/how-to/migrate.md
@@ -23,7 +23,7 @@ The current Vercel AI SDK agent surface includes [`ToolLoopAgent` and loop contr
 
 | Existing concern | Tardigrade home |
 | --- | --- |
-| `ToolLoopAgent`, `generateText`, `streamText`, or a manual model loop | `defineActor({ name, methods, actor: actor(infer([...])) })` |
+| `ToolLoopAgent`, `generateText`, `streamText`, or a manual model loop | `defineActor({ name, methods, actor: actor(infer([...], model)) })` |
 | System instructions | `system(...)` |
 | Tool declarations and handlers | Package components mounted through `codeMode`, or fixed tools mounted through `toolList` |
 | `stopWhen`, maximum steps, and retry options | `budgetFor`, `infer` policy, and domain components with explicit policy values |

--- a/examples/quickstart/actor.ts
+++ b/examples/quickstart/actor.ts
@@ -6,6 +6,7 @@ import {
 
 // actorName is the stable name used by build, push, and run.
 const actorName = "researcher"
+const actorModel = { provider: "openai", default_model: "gpt-5.2" } as const
 
 // actorInstructions is the main place to describe the job and its expected answer.
 const actorInstructions = `
@@ -37,5 +38,5 @@ export default defineActor({
     compaction(),
     // outputValidateOnce validates one structured result when the endpoint supplies no native guarantee.
     outputValidateOnce
-  ]))
+  ], actorModel))
 })

--- a/examples/rlm-agent.ts
+++ b/examples/rlm-agent.ts
@@ -1,8 +1,7 @@
 // A Recursive Language Model agent, assembled from the library's parts and run on the durable
 // Bun host: bun run examples/rlm-agent.ts. The agent acts by writing JavaScript; its code can
 // spawn child agents (agents.run) and read spilled values back (workspace.read). Set
-// MODEL_BASE_URL, MODEL_API_KEY, and MODEL_ID to an OpenAI-compatible endpoint before running;
-// add provider: "bedrock" to the infer options for Bedrock.
+// MODEL_BASE_URL, MODEL_API_KEY, MODEL_PROVIDER, and MODEL_ID before running.
 
 // The workspace names resolve in this repository. Against the published package the last two
 // are "tardie/model" and "tardie/bun/host" (tools/publish.ts).
@@ -20,7 +19,10 @@ const rlm = actor(inferAgent([
   budget, // the per-turn code budget, inherited by spawned children
   compaction(), // bounded model context over long investigations
   outputValidateOnce // handles structured results without adding a retry
-]))
+], {
+  provider: process.env.MODEL_PROVIDER!,
+  default_model: process.env.MODEL_ID!
+}))
 
 const model = infer({
   baseUrl: process.env.MODEL_BASE_URL!,

--- a/packages/agent/src/agent.types.test.ts
+++ b/packages/agent/src/agent.types.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./index"
 
 const accepts = <T>(_value: T): void => {}
+const TEST_MODEL = { provider: "test", default_model: "test-model" } as const
 
 const empty: AgentComponent = {
   name: "empty",
@@ -20,8 +21,8 @@ const empty: AgentComponent = {
   })
 }
 
-const nativeOnly = actor(infer([empty, nativeOutput]))
-const repaired = actor(infer([empty, outputRepair]))
+const nativeOnly = actor(infer([empty, nativeOutput], TEST_MODEL))
+const repaired = actor(infer([empty, outputRepair], TEST_MODEL))
 
 type Requirements<A> = A extends Actor<infer R> ? R : never
 type RequiresNative<A> = NativeOutputSupport extends Requirements<A> ? true : false

--- a/packages/agent/src/components/budget.test.ts
+++ b/packages/agent/src/components/budget.test.ts
@@ -18,7 +18,9 @@ import { reply } from "./reply"
 import { nativeOutput } from "./native-output"
 import { agentKeys } from "../events"
 
-const rootReactor = actor(infer([codeMode(), reply, budget, compaction(), nativeOutput])).reactors[0]!
+const TEST_MODEL = { provider: "test", default_model: "test-model" } as const
+
+const rootReactor = actor(infer([codeMode(), reply, budget, compaction(), nativeOutput], TEST_MODEL)).reactors[0]!
 
 // The rest of the agent's environment, which every reactor's `act` is typed against whether or not
 // it reaches for it. Naming it is what proves the tools gate answers from the log alone: no model

--- a/packages/agent/src/components/compaction.test.ts
+++ b/packages/agent/src/components/compaction.test.ts
@@ -72,8 +72,8 @@ describe("the compaction measure and guard", () => {
 
   test("the selected model resolves both hysteresis lines from one window", () => {
     const policy = contextPolicyOf(
-      { contextWindowTokens: (model) => model === "large" ? 1_000_000 : 100_000 },
-      "large"
+      { contextWindowTokens: (model) => model?.model_id === "large" ? 1_000_000 : 100_000 },
+      { provider: "test", model_id: "large" }
     )
     expect(policy.fireTokens).toBe(800_000)
     expect(policy.keepTokens).toBe(500_000)

--- a/packages/agent/src/components/compaction.ts
+++ b/packages/agent/src/components/compaction.ts
@@ -5,6 +5,7 @@ import type { Event } from "@clavia/tardigrade-core/event"
 import { turnOf, turnView } from "@clavia/tardigrade-code/turns"
 import { projectedOutput } from "../output"
 import { Infer } from "../runtime/infer"
+import { modelRefOf, type ModelRef } from "../model"
 import type { AgentComponent } from "../runtime/agent"
 
 // The compaction reactor: a pure observer of the context size, with the hysteresis design. A
@@ -52,7 +53,7 @@ export interface ContextPolicy {
   readonly summaryLineCap: number
 }
 
-export type ContextWindowTokens = number | ((model: string | undefined) => number)
+export type ContextWindowTokens = number | ((model: ModelRef | undefined) => number)
 
 export interface CompactionPolicy {
   readonly messageRenderCap: number
@@ -82,16 +83,21 @@ const ratio = (value: number, name: string): number => {
   return value
 }
 
-// modelOf returns the latest model choice recorded for the open thread. The same MessageReceived
-// field selects inference, so a replay resolves the same model window.
-const modelOf = (log: ReadonlyArray<Event>): string | undefined => {
-  let model: string | undefined
+// modelResolutionOf returns the latest model facts recorded by infer for the open thread.
+const modelResolutionOf = (log: ReadonlyArray<Event>): {
+  readonly model: ModelRef | undefined
+  readonly contextWindowTokens: number | undefined
+} => {
+  let model: ModelRef | undefined
+  let contextWindowTokens: number | undefined
   for (const event of log) {
-    if (event.type !== "MessageReceived") continue
-    const selected = (event as { readonly model?: unknown }).model
-    if (typeof selected === "string" && selected !== "") model = selected
+    if (event.type !== "ModelResolved") continue
+    const selected = modelRefOf((event as { readonly model?: unknown }).model)
+    if (selected !== undefined) model = selected
+    const window = (event as { readonly contextWindowTokens?: unknown }).contextWindowTokens
+    if (typeof window === "number") contextWindowTokens = window
   }
-  return model
+  return { model, contextWindowTokens }
 }
 
 // contextPolicyOf resolves the model-relative policy into the absolute thresholds used by the
@@ -99,7 +105,7 @@ const modelOf = (log: ReadonlyArray<Event>): string | undefined => {
 // together.
 export const contextPolicyOf = (
   policy: Partial<CompactionPolicy> = {},
-  model?: string
+  model?: ModelRef
 ): ContextPolicy => {
   const windowSource = policy.contextWindowTokens ?? DEFAULT_COMPACTION_POLICY.contextWindowTokens
   const contextWindowTokens = positive(
@@ -128,6 +134,19 @@ export const contextPolicyOf = (
       "summaryLineCap"
     )
   }
+}
+
+const contextPolicyFrom = (
+  log: ReadonlyArray<Event>,
+  policy: Partial<CompactionPolicy>
+): ContextPolicy => {
+  const selection = modelResolutionOf(log)
+  return contextPolicyOf(
+    selection.contextWindowTokens === undefined
+      ? policy
+      : { ...policy, contextWindowTokens: selection.contextWindowTokens },
+    selection.model
+  )
 }
 
 // resolvedContextPolicyOf fills a partial absolute policy at the render boundary. Components
@@ -328,7 +347,8 @@ const firedUncovered = (log: ReadonlyArray<Event>): boolean => {
 // The policy this takes must be the one the render takes, or the guard measures a request the
 // model never sees (ContextPolicy above).
 export const compactionReactor = (policy: Partial<CompactionPolicy> = {}): Reactor<Infer> => (log) => {
-  const resolved = contextPolicyOf(policy, modelOf(log))
+  const model = modelResolutionOf(log).model
+  const resolved = contextPolicyFrom(log, policy)
   // The projection runs first, so the guard, the cut, and the brief all read the history the
   // model reads. A corrected exchange the render hides can neither trigger a paid pass nor leak
   // its rejected reply into a summary (src/output.ts, projectedOutput).
@@ -372,6 +392,7 @@ export const compactionReactor = (policy: Partial<CompactionPolicy> = {}): React
           const action = yield* (yield* Infer).react(
             {
               trajectory: [{ type: "MessageReceived", id: `compact-${input.keepFrom}`, text: brief, at }],
+              ...(model === undefined ? {} : { model }),
               system: "",
               tools: []
             },
@@ -401,7 +422,7 @@ export const compaction = (policy: Partial<CompactionPolicy> = {}): AgentCompone
       view: {
         system: [],
         tools: [],
-        context: [{ component: "compaction", policy: contextPolicyOf(policy, modelOf(log)) }],
+        context: [{ component: "compaction", policy: contextPolicyFrom(log, policy) }],
         output: []
       },
       transitions: reactor(log)

--- a/packages/agent/src/events.ts
+++ b/packages/agent/src/events.ts
@@ -3,6 +3,7 @@ import { MessageReceived } from "@clavia/tardigrade-core/communication/message"
 import type { Event } from "@clavia/tardigrade-core/event"
 import type { KeyFragment } from "@clavia/tardigrade-core/event-log"
 import type { Usage } from "./usage"
+import { ModelRef, type ModelRef as ModelRefType } from "./model"
 
 // The agent's domain events. This alphabet belongs to the agent, and core never learns it: core
 // sees only the open envelope. The model responds by acting: its recorded decision is the
@@ -73,6 +74,7 @@ export const ToolReturned = Schema.Struct({
 export const ModelCalled = Schema.Struct({
   type: Schema.Literal("ModelCalled"),
   callId: Schema.String,
+  model: Schema.optional(ModelRef),
   // The occurrence: distinct per physical attempt, the dedup key's scope. callId stays the
   // provider idempotency key, shared across retries of one logical attempt.
   ordinal: Schema.optional(Schema.Finite),
@@ -81,6 +83,17 @@ export const ModelCalled = Schema.Struct({
   output: Schema.optional(OutputPolicy),
   epoch: Schema.optional(Schema.Finite),
   turn: Schema.optional(Schema.String),
+  at: Schema.Finite
+})
+
+// ModelResolved records the model reference and catalog limits used by one turn.
+export const ModelResolved = Schema.Struct({
+  type: Schema.Literal("ModelResolved"),
+  turn: Schema.String,
+  model: ModelRef,
+  contextWindowTokens: Schema.optional(Schema.Finite),
+  maxOutputTokens: Schema.optional(Schema.Finite),
+  catalogRevision: Schema.optional(Schema.String),
   at: Schema.Finite
 })
 
@@ -261,6 +274,7 @@ export const BudgetDenied = Schema.Struct({
 
 export const AgentEvent = Schema.Union([
   MessageReceived,
+  ModelResolved,
   ModelCalled,
   TextReturned,
   ToolCalled,
@@ -321,7 +335,7 @@ export type Action =
 const epochSuffix = (epoch: unknown): string => epoch === undefined || Number(epoch) === 0 ? "" : `/${String(epoch)}`
 
 export const agentKeys: KeyFragment = {
-  prefixes: ["tr:", "bdec:", "brr:", "rd:", "tn:", "rs:", "mc:", "bw:", "br:", "cc:", "or:", "oq:"],
+  prefixes: ["tr:", "bdec:", "brr:", "rd:", "tn:", "rs:", "mr:", "mc:", "bw:", "br:", "cc:", "or:", "oq:"],
   keyOf: (e) => {
     const v = e as Record<string, unknown>
     switch (e.type) {
@@ -347,6 +361,8 @@ export const agentKeys: KeyFragment = {
         // repetition that evidences died attempts is preserved. A mark predating the ordinal
         // lands unkeyed, which the folds tolerate.
         return v.ordinal === undefined ? undefined : `mc:${String(v.turn)}/${String(v.ordinal)}`
+      case "ModelResolved":
+        return `mr:${String(v.turn)}`
       case "BudgetExhausted":
         // The wall's occurrence is the ceiling it fired at: a grant raises it, so a second
         // crossing keys anew.
@@ -390,6 +406,7 @@ export const toolReturned = (fields: { readonly callId: string; readonly result:
 export const modelCalled = (
   fields: {
     readonly callId: string
+    readonly model?: ModelRefType
     readonly ordinal?: number
     readonly output?: {
       readonly contract: string
@@ -398,6 +415,16 @@ export const modelCalled = (
     }
   } & EpochStamp
 ): Event => ({ type: "ModelCalled", ...fields }) as Event
+
+export const modelResolved = (fields: {
+  readonly turn: string
+  readonly model: ModelRefType
+  readonly contextWindowTokens?: number
+  readonly maxOutputTokens?: number
+  readonly catalogRevision?: string
+  readonly at: number
+}): Event =>
+  ({ type: "ModelResolved", ...fields }) as Event
 
 export const textReturned = (fields: { readonly text: string } & Stamp): Event =>
   ({ type: "TextReturned", ...fields }) as Event

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -16,6 +16,7 @@ import { actor, budgetFor, codeMode, compaction, infer, nativeOutput, reply, too
 import type { RlmR } from "./turn"
 
 const ROOT_LANE = "ag.root"
+const TEST_MODEL = { provider: "test", default_model: "test-model" } as const
 
 // The headline: one ask, an emergent graph, one answer, library only.
 // The root's code spawns two children; the host births their lanes,
@@ -77,7 +78,7 @@ const hosted = (assembled: Actor<TestR>, mind: Mind, log: ReadonlyArray<Event> =
 // in-process host. The three policy components are always mounted, so a test that swaps the
 // work surface still runs the same turn loop, budget wall, and answer contract.
 const rlm = (mind: Mind, components: ReadonlyArray<AgentComponent<RlmR>> = [work()], log: ReadonlyArray<Event> = []) =>
-  hosted(actor(infer([...components, reply, budgetFor({}), compaction(), nativeOutput])), mind, log)
+  hosted(actor(infer([...components, reply, budgetFor({}), compaction(), nativeOutput], TEST_MODEL)), mind, log)
 
 const headText = (trajectory: ReadonlyArray<Event>): string => {
   for (let i = trajectory.length - 1; i >= 0; i--) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -30,8 +30,10 @@ export {
   DEFAULT_INFER_POLICY,
   type InferPolicy,
   type InferRequest,
+  type ModelResolution,
   type Render
 } from "./runtime/infer"
+export { ModelRef, modelRefOf, type ModelRef as ModelRefType } from "./model"
 
 // The turn's declared final response: the contract a caller states, the profile a binding can
 // send unchanged, and the implementation that obtains it. `output` is the whole declarative
@@ -169,6 +171,7 @@ export {
   type FallbackOutputFragment,
   type OutputFallbackComponent,
   type OutputFragment,
+  type InferOptions,
   type Rendered
 } from "./runtime/agent"
 export { codeMode, CODE_SYSTEM, codeSystemFor, type CodeModeOptions } from "./components/code"

--- a/packages/agent/src/message-method.test.ts
+++ b/packages/agent/src/message-method.test.ts
@@ -4,7 +4,7 @@ import { agentMessageMethod, agentMethods } from "./message-method"
 
 const head = agentMessageMethod.event({
   id: "m1",
-  input: { text: "review it", input: { pull: 227 } },
+  input: { text: "review it", input: { pull: 227 }, model: "openai/gpt-5.2" },
   at: 1
 })
 
@@ -15,6 +15,7 @@ describe("agentMessageMethod", () => {
       id: "m1",
       text: "review it",
       input: { pull: 227 },
+      model: "openai/gpt-5.2",
       at: 1
     })
     expect(agentMethods).toEqual({ message: agentMessageMethod })

--- a/packages/agent/src/message-method.ts
+++ b/packages/agent/src/message-method.ts
@@ -5,7 +5,8 @@ import { actorMethod, actorMethodsOf } from "./method"
 
 export const AgentMessageInput = Schema.Struct({
   text: Schema.String,
-  input: Schema.optionalKey(Schema.Unknown)
+  input: Schema.optionalKey(Schema.Unknown),
+  model: Schema.optionalKey(Schema.NonEmptyString)
 }).annotate({ identifier: "AgentMessageInput" })
 
 export type AgentMessageInput = typeof AgentMessageInput.Type
@@ -18,6 +19,7 @@ export const agentMessageMethod = actorMethod({
     id,
     text: input.text,
     ...(input.input === undefined ? {} : { input: input.input }),
+    ...(input.model === undefined ? {} : { model: input.model }),
     at
   }),
   state: (events, id) => {

--- a/packages/agent/src/model.test.ts
+++ b/packages/agent/src/model.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+
+import { modelRefOf } from "./model"
+
+describe("modelRefOf", () => {
+  test("reads and normalizes a complete reference", () => {
+    expect(modelRefOf({ provider: " openrouter ", model_id: " anthropic/claude-sonnet " })).toEqual({
+      provider: "openrouter",
+      model_id: "anthropic/claude-sonnet"
+    })
+  })
+
+  test("refuses incomplete or untyped input", () => {
+    expect(modelRefOf({ provider: "openrouter" })).toBeUndefined()
+    expect(modelRefOf({ provider: "", model_id: "model" })).toBeUndefined()
+    expect(modelRefOf("openrouter/model")).toBeUndefined()
+  })
+})

--- a/packages/agent/src/model.ts
+++ b/packages/agent/src/model.ts
@@ -1,0 +1,18 @@
+import { Schema } from "effect"
+
+// ModelRef identifies the provider and model an actor requests. The host supplies the provider connection.
+export const ModelRef = Schema.Struct({
+  provider: Schema.NonEmptyString,
+  model_id: Schema.NonEmptyString
+})
+
+export type ModelRef = typeof ModelRef.Type
+
+// modelRefOf reads a complete model reference from an untyped message or tool argument.
+export const modelRefOf = (value: unknown): ModelRef | undefined => {
+  if (typeof value !== "object" || value === null) return undefined
+  const reference = value as { readonly provider?: unknown; readonly model_id?: unknown }
+  if (typeof reference.provider !== "string" || reference.provider.trim().length === 0) return undefined
+  if (typeof reference.model_id !== "string" || reference.model_id.trim().length === 0) return undefined
+  return { provider: reference.provider.trim(), model_id: reference.model_id.trim() }
+}

--- a/packages/agent/src/runtime/agent.test.ts
+++ b/packages/agent/src/runtime/agent.test.ts
@@ -25,7 +25,9 @@ import { toolList } from "../components/tool-list"
 import { nativeOutput } from "../components/native-output"
 import { system } from "../components/system"
 import { receive } from "../turn"
-import { Infer, NativeOutputSupport, type InferRequest } from "./infer"
+import { Infer, NativeOutputSupport, selectedModelOf, type InferRequest } from "./infer"
+
+const TEST_MODEL = { provider: "test", default_model: "test-model" } as const
 
 // The component assembly end to end: the render the model sees is the composed view, and a call
 // routes through the same derived tool binding.
@@ -75,8 +77,67 @@ const viewComponent = (
 })
 
 describe("infer component", () => {
+  test("the actor owns model selection", () => {
+    const fallback = { provider: "cloudflare", model_id: "openai/gpt-5.6-luna" } as const
+    const message = {
+      type: "MessageReceived",
+      id: "m1",
+      text: "go",
+      model: { provider: "vercel", model_id: "anthropic/claude-sonnet-4-6" },
+      at: 1
+    } as Event
+    expect(selectedModelOf(message, fallback)).toEqual({
+      provider: "vercel",
+      model_id: "anthropic/claude-sonnet-4-6"
+    })
+    expect(selectedModelOf({ ...message, model: "openai/gpt-5.2" } as Event, fallback)).toEqual({
+      provider: "cloudflare",
+      model_id: "openai/gpt-5.2"
+    })
+    expect(selectedModelOf({ ...message, model: undefined } as Event, fallback)).toEqual(fallback)
+  })
+
+  test("the selected model reaches the model binding", async () => {
+    const seen: InferRequest[] = []
+    const mind = Layer.succeed(Infer, {
+      react: (request: InferRequest) => {
+        seen.push(request)
+        return Effect.succeed({ kind: "complete" as const, output: "done" })
+      }
+    })
+    const agent = actor(infer(
+      [
+      reply,
+      compaction({
+        contextWindowTokens: (model) =>
+          model?.provider === "vercel" ? 200_000 : 100_000
+      }),
+      nativeOutput
+    ], { provider: "vercel", default_model: "anthropic/claude-sonnet-4-6" }))
+    const events = await run(
+      Effect.gen(function* () {
+        yield* receive(agent, {
+          id: "m1",
+          text: "go",
+          model: "openai/gpt-5.2"
+        })
+        return yield* readLog
+      }),
+      Layer.mergeAll(memoryLog(), mind, noRouter, KeyValueStore.layerMemory)
+    )
+    expect(seen[0]?.model).toEqual({ provider: "vercel", model_id: "openai/gpt-5.2" })
+    expect(seen[0]?.context?.contextWindowTokens).toBe(200_000)
+    expect(events.find((event) => event.type === "ModelResolved")).toMatchObject({
+      turn: "m1",
+      model: { provider: "vercel", model_id: "openai/gpt-5.2" }
+    })
+    expect(events.find((event) => event.type === "ModelCalled")).toMatchObject({
+      model: { provider: "vercel", model_id: "openai/gpt-5.2" }
+    })
+  })
+
   test("an assembly must declare one output strategy", () => {
-    expect(() => actor(infer([echoTable]))).toThrow("must declare one output strategy")
+    expect(() => actor(infer([echoTable], TEST_MODEL))).toThrow("must declare one output strategy")
   })
 
   test("a marked output fallback must be present for every log", () => {
@@ -104,7 +165,7 @@ describe("infer component", () => {
         )
       }
     })
-    const agent = actor(infer([echoTable, reply, budget, compaction(), nativeOutput]))
+    const agent = actor(infer([echoTable, reply, budget, compaction(), nativeOutput], TEST_MODEL))
     const events = await run(
       Effect.gen(function* () {
         yield* receive(agent, { id: "m1", text: "go" })
@@ -131,7 +192,7 @@ describe("infer component", () => {
         )
       }
     })
-    const agent = actor(infer([echoTable, reply, nativeOutput]))
+    const agent = actor(infer([echoTable, reply, nativeOutput], TEST_MODEL))
     const events = await run(
       Effect.gen(function* () {
         yield* receive(agent, { id: "m1", text: "go" })
@@ -155,7 +216,7 @@ describe("infer component", () => {
         )
       }
     })
-    const agent = actor(infer([codeMode([fetchPackage()]), reply, nativeOutput]))
+    const agent = actor(infer([codeMode([fetchPackage()]), reply, nativeOutput], TEST_MODEL))
     const events = await run(
       Effect.gen(function* () {
         yield* receive(agent, { id: "m1", text: "go" })
@@ -171,7 +232,7 @@ describe("infer component", () => {
   })
 
   test("two components declaring one tool name collide at construction", () => {
-    expect(() => actor(infer([echoTable, toolList([{ spec: { name: "echo", description: "again", inputSchema: {} }, run: () => Effect.succeed({}) }]), nativeOutput]))).toThrow(
+    expect(() => actor(infer([echoTable, toolList([{ spec: { name: "echo", description: "again", inputSchema: {} }, run: () => Effect.succeed({}) }]), nativeOutput], TEST_MODEL))).toThrow(
       'tool "echo" declared more than once'
     )
   })
@@ -188,7 +249,7 @@ describe("infer component", () => {
         output: []
       })
     )
-    const agent = actor(infer([echoTable, later, nativeOutput]))
+    const agent = actor(infer([echoTable, later, nativeOutput], TEST_MODEL))
 
     expect(agent.reactors).toHaveLength(1)
     expect(() => renderOf([echoTable, later, nativeOutput], [{ type: "Ready" }])).toThrow('tool "echo" declared more than once')
@@ -215,7 +276,7 @@ describe("infer component", () => {
     })
     const events = await run(
       Effect.gen(function* () {
-        yield* receive(actor(infer([ephemeral, nativeOutput])), { id: "m1", text: "go" })
+        yield* receive(actor(infer([ephemeral, nativeOutput], TEST_MODEL)), { id: "m1", text: "go" })
         return yield* readLog
       }),
       Layer.mergeAll(memoryLog(), mind, noRouter, KeyValueStore.layerMemory)

--- a/packages/agent/src/runtime/agent.ts
+++ b/packages/agent/src/runtime/agent.ts
@@ -12,6 +12,7 @@ import type { ToolSpec } from "../request"
 import { fallbackOf, type OutputFallback } from "../output"
 import { agentKeys } from "../events"
 import { inferReactorFor, type InferPolicy } from "./infer"
+import type { ModelRef } from "../model"
 import { toolsReactorFrom, type Answer, type PendingCall } from "./tools"
 import type { ContextPolicy } from "../components/compaction"
 import type { AgentR } from "../turn"
@@ -207,6 +208,13 @@ const rootKeys = (children: KeyFragment | undefined): KeyFragment => {
   }
 }
 
+// InferOptions selects the provider connection and default model for an infer root. A message may
+// replace default_model for its turn, while provider remains assembly policy.
+export interface InferOptions extends Partial<Omit<InferPolicy, "model">> {
+  readonly provider: string
+  readonly default_model: string
+}
+
 // infer composes an agent's child components and adds the model loop over their final view.
 // Inference and dispatch derive from the same child projection, so a tool remains routed against
 // the view that offered it while every child transition remains part of the root derivation.
@@ -214,7 +222,7 @@ export const infer = <
   const Cs extends ReadonlyArray<AgentComponent<never> | AgentComponent<unknown>>
 >(
   components: Cs,
-  policy: Partial<InferPolicy> = {}
+  options: InferOptions
 ): AgentComponent<AgentR | ComponentRequirements<Cs[number]>> => {
   type ComponentR = ComponentRequirements<Cs[number]>
   type R = AgentR | ComponentR
@@ -230,7 +238,11 @@ export const infer = <
   }
 
   renderView(viewOf([]))
-  const inference = inferReactorFor(policy, (log) => renderView(viewOf(log))) as Reactor<R>
+  if (options.provider.trim().length === 0) throw new Error("infer provider cannot be empty")
+  if (options.default_model.trim().length === 0) throw new Error("infer default_model cannot be empty")
+  const { provider, default_model, ...policy } = options
+  const model: ModelRef = { provider, model_id: default_model }
+  const inference = inferReactorFor({ ...policy, model }, (log) => renderView(viewOf(log))) as Reactor<R>
   const dispatch = toolsReactorFrom(serve, (log, call) => offeredTools(log, call).map((tool) => tool.spec))
 
   return {
@@ -238,10 +250,12 @@ export const infer = <
     keys: rootKeys(combined.keys),
     derive: (log) => {
       const children = combined.derive(log)
+      const inferred = inference(log)
+      const resolvingModel = inferred.some((candidate) => candidate.key.startsWith("mr:"))
       return {
         view: children.view,
-        transitions: [
-          ...inference(log),
+        transitions: resolvingModel ? inferred : [
+          ...inferred,
           ...dispatch(log),
           ...children.transitions
         ]

--- a/packages/agent/src/runtime/infer.ts
+++ b/packages/agent/src/runtime/infer.ts
@@ -1,7 +1,7 @@
 import { Cause, Clock, Context, Effect } from "effect"
 import { EventLog } from "@clavia/tardigrade-core/event-log"
 import { transition, type Reactor } from "@clavia/tardigrade-core/actor"
-import { modelCalled, outputRejected, textReturned, turnFailed } from "../events"
+import { modelCalled, modelResolved, outputRejected, textReturned, turnFailed } from "../events"
 import type { Event } from "@clavia/tardigrade-core/event"
 import type { Action } from "../events"
 import { trajectoryOf, turnEpochOf, turnView } from "@clavia/tardigrade-code/turns"
@@ -18,6 +18,7 @@ import {
   type OutputFallback
 } from "../output"
 import type { ContextPolicy } from "../components/compaction"
+import { modelRefOf, type ModelRef } from "../model"
 
 // The infer reactor: the model loop, and nothing else. A think is owed when the current turn
 // has no unanswered tool call and no terminal; serving marks the attempt, does inference, then
@@ -30,6 +31,7 @@ import type { ContextPolicy } from "../components/compaction"
 // output implementation the assembly mounts, not here (src/components/repair.ts, RepairPolicy).
 export interface InferPolicy {
   readonly giveUpAfter: number
+  readonly model?: ModelRef
 }
 
 export const DEFAULT_INFER_POLICY: InferPolicy = { giveUpAfter: 3 }
@@ -40,6 +42,7 @@ export const DEFAULT_INFER_POLICY: InferPolicy = { giveUpAfter: 3 }
 // about tools; the actor is the render's one owner.
 export interface InferRequest {
   readonly trajectory: ReadonlyArray<Event>
+  readonly model?: ModelRef
   readonly system: string
   readonly tools: ReadonlyArray<import("../request").ToolSpec>
   // What the render truncates and where, stated by the assembly so the binding renders against
@@ -48,6 +51,33 @@ export interface InferRequest {
   // What the turn does when native structured output is unavailable for this call, and the
   // prompt that fallback needs. Absent means the assembly selected native output.
   readonly output?: { readonly fallback: OutputFallback; readonly system?: string }
+}
+
+export interface ModelResolution {
+  readonly model: ModelRef
+  readonly contextWindowTokens?: number
+  readonly maxOutputTokens?: number
+  readonly catalogRevision?: string
+}
+
+// selectedModelOf applies the visible model-selection order for one turn. A public message may
+// replace the model id while the assembly keeps its provider connection. Internal deliveries may
+// carry a complete model reference. Either durable request wins over the assembly default.
+export const selectedModelOf = (
+  head: Event,
+  policy?: ModelRef
+): ModelRef | undefined => {
+  const selected = (head as { readonly model?: unknown }).model
+  const reference = modelRefOf(selected)
+  const model = typeof selected === "string" && selected.trim().length > 0 && policy !== undefined
+    ? { provider: policy.provider, model_id: selected.trim() }
+    : undefined
+  return reference ?? model ?? policy
+}
+
+const resolvedModelOf = (events: ReadonlyArray<Event>): ModelRef | undefined => {
+  const resolved = events.find((event) => event.type === "ModelResolved") as { readonly model?: unknown } | undefined
+  return modelRefOf(resolved?.model)
 }
 
 const epochStamp = (epoch: number): { readonly epoch?: number } =>
@@ -64,7 +94,10 @@ const epochStamp = (epoch: number): { readonly epoch?: number } =>
 // recorded pair and the dispatch dedup absorbs the new work.
 export class Infer extends Context.Service<
   Infer,
-  { readonly react: (request: InferRequest, key?: string) => Effect.Effect<Action> }
+  {
+    readonly react: (request: InferRequest, key?: string) => Effect.Effect<Action>
+    readonly resolve?: (reference: ModelRef) => ModelResolution
+  }
 >()("agent/Infer") {}
 
 // NativeOutputSupport is compile-time evidence that an injected Infer binding declares native structured output beside tools. nativeOutput carries this requirement into the host type (components/native-output.ts).
@@ -227,6 +260,7 @@ const diedAttempts = (turn: ReadonlyArray<Event>, epoch: number): number => {
   for (let i = turn.length - 1; i >= 0; i--) {
     const event = turn[i]!
     if (event.type === "ModelCalled" && Number((event as { epoch?: unknown }).epoch ?? 0) === epoch) n += 1
+    else if (event.type === "ModelResolved") continue
     else break
   }
   return n
@@ -277,8 +311,41 @@ export const inferReactorFor = (policy: Partial<InferPolicy>, render: Render): R
   const giveUpAfter = policy.giveUpAfter ?? DEFAULT_INFER_POLICY.giveUpAfter
   const slice = turnView(log)
   if (slice.length === 0 || awaitingTool(slice) || terminated(slice)) return []
-  const head = slice[0] as { id?: unknown }
+  const head = slice[0] as Event & { id?: unknown }
   const turn = String(head.id)
+  const trajectory = trajectoryOf(log)
+  const resolvedModel = resolvedModelOf(slice)
+  const model = resolvedModel ?? selectedModelOf(head, policy.model)
+  if (model !== undefined && resolvedModel === undefined) {
+    return [
+      transition({
+        key: `mr:${turn}`,
+        input: { turn, model },
+        act: (input) =>
+          Effect.gen(function* () {
+            const at = yield* Clock.currentTimeMillis
+            const binding = yield* Infer
+            return yield* Effect.try({
+              try: () => binding.resolve?.(input.model) ?? { model: input.model },
+              catch: (error) => error instanceof Error ? error.message : String(error)
+            }).pipe(Effect.match({
+              onSuccess: (resolved) => [modelResolved({ turn: input.turn, ...resolved, at })],
+              onFailure: (message) => [
+                turnFailed({
+                  error: message,
+                  cause: "inference_error",
+                  attempts: 0,
+                  attemptKey: `${input.turn}/model`,
+                  policy: { model: input.model },
+                  turn: input.turn,
+                  at
+                })
+              ]
+            }))
+          })
+      })
+    ]
+  }
   const epoch = turnEpochOf(log, turn)
   const died = diedAttempts(slice, epoch)
   const marks = slice.filter((e) => e.type === "ModelCalled").length
@@ -390,7 +457,8 @@ export const inferReactorFor = (policy: Partial<InferPolicy>, render: Render): R
         epoch,
         attempt,
         ordinal: marks,
-        trajectory: trajectoryOf(log),
+        trajectory,
+        model,
         render: rendered,
         // The declared policy, stamped on the ask: the contract's identity and the fallback the
         // assembly mounted. The mode the attempt actually ran in is the binding's to report, and
@@ -416,6 +484,7 @@ export const inferReactorFor = (policy: Partial<InferPolicy>, render: Render): R
           yield* events.append([
             modelCalled({
               callId: input.attempt,
+              ...(input.model === undefined ? {} : { model: input.model }),
               ordinal: input.ordinal,
               ...(input.stamp === undefined ? {} : { output: input.stamp }),
               turn: input.turn,
@@ -424,7 +493,7 @@ export const inferReactorFor = (policy: Partial<InferPolicy>, render: Render): R
             })
           ])
           const action = yield* (yield* Infer)
-            .react({ trajectory: input.trajectory, ...input.render }, input.attempt)
+            .react({ trajectory: input.trajectory, ...(input.model === undefined ? {} : { model: input.model }), ...input.render }, input.attempt)
             .pipe(
               Effect.catchCause((cause) =>
                 Cause.hasInterruptsOnly(cause)

--- a/packages/agent/src/spawn.test.ts
+++ b/packages/agent/src/spawn.test.ts
@@ -98,6 +98,27 @@ describe("agentsPackage", () => {
     })
   })
 
+  test("the package fixes a child model outside the tool input", async () => {
+    const selected = { provider: "openrouter", model_id: "anthropic/claude-sonnet-4-6" } as const
+    const sent: Array<Sent> = []
+    const inherited = agentsPackage()
+    const fixed = agentsPackage({ model: selected })
+    await Effect.runPromise(
+      inherited.methods.run!({ text: "default pass", background: true }, { callId: "model-1" }).pipe(Effect.provide(env("mem:ag.root", sent)))
+    )
+    await Effect.runPromise(
+      fixed.methods.run!({ text: "fixed pass", background: true }, { callId: "model-2" }).pipe(Effect.provide(env("mem:ag.root", sent)))
+    )
+    expect(sent[0]!.event).not.toHaveProperty("model")
+    expect(sent[1]!.event).toMatchObject({ model: selected })
+    const refused = await Effect.runPromise(
+      fixed.methods.run!({ text: "other", background: true, model: selected }, { callId: "model-3" }).pipe(Effect.provide(env("mem:ag.root", sent)))
+    )
+    expect(refused).toEqual({ error: "agents.run does not take model; configure agentsPackage({ model })" })
+    expect(sent).toHaveLength(2)
+    expect(codeSystemFor([fixed])).not.toContain("model:")
+  })
+
   test("a reply already on the lane answers without parking", async () => {
     const sent: Array<Sent> = []
     const pkg = agentsPackage()

--- a/packages/agent/src/spawn.ts
+++ b/packages/agent/src/spawn.ts
@@ -18,6 +18,7 @@ import {
 } from "@clavia/tardigrade-core/communication/endpoint"
 import { declarationForTurn, decodeOutput, outputFrom, type OutputContract } from "./output"
 import { budgetDenied, budgetGranted } from "./events"
+import { modelRefOf, type ModelRef } from "./model"
 
 // The agents package: ad-hoc agents, reachable from code like any other package. One verb with a
 // delivery mode: `agents.run({text})` runs a fresh agent to quiescence and returns its terminal;
@@ -60,6 +61,8 @@ export interface SpawnOptions {
   // that declared it. A raw schema stays reachable and is preflighted instead (spawn.test.ts,
   // "the output a spawn asks for").
   readonly outputs?: Readonly<Record<string, OutputContract>>
+  // model is the fixed reference used by every child this package starts. An absent value leaves selection to the child actor's default.
+  readonly model?: ModelRef
   readonly actorNameOf?: () => string | undefined
   readonly reserve?: (callId: string, want: number) => Promise<number>
   readonly shadowOf?: () => boolean
@@ -107,6 +110,10 @@ export const agentsPackage = (
   const worldOf = options.worldOf ?? (() => undefined)
   const defaultBudget = budgetPolicyOf(options.budget).defaultToolBudget
   const outputs = options.outputs ?? {}
+  const model = options.model === undefined ? undefined : modelRefOf(options.model)
+  if (options.model !== undefined && model === undefined) {
+    throw new Error("agentsPackage model must be { provider, model_id }")
+  }
   const declared_ = Object.keys(outputs)
   return definePackage({
     name: "agents",
@@ -118,14 +125,13 @@ export const agentsPackage = (
     },
     docs: {
       run: {
-        description: `Brief a fresh agent. \`output\` makes the result structured and parsed: the name of a declared contract${declared_.length === 0 ? " (this host declares none)" : ` (${declared_.join(", ")})`}, or a JSON schema of your own. \`model\` picks the mind: haiku for quick, cheap work like scouting; sonnet (default) for most work; opus for the hardest judgment. \`budget\` caps the agent's tool calls: at the cap it answers with its best result, so a research agent can not run forever. \`background: true\` returns { callId } at once; result({id: callId}) awaits the reply later. \`escalatable: true\` lets the agent ask for more budget at the cap instead of answering; the run then returns { requesting, reason, amount, handle }, and you decide with continue().`,
+        description: `Brief a fresh agent. \`output\` makes the result structured and parsed: the name of a declared contract${declared_.length === 0 ? " (this host declares none)" : ` (${declared_.join(", ")})`}, or a JSON schema of your own. \`budget\` caps the agent's tool calls: at the cap it answers with its best result, so a research agent can not run forever. \`background: true\` returns { callId } at once; result({id: callId}) awaits the reply later. \`escalatable: true\` lets the agent ask for more budget at the cap instead of answering; the run then returns { requesting, reason, amount, handle }, and you decide with continue().`,
         input: {
           type: "object",
           properties: {
             text: { type: "string", description: "the brief" },
             background: { type: "boolean", description: "true: return { callId } at once, the reply arrives later via result()" },
             output: { description: "a declared contract's name, or a JSON schema for a structured answer" },
-            model: { type: "string", enum: ["haiku", "sonnet", "opus"], description: "which model runs the agent; default sonnet" },
             budget: { type: "integer", description: "max tool calls before the agent must answer, a whole number of calls; keeps a research agent bounded" },
             escalatable: { type: "boolean", description: "true: at its budget the agent may ask for more instead of answering; the run returns a request you resolve with continue()" }
           },
@@ -190,13 +196,13 @@ export const agentsPackage = (
           if (a?.output === undefined && a?.outputSchema !== undefined) {
             return { error: "agents.run takes the contract as `output`, not `outputSchema`" }
           }
+          if (a?.model !== undefined) {
+            return { error: "agents.run does not take model; configure agentsPackage({ model })" }
+          }
           const declaredOutput = outputAsked(a?.output, outputs, declared_)
           if ("error" in declaredOutput) return declaredOutput
           const output = declaredOutput.contract
           const outputDeclaration = output === undefined ? undefined : { name: output.name, schema: output.schema }
-          // The model name rides the brief's envelope: the child's log records the choice, so its
-          // Infer resolves it from trajectory and replay agrees by construction.
-          const model = a?.model === "haiku" || a?.model === "sonnet" || a?.model === "opus" ? a.model : undefined
           // asked is the tool-call budget carried on the brief. It accepts a whole positive count
           // because rounding could turn a requested child into an exhausted run (spawn.test.ts,
           // "a fractional budget"). An absent budget takes the per-agent default.
@@ -215,7 +221,7 @@ export const agentsPackage = (
           const budget = yield* Effect.promise(() => reserve(ctx.callId, want))
           if (budget <= 0) return { error: "the run's budget is exhausted; no budget to spawn this agent" }
           // The child works as the same member the parent does: the actor rides every brief in the
-          // family, so a run's whole tree resolves connections identically.
+          // family, so a run's whole tree resolves providers identically.
           const actor = actorNameOf()
           // The parent's own shadow reading, never the tool args: an agent cannot set or unset it, so
           // a whole run family is shadow by construction from the fire alone. `world` rides along

--- a/packages/agent/src/turn.test.ts
+++ b/packages/agent/src/turn.test.ts
@@ -37,10 +37,12 @@ import {
   toolList
 } from "./index"
 
+const TEST_MODEL = { provider: "test", default_model: "test-model" } as const
+
 // The default assembly over a stated scope. The infer root contains model inference, call routing,
 // and every child transition in one projection.
 const agentWith = (packages: ReadonlyArray<Package>) =>
-  actor(infer([codeMode(packages), reply, budget, compaction(), nativeOutput]))
+  actor(infer([codeMode(packages), reply, budget, compaction(), nativeOutput], TEST_MODEL))
 const rlmAgent = agentWith([])
 const rootReactor = rlmAgent.reactors[0]!
 // The agent end to end: the model writes code, the code calls packages, every call is recorded,
@@ -145,6 +147,7 @@ describe("the agent with execute as the only tool", () => {
     )
     expect(events.map((e) => e.type)).toEqual([
       "MessageReceived",
+      "ModelResolved",
       "ModelCalled",
       "ToolCalled",
       "CodeDispatched",
@@ -158,8 +161,8 @@ describe("the agent with execute as the only tool", () => {
       "TurnCompleted",
       "ReplyDelivered"
     ])
-    expect(events[4]).toMatchObject({ callId: "t1.0", name: "zohorecruit.insert_record" })
-    expect(events[8]).toMatchObject({ result: { jd_record_id: "jd-91", hits: 3 } })
+    expect(events[5]).toMatchObject({ callId: "t1.0", name: "zohorecruit.insert_record" })
+    expect(events[9]).toMatchObject({ result: { jd_record_id: "jd-91", hits: 3 } })
     expect(spies).toEqual({ insert: 1, search: 1 })
     expect(count.calls).toBe(2)
     expect(rootReactor(events)).toHaveLength(0)
@@ -369,6 +372,7 @@ describe("the agent with execute as the only tool", () => {
     )
     expect(events.map((e) => e.type)).toEqual([
       "MessageReceived",
+      "ModelResolved",
       "ModelCalled",
       "TurnCompleted",
       "ReplyDelivered"
@@ -449,7 +453,7 @@ const completedTurns = (log: ReadonlyArray<Event>): ReadonlySet<string> =>
 const REPAIR_TWO = repairFallback({ attempts: 2 })
 
 const repairAgent = (policy: Parameters<typeof outputRepairFor>[0] = {}) =>
-  actor(infer([codeMode(), reply, budget, compaction(), outputRepairFor(policy)]))
+  actor(infer([codeMode(), reply, budget, compaction(), outputRepairFor(policy)], TEST_MODEL))
 
 describe("a turn that declares an output contract", () => {
   test("a conforming response completes the turn, and outputOf reads it back typed", async () => {
@@ -861,7 +865,7 @@ describe("the repair implementation", () => {
   })
 
   test("two components declaring an output strategy collide at construction", () => {
-    expect(() => actor(infer([codeMode(), outputRepair, outputValidateOnce]))).toThrow(
+    expect(() => actor(infer([codeMode(), outputRepair, outputValidateOnce], TEST_MODEL))).toThrow(
       "output strategy declared by components output.repair and output.validate-once"
     )
   })
@@ -885,7 +889,7 @@ describe("the repair implementation", () => {
         transitions: []
       })
     }
-    expect(() => actor(infer([malformed]))).toThrow("output fallback declared by component output.malformed")
+    expect(() => actor(infer([malformed], TEST_MODEL))).toThrow("output fallback declared by component output.malformed")
   })
 })
 
@@ -905,7 +909,7 @@ describe("the mind on a native surface", () => {
       ]),
       reply,
       nativeOutput
-    ]))
+    ], TEST_MODEL))
     expect(mind.reactors).toHaveLength(1)
     const layers = Layer.mergeAll(
       memoryLog(),
@@ -931,6 +935,7 @@ describe("the mind on a native surface", () => {
     )
     expect(events.map((e) => e.type)).toEqual([
       "MessageReceived",
+      "ModelResolved",
       "ModelCalled",
       "ToolCalled",
       "ToolReturned",
@@ -944,7 +949,7 @@ describe("the mind on a native surface", () => {
 })
 
 describe("the validate-once implementation", () => {
-  const validateOnceAgent = actor(infer([codeMode(), reply, budget, compaction(), outputValidateOnce]))
+  const validateOnceAgent = actor(infer([codeMode(), reply, budget, compaction(), outputValidateOnce], TEST_MODEL))
 
   test("a missed response ends the turn with its own cause, and never asks again", async () => {
     let asked = 0
@@ -1083,7 +1088,7 @@ describe("a domain-specific implementation", () => {
       jsSandbox,
       noRouter
     )
-    const agent = actor(infer([codeMode(), reply, houseStyle({ asks: 2 })]))
+    const agent = actor(infer([codeMode(), reply, houseStyle({ asks: 2 })], TEST_MODEL))
     const events = await run(
       Effect.gen(function* () {
         yield* receive(agent, { id: "m1", text: "decompose this topic", output: SCOUT })
@@ -1129,7 +1134,7 @@ describe("a domain-specific implementation", () => {
     }
     const events = await run(
       Effect.gen(function* () {
-        yield* receive(actor(infer([codeMode(), silent])), {
+        yield* receive(actor(infer([codeMode(), silent], TEST_MODEL)), {
           id: "m1",
           text: "decompose this topic",
           output: SCOUT
@@ -1151,7 +1156,7 @@ describe("a domain-specific implementation", () => {
       jsSandbox,
       noRouter
     )
-    const agent = actor(infer([codeMode(), reply, houseStyle({ asks: 1 })]))
+    const agent = actor(infer([codeMode(), reply, houseStyle({ asks: 1 })], TEST_MODEL))
     const events = await run(
       Effect.gen(function* () {
         yield* receive(agent, { id: "m1", text: "decompose this topic", output: SCOUT })

--- a/packages/agent/src/turn.ts
+++ b/packages/agent/src/turn.ts
@@ -45,6 +45,7 @@ export const receive = <R, T = unknown>(
     readonly id: string
     readonly text: string
     readonly input?: unknown
+    readonly model?: string
     readonly output?: OutputContract<T>
   }
 ): Effect.Effect<void, never, EventLog | R> =>
@@ -59,6 +60,7 @@ export const receive = <R, T = unknown>(
       id: message.id,
       text: message.text,
       ...(message.input === undefined ? {} : { input: message.input }),
+      ...(message.model === undefined ? {} : { model: message.model }),
       ...(message.output === undefined ? {} : { output: { name: message.output.name, schema: message.output.schema } }),
       at
     })

--- a/packages/core/src/communication/message.ts
+++ b/packages/core/src/communication/message.ts
@@ -16,6 +16,8 @@ export const MessageReceived = Schema.Struct({
   // outcome marks a terminal report whose reaction turn settles locally without sending a reply (packages/agent/src/components/reply.test.ts, "terminal reports cannot start reply chains").
   outcome: Schema.optional(Schema.Literals(["completed", "failed", "requesting"])),
   input: Schema.optional(Schema.Unknown),
+  // model carries consumer-owned selection data. The receiving actor defines its shape and meaning.
+  model: Schema.optional(Schema.Unknown),
   data: Schema.optional(Schema.Unknown),
   at: Schema.Finite
 })

--- a/platform/cloudflare/src/worker.ts
+++ b/platform/cloudflare/src/worker.ts
@@ -137,12 +137,15 @@ const assemblyOf = (name: string, env: Env) => {
     reply,
     budget,
     compaction({
-      contextWindowTokens: (model) => modelContextWindowTokensOf(env, model),
+      contextWindowTokens: (model) => modelContextWindowTokensOf(env, model?.model_id),
       ...(fireRatio === undefined ? {} : { fireRatio }),
       ...(keepRatio === undefined ? {} : { keepRatio })
     }),
     outputValidateOnce
-  ]))
+  ], {
+    provider: env.MODEL_PROVIDER ?? "unconfigured",
+    default_model: env.MODEL_ID ?? "unconfigured"
+  }))
 }
 
 // ActorHost runs one actor graph over one SQLite-backed Durable Object.

--- a/platform/cloudflare/test/actor.workers.ts
+++ b/platform/cloudflare/test/actor.workers.ts
@@ -64,6 +64,7 @@ describe("cloudflare actor", () => {
     expect(events.map((row) => row.event.type)).toEqual([
       "ThreadCreated",
       "MessageReceived",
+      "ModelResolved",
       "ModelCalled",
       "TurnFailed",
       "ReplyDelivered"


### PR DESCRIPTION
## Summary

Let each inferred actor declare its provider and default model. A message can select another model for one turn while retaining the actor's provider.

Represent a complete selection as a `ModelRef` and record it with resolved metadata in a `ModelResolved` event. Runtime bindings may resolve that metadata before inference, and compaction reads the durable result when it calculates the model window.

Keep child routing under developer control. `agentsPackage({ model })` may fix the reference for its children, while `agents.run` exposes no model input. An absent package model leaves selection to the child actor's default.

## Verification

- `bun run gate`
