### PR TITLE
feat(celld): replay package calls

### DIFF
--- a/apps/cli/src/celld.test.ts
+++ b/apps/cli/src/celld.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import { parse } from "jsonc-parser"
 
-import { CELLD_OMITTED_KEYS, celldConfigOf, celldConfigWithVarOf } from "./celld"
+import {
+  CELLD_OMITTED_KEYS,
+  CELLD_SANDBOX_TRANSPORT,
+  CELLD_SANDBOX_TRANSPORT_VAR,
+  celldConfigOf,
+  celldConfigWithVarOf
+} from "./celld"
 
 const wrangler = `{
   "name": "reviewer",
@@ -27,6 +33,7 @@ describe("Celld configuration", () => {
     expect((config["vars"] as Record<string, string>)["TARDIGRADE_CONFIG"]).toBe(
       '{"models":{"default":{"provider":"openai","model_id":"gpt-5.2"}}}'
     )
+    expect((config["vars"] as Record<string, string>)[CELLD_SANDBOX_TRANSPORT_VAR]).toBe(CELLD_SANDBOX_TRANSPORT)
   })
 
   test("updates shared config without replacing Celld settings", () => {

--- a/apps/cli/src/celld.ts
+++ b/apps/cli/src/celld.ts
@@ -2,6 +2,8 @@ import { applyEdits, modify, parse, printParseErrorCode, type ParseError } from 
 
 export const CELLD_PROJECT_CONFIG_PATH = "celld.jsonc"
 export const CELLD_OMITTED_KEYS = ["limits", "observability", "worker_loaders"] as const
+export const CELLD_SANDBOX_TRANSPORT_VAR = "TARDIGRADE_SANDBOX_TRANSPORT"
+export const CELLD_SANDBOX_TRANSPORT = "replay"
 
 export interface CelldConfig {
   readonly source: string
@@ -34,11 +36,19 @@ export const celldConfigOf = (raw: string, path = "wrangler.jsonc"): CelldConfig
   const omitted = CELLD_OMITTED_KEYS.filter((key) => key in source)
   const omittedSet = new Set<string>(omitted)
   const config = Object.fromEntries(Object.entries(source).filter(([key]) => !omittedSet.has(key)))
-  if (typeof config["vars"] === "object" && config["vars"] !== null && !Array.isArray(config["vars"])) {
-    config["vars"] = Object.fromEntries(Object.entries(config["vars"] as Record<string, unknown>).map(([name, value]) => [
+  const rawVars = config["vars"]
+  if (rawVars !== undefined && (typeof rawVars !== "object" || rawVars === null || Array.isArray(rawVars))) {
+    throw new Error(`${path} vars must contain a JSON object`)
+  }
+  const vars = rawVars === undefined
+    ? {}
+    : Object.fromEntries(Object.entries(rawVars as Record<string, unknown>).map(([name, value]) => [
       name,
       celldVar(name, value)
     ]))
+  config["vars"] = {
+    ...vars,
+    [CELLD_SANDBOX_TRANSPORT_VAR]: CELLD_SANDBOX_TRANSPORT
   }
   return { source: `${JSON.stringify(config, undefined, 2)}\n`, omitted }
 }

--- a/apps/cli/src/init.test.ts
+++ b/apps/cli/src/init.test.ts
@@ -58,6 +58,7 @@ describe("initActor", () => {
       "vars"
     ])
     expect((celldManifest["vars"] as Record<string, string>)["TARDIGRADE_CONFIG"]).toBe("{}")
+    expect((celldManifest["vars"] as Record<string, string>)["TARDIGRADE_SANDBOX_TRANSPORT"]).toBe("replay")
     expect(built.manifest.name).toBe("reviewer")
   })
 

--- a/docs/how-to/celld.md
+++ b/docs/how-to/celld.md
@@ -18,9 +18,10 @@ celld deploy --config celld.jsonc --bucket s3://actors
 
 Celld reads its bucket from `--bucket` or `CELLD_BUCKET`. Use `--endpoint` for an S3-compatible service and `--region` when the region cannot be inferred. Celld also supports `gs://` buckets through Google Application Default Credentials and `az://` containers through Azure credentials.
 
-Every node needs the Worker variables that hold API credentials. Prefix an individual Worker variable with `CELLD_VAR_`, or point `CELLD_VARS_FILE` at a file containing the original variable names:
+Every node needs the Worker Loader binding for Code Mode and the Worker variables that hold API credentials. Prefix an individual Worker variable with `CELLD_VAR_`, or point `CELLD_VARS_FILE` at a file containing the original variable names:
 
 ```bash
+CELLD_WORKER_LOADER=LOADER \
 CELLD_VAR_TARDIGRADE_TOKEN="$TARDIGRADE_TOKEN" \
 CELLD_VAR_OPENAI_API_KEY="$OPENAI_API_KEY" \
 celld \
@@ -32,4 +33,4 @@ celld \
 
 Keep the internal listener on a trusted private network. A deployment is loaded when a node starts, so restart nodes through the fleet rollout procedure after publishing a new version.
 
-Code Mode package calls are not supported on Celld yet. Tardigrade passes package capabilities into a loaded Worker, while Celld's current Worker Loader accepts JSON environment values and does not accept capability stubs. HTTP methods, inference, event storage, reconciliation, and alarms do not depend on that bridge. See Celld's [Cloudflare compatibility](https://github.com/denoland/celld/blob/main/docs/cloudflare-compat.md) and [operations documentation](https://github.com/denoland/celld/blob/main/docs/README.md) for its current platform surface.
+The generated Celld manifest selects the `replay` sandbox transport. A loaded Worker returns package-call boundaries as JSON, and the actor host reruns the deterministic body with each recorded result. Cloudflare keeps its direct capability transport. See Celld's [Cloudflare compatibility](https://github.com/denoland/celld/blob/main/docs/cloudflare-compat.md) and [operations documentation](https://github.com/denoland/celld/blob/main/docs/README.md) for its current platform surface.

--- a/platform/cloudflare/README.md
+++ b/platform/cloudflare/README.md
@@ -2,7 +2,7 @@
 
 This binding mounts one actor definition into a named SQLite Durable Object. The object stores its event logs, workspace, and last valid model catalog snapshot. Every thread is a lane in the actor's event table. Each accepted event commits its log append and watchdog before reconciliation starts. One alarm recovers ready lanes after an interrupted drive. Code mode uses the `LOADER` Dynamic Worker binding. Generated code runs in a fresh Worker with direct network access disabled and calls host packages through an RPC capability.
 
-Celld implements the Worker, SQLite Durable Object, and alarm surfaces this binding uses. Its Worker Loader cannot yet pass the package capability bridge used by Code Mode. The [Celld deployment guide](../../docs/how-to/celld.md) covers the generated manifest and this constraint.
+Celld implements the Worker, SQLite Durable Object, alarm, and Worker Loader surfaces this binding uses. Code Mode uses JSON replay on Celld because its loaded Worker environment cannot carry capability stubs. The [Celld deployment guide](../../docs/how-to/celld.md) covers the generated manifest and node configuration.
 
 ## Verify and deploy
 
@@ -106,5 +106,6 @@ The response has status `202` and identifies the accepted destination.
 | `TARDIGRADE_SANDBOX_CPU_MILLIS` | Cloudflare default | Sets the Dynamic Worker CPU limit |
 | `TARDIGRADE_SANDBOX_SUBREQUESTS` | Cloudflare default | Sets the Dynamic Worker subrequest limit |
 | `TARDIGRADE_CONFIG` | `{}` | Supplies provider connections and the default model reference as visible JSON configuration in `wrangler.jsonc` |
+| `TARDIGRADE_SANDBOX_TRANSPORT` | `capability` | Selects direct capability calls or deterministic JSON `replay` for loaded Workers |
 
-`wrangler.jsonc` also makes the Dynamic Worker Loader binding, Worker CPU limit, and Durable Object migration visible. Change those values in the deployment configuration when the account or workload requires a different policy. `DEFAULT_CLOUDFLARE_SANDBOX_POLICY` exposes the Dynamic Worker compatibility date, compatibility flags, console cap, and outbound policy. `layerCloudflareSandbox` accepts overrides for each value.
+`wrangler.jsonc` also makes the Dynamic Worker Loader binding, Worker CPU limit, and Durable Object migration visible. Change those values in the deployment configuration when the account or workload requires a different policy. `DEFAULT_CLOUDFLARE_SANDBOX_POLICY` exposes the Dynamic Worker compatibility date, compatibility flags, console cap, outbound policy, and transport. `layerCloudflareSandbox` accepts overrides for each value.

--- a/platform/cloudflare/src/sandbox.test.ts
+++ b/platform/cloudflare/src/sandbox.test.ts
@@ -1,9 +1,17 @@
 import { Effect } from "effect"
 import { describe, expect, test } from "vitest"
 import { sandboxParked, sandboxReturned } from "@clavia/tardigrade-code/sandbox"
-import { cloudflareSandboxServiceFor, type SandboxBridgeBinding } from "./sandbox"
+import {
+  DEFAULT_CLOUDFLARE_SANDBOX_POLICY,
+  cloudflareSandboxServiceFor,
+  type SandboxBridgeBinding
+} from "./sandbox"
 
 describe("cloudflare sandbox bridge", () => {
+  test("keeps the capability transport as the default", () => {
+    expect(DEFAULT_CLOUDFLARE_SANDBOX_POLICY.transport).toBe("capability")
+  })
+
   test("forwards package calls and closes the capability", async () => {
     let closed = false
     const loader = {
@@ -89,5 +97,77 @@ describe("cloudflare sandbox bridge", () => {
     expect(result).toEqual({ result: 5 })
     expect(calls).toBe(5)
     expect(observed).toEqual(arrival.map((index) => ({ input: index, ordinal: index })))
+  })
+
+  test("replays JSON call boundaries without opening a capability", async () => {
+    let round = 0
+    const loader = {
+      load: (worker: WorkerLoaderWorkerCode) => ({
+        getEntrypoint: () => ({
+          fetch: async () => {
+            expect(worker.env).not.toHaveProperty("BRIDGE")
+            const input = (worker.env as { readonly INPUT: { readonly replay: ReadonlyArray<{
+              readonly outcome: { readonly _tag: string; readonly result?: unknown }
+            }> } }).INPUT
+            if (round++ === 0) {
+              expect(input.replay).toEqual([])
+              return Response.json({ calls: [
+                { ordinal: 0, packageName: "tools", method: "add", args: { left: 2, right: 3 } },
+                { ordinal: 1, packageName: "tools", method: "add", args: { left: 5, right: 8 } }
+              ] })
+            }
+            return Response.json({ result: input.replay.map((entry) => entry.outcome.result) })
+          }
+        })
+      })
+    } as unknown as WorkerLoader
+    const sandbox = cloudflareSandboxServiceFor(loader, () => {
+      throw new Error("replay transport must not open a capability")
+    }, { transport: "replay" })
+    const calls: Array<number> = []
+    const result = await Effect.runPromise(sandbox.run("return 0", {
+      tools: {
+        add: async (input, ordinal) => {
+          calls.push(ordinal)
+          const pair = input as { readonly left: number; readonly right: number }
+          return sandboxReturned(pair.left + pair.right)
+        }
+      }
+    }))
+
+    expect(result).toEqual({ result: [5, 13] })
+    expect(calls).toEqual([0, 1])
+    expect(round).toBe(2)
+  })
+
+  test("carries a parked call into the next replay", async () => {
+    let round = 0
+    const loader = {
+      load: (worker: WorkerLoaderWorkerCode) => ({
+        getEntrypoint: () => ({
+          fetch: async () => {
+            const replay = (worker.env as { readonly INPUT: { readonly replay: ReadonlyArray<{
+              readonly outcome: { readonly _tag: string }
+            }> } }).INPUT.replay
+            if (round++ === 0) {
+              return Response.json({ calls: [
+                { ordinal: 0, packageName: "agents", method: "result", args: { thread: "child" } }
+              ] })
+            }
+            expect(replay[0]?.outcome._tag).toBe("Parked")
+            return Response.json({ error: "parked call replayed" })
+          }
+        })
+      })
+    } as unknown as WorkerLoader
+    const sandbox = cloudflareSandboxServiceFor(loader, () => {
+      throw new Error("replay transport must not open a capability")
+    }, { transport: "replay" })
+    const result = await Effect.runPromise(sandbox.run("return 0", {
+      agents: { result: async () => sandboxParked }
+    }))
+
+    expect(result).toEqual({ error: "parked call replayed" })
+    expect(round).toBe(2)
   })
 })

--- a/platform/cloudflare/src/sandbox.ts
+++ b/platform/cloudflare/src/sandbox.ts
@@ -14,18 +14,23 @@ export interface CloudflareSandboxLimits {
   readonly subRequests?: number
 }
 
+export const CLOUDFLARE_SANDBOX_TRANSPORTS = ["capability", "replay"] as const
+export type CloudflareSandboxTransport = typeof CLOUDFLARE_SANDBOX_TRANSPORTS[number]
+
 export interface CloudflareSandboxPolicy extends SandboxPolicy {
   readonly compatibilityDate: string
   readonly compatibilityFlags: ReadonlyArray<string>
   readonly limits?: CloudflareSandboxLimits
   readonly globalOutbound: Fetcher | null
+  readonly transport: CloudflareSandboxTransport
 }
 
 export const DEFAULT_CLOUDFLARE_SANDBOX_POLICY: CloudflareSandboxPolicy = {
   ...DEFAULT_SANDBOX_POLICY,
   compatibilityDate: "2026-08-08",
   compatibilityFlags: [],
-  globalOutbound: null
+  globalOutbound: null,
+  transport: "capability"
 }
 
 export interface SandboxBridgeBinding {
@@ -52,7 +57,7 @@ export type SandboxBridgeFactory = (
   call: (ordinal: number, packageName: string, method: string, args: unknown) => Promise<SandboxCallOutcome>
 ) => SandboxBridgeLease
 
-const HARNESS_SOURCE = `
+const HARNESS_PREAMBLE = `
 import body from "body.js";
 
 const consoleShim = (lines, cap) => {
@@ -111,7 +116,9 @@ const ambientShims = (ambient) => {
 const response = (value) => new Response(JSON.stringify(value), {
   headers: { "content-type": "application/json" }
 });
+`
 
+const CAPABILITY_HARNESS_SOURCE = `${HARNESS_PREAMBLE}
 export default {
   async fetch(_request, env) {
     let ordinal = 0;
@@ -166,6 +173,75 @@ export default {
 };
 `
 
+// REPLAY_HARNESS_SOURCE returns JSON call boundaries and refuses positional drift (packages/core/tla/runtime/Replay.tla, RightAnswer).
+const REPLAY_HARNESS_SOURCE = `${HARNESS_PREAMBLE}
+const sameCall = (left, right) =>
+  left.ordinal === right.ordinal &&
+  left.packageName === right.packageName &&
+  left.method === right.method &&
+  JSON.stringify(left.args) === JSON.stringify(right.args);
+
+export default {
+  async fetch(_request, env) {
+    let ordinal = 0;
+    let scheduled = false;
+    let pending = [];
+    let finishBoundary;
+    const boundary = new Promise((resolve) => { finishBoundary = resolve; });
+    const never = () => new Promise(() => undefined);
+    const call = (packageName, method, args) => {
+      const requested = { ordinal: ordinal++, packageName, method, args };
+      const recorded = env.INPUT.replay[requested.ordinal];
+      if (recorded !== undefined) {
+        if (!sameCall(recorded.call, requested)) {
+          finishBoundary({ error: \`nondeterministic body: replayed call \${requested.ordinal} changed\` });
+          return never();
+        }
+        if (recorded.outcome._tag === "Returned") return Promise.resolve(recorded.outcome.result);
+        return never();
+      }
+      pending.push(requested);
+      if (!scheduled) {
+        scheduled = true;
+        queueMicrotask(() => finishBoundary({ calls: pending }));
+      }
+      return never();
+    };
+    const lines = [];
+    const logs = () => lines.length === 0 ? {} : { logs: lines };
+    const console = consoleShim(lines, env.INPUT.logCapBytes);
+    const ambient = env.INPUT.ambient === undefined ? {} : ambientShims(env.INPUT.ambient);
+    const args = env.INPUT.names.map((name) => {
+      if (name === "console") return console;
+      if (name === "Date" && ambient.Date !== undefined) return ambient.Date;
+      if (name === "Math" && ambient.Math !== undefined) return ambient.Math;
+      const methods = env.INPUT.packages[name];
+      if (methods !== undefined) {
+        return Object.fromEntries(methods.map((method) => [
+          method,
+          (args) => call(name, method, args)
+        ]));
+      }
+      return env.INPUT.values[name];
+    });
+    const completed = (async () => {
+      let outcome;
+      try {
+        outcome = { result: await body(...args) };
+      } catch (error) {
+        outcome = { error: String(error) };
+      }
+      if (pending.length > 0) return { calls: pending };
+      if (ordinal !== env.INPUT.replay.length) {
+        return { error: "nondeterministic body: replay consumed " + ordinal + " of " + env.INPUT.replay.length + " calls" };
+      }
+      return { ...outcome, ...logs() };
+    })();
+    return response(await Promise.race([completed, boundary]));
+  }
+};
+`
+
 const packageMethods = (binding: Bindings[string]): ReadonlyArray<string> | undefined => {
   if (binding === null || typeof binding !== "object" || Array.isArray(binding)) return undefined
   const entries = Object.entries(binding)
@@ -192,6 +268,15 @@ const sandboxInput = (bindings: Bindings, ambient: Ambient | undefined, policy: 
   return { names, packages, values, logCapBytes: policy.logCapBytes, ...(ambient === undefined ? {} : { ambient }) }
 }
 
+interface SandboxReplayEntry {
+  readonly call: SandboxBridgeCall
+  readonly outcome: SandboxCallOutcome
+}
+
+interface SandboxReplayBoundary extends SandboxResult {
+  readonly calls?: ReadonlyArray<SandboxBridgeCall>
+}
+
 export const cloudflareSandboxServiceFor = (
   loader: WorkerLoader,
   bridgeFor: SandboxBridgeFactory,
@@ -204,7 +289,8 @@ export const cloudflareSandboxServiceFor = (
     ...(policy.limits === undefined ? {} : { limits: policy.limits }),
     globalOutbound: policy.globalOutbound === undefined
       ? DEFAULT_CLOUDFLARE_SANDBOX_POLICY.globalOutbound
-      : policy.globalOutbound
+      : policy.globalOutbound,
+    transport: policy.transport ?? DEFAULT_CLOUDFLARE_SANDBOX_POLICY.transport
   }
   return {
     run: (code, bindings, ambient) => Effect.promise(async (signal) => {
@@ -221,6 +307,34 @@ export const cloudflareSandboxServiceFor = (
           }
           return implementation(args, ordinal)
         }
+        const input = sandboxInput(bindings, ambient, resolved)
+        const request = () => new Request("https://sandbox.invalid/run", { method: "POST", signal })
+        if (resolved.transport === "replay") {
+          const replay: Array<SandboxReplayEntry> = []
+          for (;;) {
+            const worker = loader.load({
+              compatibilityDate: resolved.compatibilityDate,
+              compatibilityFlags: [...resolved.compatibilityFlags],
+              mainModule: "index.js",
+              modules: {
+                "index.js": REPLAY_HARNESS_SOURCE,
+                "body.js": bodySource(names, code)
+              },
+              env: { INPUT: { ...input, replay } },
+              globalOutbound: resolved.globalOutbound,
+              ...(resolved.limits === undefined ? {} : { limits: resolved.limits })
+            })
+            const response = await worker.getEntrypoint().fetch(request())
+            if (!response.ok) return { error: `sandbox returned HTTP ${response.status}` }
+            const boundary = await response.json() as SandboxReplayBoundary
+            if (boundary.calls === undefined) return boundary
+            if (boundary.calls.length === 0) return { error: "sandbox replay returned an empty call boundary" }
+            const outcomes = await Promise.all(boundary.calls.map((entry) =>
+              call(entry.ordinal, entry.packageName, entry.method, entry.args)
+            ))
+            replay.push(...boundary.calls.map((entry, index) => ({ call: entry, outcome: outcomes[index]! })))
+          }
+        }
         const bridge = bridgeFor(call)
         try {
           const worker = loader.load({
@@ -228,20 +342,17 @@ export const cloudflareSandboxServiceFor = (
           compatibilityFlags: [...resolved.compatibilityFlags],
           mainModule: "index.js",
           modules: {
-            "index.js": HARNESS_SOURCE,
+            "index.js": CAPABILITY_HARNESS_SOURCE,
             "body.js": bodySource(names, code)
           },
           env: {
             BRIDGE: bridge.binding,
-            INPUT: { ...sandboxInput(bindings, ambient, resolved), execution: bridge.execution }
+            INPUT: { ...input, execution: bridge.execution }
           },
           globalOutbound: resolved.globalOutbound,
           ...(resolved.limits === undefined ? {} : { limits: resolved.limits })
         })
-          const response = await worker.getEntrypoint().fetch(new Request("https://sandbox.invalid/run", {
-            method: "POST",
-            signal
-          }))
+          const response = await worker.getEntrypoint().fetch(request())
           if (!response.ok) return { error: `sandbox returned HTTP ${response.status}` }
           return await response.json() as SandboxResult
         } finally {

--- a/platform/cloudflare/src/worker.ts
+++ b/platform/cloudflare/src/worker.ts
@@ -27,6 +27,7 @@ import {
   layerCloudflareSandbox,
   type SandboxBridgeCall,
   type CloudflareSandboxLimits,
+  type CloudflareSandboxTransport,
   type SandboxBridgeLease
 } from "./sandbox"
 import { layerCloudflareModelCatalogRepository } from "./catalog"
@@ -47,6 +48,7 @@ export interface Env {
   readonly TARDIGRADE_SANDBOX_LOG_CAP_BYTES?: string
   readonly TARDIGRADE_SANDBOX_CPU_MILLIS?: string
   readonly TARDIGRADE_SANDBOX_SUBREQUESTS?: string
+  readonly TARDIGRADE_SANDBOX_TRANSPORT?: string
 }
 
 const LANE_PREFIX = "ag."
@@ -207,6 +209,12 @@ const optionalRatio = (raw: string | undefined, name: string): number | undefine
   return value
 }
 
+const sandboxTransportOf = (raw: string | undefined): CloudflareSandboxTransport => {
+  const selected = raw ?? "capability"
+  if (selected === "capability" || selected === "replay") return selected
+  throw new Error(`TARDIGRADE_SANDBOX_TRANSPORT must be "capability" or "replay", got ${JSON.stringify(raw)}`)
+}
+
 function defaultAssemblyOf(
   env: Env,
   models: CloudflareModels | undefined,
@@ -346,6 +354,7 @@ export class ActorHost extends DurableObject<Env> {
         }
       },
       {
+        transport: sandboxTransportOf(this.env.TARDIGRADE_SANDBOX_TRANSPORT),
         ...(this.env.TARDIGRADE_SANDBOX_LOG_CAP_BYTES === undefined
           ? {}
           : { logCapBytes: nonNegativeInteger(this.env.TARDIGRADE_SANDBOX_LOG_CAP_BYTES, 0, "TARDIGRADE_SANDBOX_LOG_CAP_BYTES") }),

--- a/platform/cloudflare/test/sandbox.workers.ts
+++ b/platform/cloudflare/test/sandbox.workers.ts
@@ -1,6 +1,7 @@
 import { env } from "cloudflare:test"
 import { Effect } from "effect"
 import { describe, expect, test } from "vitest"
+import { sandboxReturned } from "@clavia/tardigrade-code/sandbox"
 import type { Env } from "../src/worker"
 import { cloudflareSandboxServiceFor, type SandboxBridgeFactory } from "../src/sandbox"
 
@@ -54,6 +55,35 @@ describe("cloudflare sandbox", () => {
       {}
     ))
     expect(result).toEqual({ result: "blocked" })
+  })
+
+  test("replays sequential and concurrent package calls", async () => {
+    const sandbox = cloudflareSandboxServiceFor((env as Env).LOADER, bridgeFor, { transport: "replay" })
+    const observed: Array<{ readonly ordinal: number; readonly value: number }> = []
+    const result = await Effect.runPromise(sandbox.run(
+      `const first = await tools.double({ value: 3 })
+      const pair = await Promise.all([
+        tools.double({ value: first }),
+        tools.double({ value: 5 })
+      ])
+      return pair`,
+      {
+        tools: {
+          double: async (input, ordinal) => {
+            const value = (input as { readonly value: number }).value
+            observed.push({ ordinal, value })
+            return sandboxReturned(value * 2)
+          }
+        }
+      }
+    ))
+
+    expect(result).toEqual({ result: [12, 10] })
+    expect(observed).toEqual([
+      { ordinal: 0, value: 3 },
+      { ordinal: 1, value: 6 },
+      { ordinal: 2, value: 5 }
+    ])
   })
 
 })


### PR DESCRIPTION
## Summary

Add an explicit `capability` or `replay` transport to the Worker sandbox. Cloudflare keeps `capability` as its default. Generated Celld manifests select `replay` because Celld loaded Worker environments accept JSON values and cannot carry the package capability stub.

Under replay, a loaded Worker returns its next package-call batch as JSON. The actor host executes the batch concurrently, records each outcome through the existing package funnel, and reruns the deterministic body with those outcomes. The guest refuses changed or unconsumed replay positions under the invariant in `packages/core/tla/runtime/Replay.tla`.

Update the Celld deployment guide and platform configuration reference. The node still enables `CELLD_WORKER_LOADER=LOADER`; Code Mode no longer depends on a capability inside the loaded Worker environment.

## Verification

- `bun run gate`
- 47 repository tasks passed
- Real Worker Loader coverage passes sequential and concurrent replay calls
- Unit coverage passes direct capability, replay boundary, drift, and parked-outcome behavior