### PR TITLE
fix(cli): complete published deploys

### DIFF
--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -38,6 +38,7 @@ interface Recorded {
   readonly invoked: Array<{ thread: string; method: string; id: string; input: unknown }>
   readonly asked: Array<{ thread: string; options: unknown }>
   readonly catalog: Array<{ kind: "models" | "providers"; options: unknown }>
+  readonly installed: Array<string>
   methodReads: number
 }
 
@@ -144,12 +145,16 @@ const drive = async (
   } = {}
 ): Promise<Ran> => {
   const lines: Array<string> = []
-  const recorded: Recorded = { invoked: [], asked: [], catalog: [], methodReads: 0 }
+  const recorded: Recorded = { invoked: [], asked: [], catalog: [], installed: [], methodReads: 0 }
   const minted = [...(options.ids ?? ["minted-1", "minted-2", "minted-3"])]
   const services: CliServices = {
     env: options.env ?? {},
     cwd: options.cwd ?? process.cwd(),
     openClient: () => clientOf(recorded, options.answers ?? {}),
+    installProject: (directory) => {
+      recorded.installed.push(directory)
+      return Promise.resolve()
+    },
     mintId: () => minted.shift() ?? "exhausted"
   }
   const capture: Console.Console = Object.assign(Object.create(console), {
@@ -278,6 +283,7 @@ describe("parsing", () => {
       expect(actor).toContain('provider: "openrouter", default_model: "anthropic/claude-sonnet-4-6"')
       expect(config).toContain('"provider": "openrouter"')
       expect(config).toContain('"model_id": "anthropic/claude-sonnet-4-6"')
+      expect(ran.recorded.installed).toEqual([directory])
       await expect(readFile(join(directory, ".dev.vars"), "utf8")).rejects.toThrow()
       expect(ran.lines.join("\n")).toContain('"credential": "environment"')
     } finally {

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -295,7 +295,7 @@ export const setupDefaultCommand = Command.make("default", {
   Command.withDescription("Choose the default model from configured provider connections."),
   Command.withExamples([
     { command: "tdg setup default", description: "Choose the default provider and model" },
-    { command: "tdg setup default --provider openrouter --model anthropic/claude-sonnet-4-6", description: "Select a default from explicit values" }
+    { command: "tdg setup default --provider openrouter --model anthropic/claude-sonnet-4.6", description: "Select a default from explicit values" }
   ])
 )
 
@@ -358,6 +358,10 @@ export const initCommand = Command.make("init", {
       catch: userErrorOf
     })
     const files = yield* Effect.mapError(writeSetup(initialized.directory, answers, cli.env), userErrorOf)
+    yield* Effect.tryPromise({
+      try: () => cli.installProject(initialized.directory),
+      catch: userErrorOf
+    })
     yield* Console.log(flags.json
       ? jsonOf({ ...initialized, setup: setupJson(files, answers) })
       : `${setupSummary(files, answers)}\n\n${initSummary(initialized, cli.cwd)}`)
@@ -366,7 +370,7 @@ export const initCommand = Command.make("init", {
     Command.withExamples([
       { command: "tdg init researcher", description: "Choose a provider and create a ready actor" },
       {
-        command: "tdg init researcher --provider openrouter --provider-config '{\"env\":[\"OPENROUTER_API_KEY\"]}' --default-model anthropic/claude-sonnet-4-6",
+        command: "tdg init researcher --provider openrouter --provider-config '{\"env\":[\"OPENROUTER_API_KEY\"]}' --default-model anthropic/claude-sonnet-4.6",
         description: "Create a ready actor from provider JSON"
       }
     ])

--- a/apps/cli/src/init.test.ts
+++ b/apps/cli/src/init.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 
 import { buildActor } from "./build"
 import { CELLD_PROJECT_CONFIG_PATH } from "./celld"
-import { DEFAULT_ACTOR_ENTRY, DEFAULT_WORKER_ENTRY, defaultInitDirectory, initActor, initSummary } from "./init"
+import { DEFAULT_ACTOR_ENTRY, DEFAULT_PACKAGE_MANIFEST, DEFAULT_WORKER_ENTRY, defaultInitDirectory, initActor, initSummary } from "./init"
 
 let root = ""
 const model = { provider: "openrouter", defaultModel: "anthropic/claude-sonnet-4-6" }
@@ -21,18 +21,20 @@ const temporaryRoot = async (): Promise<string> => {
 describe("initActor", () => {
   test("creates a buildable named quickstart", async () => {
     const cwd = await temporaryRoot()
-    const initialized = await initActor("reviewer", { cwd, model, now: new Date("2026-08-24T00:00:00Z") })
+    const initialized = await initActor("reviewer", { cwd, model, now: new Date("2026-08-24T00:00:00Z"), packageVersion: "0.7.1-test" })
     const source = await readFile(initialized.entry, "utf8")
     const worker = await readFile(initialized.worker, "utf8")
     const manifestSource = await readFile(initialized.manifest, "utf8")
     const manifest = JSON.parse(manifestSource) as Record<string, unknown>
     const celldManifest = JSON.parse(await readFile(initialized.celldManifest, "utf8")) as Record<string, unknown>
+    const packageManifest = JSON.parse(await readFile(initialized.packageManifest, "utf8")) as Record<string, unknown>
     const built = await buildActor(initialized.entry, { cwd: initialized.directory, out: "output" })
 
     expect(defaultInitDirectory("reviewer")).toBe("reviewer")
     expect(initialized.entry).toBe(join(cwd, "reviewer", DEFAULT_ACTOR_ENTRY))
     expect(initialized.worker).toBe(join(cwd, "reviewer", DEFAULT_WORKER_ENTRY))
     expect(initialized.celldManifest).toBe(join(cwd, "reviewer", CELLD_PROJECT_CONFIG_PATH))
+    expect(initialized.packageManifest).toBe(join(cwd, "reviewer", DEFAULT_PACKAGE_MANIFEST))
     expect(source).toContain('const actorName = "reviewer"')
     expect(source).toContain('provider: "openrouter", default_model: "anthropic/claude-sonnet-4-6"')
     expect(worker).toContain('import definition from "./actor"')
@@ -59,6 +61,7 @@ describe("initActor", () => {
     ])
     expect((celldManifest["vars"] as Record<string, string>)["TARDIGRADE_CONFIG"]).toBe("{}")
     expect((celldManifest["vars"] as Record<string, string>)["TARDIGRADE_SANDBOX_TRANSPORT"]).toBe("replay")
+    expect(packageManifest).toEqual({ private: true, type: "module", dependencies: { tardie: "0.7.1-test" } })
     expect(built.manifest.name).toBe("reviewer")
   })
 
@@ -81,6 +84,26 @@ describe("initActor", () => {
 
     expect(initialized.entry).toBe(join(cwd, "actors", "custom", DEFAULT_ACTOR_ENTRY))
   })
+
+  test("adds its exact version to an existing project manifest", async () => {
+    const cwd = await temporaryRoot()
+    const directory = join(cwd, "reviewer")
+    await mkdir(directory)
+    await writeFile(join(directory, "package.json"), `${JSON.stringify({
+      private: true,
+      scripts: { check: "tsc --noEmit" },
+      dependencies: { effect: "4.0.0-rc.110" }
+    })}\n`, "utf8")
+
+    const initialized = await initActor("reviewer", { cwd, model, packageVersion: "0.7.1-rc.158" })
+    const manifest = JSON.parse(await readFile(initialized.packageManifest, "utf8")) as Record<string, unknown>
+
+    expect(manifest).toEqual({
+      private: true,
+      scripts: { check: "tsc --noEmit" },
+      dependencies: { effect: "4.0.0-rc.110", tardie: "0.7.1-rc.158" }
+    })
+  })
 })
 
 describe("initSummary", () => {
@@ -93,6 +116,7 @@ describe("initSummary", () => {
     expect(summary).toContain("created reviewer/worker.ts")
     expect(summary).toContain("created reviewer/wrangler.jsonc")
     expect(summary).toContain("created reviewer/celld.jsonc")
+    expect(summary).toContain("created reviewer/package.json")
     expect(summary).toContain("cd reviewer")
     expect(summary).not.toContain("tdg push")
     expect(summary).not.toContain("tdg build actor.ts")

--- a/apps/cli/src/init.ts
+++ b/apps/cli/src/init.ts
@@ -4,10 +4,12 @@ import { DEFAULT_PROJECT_CONFIG_PATH } from "@clavia/tardigrade-server/config"
 
 import { CELLD_PROJECT_CONFIG_PATH, celldConfigOf } from "./celld"
 import { actorTemplate, type ActorTemplateModel } from "./template"
+import { versionIn } from "./version"
 import { callCommandFor, shellWord } from "./workflow"
 
 export const DEFAULT_ACTOR_ENTRY = "actor.ts"
 export const DEFAULT_WORKER_ENTRY = "worker.ts"
+export const DEFAULT_PACKAGE_MANIFEST = "package.json"
 
 export interface InitActorOptions {
   readonly model: ActorTemplateModel
@@ -15,6 +17,7 @@ export interface InitActorOptions {
   readonly directory?: string
   readonly force?: boolean
   readonly now?: Date
+  readonly packageVersion?: string
 }
 
 export interface InitializedActor {
@@ -24,6 +27,7 @@ export interface InitializedActor {
   readonly worker: string
   readonly manifest: string
   readonly celldManifest: string
+  readonly packageManifest: string
 }
 
 export const defaultInitDirectory = (name: string): string => name
@@ -60,6 +64,12 @@ export { ActorHost }
 export default cloudflareWorker(definition)
 `
 
+const packageTemplate = (version: string): string => `${JSON.stringify({
+  private: true,
+  type: "module",
+  dependencies: { tardie: version }
+}, undefined, 2)}\n`
+
 const existsError = (error: unknown): boolean =>
   typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST"
 
@@ -70,8 +80,11 @@ export const initActor = async (name: string, options: InitActorOptions): Promis
   const worker = resolve(directory, DEFAULT_WORKER_ENTRY)
   const manifest = resolve(directory, DEFAULT_PROJECT_CONFIG_PATH)
   const celldManifest = resolve(directory, CELLD_PROJECT_CONFIG_PATH)
+  const packageManifest = resolve(directory, DEFAULT_PACKAGE_MANIFEST)
   const source = await actorTemplate({ name, model: options.model })
   const manifestSource = manifestTemplate(name, options.now ?? new Date())
+  const packageVersion = options.packageVersion ?? await versionIn(import.meta.url)
+  if (packageVersion.endsWith("-unknown")) throw new Error("cannot determine the installed Tardigrade version")
 
   await mkdir(dirname(entry), { recursive: true })
   try {
@@ -102,7 +115,22 @@ export const initActor = async (name: string, options: InitActorOptions): Promis
     if (!existsError(error)) throw error
   }
 
-  return { name, directory, entry, worker, manifest, celldManifest }
+  try {
+    await writeFile(packageManifest, packageTemplate(packageVersion), { encoding: "utf8", flag: "wx" })
+  } catch (error) {
+    if (!existsError(error)) throw error
+    const current = JSON.parse(await readFile(packageManifest, "utf8")) as Record<string, unknown>
+    const dependencies = current["dependencies"]
+    if (dependencies !== undefined && (typeof dependencies !== "object" || dependencies === null || Array.isArray(dependencies))) {
+      throw new Error(`${packageManifest} dependencies must contain a JSON object`)
+    }
+    await writeFile(packageManifest, `${JSON.stringify({
+      ...current,
+      dependencies: { ...(dependencies as Record<string, unknown> | undefined), tardie: packageVersion }
+    }, undefined, 2)}\n`)
+  }
+
+  return { name, directory, entry, worker, manifest, celldManifest, packageManifest }
 }
 
 const shownPath = (cwd: string, path: string): string => {
@@ -117,6 +145,7 @@ export const initSummary = (actor: InitializedActor, cwd: string = process.cwd()
     `created ${shownPath(cwd, actor.worker)}`,
     `created ${shownPath(cwd, actor.manifest)}`,
     `created ${shownPath(cwd, actor.celldManifest)}`,
+    `created ${shownPath(cwd, actor.packageManifest)}`,
     "",
     "next",
     `  cd ${shellWord(directory)}`,

--- a/apps/cli/src/services.ts
+++ b/apps/cli/src/services.ts
@@ -3,24 +3,39 @@ import { makeClient, type Client, type ClientOptions } from "@clavia/tardigrade-
 
 import type { Env } from "./config"
 
-// The two things a command reads that are not its own arguments: the environment it resolves
-// configuration from, and the client it calls a server with. They are one service so that a test
-// drives a real command tree against a client it wrote, with an environment it stated, and no
-// process to spawn (commands.test.ts).
+// CliServices holds the process capabilities used by command handlers. Tests replace them to drive
+// the command tree without network access or child processes (commands.test.ts).
 
 export interface CliServices {
   readonly env: Env
   readonly cwd: string
   readonly openClient: (options: ClientOptions) => Client
+  readonly installProject: (directory: string) => Promise<void>
   // mintId supplies the durable thread and call ids used when a caller states neither.
   readonly mintId: () => string
 }
 
 export class Cli extends Context.Service<Cli, CliServices>()("tardigrade/cli/Cli") {}
 
+const installProject = async (directory: string): Promise<void> => {
+  const child = Bun.spawn(["bun", "install"], {
+    cwd: directory,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe"
+  })
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited
+  ])
+  if (code !== 0) throw new Error(`bun install exited ${code}: ${(stderr || stdout).trim()}`)
+}
+
 export const layerCli: Layer.Layer<Cli> = Layer.succeed(Cli)({
   env: process.env,
   cwd: process.cwd(),
   openClient: (options) => makeClient(options),
+  installProject,
   mintId: () => crypto.randomUUID()
 })

--- a/docs/how-to/cli.md
+++ b/docs/how-to/cli.md
@@ -64,7 +64,7 @@ An agent or CI job can avoid prompts by supplying the provider connection as JSO
 tdg init researcher \
   --provider openrouter \
   --provider-config '{"env":["OPENROUTER_API_KEY"]}' \
-  --default-model anthropic/claude-sonnet-4-6
+  --default-model anthropic/claude-sonnet-4.6
 ```
 
 Partial declarative initialization fails and lists the missing options. Declarative initialization does not read or write `OPENROUTER_API_KEY`; set it in the environment that runs the server. Agents and CI can add a connection and select it as the default in two focused commands:
@@ -74,7 +74,7 @@ tdg setup provider openrouter '{"env":["OPENROUTER_API_KEY"]}'
 
 tdg setup default \
   --provider openrouter \
-  --model anthropic/claude-sonnet-4-6
+  --model anthropic/claude-sonnet-4.6
 ```
 
 Known providers supply their standard protocol and endpoint. A provider whose connection needs more fields states them in the same object. Amazon Bedrock requires its gateway endpoint and AWS region:
@@ -94,7 +94,7 @@ tdg setup provider private-gateway '{"baseUrl":"https://models.example.com/v1","
   "vars": {
     "TARDIGRADE_CONFIG": {
       "models": {
-        "default": { "provider": "openrouter", "model_id": "anthropic/claude-sonnet-4-6" },
+        "default": { "provider": "openrouter", "model_id": "anthropic/claude-sonnet-4.6" },
         "providers": {
           "openrouter": {
             "baseUrl": "https://openrouter.ai/api/v1",

--- a/docs/how-to/server.md
+++ b/docs/how-to/server.md
@@ -80,7 +80,7 @@ The server boots without a provider connection and serves every read; turns fail
   "vars": {
     "TARDIGRADE_CONFIG": {
       "models": {
-        "default": { "provider": "openrouter", "model_id": "anthropic/claude-sonnet-4-6" },
+        "default": { "provider": "openrouter", "model_id": "anthropic/claude-sonnet-4.6" },
         "providers": {
           "openrouter": {
             "baseUrl": "https://openrouter.ai/api/v1",

--- a/platform/cloudflare/src/worker.ts
+++ b/platform/cloudflare/src/worker.ts
@@ -12,6 +12,7 @@ import {
 } from "@clavia/tardigrade-server/catalog"
 import { modelsPageOf, providersPageOf } from "@clavia/tardigrade-server/catalog-page"
 import { modelConfigOf, type ModelProviderConfig } from "@clavia/tardigrade-server/config"
+import { treeOf, type ThreadNode, type ThreadSummary } from "@clavia/tardigrade-server/projections"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { traceparentOf } from "@clavia/tardigrade-core/trace"
 import { mappedDirectory } from "@clavia/tardigrade-core/communication/directory"
@@ -54,6 +55,9 @@ export interface Env {
 const LANE_PREFIX = "ag."
 const laneOf = (thread: string): string => `${LANE_PREFIX}${thread}`
 const threadOf = (lane: string): string | undefined => lane.startsWith(LANE_PREFIX) ? lane.slice(LANE_PREFIX.length) : undefined
+
+const flattenThreads = (nodes: ReadonlyArray<ThreadNode>): ReadonlyArray<ThreadSummary> =>
+  nodes.flatMap(({ children, ...summary }) => [summary, ...flattenThreads(children)])
 
 const DEFAULT_ACTOR_NAME = "default"
 
@@ -463,14 +467,14 @@ export class ActorHost extends DurableObject<Env> {
     return (await this.host()).read(laneOf(thread))
   }
 
-  async threads(): Promise<ReadonlyArray<{ readonly id: string; readonly events: number }>> {
+  async threads(): Promise<ReadonlyArray<ThreadSummary>> {
     const host = await this.host()
-    const summaries: Array<{ readonly id: string; readonly events: number }> = []
+    const logs = new Map<string, ReadonlyArray<Event>>()
     for (const lane of await host.lanes()) {
       const id = threadOf(lane)
-      if (id !== undefined) summaries.push({ id, events: (await host.read(lane)).length })
+      if (id !== undefined) logs.set(id, await host.read(lane))
     }
-    return summaries
+    return flattenThreads(treeOf(logs))
   }
 
   async status(): Promise<{ readonly status: "resting" | "driving"; readonly dirty: number }> {
@@ -530,7 +534,7 @@ const guard = (request: HttpServerRequest.HttpServerRequest, env: Env) => {
 }
 
 const catalogQueryOf = (request: HttpServerRequest.HttpServerRequest) => {
-  const query = new URL(request.url).searchParams
+  const query = new URL(request.url, "http://worker").searchParams
   const value = (name: string): string | undefined => query.get(name) ?? undefined
   const limit = value("limit")
   return {
@@ -587,7 +591,7 @@ const routes = [
         if (catalog.snapshot === undefined) {
           throw new Error(catalog.refreshError ?? catalog.cacheError ?? "no validated model catalog is available")
         }
-        const query = new URL(request.url).searchParams
+        const query = new URL(request.url, "http://worker").searchParams
         return modelsPageOf(catalog.snapshot, {
           ...catalogQueryOf(request),
           provider: query.get("provider") ?? undefined
@@ -599,9 +603,12 @@ const routes = [
       onSuccess: (page) => json(page)
     }))
   })),
-  HttpRouter.route("GET", "/v1/methods", protectedRoute((_request, _env) =>
+  HttpRouter.route("GET", "/v1/actors/:actor/methods", protectedRoute((_request, _env) =>
     Effect.gen(function* () {
-      const methods = methodsOf(deployedActor)
+      const params = yield* HttpRouter.params
+      const actor = decodeURIComponent(params.actor ?? "")
+      const methods = methodsOf(actor)
+      if (!deployed(actor)) return json({ error: "unknown actor" }, 404)
       if (methods === undefined) return json({ error: "actor assembly is not deployed" }, 503)
       return json(Object.entries(methods).map(([name, method]) => ({
         name,
@@ -610,33 +617,37 @@ const routes = [
       })))
     })
   )),
-  HttpRouter.route("PUT", "/v1/threads/:thread/methods/:method/calls/:call", protectedRoute((request, env) =>
+  HttpRouter.route("PUT", "/v1/actors/:actor/threads/:thread/methods/:method/calls/:call", protectedRoute((request, env) =>
     Effect.gen(function* () {
       const params = yield* HttpRouter.params
+      const actor = decodeURIComponent(params.actor ?? "")
       const thread = decodeURIComponent(params.thread ?? "")
       const methodName = decodeURIComponent(params.method ?? "")
       const call = decodeURIComponent(params.call ?? "")
-      const method = methodsOf(deployedActor)?.[methodName]
+      if (!deployed(actor)) return json({ error: "unknown actor" }, 404)
+      const method = methodsOf(actor)?.[methodName]
       if (method === undefined) return json({ error: "unknown method" }, 404)
       const input = yield* request.json.pipe(Effect.orElseSucceed(() => undefined))
       const at = yield* Clock.currentTimeMillis
       const decoded = methodEventOf(method, { id: call, input, at })
       if ("error" in decoded) return json({ error: decoded.error }, 400)
-      const stub = yield* Effect.promise(() => actorStub(env, deployedActor))
+      const stub = yield* Effect.promise(() => actorStub(env, actor))
       if (stub === undefined) return json({ error: "actor is not deployed" }, 503)
       yield* Effect.promise(() => stub.append(thread, decoded.event))
-      return json({ thread, method: methodName, call }, 202)
+      return json({ actor, thread, method: methodName, call }, 202)
     })
   )),
-  HttpRouter.route("GET", "/v1/threads/:thread/methods/:method/calls/:call", protectedRoute((_request, env) =>
+  HttpRouter.route("GET", "/v1/actors/:actor/threads/:thread/methods/:method/calls/:call", protectedRoute((_request, env) =>
     Effect.gen(function* () {
       const params = yield* HttpRouter.params
+      const actor = decodeURIComponent(params.actor ?? "")
       const thread = decodeURIComponent(params.thread ?? "")
       const methodName = decodeURIComponent(params.method ?? "")
       const call = decodeURIComponent(params.call ?? "")
-      const method = methodsOf(deployedActor)?.[methodName]
+      if (!deployed(actor)) return json({ error: "unknown actor" }, 404)
+      const method = methodsOf(actor)?.[methodName]
       if (method === undefined) return json({ error: "unknown method" }, 404)
-      const stub = yield* Effect.promise(() => actorStub(env, deployedActor))
+      const stub = yield* Effect.promise(() => actorStub(env, actor))
       if (stub === undefined) return json({ error: "actor is not deployed" }, 503)
       const events = yield* Effect.promise(() => stub.events(thread)).pipe(
         Effect.map((value) => value as ReadonlyArray<Event>)
@@ -645,32 +656,39 @@ const routes = [
       return state === undefined ? json({ error: "unknown method call" }, 404) : json(state)
     })
   )),
-  HttpRouter.route("GET", "/v1/threads", protectedRoute((_request, env) =>
+  HttpRouter.route("GET", "/v1/actors/:actor/threads", protectedRoute((_request, env) =>
     Effect.gen(function* () {
-      const stub = yield* Effect.promise(() => actorStub(env, deployedActor))
+      const params = yield* HttpRouter.params
+      const actor = decodeURIComponent(params.actor ?? "")
+      if (!deployed(actor)) return json({ error: "unknown actor" }, 404)
+      const stub = yield* Effect.promise(() => actorStub(env, actor))
       if (stub === undefined) return json({ error: "actor is not deployed" }, 503)
       return json(yield* Effect.promise(() => stub.threads()))
     })
   )),
-  HttpRouter.route("POST", "/v1/threads/:thread/events", protectedRoute((request, env) =>
+  HttpRouter.route("POST", "/v1/actors/:actor/threads/:thread/events", protectedRoute((request, env) =>
     Effect.gen(function* () {
       const params = yield* HttpRouter.params
+      const actor = decodeURIComponent(params.actor ?? "")
       const thread = decodeURIComponent(params.thread ?? "")
-      const stub = yield* Effect.promise(() => actorStub(env, deployedActor))
+      if (!deployed(actor)) return json({ error: "unknown actor" }, 404)
+      const stub = yield* Effect.promise(() => actorStub(env, actor))
       if (stub === undefined) return json({ error: "actor is not deployed" }, 503)
       const event = (yield* request.json.pipe(Effect.orElseSucceed(() => undefined))) as Event | undefined
       if (typeof event !== "object" || event === null || typeof event.type !== "string" || event.type === "") {
         return json({ error: "event type is required" }, 400)
       }
       yield* Effect.promise(() => stub.append(thread, event))
-      return json({ thread }, 202)
+      return json({ actor, thread }, 202)
     })
   )),
-  HttpRouter.route("GET", "/v1/threads/:thread/events", protectedRoute((request, env) =>
+  HttpRouter.route("GET", "/v1/actors/:actor/threads/:thread/events", protectedRoute((request, env) =>
     Effect.gen(function* () {
       const params = yield* HttpRouter.params
+      const actor = decodeURIComponent(params.actor ?? "")
       const thread = decodeURIComponent(params.thread ?? "")
-      const stub = yield* Effect.promise(() => actorStub(env, deployedActor))
+      if (!deployed(actor)) return json({ error: "unknown actor" }, 404)
+      const stub = yield* Effect.promise(() => actorStub(env, actor))
       if (stub === undefined) return json({ error: "actor is not deployed" }, 503)
       const url = new URL(request.url, "http://worker")
       const after = Number(url.searchParams.get("after") ?? 0)
@@ -681,9 +699,11 @@ const routes = [
         catch: (cause) => cause instanceof Error ? cause.message : String(cause)
       }).pipe(Effect.match({
         onFailure: (error) => json({ error }, 500),
-        onSuccess: (events) => json(events.map((event, index) => ({ seq: index + 1, event }))
-          .filter((row) => row.seq > after && (types === undefined || types.includes(row.event.type)))
-          .slice(0, limit))
+        onSuccess: (events) => events.length === 0
+          ? json({ error: "unknown thread" }, 404)
+          : json(events.map((event, index) => ({ seq: index + 1, event }))
+            .filter((row) => row.seq > after && (types === undefined || types.includes(row.event.type)))
+            .slice(0, limit))
       }))
     })
   )),

--- a/platform/cloudflare/test/actor.workers.ts
+++ b/platform/cloudflare/test/actor.workers.ts
@@ -1,6 +1,7 @@
 import { env, runInDurableObject, SELF } from "cloudflare:test"
 import { Effect, ManagedRuntime } from "effect"
 import { describe, expect, test } from "vitest"
+import { makeClient } from "@clavia/tardigrade-client"
 import type { ModelCatalog } from "@clavia/tardigrade-client/contract"
 import { ModelCatalogRepository } from "@clavia/tardigrade-server/catalog-store"
 import type { Env } from "../src/worker"
@@ -12,7 +13,7 @@ const alarm = () => runInDurableObject(actorStub(), (_instance, state) => state.
 
 const methodState = async (): Promise<unknown> => {
   for (let attempt = 0; attempt < 100; attempt++) {
-    const response = await SELF.fetch("http://test/v1/threads/root/methods/echo/calls/workers-smoke", {
+    const response = await SELF.fetch("http://test/v1/actors/echo/threads/root/methods/echo/calls/workers-smoke", {
       headers: authorization
     })
     const state = await response.json() as { readonly status?: unknown }
@@ -50,34 +51,44 @@ describe("cloudflare actor", () => {
         await runtime.dispose()
       }
     })
+    const providers = await SELF.fetch("http://test/v1/providers?search=open&limit=1")
+    expect(providers.status).toBe(200)
+    expect(await providers.json()).toEqual(expect.objectContaining({
+      total: 2,
+      items: [expect.objectContaining({ id: "openai" })]
+    }))
   })
 
   test("a mounted actor exposes durable methods", async () => {
-    const refused = await SELF.fetch("http://test/v1/methods")
+    const refused = await SELF.fetch("http://test/v1/actors/echo/methods")
     expect(refused.status).toBe(401)
-    const methods = await SELF.fetch("http://test/v1/methods", { headers: authorization })
+    const methods = await SELF.fetch("http://test/v1/actors/echo/methods", { headers: authorization })
     expect(await methods.json()).toEqual([expect.objectContaining({
       name: "echo",
       inputSchema: expect.objectContaining({ type: "object" }),
       outputSchema: expect.objectContaining({ type: "string" })
     })])
-    const accepted = await SELF.fetch("http://test/v1/threads/root/methods/echo/calls/workers-smoke", {
+    const accepted = await SELF.fetch("http://test/v1/actors/echo/threads/root/methods/echo/calls/workers-smoke", {
       method: "PUT",
       headers: { ...authorization, "content-type": "application/json" },
       body: JSON.stringify({ text: "Run in workerd." })
     })
     expect(accepted.status).toBe(202)
-    expect(await accepted.json()).toEqual({ thread: "root", method: "echo", call: "workers-smoke" })
+    expect(await accepted.json()).toEqual({ actor: "echo", thread: "root", method: "echo", call: "workers-smoke" })
     expect(await alarm()).not.toBeNull()
     expect(await methodState()).toEqual({ status: "completed", output: "Run in workerd." })
     expect(await alarm()).toBeNull()
-    const redelivered = await SELF.fetch("http://test/v1/threads/root/methods/echo/calls/workers-smoke", {
-      method: "PUT",
-      headers: { ...authorization, "content-type": "application/json" },
-      body: JSON.stringify({ text: "Run in workerd." })
+    const client = makeClient({
+      baseUrl: "http://test",
+      actor: "echo",
+      token: "workers-test-token",
+      fetch: (input, init) => SELF.fetch(input, init)
     })
-    expect(redelivered.status).toBe(202)
-    const events = await SELF.fetch("http://test/v1/threads/root/events", { headers: authorization })
+    expect(await client.invoke("root", "echo", { id: "workers-smoke", input: { text: "Run in workerd." } }))
+      .toEqual({ actor: "echo", thread: "root", method: "echo", call: "workers-smoke" })
+    expect(await client.methodState("root", "echo", "workers-smoke"))
+      .toEqual({ status: "completed", output: "Run in workerd." })
+    const events = await SELF.fetch("http://test/v1/actors/echo/threads/root/events", { headers: authorization })
     expect((await events.json() as ReadonlyArray<{ readonly event: { readonly type: string } }>).map((row) => row.event.type)).toEqual([
       "ThreadCreated",
       "EchoRequested",
@@ -85,5 +96,11 @@ describe("cloudflare actor", () => {
     ])
     const health = await SELF.fetch("http://test/healthz")
     expect(await health.json()).toEqual({ status: "resting", dirty: 0 })
+    const threads = await SELF.fetch("http://test/v1/actors/echo/threads", { headers: authorization })
+    expect(await threads.json()).toEqual([expect.objectContaining({ id: "root", depth: 0, events: 3, status: "settled" })])
+    expect(await client.methods()).toEqual([expect.objectContaining({ name: "echo" })])
+    expect(await client.list()).toEqual([expect.objectContaining({ id: "root", status: "settled" })])
+    const unknown = await SELF.fetch("http://test/v1/actors/missing/methods", { headers: authorization })
+    expect(unknown.status).toBe(404)
   })
 })

--- a/platform/cloudflare/vitest.config.ts
+++ b/platform/cloudflare/vitest.config.ts
@@ -7,7 +7,9 @@ export default defineConfig({
     miniflare: {
       bindings: {
         TARDIGRADE_TOKEN: "workers-test-token",
-        TARDIGRADE_ALARM_DELAY_MILLIS: "60000"
+        TARDIGRADE_ALARM_DELAY_MILLIS: "60000",
+        TARDIGRADE_MODEL_CATALOG_URL: "https://models.test/catalog.json",
+        TARDIGRADE_MODEL_CATALOG_LOAD_POLICY: "cache-first"
       }
     }
   })],

--- a/skills/tardigrade/SKILL.md
+++ b/skills/tardigrade/SKILL.md
@@ -20,7 +20,7 @@ In a non-interactive terminal, state the provider connection as JSON. The JSON n
 tdg init researcher \
   --provider openrouter \
   --provider-config '{"env":["OPENROUTER_API_KEY"]}' \
-  --default-model anthropic/claude-sonnet-4-6
+  --default-model anthropic/claude-sonnet-4.6
 cd researcher
 ```
 


### PR DESCRIPTION
## Summary

Make `tdg init` create an exact-version project manifest and install its runtime dependency. Align the Cloudflare adapter with the actor-scoped client routes, return complete thread summaries, and parse catalog queries from relative Worker URLs. Correct the OpenRouter Sonnet 4.6 model ID used by the CLI and guides.

## Why

A project created by the published CLI could not resolve `tardie` during deployment. After a manual install, the CLI received 404 responses from Cloudflare because the adapter served older paths, and catalog discovery failed while parsing the Worker request URL.

## Verification

- `bun run gate` passes all 47 tasks
- Built the npm-format tarball and initialized a fresh project
- Deployed the generated Worker to Cloudflare
- Used the packaged CLI to discover methods, providers, and models
- Completed a real OpenRouter message call and read its durable event log