### PR TITLE
fix(code): compare replay arguments structurally

### DIFF
--- a/packages/code/src/execute.test.ts
+++ b/packages/code/src/execute.test.ts
@@ -177,6 +177,43 @@ describe("the replay guard", () => {
     expect(settle.error).toContain("nondeterministic body")
     expect(settle.error).toContain("different arguments")
   })
+
+  test("object member order survives replay", async () => {
+    const replayed = `
+      const a = await world.read({
+        tool: "list_deployments",
+        parameters: { region: "us", filters: { owner: "me", status: "active" } },
+        order: ["newest", "oldest"]
+      })
+      return { a }
+    `
+    const log: Event[] = [
+      { type: "MessageReceived", id: "t1", text: "go", at: 1 },
+      { type: "CodeDispatched", execId: "e1", code: replayed, turn: "t1", at: 2 },
+      {
+        type: "PackageCalled",
+        callId: "e1.0",
+        name: "world.read",
+        arguments: {
+          order: ["newest", "oldest"],
+          parameters: { filters: { status: "active", owner: "me" }, region: "us" },
+          tool: "list_deployments"
+        },
+        turn: "t1",
+        at: 3
+      },
+      { type: "PackageReturned", callId: "e1.0", result: { ok: "read" }, turn: "t1", at: 4 }
+    ]
+    const events = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* settleActor({ reactors: [codeReactorFor({}, [worldPackage])], keyOf: composeKeys(messageKeys, codeKeys) })
+        return yield* Effect.flatMap(EventLog, (l) => l.read)
+      }).pipe(Effect.provide(Layer.mergeAll(memoryLog(log), jsSandbox, KeyValueStore.layerMemory))) as Effect.Effect<ReadonlyArray<Event>>
+    )
+    const settle = events.find((e) => e.type === "CodeSettled") as { error?: string; result?: unknown }
+    expect(settle.error).toBeUndefined()
+    expect(settle.result).toEqual({ a: { ok: "read" } })
+  })
 })
 
 describe("the shadow router rule", () => {

--- a/packages/code/src/execute.ts
+++ b/packages/code/src/execute.ts
@@ -36,6 +36,15 @@ import { blockedOn, codeSettled, packageCalled, packageReturned } from "./events
 // never settles) or settled (the body's promise resolves with the result).
 type CallOutcome = { readonly parked: true } | { readonly parked: false; readonly result: unknown }
 
+// canonicalJson sorts object members recursively and preserves array order
+// (execute.test.ts, "object member order survives replay").
+const canonicalJson = (value: unknown): string | undefined =>
+  JSON.stringify(value, (_key, entry: unknown) => {
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) return entry
+    const record = entry as Readonly<Record<string, unknown>>
+    return Object.fromEntries(Object.keys(record).sort().map((key) => [key, record[key]]))
+  })
+
 // executeRecorded runs one attempt. The proxy keys each call {execId}.{n} in execution order
 // (callId, src/grammar/grammar.ts); a committed answer replays, an uncommitted call runs live
 // and records its pair before the body continues. A parked call records no pair: the next
@@ -103,7 +112,7 @@ const executeRecorded = <R = never>(
                 const drift =
                   String(sent.name) !== askedName
                     ? `asked ${askedName} where the log recorded ${String(sent.name)}`
-                    : JSON.stringify(sent.arguments) !== JSON.stringify(args)
+                    : canonicalJson(sent.arguments) !== canonicalJson(args)
                       ? `asked ${askedName} with different arguments than the log recorded`
                       : undefined
                 if (drift !== undefined) {

--- a/platform/cloudflare/src/sandbox.ts
+++ b/platform/cloudflare/src/sandbox.ts
@@ -175,11 +175,16 @@ export default {
 
 // REPLAY_HARNESS_SOURCE returns JSON call boundaries and refuses positional drift (packages/core/tla/runtime/Replay.tla, RightAnswer).
 const REPLAY_HARNESS_SOURCE = `${HARNESS_PREAMBLE}
+const canonicalJson = (value) => JSON.stringify(value, (_key, entry) => {
+  if (entry === null || typeof entry !== "object" || Array.isArray(entry)) return entry;
+  return Object.fromEntries(Object.keys(entry).sort().map((key) => [key, entry[key]]));
+});
+
 const sameCall = (left, right) =>
   left.ordinal === right.ordinal &&
   left.packageName === right.packageName &&
   left.method === right.method &&
-  JSON.stringify(left.args) === JSON.stringify(right.args);
+  canonicalJson(left.args) === canonicalJson(right.args);
 
 export default {
   async fetch(_request, env) {

--- a/platform/cloudflare/test/sandbox.workers.ts
+++ b/platform/cloudflare/test/sandbox.workers.ts
@@ -11,6 +11,35 @@ const bridgeFor: SandboxBridgeFactory = (_call) => ({
   close: () => undefined
 })
 
+const mapLoaderInput = (map: (input: unknown) => unknown): WorkerLoader => ({
+  load: (worker: WorkerLoaderWorkerCode) => {
+    const workerEnv = worker.env as Readonly<Record<string, unknown>>
+    return (env as Env).LOADER.load({
+      ...worker,
+      env: { ...workerEnv, INPUT: map(workerEnv["INPUT"]) }
+    })
+  }
+}) as WorkerLoader
+
+const reorderObjectKeys = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(reorderObjectKeys)
+  if (value === null || typeof value !== "object") return value
+  return Object.fromEntries(
+    Object.entries(value as Readonly<Record<string, unknown>>)
+      .sort(([left], [right]) => right.localeCompare(left))
+      .map(([key, entry]) => [key, reorderObjectKeys(entry)])
+  )
+}
+
+const reverseRecordedOrder = (value: unknown): unknown => {
+  const input = structuredClone(value) as {
+    replay?: Array<{ call?: { args?: { order?: unknown[] } } }>
+  }
+  const order = input.replay?.[0]?.call?.args?.order
+  if (order !== undefined) order.reverse()
+  return input
+}
+
 describe("cloudflare sandbox", () => {
   test("runs generated code with deterministic ambient values", async () => {
     const sandbox = cloudflareSandboxServiceFor((env as Env).LOADER, bridgeFor)
@@ -84,6 +113,36 @@ describe("cloudflare sandbox", () => {
       { ordinal: 1, value: 6 },
       { ordinal: 2, value: 5 }
     ])
+  })
+
+  test("replay ignores object member order across the loader boundary", async () => {
+    const sandbox = cloudflareSandboxServiceFor(mapLoaderInput(reorderObjectKeys), bridgeFor, { transport: "replay" })
+    const result = await Effect.runPromise(sandbox.run(
+      `return await tools.inspect({
+        tool: "list_deployments",
+        parameters: { region: "us", filters: { owner: "me", status: "active" } },
+        order: ["newest", "oldest"]
+      })`,
+      { tools: { inspect: async (input) => sandboxReturned(input) } }
+    ))
+
+    expect(result).toEqual({
+      result: {
+        tool: "list_deployments",
+        parameters: { region: "us", filters: { owner: "me", status: "active" } },
+        order: ["newest", "oldest"]
+      }
+    })
+  })
+
+  test("replay keeps argument array order significant", async () => {
+    const sandbox = cloudflareSandboxServiceFor(mapLoaderInput(reverseRecordedOrder), bridgeFor, { transport: "replay" })
+    const result = await Effect.runPromise(sandbox.run(
+      `return await tools.inspect({ order: ["newest", "oldest"] })`,
+      { tools: { inspect: async (input) => sandboxReturned(input) } }
+    ))
+
+    expect(result.error).toBe("nondeterministic body: replayed call 0 changed")
   })
 
 })


### PR DESCRIPTION
Replay now compares JSON-compatible call arguments structurally. Object member order is ignored recursively, while array order and call order remain strict. This prevents loader JSON round trips from falsely reporting nondeterminism.

The change covers the in-process replay guard and the loaded Worker harness. Platform tests run the real Worker Loader through a fake JSON boundary that reorders nested object keys, then prove that changing an argument array still fails replay.

Tested with bun run gate.

Closes #252