### PR TITLE
fix(cloudflare): dispose loaded workers

### DIFF
--- a/platform/cloudflare/README.md
+++ b/platform/cloudflare/README.md
@@ -10,9 +10,12 @@ Celld implements the Worker, SQLite Durable Object, alarm, and Worker Loader sur
 bun run --cwd platform/cloudflare typecheck
 bun run --cwd platform/cloudflare test
 bun run --cwd platform/cloudflare test:workers
+bun run --cwd platform/cloudflare test:celld
 bun run --cwd platform/cloudflare bundle
 bun run --cwd platform/cloudflare deploy
 ```
+
+`test:workers` runs the runtime suite on workerd. `test:celld` requires a running Apple Container service and runs the shared replay case on Celld with a loaded Worker limit of one. It starts a local object store, deploys the fixture, verifies the result through HTTP, and removes its generated containers, network, and deploy image. Set `TARDIGRADE_CELLD_IMAGE`, `TARDIGRADE_CELLD_NODE_IMAGE`, `TARDIGRADE_CELLD_ESBUILD_VERSION`, `TARDIGRADE_CELLD_STORE_IMAGE`, `TARDIGRADE_CELLD_STORE_CLIENT_IMAGE`, `TARDIGRADE_CELLD_LOADED_WORKER_LIMIT`, `TARDIGRADE_CELLD_PORT`, or `TARDIGRADE_CELLD_TIMEOUT_MILLIS` to override a test dependency or policy.
 
 Set authentication before using the event API:
 

--- a/platform/cloudflare/package.json
+++ b/platform/cloudflare/package.json
@@ -40,6 +40,7 @@
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
-    "test:workers": "vitest run --config vitest.config.ts"
+    "test:workers": "vitest run --config vitest.config.ts",
+    "test:celld": "bun run test/celld/run.ts"
   }
 }

--- a/platform/cloudflare/src/sandbox.test.ts
+++ b/platform/cloudflare/src/sandbox.test.ts
@@ -170,4 +170,76 @@ describe("cloudflare sandbox bridge", () => {
     expect(result).toEqual({ error: "parked call replayed" })
     expect(round).toBe(2)
   })
+
+  test("disposes every replay worker before loading the next round", async () => {
+    let round = 0
+    let live = 0
+    let disposed = 0
+    const loader = {
+      load: () => {
+        if (live !== 0) throw new Error("worker capacity exhausted")
+        live++
+        let released = false
+        return {
+          getEntrypoint: () => ({
+            fetch: async () => round++ === 0
+              ? Response.json({ calls: [
+                  { ordinal: 0, packageName: "tools", method: "read", args: { id: 1 } }
+                ] })
+              : Response.json({ result: "done" })
+          }),
+          dispose: async () => {
+            if (released) throw new Error("worker disposed twice")
+            released = true
+            live--
+            disposed++
+          }
+        }
+      }
+    } as unknown as WorkerLoader
+    const sandbox = cloudflareSandboxServiceFor(loader, () => {
+      throw new Error("replay transport must not open a capability")
+    }, { transport: "replay" })
+    const result = await Effect.runPromise(sandbox.run("return 0", {
+      tools: { read: async () => sandboxReturned("value") }
+    }))
+
+    expect(result).toEqual({ result: "done" })
+    expect(round).toBe(2)
+    expect(disposed).toBe(2)
+    expect(live).toBe(0)
+  })
+
+  test("disposes a failed capability worker", async () => {
+    let live = 0
+    let disposed = 0
+    let closed = false
+    const symbolDispose = (Symbol as { readonly dispose?: symbol }).dispose
+    if (symbolDispose === undefined) throw new Error("Symbol.dispose is unavailable")
+    const loader = {
+      load: () => {
+        live++
+        return {
+          getEntrypoint: () => ({ fetch: async () => new Response("unavailable", { status: 503 }) }),
+          [symbolDispose]: () => {
+            live--
+            disposed++
+          }
+        }
+      }
+    } as unknown as WorkerLoader
+    const sandbox = cloudflareSandboxServiceFor(loader, () => ({
+      binding: { sandboxCallBatch: async () => [] },
+      execution: "test-execution",
+      close: () => {
+        closed = true
+      }
+    }))
+    const result = await Effect.runPromise(sandbox.run("return 0", {}))
+
+    expect(result).toEqual({ error: "sandbox returned HTTP 503" })
+    expect(disposed).toBe(1)
+    expect(live).toBe(0)
+    expect(closed).toBe(true)
+  })
 })

--- a/platform/cloudflare/src/sandbox.ts
+++ b/platform/cloudflare/src/sandbox.ts
@@ -282,6 +282,22 @@ interface SandboxReplayBoundary extends SandboxResult {
   readonly calls?: ReadonlyArray<SandboxBridgeCall>
 }
 
+// disposeWorker releases loader implementations that expose deterministic cleanup. Worker stubs without either extension remain governed by their platform lifecycle (sandbox.test.ts, "disposes every replay worker before loading the next round" and "disposes a failed capability worker").
+const disposeWorker = async (worker: WorkerStub): Promise<void> => {
+  const candidate = worker as unknown as Readonly<Record<PropertyKey, unknown>>
+  const dispose = candidate["dispose"]
+  if (typeof dispose === "function") {
+    await dispose.call(worker)
+    return
+  }
+  const symbol = (Symbol as { readonly dispose?: symbol }).dispose
+  if (symbol === undefined) return
+  const symbolDispose = candidate[symbol]
+  if (typeof symbolDispose === "function") await symbolDispose.call(worker)
+}
+
+const discardBody = (response: Response): Promise<ArrayBuffer> => response.arrayBuffer()
+
 export const cloudflareSandboxServiceFor = (
   loader: WorkerLoader,
   bridgeFor: SandboxBridgeFactory,
@@ -329,15 +345,22 @@ export const cloudflareSandboxServiceFor = (
               globalOutbound: resolved.globalOutbound,
               ...(resolved.limits === undefined ? {} : { limits: resolved.limits })
             })
-            const response = await worker.getEntrypoint().fetch(request())
-            if (!response.ok) return { error: `sandbox returned HTTP ${response.status}` }
-            const boundary = await response.json() as SandboxReplayBoundary
-            if (boundary.calls === undefined) return boundary
-            if (boundary.calls.length === 0) return { error: "sandbox replay returned an empty call boundary" }
-            const outcomes = await Promise.all(boundary.calls.map((entry) =>
-              call(entry.ordinal, entry.packageName, entry.method, entry.args)
-            ))
-            replay.push(...boundary.calls.map((entry, index) => ({ call: entry, outcome: outcomes[index]! })))
+            try {
+              const response = await worker.getEntrypoint().fetch(request())
+              if (!response.ok) {
+                await discardBody(response)
+                return { error: `sandbox returned HTTP ${response.status}` }
+              }
+              const boundary = await response.json() as SandboxReplayBoundary
+              if (boundary.calls === undefined) return boundary
+              if (boundary.calls.length === 0) return { error: "sandbox replay returned an empty call boundary" }
+              const outcomes = await Promise.all(boundary.calls.map((entry) =>
+                call(entry.ordinal, entry.packageName, entry.method, entry.args)
+              ))
+              replay.push(...boundary.calls.map((entry, index) => ({ call: entry, outcome: outcomes[index]! })))
+            } finally {
+              await disposeWorker(worker)
+            }
           }
         }
         const bridge = bridgeFor(call)
@@ -357,9 +380,16 @@ export const cloudflareSandboxServiceFor = (
           globalOutbound: resolved.globalOutbound,
           ...(resolved.limits === undefined ? {} : { limits: resolved.limits })
         })
-          const response = await worker.getEntrypoint().fetch(request())
-          if (!response.ok) return { error: `sandbox returned HTTP ${response.status}` }
-          return await response.json() as SandboxResult
+          try {
+            const response = await worker.getEntrypoint().fetch(request())
+            if (!response.ok) {
+              await discardBody(response)
+              return { error: `sandbox returned HTTP ${response.status}` }
+            }
+            return await response.json() as SandboxResult
+          } finally {
+            await disposeWorker(worker)
+          }
         } finally {
           bridge.close()
         }

--- a/platform/cloudflare/test/celld/Dockerfile
+++ b/platform/cloudflare/test/celld/Dockerfile
@@ -1,0 +1,11 @@
+ARG CELLD_IMAGE=ghcr.io/denoland/celld:v0.3.0
+ARG NODE_IMAGE=docker.io/library/node@sha256:03eae3ef7e88a9de535496fb488d67e02b9d96a063a8967bae657744ecd513f2
+
+FROM ${CELLD_IMAGE} AS celld
+FROM ${NODE_IMAGE}
+
+ARG ESBUILD_VERSION=0.28.1
+RUN npm install --global "esbuild@${ESBUILD_VERSION}" && npm cache clean --force
+COPY --from=celld /usr/local/bin/celld /usr/local/bin/celld
+
+ENTRYPOINT ["celld"]

--- a/platform/cloudflare/test/celld/run.ts
+++ b/platform/cloudflare/test/celld/run.ts
@@ -1,0 +1,172 @@
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const directory = dirname(fileURLToPath(import.meta.url))
+const repository = resolve(directory, "../../../..")
+const suffix = `${process.pid}`
+const network = `tardigrade-celld-${suffix}`
+const store = `tardigrade-celld-store-${suffix}`
+const runtime = `tardigrade-celld-runtime-${suffix}`
+const deployImage = `tardigrade-celld-deploy:${suffix}`
+
+export const DEFAULT_CELLD_TEST_PORT = 14_251
+export const DEFAULT_CELLD_TEST_TIMEOUT_MILLIS = 30_000
+export const DEFAULT_CELLD_TEST_LOADED_WORKER_LIMIT = 1
+export const DEFAULT_CELLD_TEST_IMAGE = "ghcr.io/denoland/celld:v0.3.0"
+export const DEFAULT_CELLD_TEST_NODE_IMAGE = "docker.io/library/node@sha256:03eae3ef7e88a9de535496fb488d67e02b9d96a063a8967bae657744ecd513f2"
+export const DEFAULT_CELLD_TEST_ESBUILD_VERSION = "0.28.1"
+export const DEFAULT_CELLD_TEST_STORE_IMAGE = "quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e"
+export const DEFAULT_CELLD_TEST_STORE_CLIENT_IMAGE = "quay.io/minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727"
+
+const container = "container"
+const port = Number(process.env.TARDIGRADE_CELLD_PORT ?? DEFAULT_CELLD_TEST_PORT)
+const timeoutMillis = Number(process.env.TARDIGRADE_CELLD_TIMEOUT_MILLIS ?? DEFAULT_CELLD_TEST_TIMEOUT_MILLIS)
+const loadedWorkerLimit = Number(
+  process.env.TARDIGRADE_CELLD_LOADED_WORKER_LIMIT ?? DEFAULT_CELLD_TEST_LOADED_WORKER_LIMIT
+)
+const celldImage = process.env.TARDIGRADE_CELLD_IMAGE ?? DEFAULT_CELLD_TEST_IMAGE
+const nodeImage = process.env.TARDIGRADE_CELLD_NODE_IMAGE ?? DEFAULT_CELLD_TEST_NODE_IMAGE
+const esbuildVersion = process.env.TARDIGRADE_CELLD_ESBUILD_VERSION ?? DEFAULT_CELLD_TEST_ESBUILD_VERSION
+const storeImage = process.env.TARDIGRADE_CELLD_STORE_IMAGE ?? DEFAULT_CELLD_TEST_STORE_IMAGE
+const storeClientImage = process.env.TARDIGRADE_CELLD_STORE_CLIENT_IMAGE ?? DEFAULT_CELLD_TEST_STORE_CLIENT_IMAGE
+
+interface CommandResult {
+  readonly code: number
+  readonly stdout: string
+  readonly stderr: string
+}
+
+const command = async (args: ReadonlyArray<string>, accepted = [0]): Promise<CommandResult> => {
+  const child = Bun.spawn([container, ...args], { stdout: "pipe", stderr: "pipe" })
+  const [code, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text()
+  ])
+  if (!accepted.includes(code)) {
+    throw new Error(`${container} ${args.join(" ")} exited ${code}\n${stdout}${stderr}`.trim())
+  }
+  return { code, stdout, stderr }
+}
+
+const addressOf = async (name: string): Promise<string> => {
+  const result = await command(["inspect", name])
+  const inspected = JSON.parse(result.stdout) as ReadonlyArray<{
+    readonly networks?: ReadonlyArray<{ readonly ipv4Address?: string }>
+  }>
+  const address = inspected[0]?.networks?.[0]?.ipv4Address?.split("/")[0]
+  if (address === undefined || address.length === 0) throw new Error(`${name} has no IPv4 address`)
+  return address
+}
+
+const waitForStore = async (address: string): Promise<void> => {
+  const until = Date.now() + timeoutMillis
+  let lastError = "no response"
+  while (Date.now() < until) {
+    const result = await command([
+      "run", "--rm", "--network", network, "--entrypoint", "sh", storeClientImage, "-c",
+      `mc alias set local http://${address}:9000 minio minio123 >/dev/null && mc mb --ignore-existing local/tardigrade`
+    ], [0, 1])
+    if (result.code === 0) return
+    lastError = `${result.stdout}${result.stderr}`.trim()
+    await Bun.sleep(250)
+  }
+  throw new Error(`object store was not ready within ${timeoutMillis}ms: ${lastError}`)
+}
+
+const waitForRuntime = async (): Promise<unknown> => {
+  const until = Date.now() + timeoutMillis
+  let lastError = "no response"
+  while (Date.now() < until) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}`)
+      const body = await response.text()
+      if (!response.ok) throw new Error(`HTTP ${response.status}: ${body}`)
+      return JSON.parse(body) as unknown
+    } catch (cause) {
+      lastError = cause instanceof Error ? cause.message : String(cause)
+      await Bun.sleep(250)
+    }
+  }
+  throw new Error(`Celld was not ready within ${timeoutMillis}ms: ${lastError}`)
+}
+
+const cleanup = async (): Promise<void> => {
+  for (const name of [runtime, store]) {
+    await command(["stop", "--time", "1", name], [0, 1])
+    await command(["delete", name], [0, 1])
+  }
+  await command(["network", "delete", network], [0, 1])
+  await command(["image", "delete", "--force", deployImage], [0, 1])
+}
+
+const main = async (): Promise<void> => {
+  console.log(`celld runtime ${celldImage}`)
+  console.log(`loaded worker limit ${loadedWorkerLimit}`)
+  try {
+    await command([
+      "build", "--tag", deployImage, "--file", resolve(directory, "Dockerfile"),
+      "--build-arg", `CELLD_IMAGE=${celldImage}`,
+      "--build-arg", `NODE_IMAGE=${nodeImage}`,
+      "--build-arg", `ESBUILD_VERSION=${esbuildVersion}`,
+      repository
+    ])
+    await command(["network", "create", network])
+    await command([
+      "run", "--detach", "--name", store, "--network", network,
+      "--env", "MINIO_ROOT_USER=minio", "--env", "MINIO_ROOT_PASSWORD=minio123",
+      storeImage, "server", "/data"
+    ])
+    const storeAddress = await addressOf(store)
+    await waitForStore(storeAddress)
+    const common = [
+      "--env", "AWS_ACCESS_KEY_ID=minio",
+      "--env", "AWS_SECRET_ACCESS_KEY=minio123",
+      "--env", "AWS_REGION=us-east-1",
+      "--network", network
+    ]
+    await command([
+      "run", "--rm", ...common,
+      "--mount", `type=bind,source=${repository},target=/workspace,readonly`,
+      "--workdir", "/workspace/platform/cloudflare/test/celld",
+      deployImage, "deploy", ".", "--bucket", "s3://tardigrade",
+      "--endpoint", `http://${storeAddress}:9000`, "--region", "us-east-1"
+    ])
+    await command([
+      "run", "--detach", "--name", runtime, ...common,
+      "--publish", `${port}:8080`,
+      "--env", "CELLD_STORAGE_PROBE=0",
+      "--env", "CELLD_WORKER_LOADER=LOADER",
+      "--env", `CELLD_MAX_LOADED_WORKERS=${loadedWorkerLimit}`,
+      deployImage, "--bucket", "s3://tardigrade", "--endpoint", `http://${storeAddress}:9000`,
+      "--region", "us-east-1", "--listen", "0.0.0.0:8080",
+      "--internal-listen", "127.0.0.1:8081"
+    ])
+    const actual = await waitForRuntime()
+    const expected = {
+      runtime: "celld",
+      result: { result: [12, 10] },
+      observed: [
+        { ordinal: 0, value: 3 },
+        { ordinal: 1, value: 6 },
+        { ordinal: 2, value: 5 }
+      ]
+    }
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      throw new Error(`unexpected Celld result: ${JSON.stringify(actual)}`)
+    }
+    console.log("celld replay passed")
+  } catch (cause) {
+    for (const name of [runtime, store]) {
+      const logs = await command(["logs", name], [0, 1])
+      if (logs.code === 0 && (logs.stdout.trim().length > 0 || logs.stderr.trim().length > 0)) {
+        console.error(`${logs.stdout}${logs.stderr}`.trim())
+      }
+    }
+    throw cause
+  } finally {
+    await cleanup()
+  }
+}
+
+await main()

--- a/platform/cloudflare/test/celld/worker.ts
+++ b/platform/cloudflare/test/celld/worker.ts
@@ -1,0 +1,13 @@
+import { replaySequenceWith } from "../sandbox.cases"
+
+interface CelldTestEnv {
+  readonly LOADER: WorkerLoader
+}
+
+const worker = {
+  async fetch(_request: Request, env: CelldTestEnv): Promise<Response> {
+    return Response.json({ runtime: "celld", ...await replaySequenceWith(env.LOADER) })
+  }
+} satisfies ExportedHandler<CelldTestEnv>
+
+export default worker

--- a/platform/cloudflare/test/celld/wrangler.jsonc
+++ b/platform/cloudflare/test/celld/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../../node_modules/wrangler/config-schema.json",
+  "name": "tardigrade-celld-test",
+  "main": "worker.ts",
+  "compatibility_date": "2026-08-08",
+  "compatibility_flags": ["nodejs_compat"]
+}

--- a/platform/cloudflare/test/sandbox.cases.ts
+++ b/platform/cloudflare/test/sandbox.cases.ts
@@ -1,0 +1,34 @@
+import { Effect } from "effect"
+import { sandboxReturned } from "@clavia/tardigrade-code/sandbox"
+import { cloudflareSandboxServiceFor } from "../src/sandbox"
+
+export interface ReplaySequenceResult {
+  readonly result: unknown
+  readonly observed: ReadonlyArray<{ readonly ordinal: number; readonly value: number }>
+}
+
+// replaySequenceWith runs the replay sequence shared by the workerd and Celld runtime suites.
+export const replaySequenceWith = async (loader: WorkerLoader): Promise<ReplaySequenceResult> => {
+  const observed: Array<{ readonly ordinal: number; readonly value: number }> = []
+  const sandbox = cloudflareSandboxServiceFor(loader, () => {
+    throw new Error("replay transport must not open a capability")
+  }, { transport: "replay" })
+  const result = await Effect.runPromise(sandbox.run(
+    `const first = await tools.double({ value: 3 })
+    const pair = await Promise.all([
+      tools.double({ value: first }),
+      tools.double({ value: 5 })
+    ])
+    return pair`,
+    {
+      tools: {
+        double: async (input, ordinal) => {
+          const value = (input as { readonly value: number }).value
+          observed.push({ ordinal, value })
+          return sandboxReturned(value * 2)
+        }
+      }
+    }
+  ))
+  return { result, observed }
+}

--- a/platform/cloudflare/test/sandbox.workers.ts
+++ b/platform/cloudflare/test/sandbox.workers.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "vitest"
 import { sandboxReturned } from "@clavia/tardigrade-code/sandbox"
 import type { Env } from "../src/worker"
 import { cloudflareSandboxServiceFor, type SandboxBridgeFactory } from "../src/sandbox"
+import { replaySequenceWith } from "./sandbox.cases"
 
 const bridgeFor: SandboxBridgeFactory = (_call) => ({
   binding: (env as Env).ACTORS.getByName("sandbox-test"),
@@ -87,25 +88,7 @@ describe("cloudflare sandbox", () => {
   })
 
   test("replays sequential and concurrent package calls", async () => {
-    const sandbox = cloudflareSandboxServiceFor((env as Env).LOADER, bridgeFor, { transport: "replay" })
-    const observed: Array<{ readonly ordinal: number; readonly value: number }> = []
-    const result = await Effect.runPromise(sandbox.run(
-      `const first = await tools.double({ value: 3 })
-      const pair = await Promise.all([
-        tools.double({ value: first }),
-        tools.double({ value: 5 })
-      ])
-      return pair`,
-      {
-        tools: {
-          double: async (input, ordinal) => {
-            const value = (input as { readonly value: number }).value
-            observed.push({ ordinal, value })
-            return sandboxReturned(value * 2)
-          }
-        }
-      }
-    ))
+    const { result, observed } = await replaySequenceWith((env as Env).LOADER)
 
     expect(result).toEqual({ result: [12, 10] })
     expect(observed).toEqual([


### PR DESCRIPTION
The Cloudflare-compatible sandbox now releases anonymous loaded Worker stubs when the loader exposes deterministic cleanup. Each replay round disposes its stub after the response body is consumed, and capability mode does the same before closing its bridge. Standard Cloudflare stubs continue through the platform lifecycle when neither cleanup extension exists.

Unit tests use Celld-like stubs to prove that replay never holds more than one loaded Worker and that the HTTP failure path releases its worker and closes its bridge. A shared replay case also runs on workerd and on Celld 0.3.0 through Apple Container. The Celld run sets the loaded Worker limit to one, deploys a real Worker fixture, verifies its HTTP result, and cleans its generated resources.

Tested with bun run gate and bun run --cwd platform/cloudflare test:celld.

Closes #251