### PR TITLE
fix(publish): export actor methods

### DIFF
--- a/tools/publish.ts
+++ b/tools/publish.ts
@@ -1,4 +1,4 @@
-import { cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
+import { cp, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { isAbsolute, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -225,6 +225,8 @@ try {
       "./runtime/*": "./src/agent/runtime/*.ts",
       "./core/actor": "./src/core/actor/index.ts",
       "./core/actor/*": "./src/core/actor/*.ts",
+      "./core/actor/method": "./src/core/actor/method/index.ts",
+      "./core/actor/method/*": "./src/core/actor/method/*.ts",
       "./core/communication": "./src/core/communication/index.ts",
       "./core/communication/*": "./src/core/communication/*.ts",
       "./core/log": "./src/core/log/index.ts",
@@ -254,6 +256,15 @@ try {
     dependencies: dependencyUnion(packages.map((source) => source.pkg))
   }
   await writeFile(join(stage, "package.json"), `${JSON.stringify(publishManifest, null, 2)}\n`)
+
+  // The staged package must resolve its rewritten self-imports through the public export map.
+  const stagedModules = join(stage, "node_modules")
+  await symlink(join(root, "node_modules"), stagedModules, "dir")
+  try {
+    await run([process.execPath, "-e", "await import('tardie')"], stage)
+  } finally {
+    await rm(stagedModules)
+  }
 
   const filename = await output(["bun", "pm", "pack", "--destination", destination, "--quiet", "--ignore-scripts"], stage)
   const tarball = isAbsolute(filename) ? filename : join(destination, filename)


### PR DESCRIPTION
The published 0.10.0 package cannot import its front door because the flattened export map omits the new core actor method directory. Fresh consumers resolve tardie/core/actor/method to a file that does not exist.

This adds the directory exports already declared by the core workspace package. The publisher now imports the staged package through its public export map before creating or publishing the tarball, using the locked workspace dependencies during that check.

Verification:

- Fresh install of the generated tarball imports tardie
- Fresh install runs the published tdg command
- bun run gate: all 58 tasks pass
- git diff --check passes