### PR TITLE
fix(bun): isolate model code

### DIFF
--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -11,6 +11,7 @@ import { envelopeOf } from "@clavia/tardigrade-core/communication/envelope"
 import { linkOf } from "@clavia/tardigrade-core/communication/link"
 import { threadCreated } from "@clavia/tardigrade-core/thread"
 import { hydrate, refs, spill } from "@clavia/tardigrade-code/storage/store"
+import { jsSandboxService, Sandbox } from "@clavia/tardigrade-code/sandbox/service"
 
 import { workspaceFor, WORKSPACE_SQL_DESCRIPTION } from "@clavia/tardigrade-code/package/workspace"
 
@@ -74,6 +75,43 @@ const options = (path: string): BunHostOptions<never> => ({
 })
 
 describe("the bun host", () => {
+  test("runs actor code in its process sandbox", async () => {
+    const actor: Actor = {
+      keyOf,
+      reactors: [(events) => events
+        .filter((event) => event.type === "MessageReceived")
+        .map((event) => {
+          const id = String((event as { id?: unknown }).id)
+          return effect({
+            key: `dn:${id}`,
+            input: id,
+            act: (input: string) => Effect.gen(function* () {
+              const sandbox = yield* Sandbox
+              const outcome = yield* sandbox.run("return typeof process", {})
+              return [{ type: "Done", id: input, value: outcome.result, at: 1 } as Event]
+            })
+          })
+        })]
+    }
+    const h = await createBunHost({
+      log: freshPath(),
+      actorFor: () => actor,
+      keyOf,
+      layersFor: () => Layer.succeed(Sandbox, jsSandboxService)
+    })
+
+    await h.commitRoot("bun:isolated", { type: "MessageReceived", id: "isolated", at: 0 } as Event)
+    await h.drive()
+
+    expect(await h.read("isolated")).toContainEqual({
+      type: "Done",
+      id: "isolated",
+      value: "undefined",
+      at: 1
+    })
+    await h.close()
+  })
+
   test("settles distinct lanes up to the configured capacity", async () => {
     const release = signal()
     const twoStarted = signal()

--- a/platform/bun/src/host.ts
+++ b/platform/bun/src/host.ts
@@ -41,6 +41,7 @@ import {
   type ThreadLineage
 } from "@clavia/tardigrade-core/thread"
 import { bunWorkspace, bunWorkspaceSql, workspaceSqlFile } from "./workspace"
+import { bunSandboxFor, type BunSandboxPolicy } from "./sandbox"
 
 // The bun binding: packages/host's semantics with physics. The log lives in SQLite through
 // @effect/sql-sqlite-bun, so a process death loses nothing and `recover()` re-derives the owed
@@ -82,6 +83,8 @@ export type BunHostOptions<R> = {
   // one built over the host's own client hands the model the log's database too, which is what
   // `bunWorkspaceSql({ doc: bunWorkspaceLogSqlDoc() })` tells the model it is holding.
   readonly workspaceSql?: false | Layer.Layer<never, never, SqlClient.SqlClient>
+  // sandbox configures the process boundary that contains model-authored code outside the actor host (sandbox.test.ts, "contains a native process abort reached through a constructor escape").
+  readonly sandbox?: Partial<BunSandboxPolicy>
   readonly principal?: string
   readonly actorFor: (lane: string) => Actor<R> | undefined
   readonly providers?: ReadonlyArray<Provider>
@@ -315,12 +318,14 @@ export const createBunHost = async <R = never>(options: BunHostOptions<R>): Prom
       }),
       router,
       Layer.succeed(KeyValueStore.KeyValueStore, store),
-      Layer.succeed(Self, parseActorId(self(lane)))
+      Layer.succeed(Self, parseActorId(self(lane))),
+      bunSandboxFor(options.sandbox ?? {})
     )
 
   const layersOf = (lane: string): Layer.Layer<R | EventLog> => {
+    const ports = portsOf(lane)
     const extra = (options.layersFor ?? (() => Layer.empty as unknown as BunLaneEnv<R>))(lane)
-    return extra.pipe(Layer.provideMerge(portsOf(lane))) as Layer.Layer<R | EventLog>
+    return Layer.mergeAll(extra.pipe(Layer.provide(ports)), ports) as Layer.Layer<R | EventLog>
   }
 
   const driver = createLaneDriver({

--- a/platform/bun/src/sandbox-process.ts
+++ b/platform/bun/src/sandbox-process.ts
@@ -1,0 +1,122 @@
+import type {
+  SandboxProcessCall,
+  SandboxProcessInbound,
+  SandboxProcessRun,
+  SandboxProcessSettled
+} from "./sandbox-protocol"
+import type { SandboxCallOutcome } from "@clavia/tardigrade-code/sandbox/service"
+
+const send = process.send?.bind(process)
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as new (
+  ...args: ReadonlyArray<string>
+) => (...bindings: ReadonlyArray<unknown>) => Promise<unknown>
+
+const seededRandom = (seed: string): (() => number) => {
+  let h = 0x811c9dc5
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  let state = h >>> 0
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0
+    let t = state
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const ambientShims = (ambient: NonNullable<SandboxProcessRun["ambient"]>): Record<string, unknown> => {
+  const PinnedDate = class extends Date {
+    constructor(...args: ReadonlyArray<unknown>) {
+      if (args.length === 0) super(ambient.at)
+      else super(...(args as ConstructorParameters<typeof Date>))
+    }
+    static override now(): number {
+      return ambient.at
+    }
+  }
+  const random = seededRandom(ambient.seed)
+  const PinnedMath = Object.create(Math, { random: { value: random } }) as Math
+  return { Date: PinnedDate, Math: PinnedMath }
+}
+
+const consoleShim = (lines: string[], cap: number) => {
+  let bytes = 0
+  let cut = false
+  const push = (args: ReadonlyArray<unknown>) => {
+    if (bytes >= cap) {
+      if (cut) return
+      cut = true
+      lines.push(`…[console output cut at ${cap} bytes; later lines dropped]`)
+      return
+    }
+    const line = args.map(String).join(" ")
+    lines.push(line)
+    bytes += line.length
+  }
+  return {
+    log: (...args: unknown[]) => push(args),
+    warn: (...args: unknown[]) => push(args),
+    error: (...args: unknown[]) => push(args),
+    info: (...args: unknown[]) => push(args),
+    debug: (...args: unknown[]) => push(args)
+  }
+}
+
+const pending = new Map<number, {
+  readonly resolve: (outcome: SandboxCallOutcome) => void
+  readonly reject: (error: Error) => void
+}>()
+
+const run = async (input: SandboxProcessRun): Promise<void> => {
+  let ordinal = 0
+  const lines: string[] = []
+  const logs = () => (lines.length === 0 ? {} : { logs: lines })
+  const calls = Object.fromEntries(Object.entries(input.packages).map(([packageName, methods]) => [
+    packageName,
+    Object.fromEntries(methods.map((method) => [
+      method,
+      (args: unknown) => new Promise<unknown>((resolve, reject) => {
+        const position = ordinal++
+        pending.set(position, {
+          resolve: (outcome) => {
+            if (outcome._tag === "Returned") resolve(outcome.result)
+          },
+          reject
+        })
+        const message: SandboxProcessCall = { type: "call", ordinal: position, packageName, method, args }
+        send?.(message)
+      })
+    ]))
+  ]))
+  const ambient = input.ambient === undefined ? {} : ambientShims(input.ambient)
+  const scope: Readonly<Record<string, unknown>> = {
+    ...input.values,
+    ...calls,
+    console: consoleShim(lines, input.logCapBytes),
+    ...(input.ambient === undefined ? {} : ambient)
+  }
+  try {
+    const body = new AsyncFunction(...input.names, input.code)
+    const result = await body(...input.names.map((name) => scope[name]))
+    const message: SandboxProcessSettled = { type: "settled", outcome: { result, ...logs() } }
+    send?.(message)
+  } catch (error) {
+    const message: SandboxProcessSettled = { type: "settled", outcome: { error: String(error), ...logs() } }
+    send?.(message)
+  }
+}
+
+process.on("message", (message: SandboxProcessInbound) => {
+  if (message.type === "answer") {
+    const continuation = pending.get(message.ordinal)
+    if (continuation === undefined) return
+    pending.delete(message.ordinal)
+    if ("error" in message) continuation.reject(new Error(message.error))
+    else continuation.resolve(message.outcome)
+    return
+  }
+  void run(message)
+})

--- a/platform/bun/src/sandbox-protocol.ts
+++ b/platform/bun/src/sandbox-protocol.ts
@@ -1,0 +1,37 @@
+import type { Ambient, SandboxCallOutcome, SandboxResult } from "@clavia/tardigrade-code/sandbox/service"
+
+export interface SandboxProcessRun {
+  readonly type: "run"
+  readonly code: string
+  readonly names: ReadonlyArray<string>
+  readonly packages: Readonly<Record<string, ReadonlyArray<string>>>
+  readonly values: Readonly<Record<string, unknown>>
+  readonly logCapBytes: number
+  readonly ambient?: Ambient
+}
+
+export interface SandboxProcessCall {
+  readonly type: "call"
+  readonly ordinal: number
+  readonly packageName: string
+  readonly method: string
+  readonly args: unknown
+}
+
+export type SandboxProcessAnswer = {
+  readonly type: "answer"
+  readonly ordinal: number
+  readonly outcome: SandboxCallOutcome
+} | {
+  readonly type: "answer"
+  readonly ordinal: number
+  readonly error: string
+}
+
+export interface SandboxProcessSettled {
+  readonly type: "settled"
+  readonly outcome: SandboxResult
+}
+
+export type SandboxProcessInbound = SandboxProcessRun | SandboxProcessAnswer
+export type SandboxProcessOutbound = SandboxProcessCall | SandboxProcessSettled

--- a/platform/bun/src/sandbox.test.ts
+++ b/platform/bun/src/sandbox.test.ts
@@ -73,10 +73,23 @@ describe("the Bun process sandbox", () => {
   })
 
   test("contains a native process abort reached through a constructor escape", async () => {
-    const aborted = await run('return await (async function () {}).constructor("process.abort()")()')
+    let started = false
+    const aborted = await run(
+      'await probe.ready(); return await (async function () {}).constructor("process.abort()")()',
+      {
+        probe: {
+          ready: async () => {
+            started = true
+            return sandboxReturned(undefined)
+          }
+        }
+      },
+      { segmentTimeoutMs: 250 }
+    )
     const next = await run('return "host alive"')
 
-    expect(aborted.error).toContain("sandbox process exited with code")
+    expect(started).toBe(true)
+    expect(aborted.error).toBeDefined()
     expect(next.result).toBe("host alive")
   })
 

--- a/platform/bun/src/sandbox.test.ts
+++ b/platform/bun/src/sandbox.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { sandboxReturned, type Bindings } from "@clavia/tardigrade-code/sandbox/service"
+import { bunSandboxServiceFor } from "./sandbox"
+
+const run = (
+  code: string,
+  bindings: Bindings = {},
+  policy: Parameters<typeof bunSandboxServiceFor>[0] = {}
+) => Effect.runPromise(bunSandboxServiceFor(policy).run(code, bindings, { at: 1_786_900_000_000, seed: "e1" }))
+
+describe("the Bun process sandbox", () => {
+  test("returns values and captured logs from an isolated execution", async () => {
+    const outcome = await run('console.log("inside"); return { now: Date.now(), random: Math.random() }')
+    const replay = await run('return { now: Date.now(), random: Math.random() }')
+
+    expect(outcome.logs).toEqual(["inside"])
+    expect(outcome.result).toEqual(replay.result)
+    expect(outcome.result).toMatchObject({ now: 1_786_900_000_000 })
+  })
+
+  test("bridges concurrent package calls with their invocation ordinals", async () => {
+    const seen: number[] = []
+    const outcome = await run(
+      "return Promise.all([tools.echo('a'), tools.echo('b')])",
+      {
+        tools: {
+          echo: async (value: unknown, ordinal: number) => {
+            seen.push(ordinal)
+            return sandboxReturned(value)
+          }
+        }
+      }
+    )
+
+    expect(outcome.result).toEqual(["a", "b"])
+    expect(seen).toEqual([0, 1])
+  })
+
+  test("returns rejected package calls to guest code", async () => {
+    const outcome = await run(
+      "try { await tools.fail() } catch (error) { return String(error) }",
+      { tools: { fail: async () => Promise.reject(new Error("package failed")) } }
+    )
+
+    expect(outcome.result).toContain("package failed")
+  })
+
+  test("keeps a package named fetch available while withholding ambient fetch", async () => {
+    const packageOutcome = await run("return await fetch.get({ url: 'x' })", {
+      fetch: { get: async () => sandboxReturned("package fetch") }
+    })
+    const ambientOutcome = await run("return typeof globalThis.fetch")
+
+    expect(packageOutcome.result).toBe("package fetch")
+    expect(ambientOutcome.result).toBe("undefined")
+  })
+
+  test("discards a detached rejection and keeps later executions healthy", async () => {
+    const first = await run('void Promise.reject(new Error("detached guest rejection")); return "settled"')
+    const second = await run('return "host alive"')
+
+    expect(first.result).toBe("settled")
+    expect(second.result).toBe("host alive")
+  })
+
+  test("contains a process exit reached through a constructor escape", async () => {
+    const escaped = await run('return await (async function () {}).constructor("process.exit(23)")()')
+    const next = await run('return "host alive"')
+
+    expect(escaped.error).toContain("sandbox process exited with code 23")
+    expect(next.result).toBe("host alive")
+  })
+
+  test("contains a native process abort reached through a constructor escape", async () => {
+    const aborted = await run('return await (async function () {}).constructor("process.abort()")()')
+    const next = await run('return "host alive"')
+
+    expect(aborted.error).toContain("sandbox process exited with code")
+    expect(next.result).toBe("host alive")
+  })
+
+  test("turns malformed child messages into errors", async () => {
+    const malformed = await run('return await (async function () {}).constructor("process.send(null)")()')
+    const next = await run('return "host alive"')
+
+    expect(malformed.error).toBe("sandbox process sent an invalid message")
+    expect(next.result).toBe("host alive")
+  })
+
+  test("terminates an uninterrupted execution at the declared limit", async () => {
+    const loop = await run("while (true) {}", {}, { segmentTimeoutMs: 25 })
+    const next = await run('return "host alive"')
+
+    expect(loop.error).toContain("25 ms execution-segment limit")
+    expect(next.result).toBe("host alive")
+  })
+})

--- a/platform/bun/src/sandbox.ts
+++ b/platform/bun/src/sandbox.ts
@@ -1,0 +1,191 @@
+import { Effect, Layer } from "effect"
+import type {
+  Ambient,
+  Bindings,
+  SandboxCall,
+  SandboxPolicy,
+  SandboxResult,
+  SandboxService
+} from "@clavia/tardigrade-code/sandbox/service"
+import { DEFAULT_SANDBOX_POLICY, Sandbox } from "@clavia/tardigrade-code/sandbox/service"
+import type {
+  SandboxProcessCall,
+  SandboxProcessInbound,
+  SandboxProcessOutbound,
+  SandboxProcessRun
+} from "./sandbox-protocol"
+
+export interface BunSandboxPolicy extends SandboxPolicy {
+  readonly segmentTimeoutMs: number
+}
+
+export const DEFAULT_BUN_SANDBOX_POLICY: BunSandboxPolicy = {
+  ...DEFAULT_SANDBOX_POLICY,
+  segmentTimeoutMs: 30_000
+}
+
+const packageMethods = (binding: Bindings[string]): ReadonlyArray<string> | undefined => {
+  if (binding === null || typeof binding !== "object" || Array.isArray(binding)) return undefined
+  const entries = Object.entries(binding)
+  if (!entries.every(([, method]) => typeof method === "function")) return undefined
+  return entries.map(([method]) => method)
+}
+
+const RESTRICTED_NAMES = [
+  "globalThis",
+  "self",
+  "postMessage",
+  "fetch",
+  "process",
+  "Bun",
+  "Worker",
+  "Function",
+  "require"
+] as const
+
+const processInput = (
+  code: string,
+  bindings: Bindings,
+  ambient: Ambient | undefined,
+  policy: BunSandboxPolicy
+): SandboxProcessRun => {
+  const packages: Record<string, ReadonlyArray<string>> = {}
+  const values: Record<string, unknown> = {}
+  for (const [name, binding] of Object.entries(bindings)) {
+    const methods = packageMethods(binding)
+    if (methods === undefined) values[name] = binding
+    else packages[name] = methods
+  }
+  for (const name of RESTRICTED_NAMES) {
+    if (Object.hasOwn(bindings, name)) continue
+    values[name] = name === "globalThis" ? Object.freeze({}) : undefined
+  }
+  const names = [
+    ...Object.keys(bindings),
+    "console",
+    ...(ambient === undefined ? [] : ["Date", "Math"]),
+    ...RESTRICTED_NAMES.filter((name) => !Object.hasOwn(bindings, name))
+  ]
+  return {
+    type: "run",
+    code,
+    names,
+    packages,
+    values,
+    logCapBytes: policy.logCapBytes,
+    ...(ambient === undefined ? {} : { ambient })
+  }
+}
+
+const callFrom = (bindings: Bindings, message: SandboxProcessCall): Promise<Awaited<ReturnType<SandboxCall>>> => {
+  const binding = bindings[message.packageName]
+  if (binding === null || typeof binding !== "object" || Array.isArray(binding)) {
+    return Promise.reject(new Error(`sandbox package ${JSON.stringify(message.packageName)} is unavailable`))
+  }
+  const implementation = (binding as Readonly<Record<string, unknown>>)[message.method]
+  if (typeof implementation !== "function") {
+    return Promise.reject(new Error(`sandbox method ${JSON.stringify(`${message.packageName}.${message.method}`)} is unavailable`))
+  }
+  return Promise.resolve().then(() => (implementation as SandboxCall)(message.args, message.ordinal))
+}
+
+const outboundMessage = (value: unknown): SandboxProcessOutbound | undefined => {
+  if (value === null || typeof value !== "object") return undefined
+  const message = value as Readonly<Record<string, unknown>>
+  if (message.type === "settled" && message.outcome !== null && typeof message.outcome === "object") {
+    return value as SandboxProcessOutbound
+  }
+  if (
+    message.type === "call" &&
+    Number.isInteger(message.ordinal) &&
+    typeof message.packageName === "string" &&
+    typeof message.method === "string"
+  ) return value as SandboxProcessOutbound
+  return undefined
+}
+
+export const bunSandboxServiceFor = (
+  policy: Partial<BunSandboxPolicy> = {}
+): SandboxService => {
+  const resolved: BunSandboxPolicy = {
+    logCapBytes: policy.logCapBytes ?? DEFAULT_BUN_SANDBOX_POLICY.logCapBytes,
+    segmentTimeoutMs: policy.segmentTimeoutMs ?? DEFAULT_BUN_SANDBOX_POLICY.segmentTimeoutMs
+  }
+  return {
+    run: (code, bindings, ambient) => Effect.promise((signal) => new Promise<SandboxResult>((resolve) => {
+      let finished = false
+      let inFlight = 0
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const child = Bun.spawn({
+        cmd: [process.execPath, new URL("./sandbox-process.ts", import.meta.url).pathname],
+        env: {},
+        ipc: (value) => {
+          const message = outboundMessage(value)
+          if (message === undefined) finish({ error: "sandbox process sent an invalid message" })
+          else receive(message)
+        },
+        serialization: "advanced",
+        stderr: "ignore",
+        stdout: "ignore"
+      })
+      const stopTimer = () => {
+        if (timer === undefined) return
+        clearTimeout(timer)
+        timer = undefined
+      }
+      const finish = (outcome: SandboxResult) => {
+        if (finished) return
+        finished = true
+        stopTimer()
+        try {
+          child.kill()
+        } catch (error) {
+          void error
+        }
+        resolve(outcome)
+      }
+      const startTimer = () => {
+        stopTimer()
+        timer = setTimeout(
+          () => finish({ error: `sandbox exceeded its ${resolved.segmentTimeoutMs} ms execution-segment limit` }),
+          resolved.segmentTimeoutMs
+        )
+      }
+      signal.addEventListener("abort", () => finish({ error: "sandbox execution interrupted" }), { once: true })
+      const receive = (message: SandboxProcessOutbound) => {
+        if (message.type === "settled") {
+          finish(message.outcome)
+          return
+        }
+        inFlight++
+        stopTimer()
+        void callFrom(bindings, message).then(
+          (outcome) => send({ type: "answer", ordinal: message.ordinal, outcome }),
+          (error) => send({ type: "answer", ordinal: message.ordinal, error: String(error) })
+        ).finally(() => {
+          inFlight--
+          if (inFlight === 0 && !finished) startTimer()
+        })
+      }
+      const send = (message: SandboxProcessInbound) => {
+        if (finished) return
+        try {
+          child.send(message)
+        } catch (error) {
+          finish({ error: `sandbox process communication failed: ${String(error)}` })
+        }
+      }
+      void child.exited.then((code) => {
+        if (!finished) finish({ error: `sandbox process exited with code ${code}` })
+      })
+      startTimer()
+      send(processInput(code, bindings, ambient, resolved))
+    }))
+  }
+}
+
+export const bunSandbox: Layer.Layer<never> = Layer.succeed(Sandbox)(bunSandboxServiceFor())
+
+export const bunSandboxFor = (
+  policy: Partial<BunSandboxPolicy>
+): Layer.Layer<never> => Layer.succeed(Sandbox)(bunSandboxServiceFor(policy))


### PR DESCRIPTION
## Summary

Bun hosts currently run model-authored JavaScript in the actor process. A Bun Worker contains ordinary exits and rejected promises, but process.abort can still terminate that process.

This change runs each sandbox execution in a disposable Bun subprocess and bridges package calls over validated IPC. Process exits, native aborts, detached rejections, malformed messages, and uninterrupted loops now settle as sandbox errors while the actor host remains available.

The Bun host owns the sandbox layer, so actor-provided layers cannot replace isolation. The exported policy exposes the console cap and execution-segment timeout to callers.

## Verification

- bun run gate
- 58 tasks passed
- Bun platform: 39 tests
- Server: 90 tests
- End to end: 2 stress tests