### PR TITLE
fix(code): bound package calls

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -180,6 +180,13 @@ export {
   DEFAULT_CODE_SUMMARY_MAX_LENGTH,
   type CodeModeOptions
 } from "./components/code"
+export {
+  DEFAULT_PACKAGE_CALL_POLICY,
+  packageCallPolicyOf,
+  type CodePolicy,
+  type PackageCallFailure,
+  type PackageCallPolicy
+} from "@clavia/tardigrade-code/execution/reactor"
 export { system, type SystemText } from "./components/system"
 export { toolList, type NativeTool } from "./components/tool-list"
 export {

--- a/packages/code/src/execution/reactor.test.ts
+++ b/packages/code/src/execution/reactor.test.ts
@@ -7,7 +7,7 @@ import { settleActor, type Reactor } from "@clavia/tardigrade-core/reconciliatio
 import { messageKeys } from "@clavia/tardigrade-core/communication/message"
 import { definePackage, type Package } from "../package/definition"
 import { guestBindings, Sandbox, type Bindings } from "../sandbox/service"
-import { codeReactor, codeReactorFor } from "./reactor"
+import { DEFAULT_PACKAGE_CALL_POLICY, codeReactor, codeReactorFor, packageCallPolicyOf } from "./reactor"
 import { codeKeys } from "./events"
 
 // The shadow router rule, over the one funnel every package call crosses: `executeRecorded`. A
@@ -81,13 +81,13 @@ const settled = async (head: Event): Promise<ReadonlyArray<Event>> => {
   )
 }
 
-describe("transience never reaches the body", () => {
+describe("package call failure policy", () => {
   // A package fn's transient failure (an RPC hiccup, a reset stub) must never surface as a
   // rejected promise the body can catch and branch on: a rejection is an input that exists
   // nowhere in the log, so it makes replay a function of infrastructure luck (the real run
   // run-d7b8b037-183, 2026-08-16: a post-delivery failure fed a `.catch` fallback and the
-  // next attempt drifted). The failing call parks instead; the next attempt asks again.
-  test("a transiently failing call parks and the re-drive gets the real answer", async () => {
+  // next attempt drifted). A retry stays inside the call, and exhaustion becomes recorded data.
+  test("a transiently failing call retries before the body sees an answer", async () => {
     let attempts = 0
     const flakyPackage: Package = definePackage({
       name: "flaky",
@@ -112,19 +112,65 @@ describe("transience never reaches the body", () => {
     ]
     const events = await Effect.runPromise(
       Effect.gen(function* () {
-        yield* settleActor({ reactors: [codeReactorFor({}, [flakyPackage])], keyOf: composeKeys(messageKeys, codeKeys) })
+        yield* settleActor({
+          reactors: [codeReactorFor({ call: { retryDelaysMs: [0] } }, [flakyPackage])],
+          keyOf: composeKeys(messageKeys, codeKeys)
+        })
         return yield* Effect.flatMap(EventLog, (l) => l.read)
       }).pipe(Effect.provide(Layer.mergeAll(memoryLog(log), jsSandbox, KeyValueStore.layerMemory))) as Effect.Effect<ReadonlyArray<Event>>
     )
     const settle = events.find((e) => e.type === "CodeSettled") as { result?: { a: unknown } } | undefined
     expect(settle).toBeDefined()
-    // The real answer, never the fallback: the first attempt parked on the transient failure
-    // and appended no return; the second asked again and got the truth.
+    // The real answer, never the fallback: the retry stays inside the recorded call.
     expect(settle!.result?.a).toEqual({ ok: "real" })
     expect(attempts).toBe(2)
-    // One send, one return: the transient attempt recorded nothing beyond the send.
+    // One send, one return: attempts are infrastructure detail until exhaustion.
     expect(events.filter((e) => e.type === "PackageCalled").length).toBe(1)
     expect(events.filter((e) => e.type === "PackageReturned").length).toBe(1)
+  })
+
+  test("a hanging call exhausts its deadline and backoff as one durable error", async () => {
+    let attempts = 0
+    const hangingPackage: Package = definePackage({
+      name: "hanging",
+      description: "never answers",
+      methods: {
+        read: () => Effect.sync(() => attempts++).pipe(Effect.andThen(Effect.never))
+      }
+    })
+    const log: Event[] = [
+      { type: "MessageReceived", id: "t1", text: "go", at: 1 },
+      {
+        type: "CodeDispatched",
+        execId: "e1",
+        code: "return await hanging.read({})",
+        turn: "t1",
+        at: 2
+      }
+    ]
+    const events = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* settleActor({
+          reactors: [codeReactorFor({ call: { attemptTimeoutMs: 10, retryDelaysMs: [1, 2] } }, [hangingPackage])],
+          keyOf: composeKeys(messageKeys, codeKeys)
+        })
+        return yield* Effect.flatMap(EventLog, (l) => l.read)
+      }).pipe(Effect.provide(Layer.mergeAll(memoryLog(log), jsSandbox, KeyValueStore.layerMemory))) as Effect.Effect<ReadonlyArray<Event>>
+    )
+    const returned = events.find((e) => e.type === "PackageReturned") as { result?: unknown } | undefined
+    expect(attempts).toBe(3)
+    expect(returned?.result).toEqual({
+      error: "hanging.read failed after 3 attempts: timed out after 10ms",
+      attempts: 3,
+      policy: { attemptTimeoutMs: 10, retryDelaysMs: [1, 2] }
+    })
+    expect(events.some((e) => e.type === "CodeSettled")).toBe(true)
+  })
+
+  test("the exported policy resolves and validates every bound", () => {
+    expect(packageCallPolicyOf()).toEqual(DEFAULT_PACKAGE_CALL_POLICY)
+    expect(() => packageCallPolicyOf({ attemptTimeoutMs: 0 })).toThrow("attemptTimeoutMs")
+    expect(() => packageCallPolicyOf({ retryDelaysMs: [1, -1] })).toThrow("retryDelaysMs[1]")
   })
 })
 

--- a/packages/code/src/execution/reactor.ts
+++ b/packages/code/src/execution/reactor.ts
@@ -36,6 +36,41 @@ import { blockedOn, codeSettled, packageCalled, packageReturned } from "./events
 // never settles) or settled (the body's promise resolves with the result).
 type CallOutcome = { readonly parked: true } | { readonly parked: false; readonly result: unknown }
 
+// PackageCallPolicy bounds each live attempt and the retries performed before its failure is
+// committed as an answer (reactor.test.ts, "a hanging call exhausts its deadline and backoff as
+// one durable error").
+export interface PackageCallPolicy {
+  readonly attemptTimeoutMs: number
+  readonly retryDelaysMs: ReadonlyArray<number>
+}
+
+export interface PackageCallFailure {
+  readonly error: string
+  readonly attempts: number
+  readonly policy: PackageCallPolicy
+}
+
+export const DEFAULT_PACKAGE_CALL_POLICY: PackageCallPolicy = {
+  attemptTimeoutMs: 30_000,
+  retryDelaysMs: [250, 1_000, 4_000]
+}
+
+export const packageCallPolicyOf = (policy: Partial<PackageCallPolicy> = {}): PackageCallPolicy => {
+  const attemptTimeoutMs = policy.attemptTimeoutMs ?? DEFAULT_PACKAGE_CALL_POLICY.attemptTimeoutMs
+  if (!Number.isSafeInteger(attemptTimeoutMs) || attemptTimeoutMs < 1) {
+    throw new Error("package call attemptTimeoutMs must be a positive safe integer")
+  }
+  const retryDelaysMs = policy.retryDelaysMs ?? DEFAULT_PACKAGE_CALL_POLICY.retryDelaysMs
+  for (const [index, delay] of retryDelaysMs.entries()) {
+    if (!Number.isSafeInteger(delay) || delay < 0) {
+      throw new Error(`package call retryDelaysMs[${index}] must be a non-negative safe integer`)
+    }
+  }
+  return { attemptTimeoutMs, retryDelaysMs: [...retryDelaysMs] }
+}
+
+const failureOf = (failure: unknown): string => failure instanceof Error ? failure.message : String(failure)
+
 // canonicalJson sorts object members recursively and preserves array order
 // (execute.test.ts, "object member order survives replay").
 const canonicalJson = (value: unknown): string | undefined =>
@@ -53,6 +88,7 @@ const executeRecorded = <R = never>(
   execId: string,
   code: string,
   spill: SpillPolicy,
+  callPolicy: PackageCallPolicy,
   packages: ReadonlyArray<Package<R>>,
   turn?: string,
   dispatchedAt?: number
@@ -185,25 +221,42 @@ const executeRecorded = <R = never>(
                   return { parked: false, result }
                 }
               }
-              // A defect in the fn is TRANSIENCE (an RPC hiccup, a reset stub), and it takes the
-              // park branch: nothing recorded beyond the send, the body's promise never settles,
-              // the next attempt asks again. It must never become a rejection the body can catch:
-              // a rejection is an input that exists nowhere in the log, so replay would depend on
-              // infrastructure luck (execute.test.ts, "transience never reaches the body"; the
-              // 2026-08-16 run-d7b8b037-183 drift). A method's real failure is an {error} RESULT,
-              // and its declared error channel carries `Park` alone (packages.ts, Package), so a
-              // failure that is not a park cannot arrive here to be caught.
               const parkOut = (awaiting?: string): Effect.Effect<CallOutcome, never, never> =>
                 Effect.gen(function* () {
                   parked = true
                   blocked.push({ callId, ...(awaiting === undefined ? {} : { awaiting }) })
                   return { parked: true }
                 })
-              const attempt = yield* fn(args, { callId }).pipe(
-                Effect.map((result): CallOutcome => ({ parked: false, result })),
-                Effect.catchTag("Park", (p) => parkOut(p.awaiting)),
-                Effect.catchDefect(() => parkOut())
-              )
+              // A transient defect or timeout retries inside the recorded call. Exhaustion is a
+              // durable answer, so the body can react and replay sees the same value. Park keeps
+              // its actor-wait meaning and never consumes the infrastructure retry schedule
+              // (reactor.test.ts, "a transiently failing call retries before the body sees an
+              // answer"; "a hanging call exhausts its deadline and backoff as one durable error").
+              const invoke = (attemptIndex: number): Effect.Effect<CallOutcome, never, R> => {
+                const fail = (reason: string): Effect.Effect<CallOutcome, never, R> => {
+                  const delay = callPolicy.retryDelaysMs[attemptIndex]
+                  if (delay !== undefined) return Effect.sleep(delay).pipe(Effect.andThen(invoke(attemptIndex + 1)))
+                  const attempts = attemptIndex + 1
+                  return Effect.succeed({
+                    parked: false,
+                    result: {
+                      error: `${pkg.name}.${method} failed after ${attempts} attempts: ${reason}`,
+                      attempts,
+                      policy: callPolicy
+                    }
+                  })
+                }
+                return fn(args, { callId }).pipe(
+                  Effect.timeout(callPolicy.attemptTimeoutMs),
+                  Effect.map((result): CallOutcome => ({ parked: false, result })),
+                  Effect.catchTags({
+                    Park: (park) => parkOut(park.awaiting),
+                    TimeoutError: () => fail(`timed out after ${callPolicy.attemptTimeoutMs}ms`)
+                  }),
+                  Effect.catchDefect((defect) => fail(failureOf(defect)))
+                )
+              }
+              const attempt = yield* invoke(0)
               if (attempt.parked) return attempt
               // A large result goes to the spill store: the event keeps the pointer, the body still
               // receives the whole value, and replay hydrates the ref.
@@ -299,10 +352,11 @@ const executeRecorded = <R = never>(
     return [{ type: "CodeSettled", execId, error: outcome.error, ...logs, ...stamp, at }]
   })
 
-// CodePolicy is the lane's policy: where a result stops fitting in an agent's context and
-// spills to the store instead (spill.ts, SpillPolicy).
+// CodePolicy bounds live package calls and where a result stops fitting in an agent's context
+// (reactor.test.ts, "package call failure policy"; spill.ts, SpillPolicy).
 export interface CodePolicy {
   readonly spill: Partial<SpillPolicy>
+  readonly call: Partial<PackageCallPolicy>
 }
 
 // codeReactorFor derives the executable head as one transition: the settle is the record
@@ -351,6 +405,7 @@ export const codeReactorFor = <const P extends ReadonlyArray<Package<never>> | R
     ...policy.spill,
     note: policy.spill?.note ?? (workspace === undefined ? BARE_SPILL_NOTE : WORKSPACE_SPILL_NOTE)
   })
+  const callPolicy = packageCallPolicyOf(policy.call)
   return (events) => {
     const owed = workOwed(events)
     if (owed === undefined) return []
@@ -371,7 +426,7 @@ export const codeReactorFor = <const P extends ReadonlyArray<Package<never>> | R
           turn: turnOf(dispatch),
           at: typeof d.at === "number" ? d.at : undefined
         },
-        act: (input) => executeRecorded<R>(input.execId, input.code, spill, mounted, input.turn, input.at)
+        act: (input) => executeRecorded<R>(input.execId, input.code, spill, callPolicy, mounted, input.turn, input.at)
       })
     ]
   }


### PR DESCRIPTION
Package methods can wait indefinitely when an external operation stalls. This change applies a configurable deadline and finite retry schedule at the shared package-call funnel so every live reach has a bounded outcome.

- Export the default package-call policy and accept code-mode overrides.
- Retry timeouts and transient defects inside the existing durable call.
- Commit exhausted attempts as a PackageReturned error with the attempt count and effective policy.
- Preserve Park as the separate protocol for waiting on an actor response.

Verified with the full repository gate: all 58 tasks pass.