### PR TITLE
feat(models): add catalog policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,6 @@ const instructions = system(
   "You are a release analyst. Identify risky changes and recommend the safest next action."
 )
 
-const model = { provider: "openai", default_model: "gpt-5.2" } as const
-
 const releaseAnalyst = actor({
   // name supplies the actor's stable identity.
   name: "release-analyst",
@@ -163,13 +161,13 @@ const releaseAnalyst = actor({
       ], { authority: caller() }),
       compaction(), // bounded model context
       outputValidateOnce // validates structured result once without correction
-    ], model),
+    ]),
     budgetAuthority() // budgetAuthority handles requestBudget for this actor.
   ]
 })
 ```
 
-`infer` composes the components into an agent loop. Its trailing options select a private provider connection and the default model used through it. `actor` binds those components to a stable name and callable interface. `agentMethods` provides `message` and `requestBudget`. Every actor method call is a durable future that remains pending until it receives one completed or failed terminal response. `model` is a model ID for that turn; it cannot change the actor's provider connection.
+`infer` composes the components into an agent loop. With no model override it inherits the host's allowed coordinates and default. An actor can pass `models: { allow?, default? }` to narrow that set, change its default, or do both. Every effective default must belong to the effective set. `actor` binds those components to a stable name and callable interface. `agentMethods` provides `message` and `requestBudget`. Every actor method call is a durable future that remains pending until it receives one completed or failed terminal response. A message may select another allowed model with a complete `{ provider, model_id }` reference.
 
 `compaction(policy?)` bounds model context. The host resolves the selected model's window from its catalog snapshot. Compaction fires at 80 percent and keeps a 50 percent tail unless the actor states other ratios:
 
@@ -213,8 +211,8 @@ import { createBunHost } from "tardie/bun/host"
 const model = infer({
   baseUrl: "https://api.openai.com/v1",
   apiKey: process.env.OPENAI_API_KEY!,
-  provider: releaseModel.provider,
-  model: releaseModel.default_model,
+  provider: "openai",
+  model: "gpt-5.2",
   protocol: "openai-responses",
   contextWindowTokens: 400_000
 })

--- a/apps/cli/src/build.test.ts
+++ b/apps/cli/src/build.test.ts
@@ -83,8 +83,10 @@ describe("lintActor", () => {
         methods: agentMethods,
         components: [
           infer([budget([codeMode()], { authority: caller() }), nativeOutput], {
-            provider: "test",
-            default_model: "test"
+            models: {
+              default: { provider: "test", model_id: "test" },
+              allow: "*"
+            }
           }),
           budgetAuthority()
         ]

--- a/apps/cli/src/celld.test.ts
+++ b/apps/cli/src/celld.test.ts
@@ -17,7 +17,7 @@ const wrangler = `{
   "limits": { "cpu_ms": 300000 },
   "vars": {
     "TARDIGRADE_ALARM_DELAY_MILLIS": "120000",
-    "TARDIGRADE_CONFIG": { "models": { "default": { "provider": "openai", "model_id": "gpt-5.2" } } }
+    "TARDIGRADE_CONFIG": { "models": { "default": { "provider": "openai", "model_id": "gpt-5.2" }, "allow": "*" } }
   }
 }`
 
@@ -31,7 +31,7 @@ describe("Celld configuration", () => {
     expect(config).not.toHaveProperty("observability")
     expect(config).not.toHaveProperty("limits")
     expect((config["vars"] as Record<string, string>)["TARDIGRADE_CONFIG"]).toBe(
-      '{"models":{"default":{"provider":"openai","model_id":"gpt-5.2"}}}'
+      '{"models":{"default":{"provider":"openai","model_id":"gpt-5.2"},"allow":"*"}}'
     )
     expect((config["vars"] as Record<string, string>)[CELLD_SANDBOX_TRANSPORT_VAR]).toBe(CELLD_SANDBOX_TRANSPORT)
   })
@@ -51,7 +51,7 @@ describe("Celld configuration", () => {
     expect(updated).toContain('"CELLD_ONLY": "kept"')
     const config = parse(updated) as { readonly vars: Readonly<Record<string, string>> }
     expect(config.vars["TARDIGRADE_CONFIG"]).toBe(
-      '{"models":{"default":{"provider":"openai","model_id":"gpt-5.2"}}}'
+      '{"models":{"default":{"provider":"openai","model_id":"gpt-5.2"},"allow":"*"}}'
     )
   })
 })

--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -67,6 +67,7 @@ const clientOf = (
         revision: "catalog-1",
         status: "fresh",
         refreshed_at: 1,
+        policy: { allow: "*" },
         total: 0,
         limit: 50,
         items: []
@@ -78,6 +79,7 @@ const clientOf = (
         revision: "catalog-1",
         status: "fresh",
         refreshed_at: 1,
+        policy: { allow: "*" },
         total: 0,
         limit: 50,
         items: []
@@ -235,32 +237,25 @@ describe("parsing", () => {
   test("setup gives agents a declarative path instead of prompting", async () => {
     const ran = await drive(["setup"])
     expect(ran.failed).toBe(true)
-    expect(failureText(ran)).toContain("setup provider")
-    expect(failureText(ran)).toContain("setup default")
+    expect(failureText(ran)).toContain("--provider")
+    expect(failureText(ran)).toContain("--provider-config")
+    expect(failureText(ran)).toContain("--default-model")
   })
 
-  test("setup provider and default are independent declarative operations", async () => {
+  test("setup writes the first provider and default atomically", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "tdg-setup-command-"))
     try {
-      const provider = await drive([
+      const configured = await drive([
         "setup",
-        "provider",
-        "openrouter",
-        '{"env":["OPENROUTER_API_KEY"]}'
-      ], { cwd })
-      expect(provider.failed).toBe(false)
-      expect(await readFile(join(cwd, "wrangler.jsonc"), "utf8")).not.toContain('"default"')
-      await expect(readFile(join(cwd, ".dev.vars"), "utf8")).rejects.toThrow()
-
-      const selected = await drive([
-        "setup",
-        "default",
         "--provider",
         "openrouter",
-        "--model",
+        "--provider-config",
+        '{"env":["OPENROUTER_API_KEY"]}',
+        "--default-model",
         "anthropic/claude-sonnet-4-6"
       ], { cwd })
-      expect(selected.failed).toBe(false)
+      expect(configured.failed).toBe(false)
+      await expect(readFile(join(cwd, ".dev.vars"), "utf8")).rejects.toThrow()
       const config = await readFile(join(cwd, "wrangler.jsonc"), "utf8")
       expect(config).toContain('"provider": "openrouter"')
       expect(config).toContain('"model_id": "anthropic/claude-sonnet-4-6"')
@@ -300,7 +295,7 @@ describe("parsing", () => {
       const config = await readFile(join(directory, "wrangler.jsonc"), "utf8")
 
       expect(ran.failed).toBe(false)
-      expect(actor).toContain('provider: "openrouter", default_model: "anthropic/claude-sonnet-4-6"')
+      expect(actor).toContain("infer([")
       expect(config).toContain('"provider": "openrouter"')
       expect(config).toContain('"model_id": "anthropic/claude-sonnet-4-6"')
       expect(ran.recorded.installed).toEqual([directory])
@@ -430,18 +425,23 @@ describe("ls", () => {
 
 describe("catalog discovery", () => {
   test("providers forwards search and pagination and prints requirements", async () => {
-    const ran = await drive(["providers", "--search", "open", "--limit", "1", "--cursor", "next"], {
+    const ran = await drive(["providers", "--availability", "available", "--search", "open", "--limit", "1", "--cursor", "next"], {
       answers: {
         providers: {
           revision: "catalog-2",
           status: "cached",
           refreshed_at: 2,
+          policy: {
+            default: { provider: "openrouter", model_id: "anthropic/claude-sonnet-4-6" },
+            allow: "*"
+          },
           total: 2,
           limit: 1,
           next_cursor: "last",
           items: [{
             id: "openrouter",
             name: "OpenRouter",
+            availability: { status: "available" },
             protocol: "openai-chat-completions",
             baseUrl: "https://openrouter.ai/api/v1",
             env: ["OPENROUTER_API_KEY"],
@@ -454,18 +454,42 @@ describe("catalog discovery", () => {
     expect(ran.failed).toBe(false)
     expect(ran.recorded.catalog).toEqual([{
       kind: "providers",
-      options: { cursor: "next", limit: 1, search: "open" }
+      options: { availability: "available", cursor: "next", limit: 1, search: "open" }
     }])
     expect(ran.lines.join("\n")).toContain("openrouter")
     expect(ran.lines.join("\n")).toContain("next cursor last")
   })
 
   test("models forwards its provider filter and prints the page as JSON", async () => {
-    const ran = await drive(["models", "--provider", "openrouter", "--search", "claude", "--json"])
+    const ran = await drive([
+      "models",
+      "--provider",
+      "openrouter",
+      "--search",
+      "claude",
+      "--availability",
+      "available",
+      "--sort",
+      "completionUsdPerToken",
+      "--order",
+      "asc",
+      "--unpriced",
+      "last",
+      "--json"
+    ])
     expect(ran.failed).toBe(false)
     expect(ran.recorded.catalog).toEqual([{
       kind: "models",
-      options: { cursor: undefined, limit: undefined, provider: "openrouter", search: "claude" }
+      options: {
+        cursor: undefined,
+        availability: "available",
+        limit: undefined,
+        provider: "openrouter",
+        search: "claude",
+        sort: "completionUsdPerToken",
+        order: "asc",
+        unpriced: "last"
+      }
     }])
     expect(JSON.parse(ran.lines[0]!)).toMatchObject({ revision: "catalog-1", items: [] })
   })

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -4,7 +4,16 @@ import { rm } from "node:fs/promises"
 import { resolve } from "node:path"
 import { Argument, CliError, Command, Flag, Prompt } from "effect/unstable/cli"
 import { ACTOR_NAME_PATTERN, type Actor } from "tardie"
-import { NO_ANSWER, ProblemError, type ActorClient, type MethodState } from "@clavia/tardigrade-client"
+import {
+  CATALOG_AVAILABILITY_FILTERS,
+  MODEL_CATALOG_PRICE_SORTS,
+  MODEL_CATALOG_SORT_ORDERS,
+  MODEL_CATALOG_UNPRICED_ORDERS,
+  NO_ANSWER,
+  ProblemError,
+  type ActorClient,
+  type MethodState
+} from "@clavia/tardigrade-client"
 
 import type { ServerR } from "@clavia/tardigrade-server/actor"
 import { modelIsConfigured } from "@clavia/tardigrade-server/host"
@@ -159,6 +168,11 @@ const catalogLimit = Flag.integer("limit").pipe(
   Flag.optional
 )
 
+const catalogAvailability = Flag.choice("availability", CATALOG_AVAILABILITY_FILTERS).pipe(
+  Flag.withDescription("Include every catalog provider or only providers this host can use."),
+  Flag.optional
+)
+
 // clientOf resolves where to call and opens the client, which is the one place the two sources meet
 // (config.ts, resolveRemote).
 const clientOf = (flags: {
@@ -228,7 +242,7 @@ const setupPromptIn = (root: string, env: Readonly<Record<string, string | undef
   setupPrompt(setupPromptOptionsIn(root, env))
 
 export const NON_INTERACTIVE_SETUP =
-  "tdg setup needs an interactive terminal; use `tdg setup provider` and `tdg setup default` in scripts"
+  "tdg setup needs --provider, --provider-config, and --default-model when stdin is not interactive; see `tdg setup --help`"
 export const NON_INTERACTIVE_PROVIDER_SETUP =
   "tdg setup provider needs <provider> and <config> when stdin is not interactive; see `tdg setup provider --help`"
 export const NON_INTERACTIVE_DEFAULT_SETUP =
@@ -251,6 +265,10 @@ export const setupProviderCommand = Command.make("provider", {
 }, (flags) =>
   Effect.gen(function*() {
     const cli = yield* Cli
+    const project = yield* Effect.mapError(readProjectConfig(cli.cwd, cli.env), userErrorOf)
+    if (project.models.default === undefined) {
+      return yield* userErrorOf("the first provider and default must be configured together; run `tdg setup`")
+    }
     const declared = yield* Effect.try({
       try: () => providerAnswersFrom({
         provider: stated(flags.provider),
@@ -267,7 +285,7 @@ export const setupProviderCommand = Command.make("provider", {
       : providerSetupSummary(files, [answers]))
   })).pipe(
     Command.withDescription(
-      "Add or update one provider connection in the platform manifests."
+      "Add or update one provider connection after the host default is configured."
     ),
     Command.withExamples([
       { command: "tdg setup provider", description: "Prompt for a provider connection" },
@@ -308,7 +326,26 @@ export const setupDefaultCommand = Command.make("default", {
   ])
 )
 
-export const setupCommand = Command.make("setup", {}, () => Effect.gen(function*() {
+export const setupCommand = Command.make("setup", {
+  provider: setupProvider,
+  providerConfig: setupProviderConfig,
+  defaultModel: setupDefaultModel,
+  json
+}, (flags) => Effect.gen(function*() {
+  const declared = yield* Effect.try({
+    try: () => setupAnswersFrom({
+      provider: stated(flags.provider),
+      providerConfig: stated(flags.providerConfig),
+      defaultModel: stated(flags.defaultModel)
+    }),
+    catch: userErrorOf
+  })
+  if (declared !== undefined) {
+    const cli = yield* Cli
+    const files = yield* Effect.mapError(writeSetup(cli.cwd, declared, cli.env), userErrorOf)
+    yield* Console.log(flags.json ? jsonOf(setupJson(files, declared)) : setupSummary(files, declared))
+    return
+  }
   if (!canAsk()) return yield* userErrorOf(NON_INTERACTIVE_SETUP)
   const cli = yield* Cli
   const project = yield* Effect.mapError(readProjectConfig(cli.cwd, cli.env), userErrorOf)
@@ -324,6 +361,10 @@ export const setupCommand = Command.make("setup", {}, () => Effect.gen(function*
   yield* Console.log(setupPlanSummary(files, plan))
 })).pipe(
   Command.withDescription("Configure project providers and a default model in the platform manifests. Entered credentials are stored in .dev.vars at 0600."),
+  Command.withExamples([{
+    command: "tdg setup --provider openrouter --provider-config '{\"env\":[\"OPENROUTER_API_KEY\"]}' --default-model anthropic/claude-sonnet-4.6",
+    description: "Configure the first provider and default atomically"
+  }]),
   Command.withSubcommands([setupProviderCommand, setupDefaultCommand])
 )
 
@@ -374,8 +415,7 @@ export const initCommand = Command.make("init", {
     const initialized = yield* Effect.tryPromise({
       try: () => initActor(name, {
         cwd: cli.cwd,
-        ...(directory === undefined ? {} : { directory }),
-        model: { provider: answers.provider, defaultModel: answers.model_id }
+        ...(directory === undefined ? {} : { directory })
       }),
       catch: userErrorOf
     })
@@ -626,6 +666,7 @@ export const lsCommand = Command.make("ls", remote, (flags) =>
 
 export const providersCommand = Command.make("providers", {
   search: catalogSearch,
+  availability: catalogAvailability,
   cursor: catalogCursor,
   limit: catalogLimit,
   ...catalogRemote
@@ -633,6 +674,7 @@ export const providersCommand = Command.make("providers", {
   Effect.gen(function*() {
     const client = yield* clientOf(flags)
     const page = yield* call(() => client.providers({
+      availability: Option.getOrUndefined(flags.availability),
       cursor: stated(flags.cursor),
       limit: Option.getOrUndefined(flags.limit),
       search: stated(flags.search)
@@ -652,6 +694,19 @@ export const modelsCommand = Command.make("models", {
     Flag.optional
   ),
   search: catalogSearch,
+  availability: catalogAvailability,
+  sort: Flag.choice("sort", MODEL_CATALOG_PRICE_SORTS).pipe(
+    Flag.withDescription("Order models by this token price."),
+    Flag.optional
+  ),
+  order: Flag.choice("order", MODEL_CATALOG_SORT_ORDERS).pipe(
+    Flag.withDescription("Order selected prices from low to high or high to low."),
+    Flag.optional
+  ),
+  unpriced: Flag.choice("unpriced", MODEL_CATALOG_UNPRICED_ORDERS).pipe(
+    Flag.withDescription("Place models without the selected price first or last."),
+    Flag.optional
+  ),
   cursor: catalogCursor,
   limit: catalogLimit,
   ...catalogRemote
@@ -659,16 +714,21 @@ export const modelsCommand = Command.make("models", {
   Effect.gen(function*() {
     const client = yield* clientOf(flags)
     const page = yield* call(() => client.models({
+      availability: Option.getOrUndefined(flags.availability),
       cursor: stated(flags.cursor),
       limit: Option.getOrUndefined(flags.limit),
       provider: stated(flags.provider),
-      search: stated(flags.search)
+      search: stated(flags.search),
+      sort: Option.getOrUndefined(flags.sort),
+      order: Option.getOrUndefined(flags.order),
+      unpriced: Option.getOrUndefined(flags.unpriced)
     }))
     yield* Console.log(flags.json ? jsonOf(page) : modelsTable(page))
   })).pipe(
     Command.withDescription("Search and page the public model catalog."),
     Command.withExamples([
       { command: "tdg models --provider openrouter --search claude", description: "Search OpenRouter models" },
+      { command: "tdg models --sort completionUsdPerToken --order asc", description: "List the cheapest completion prices first" },
       { command: "tdg models --cursor <cursor> --json", description: "Read the next page as JSON" }
     ])
   )

--- a/apps/cli/src/config.test.ts
+++ b/apps/cli/src/config.test.ts
@@ -74,7 +74,7 @@ describe("resolveServer", () => {
     expect(config.port).toBe(8080)
     expect(config.db).toBe("runs.sqlite")
     expect(config.maxConcurrentLanes).toBe(6)
-    expect(config.model).toEqual({ default: undefined, providers: {} })
+    expect(config.model).toEqual({ allow: "*", providers: {} })
   })
 
   test("a flag beats the environment", () => {
@@ -161,6 +161,7 @@ describe("the config file", () => {
         "TARDIGRADE_CONFIG": {
           "models": {
             "default": { "provider": "openai", "model_id": "file-model" },
+            "allow": "*",
             "providers": {
               "openai": {
                 "baseUrl": "https://file.example.com",
@@ -175,6 +176,7 @@ describe("the config file", () => {
     const resolved = resolveServer({}, { OPENAI_API_KEY: "environment-key" }, project)
     expect(resolved.model).toEqual({
       default: { provider: "openai", model_id: "file-model" },
+      allow: "*",
       providers: {
         openai: {
           baseUrl: "https://file.example.com",
@@ -189,12 +191,12 @@ describe("the config file", () => {
   test("the project path is configurable and JSONC comments are accepted", async () => {
     const path = projectConfigPathIn(home, { TARDIGRADE_CONFIG_PATH: "config/custom.jsonc" })
     await mkdir(join(home, "config"), { recursive: true })
-    await writeFile(path, '{ // visible\n "vars": { "TARDIGRADE_CONFIG": { "models": {} } }\n}')
+    await writeFile(path, '{ // visible\n "vars": { "TARDIGRADE_CONFIG": { "models": { "allow": "*" } } }\n}')
     const project = await Effect.runPromise(Effect.provide(
       readProjectConfig(home, { TARDIGRADE_CONFIG_PATH: "config/custom.jsonc" }),
       BunFileSystem.layer
     ))
-    expect(project.models).toEqual({ default: undefined, providers: {} })
+    expect(project.models).toEqual({ allow: "*", providers: {} })
   })
 
   test("the file is the third source for the remote, and a flag beats both", async () => {

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -53,7 +53,7 @@ export class ProjectFileError extends Data.TaggedError("ProjectFileError")<{
   readonly cause?: unknown
 }> {}
 
-// parseProjectConfig validates JSONC syntax and the project configuration shape.
+// parseProjectConfig validates JSONC syntax and configuration that can start a host.
 export const parseProjectConfig = (raw: string, path = "wrangler.jsonc"): ProjectConfig => {
   const errors: Array<ParseError> = []
   const value = parse(raw, errors, { allowTrailingComma: true }) as unknown
@@ -95,6 +95,7 @@ export const readProjectConfig = (
         : new ProjectFileError({ message: String(cause), cause })
     })
   })
+
 
 // FileConfig is the user-level file's whole shape. It holds remote client settings that apply
 // across projects. Model connections belong to each project's JSONC file (setup.ts).

--- a/apps/cli/src/dev.test.ts
+++ b/apps/cli/src/dev.test.ts
@@ -33,6 +33,7 @@ setDefaultTimeout(BOOT_MS)
 const INDEX = "<!doctype html><title>voyager</title>"
 
 const SCRIPT = "console.log(\"voyager\")"
+const testModel = { provider: "test", model_id: "scripted" } as const
 
 // A directory shaped like the build vite writes: one index and one hashed asset beside it.
 const buildDirectory = (): string => {
@@ -44,6 +45,7 @@ const buildDirectory = (): string => {
 }
 
 const layerScripted: Layer.Layer<Infer> = Layer.succeed(Infer)({
+  resolve: (model = testModel) => ({ model, models: { default: model, allow: "*" } }),
   react: () => Effect.succeed({ kind: "complete", output: "the scripted answer" } satisfies Action)
 })
 

--- a/apps/cli/src/init.test.ts
+++ b/apps/cli/src/init.test.ts
@@ -7,8 +7,6 @@ import { CELLD_PROJECT_CONFIG_PATH } from "./celld"
 import { DEFAULT_ACTOR_ENTRY, DEFAULT_PACKAGE_MANIFEST, DEFAULT_WORKER_ENTRY, defaultInitDirectory, initActor, initSummary, terminalColorsEnabled } from "./init"
 
 let root = ""
-const model = { provider: "openrouter", defaultModel: "anthropic/claude-sonnet-4-6" }
-
 afterEach(async () => {
   if (root.length > 0) await rm(root, { recursive: true, force: true })
 })
@@ -21,7 +19,7 @@ const temporaryRoot = async (): Promise<string> => {
 describe("initActor", () => {
   test("creates a buildable named quickstart", async () => {
     const cwd = await temporaryRoot()
-    const initialized = await initActor("reviewer", { cwd, model, now: new Date("2026-08-24T00:00:00Z"), packageVersion: "0.7.1-test" })
+    const initialized = await initActor("reviewer", { cwd, now: new Date("2026-08-24T00:00:00Z"), packageVersion: "0.7.1-test" })
     const source = await readFile(initialized.entry, "utf8")
     const worker = await readFile(initialized.worker, "utf8")
     const manifestSource = await readFile(initialized.manifest, "utf8")
@@ -36,7 +34,7 @@ describe("initActor", () => {
     expect(initialized.celldManifest).toBe(join(cwd, "reviewer", CELLD_PROJECT_CONFIG_PATH))
     expect(initialized.packageManifest).toBe(join(cwd, "reviewer", DEFAULT_PACKAGE_MANIFEST))
     expect(source).toContain('const actorName = "reviewer"')
-    expect(source).toContain('provider: "openrouter", default_model: "anthropic/claude-sonnet-4-6"')
+    expect(source).toContain("infer([")
     expect(worker).toContain('import definition from "./actor"')
     expect(worker).toContain('from "tardie/cloudflare"')
     expect(worker).toContain("cloudflareWorker(definition)")
@@ -72,13 +70,13 @@ describe("initActor", () => {
     await mkdir(directory)
     await writeFile(held, "keep me", "utf8")
 
-    await expect(initActor("reviewer", { cwd, model })).rejects.toThrow("target already exists")
+    await expect(initActor("reviewer", { cwd })).rejects.toThrow("target already exists")
     expect(await readFile(held, "utf8")).toBe("keep me")
   })
 
   test("writes into a stated directory", async () => {
     const cwd = await temporaryRoot()
-    const initialized = await initActor("reviewer", { cwd, directory: "actors/custom", model })
+    const initialized = await initActor("reviewer", { cwd, directory: "actors/custom" })
 
     expect(initialized.entry).toBe(join(cwd, "actors", "custom", DEFAULT_ACTOR_ENTRY))
   })
@@ -88,7 +86,7 @@ describe("initActor", () => {
 describe("initSummary", () => {
   test("prints the complete local path", async () => {
     const cwd = await temporaryRoot()
-    const initialized = await initActor("reviewer", { cwd, model })
+    const initialized = await initActor("reviewer", { cwd })
     const summary = initSummary(initialized, {
       configPath: initialized.manifest,
       celldConfigPath: initialized.celldManifest,

--- a/apps/cli/src/init.ts
+++ b/apps/cli/src/init.ts
@@ -3,7 +3,7 @@ import { relative, resolve } from "node:path"
 import { DEFAULT_PROJECT_CONFIG_PATH } from "@clavia/tardigrade-server/config"
 
 import { CELLD_PROJECT_CONFIG_PATH, celldConfigOf } from "./celld"
-import { actorTemplate, type ActorTemplateModel } from "./template"
+import { actorTemplate } from "./template"
 import type { SetupAnswers, SetupFiles } from "./setup"
 import { versionIn } from "./version"
 import { callCommand, shellWord } from "./workflow"
@@ -14,7 +14,6 @@ export const DEFAULT_PACKAGE_MANIFEST = "package.json"
 export const DISCORD_INVITE_URL = "https://discord.gg/Z74jwRxz4k"
 
 export interface InitActorOptions {
-  readonly model: ActorTemplateModel
   readonly cwd?: string
   readonly directory?: string
   readonly now?: Date
@@ -79,7 +78,7 @@ export const initActor = async (name: string, options: InitActorOptions): Promis
   const manifest = resolve(directory, DEFAULT_PROJECT_CONFIG_PATH)
   const celldManifest = resolve(directory, CELLD_PROJECT_CONFIG_PATH)
   const packageManifest = resolve(directory, DEFAULT_PACKAGE_MANIFEST)
-  const source = await actorTemplate({ name, model: options.model })
+  const source = await actorTemplate({ name })
   const manifestSource = manifestTemplate(name, options.now ?? new Date())
   const packageVersion = options.packageVersion ?? await versionIn(import.meta.url)
   if (packageVersion.endsWith("-unknown")) throw new Error("cannot determine the installed Tardigrade version")

--- a/apps/cli/src/render.ts
+++ b/apps/cli/src/render.ts
@@ -77,9 +77,10 @@ export const providersTable = (page: ProviderCatalogPage): string => {
   const body = page.items.length === 0
     ? "no providers"
     : table(
-      ["PROVIDER", "PROTOCOL", "ENDPOINT", "REQUIRED", "ENV"],
+      ["PROVIDER", "STATUS", "PROTOCOL", "ENDPOINT", "REQUIRED", "ENV"],
       page.items.map((provider) => [
         provider.id,
+        provider.availability.status === "available" ? "available" : provider.availability.reason,
         provider.protocol ?? ABSENT,
         provider.baseUrl ?? ABSENT,
         provider.required.join(",") || ABSENT,

--- a/apps/cli/src/setup.test.ts
+++ b/apps/cli/src/setup.test.ts
@@ -224,6 +224,7 @@ describe("writeSetup", () => {
     const project = parseProjectConfig(await readFile(projectConfigPathIn(root), "utf8"))
     expect(project.models).toEqual({
       default: { provider: "openai", model_id: "a-model" },
+      allow: "*",
       providers: {
         openai: {
           baseUrl: "https://api.example.com/v1",
@@ -268,6 +269,7 @@ describe("writeSetup", () => {
     expect(JSON.parse(config.vars["TARDIGRADE_CONFIG"]!)).toEqual({
       models: {
         default: { provider: "openai", model_id: "a-model" },
+        allow: "*",
         providers: {
           openai: {
             baseUrl: "https://api.example.com/v1",
@@ -305,7 +307,7 @@ describe("writeSetup", () => {
     expect(held.OPENROUTER_API_KEY).toBe("secondary-key")
   })
 
-  test("provider and default writes remain independent", async () => {
+  test("later provider and default writes preserve runnable configuration", async () => {
     await write()
     const anthropic: ProviderAnswers = {
       provider: "anthropic",

--- a/apps/cli/src/setup.ts
+++ b/apps/cli/src/setup.ts
@@ -2,7 +2,7 @@ import { Console, Data, Effect, Layer, Redacted } from "effect"
 import type { PlatformError } from "effect/PlatformError"
 import { FileSystem, type FileSystem as FileSystemService } from "effect/FileSystem"
 import { Prompt } from "effect/unstable/cli"
-import { applyEdits, modify } from "jsonc-parser"
+import { applyEdits, modify, parse } from "jsonc-parser"
 import { BunFileSystem } from "@effect/platform-bun"
 import type { ModelCatalog } from "@clavia/tardigrade-client/contract"
 import {
@@ -673,6 +673,11 @@ const updatedProject = (
 ): string => {
   const formattingOptions = { insertSpaces: true, tabSize: 2, eol: "\n" }
   let next = raw.trim().length === 0 ? "{}\n" : raw
+  const document = parse(next) as { readonly vars?: Readonly<Record<string, unknown>> }
+  const config = document.vars?.[TARDIGRADE_CONFIG_VAR] as { readonly models?: { readonly allow?: unknown } } | undefined
+  if (config?.models?.allow === undefined) {
+    next = applyEdits(next, modify(next, ["vars", TARDIGRADE_CONFIG_VAR, "models", "allow"], "*", { formattingOptions }))
+  }
   for (const provider of providers) {
     next = applyEdits(next, modify(next, ["vars", TARDIGRADE_CONFIG_VAR, "models", "providers", provider.provider], {
       baseUrl: provider.baseUrl,
@@ -712,6 +717,13 @@ const writeSetupChanges = (
     })
     const secretsPath = envPathIn(root)
     const updatedConfig = updatedProject(configRaw, selected, providers)
+    yield* Effect.try({
+      try: () => parseProjectConfig(updatedConfig, configPath),
+      catch: (cause) => new SetupConfigError({
+        message: cause instanceof Error ? cause.message : String(cause),
+        cause
+      })
+    })
     const celldConfigPath = `${root.replace(/\/$/, "")}/${CELLD_PROJECT_CONFIG_PATH}`
     const celldConfigRaw = yield* readOrEmpty(fs, celldConfigPath)
     const updatedCelldConfig = celldConfigRaw.trim().length === 0

--- a/apps/cli/src/template.test.ts
+++ b/apps/cli/src/template.test.ts
@@ -7,7 +7,6 @@ import { buildActor } from "./build"
 import { actorTemplate, renderActorTemplate } from "./template"
 
 let root = ""
-const model = { provider: "openrouter", defaultModel: "anthropic/claude-sonnet-4-6" }
 
 afterEach(async () => {
   if (root.length > 0) await rm(root, { recursive: true, force: true })
@@ -22,12 +21,12 @@ const build = async (source: string) => {
 
 describe("actorTemplate", () => {
   test("builds a named actor with the useful local reach", async () => {
-    const source = await actorTemplate({ name: "reviewer", model })
+    const source = await actorTemplate({ name: "reviewer" })
     const built = await build(source)
 
     expect(built.manifest.name).toBe("reviewer")
     expect(source).toContain('const actorName = "reviewer"')
-    expect(source).toContain('provider: "openrouter", default_model: "anthropic/claude-sonnet-4-6"')
+    expect(source).toContain("infer([")
     expect(source).toContain("You are ${actorName}, a focused research agent.")
     expect(source).toContain("filesPackage()")
     expect(source).toContain("fetchPackage()")
@@ -38,7 +37,6 @@ describe("actorTemplate", () => {
   test("keeps custom instructions valid inside the editable template literal", async () => {
     const source = await actorTemplate({
       name: "reviewer",
-      model,
       instructions: "Review `src` and explain ${findings}.\nKeep Windows paths like C:\\code intact."
     })
     const built = await build(source)
@@ -49,14 +47,14 @@ describe("actorTemplate", () => {
   })
 
   test("refuses an invalid name or blank instructions", async () => {
-    await expect(actorTemplate({ name: "Release Analyst", model })).rejects.toThrow("actor name must match")
-    await expect(actorTemplate({ name: "reviewer", model, instructions: "   " })).rejects.toThrow(
+    await expect(actorTemplate({ name: "Release Analyst" })).rejects.toThrow("actor name must match")
+    await expect(actorTemplate({ name: "reviewer", instructions: "   " })).rejects.toThrow(
       "actor instructions must not be blank"
     )
   })
 
   test("refuses a template without its editable fields", () => {
-    expect(() => renderActorTemplate("export default {}", { name: "reviewer", model })).toThrow(
+    expect(() => renderActorTemplate("export default {}", { name: "reviewer" })).toThrow(
       "quickstart template must contain one actorName declaration"
     )
   })

--- a/apps/cli/src/template.ts
+++ b/apps/cli/src/template.ts
@@ -3,14 +3,8 @@ import { existsSync } from "node:fs"
 import { readFile } from "node:fs/promises"
 import { fileURLToPath } from "node:url"
 
-export interface ActorTemplateModel {
-  readonly provider: string
-  readonly defaultModel: string
-}
-
 export interface ActorTemplateOptions {
   readonly name: string
-  readonly model: ActorTemplateModel
   readonly instructions?: string
 }
 
@@ -40,12 +34,6 @@ export const renderActorTemplate = (source: string, options: ActorTemplateOption
     /^const actorName = .+$/gmu,
     `const actorName = ${JSON.stringify(options.name)}`,
     "actorName declaration"
-  )
-  rendered = replaceExactlyOnce(
-    rendered,
-    /^const actorModel = .+$/gmu,
-    `const actorModel = { provider: ${JSON.stringify(options.model.provider)}, default_model: ${JSON.stringify(options.model.defaultModel)} } as const`,
-    "actorModel declaration"
   )
   if (options.instructions === undefined) return rendered
 

--- a/apps/server/src/actor.ts
+++ b/apps/server/src/actor.ts
@@ -15,6 +15,7 @@ import {
   infer,
   outputValidateOnce,
   workspacePackage,
+  type AgentCatalog,
   type ModelRef
 } from "tardie"
 import { turnEpochOf } from "@clavia/tardigrade-code/execution/turns"
@@ -40,15 +41,11 @@ import { inboundOf } from "./projections"
 // requests to any host. There is no shell: a shell cannot be scoped the way a root or an origin can,
 // and this build has no place to ask an operator whether one command is allowed.
 export interface AssemblyModelPolicy {
-  readonly provider: string
-  readonly default_model: string
   readonly contextWindowTokens?: number | ((model: ModelRef | undefined) => number)
+  readonly catalog?: AgentCatalog
 }
 
-export const UNCONFIGURED_MODEL: AssemblyModelPolicy = {
-  provider: "unconfigured",
-  default_model: "unconfigured"
-}
+export const UNCONFIGURED_MODEL: AssemblyModelPolicy = {}
 
 const assemblyOf = (models: AssemblyModelPolicy = UNCONFIGURED_MODEL) =>
   actor({
@@ -56,13 +53,15 @@ const assemblyOf = (models: AssemblyModelPolicy = UNCONFIGURED_MODEL) =>
     methods: agentMethods,
     components: [
       infer([
-        budget([codeMode([agentsPackage(), workspacePackage(), filesPackage(), fetchPackage()])], { authority: caller() }),
+        budget([codeMode([
+          agentsPackage(models.catalog === undefined ? {} : { catalog: models.catalog }),
+          workspacePackage(),
+          filesPackage(),
+          fetchPackage()
+        ])], { authority: caller() }),
         compaction(models.contextWindowTokens === undefined ? {} : { contextWindowTokens: models.contextWindowTokens }),
         outputValidateOnce
-      ], {
-        provider: models.provider,
-        default_model: models.default_model
-      }),
+      ]),
       budgetAuthority()
     ]
   })

--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -60,13 +60,29 @@ const scripted = ({ trajectory }: InferRequest): Action => {
   }
 }
 
+const testModel = { provider: "openai", model_id: "gpt-mini" } as const
+
 const layerScripted: Layer.Layer<Infer> = Layer.succeed(Infer)({
+  resolve: (model = testModel) => ({ model, models: { default: model, allow: "*" } }),
   react: (request: InferRequest) => Effect.succeed(scripted(request))
 })
 
 const config = layerConfig(readConfig({
   TARDIGRADE_DB: ":memory:",
-  TARDIGRADE_ACTORS: `/tmp/tardigrade-api-test-${process.pid}`
+  TARDIGRADE_ACTORS: `/tmp/tardigrade-api-test-${process.pid}`,
+  OPENAI_API_KEY: "test-key"
+}, {
+  models: {
+    default: { provider: "openai", model_id: "gpt-mini" },
+    allow: "*",
+    providers: {
+      openai: {
+        baseUrl: "https://api.openai.com/v1",
+        protocol: "openai-responses",
+        env: ["OPENAI_API_KEY"]
+      }
+    }
+  }
 }))
 
 const catalog: ModelCatalog = {
@@ -74,15 +90,23 @@ const catalog: ModelCatalog = {
   revision: "catalog-1",
   refreshedAt: 1_700_000_000_000,
   status: "fresh",
-  providers: [{
-    id: "openai",
-    name: "OpenAI",
-    env: ["OPENAI_API_KEY"],
-    models: [
-      { id: "gpt-mini", metadata: { contextWindowTokens: 64_000 } },
-      { id: "gpt-test", metadata: { contextWindowTokens: 128_000 } }
-    ]
-  }]
+  providers: [
+    {
+      id: "openai",
+      name: "OpenAI",
+      env: ["OPENAI_API_KEY"],
+      models: [
+        { id: "gpt-mini", metadata: { contextWindowTokens: 64_000, pricing: { promptUsdPerToken: 0.000_001, completionUsdPerToken: 0.000_004 } } },
+        { id: "gpt-test", metadata: { contextWindowTokens: 128_000, pricing: { promptUsdPerToken: 0.000_002, completionUsdPerToken: 0.000_003 } } }
+      ]
+    },
+    {
+      id: "anthropic",
+      name: "Anthropic",
+      env: ["ANTHROPIC_API_KEY"],
+      models: [{ id: "claude-test", metadata: { contextWindowTokens: 200_000 } }]
+    }
+  ]
 }
 const catalogLayer = layerModelCatalogValue(catalog)
 
@@ -180,11 +204,16 @@ describe("models", () => {
   test("the public catalog pages model metadata without credentials", async () => {
     const first = await serving(async (base) => await (await get(base, "/v1/models?provider=openai&limit=1")).json()) as {
       readonly items: ReadonlyArray<{ readonly id: string }>
+      readonly policy: unknown
       readonly next_cursor?: string
       readonly limit: number
       readonly total: number
     }
     expect(first).toMatchObject({ limit: 1, total: 2, items: [{ id: "gpt-mini" }] })
+    expect(first.policy).toEqual({
+      default: { provider: "openai", model_id: "gpt-mini" },
+      allow: "*"
+    })
     expect(typeof first.next_cursor).toBe("string")
     const second = await serving(async (base) => await (await get(
       base,
@@ -200,12 +229,45 @@ describe("models", () => {
       revision: "catalog-1",
       items: [{
         id: "openai",
+        availability: { status: "available" },
         protocol: "openai-responses",
         baseUrl: "https://api.openai.com/v1",
         env: ["OPENAI_API_KEY"],
         required: ["env"]
       }]
     })
+  })
+
+  test("provider discovery reports configuration availability", async () => {
+    const response = await serving(async (base) => await (await get(base, "/v1/providers?search=anthropic")).json())
+    expect(response).toMatchObject({
+      items: [{
+        id: "anthropic",
+        availability: { status: "unavailable", reason: "not_configured" }
+      }]
+    })
+  })
+
+  test("the model route sorts by the selected price", async () => {
+    const page = await serving(async (base) => await (await get(
+      base,
+      "/v1/models?sort=completionUsdPerToken&order=asc"
+    )).json()) as { readonly items: ReadonlyArray<{ readonly id: string }> }
+    expect(page.items.map((model) => model.id)).toEqual(["gpt-test", "gpt-mini", "claude-test"])
+  })
+
+  test("the host model route includes unconfigured catalog providers", async () => {
+    const page = await serving(async (base) => await (await get(base, "/v1/models?search=claude-test")).json()) as {
+      readonly items: ReadonlyArray<{ readonly provider: string; readonly id: string; readonly metadata: unknown }>
+    }
+    expect(page.items).toEqual([{ provider: "anthropic", id: "claude-test", metadata: { contextWindowTokens: 200_000 } }])
+  })
+
+  test("the host model route exposes its available view", async () => {
+    const page = await serving(async (base) => await (await get(base, "/v1/models?availability=available")).json()) as {
+      readonly items: ReadonlyArray<{ readonly provider: string }>
+    }
+    expect(page.items.map((model) => model.provider)).toEqual(["openai", "openai"])
   })
 
   test("a cursor cannot change its query", async () => {
@@ -234,15 +296,40 @@ describe("actor methods", () => {
     expect(methods[0]?.inputSchema.$defs?.["AgentMessageInput"]).toMatchObject({
       type: "object",
       required: ["text"],
-      properties: { model: { type: "string" } }
+      properties: {
+        model: {
+          type: "object",
+          required: ["provider", "model_id"],
+          properties: {
+            provider: { type: "string" },
+            model_id: { type: "string" }
+          }
+        }
+      }
     })
     expect(methods[0]?.outputSchema).toMatchObject({ type: "string" })
     expect(methods[1]?.inputSchema.$ref).toBe("#/$defs/BudgetRequestInput")
   })
 
   test("an invocation births a thread and exposes its completed state", async () => {
-    const state = await serving((base) => callMessage(base, "alpha", "m1", "hello"))
-    expect(state).toEqual({ status: "completed", output: "ok: hello" })
+    const result = await serving(async (base) => {
+      const response = await put(base, "/v1/threads/alpha/methods/message/calls/m1", {
+        text: "hello",
+        model: { provider: "openai", model_id: "gpt-test" }
+      })
+      expect(response.status).toBe(202)
+      const state = await until("method call m1 of alpha", async () => {
+        const current = await get(base, "/v1/threads/alpha/methods/message/calls/m1")
+        const body = await current.json() as Record<string, unknown>
+        return body["status"] === "pending" ? undefined : body
+      })
+      const events = await (await get(base, "/v1/threads/alpha/events")).json() as ReadonlyArray<EventRow>
+      return { state, events }
+    })
+    expect(result.state).toEqual({ status: "completed", output: "ok: hello" })
+    expect(result.events.find((row) => row.event.type === "MessageReceived")?.event).toMatchObject({
+      model: { provider: "openai", model_id: "gpt-test" }
+    })
   })
 
   test("putting the same call URL is absorbed", async () => {

--- a/apps/server/src/api.ts
+++ b/apps/server/src/api.ts
@@ -21,7 +21,9 @@ import {
 } from "@clavia/tardigrade-client/contract"
 import { agentProjections } from "./actor"
 import { ModelCatalogStore } from "./catalog"
+import { providerAvailabilitiesOf } from "./catalog-availability"
 import { modelsPageOf, providersPageOf } from "./catalog-page"
+import { ServerConfig } from "./config"
 import { Threads, type ActorThreads } from "./host"
 import { problemResponse } from "./problem"
 import { treeOf, type ThreadSummary } from "./projections"
@@ -394,16 +396,24 @@ const catalogSnapshot = Effect.flatMap(ModelCatalogStore, (catalog) =>
     ))
     : Effect.succeed(catalog.snapshot))
 
-// layerModelsGroup pages the process snapshot and never reads the private provider directory.
+const catalogDiscovery = Effect.all([catalogSnapshot, ServerConfig]).pipe(
+  Effect.map(([catalog, config]) => ({
+    catalog,
+    availability: providerAvailabilitiesOf(config.model, config.modelCredentials),
+    policy: { ...(config.model.default === undefined ? {} : { default: config.model.default }), allow: config.model.allow }
+  }))
+)
+
+// layerModelsGroup pages the process snapshot using provider readiness derived without credential values.
 export const layerModelsGroup = HttpApiBuilder.group(ServerApi, "models", (handlers) =>
   handlers
-    .handle("providers", ({ query }) => Effect.flatMap(catalogSnapshot, (catalog) =>
+    .handle("providers", ({ query }) => Effect.flatMap(catalogDiscovery, ({ catalog, availability, policy }) =>
       Effect.try({
-        try: () => providersPageOf(catalog, query),
+        try: () => providersPageOf(catalog, availability, { ...query, policy }),
         catch: (error) => InvalidRequest.of(failureMessage(error))
       })))
-    .handle("models", ({ query }) => Effect.flatMap(catalogSnapshot, (catalog) =>
+    .handle("models", ({ query }) => Effect.flatMap(catalogDiscovery, ({ catalog, availability, policy }) =>
       Effect.try({
-        try: () => modelsPageOf(catalog, query),
+        try: () => modelsPageOf(catalog, availability, { ...query, policy }),
         catch: (error) => InvalidRequest.of(failureMessage(error))
       }))))

--- a/apps/server/src/catalog-availability.test.ts
+++ b/apps/server/src/catalog-availability.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test"
+
+import { providerAvailabilitiesOf, providerAvailabilityOf } from "./catalog-availability"
+
+describe("provider availability", () => {
+  test("describes usable, incomplete, and absent provider connections", () => {
+    const availability = providerAvailabilitiesOf({
+      allow: "*",
+      providers: {
+        ready: { baseUrl: "https://ready.test", protocol: "openai-responses", env: ["READY_KEY"] },
+        incomplete: { baseUrl: "https://incomplete.test", protocol: "openai-responses", env: ["MISSING_KEY"] }
+      }
+    }, { READY_KEY: "secret" })
+
+    expect(availability).toEqual({
+      ready: { status: "available" },
+      incomplete: { status: "unavailable", reason: "credential_missing" }
+    })
+    expect(providerAvailabilityOf(availability, "absent")).toEqual({
+      status: "unavailable",
+      reason: "not_configured"
+    })
+  })
+})

--- a/apps/server/src/catalog-availability.ts
+++ b/apps/server/src/catalog-availability.ts
@@ -1,0 +1,25 @@
+import type { ProviderAvailability } from "@clavia/tardigrade-client/contract"
+
+import type { ModelConfig, ModelCredentials } from "./config"
+
+// ProviderAvailabilities records whether each declared provider connection has a usable credential.
+export type ProviderAvailabilities = Readonly<Record<string, ProviderAvailability>>
+
+// providerAvailabilitiesOf derives public readiness without exposing credential values.
+export const providerAvailabilitiesOf = (
+  config: ModelConfig,
+  credentials: ModelCredentials
+): ProviderAvailabilities => Object.fromEntries(
+  Object.entries(config.providers).map(([id, provider]) => [
+    id,
+    provider.env.some((name) => credentials[name] !== undefined)
+      ? { status: "available" as const }
+      : { status: "unavailable" as const, reason: "credential_missing" as const }
+  ])
+)
+
+// providerAvailabilityOf resolves providers absent from host configuration as unavailable.
+export const providerAvailabilityOf = (
+  providers: ProviderAvailabilities,
+  id: string
+): ProviderAvailability => providers[id] ?? { status: "unavailable", reason: "not_configured" }

--- a/apps/server/src/catalog-page.test.ts
+++ b/apps/server/src/catalog-page.test.ts
@@ -6,6 +6,7 @@ import {
   modelsPageOf,
   providersPageOf
 } from "./catalog-page"
+import type { ProviderAvailabilities } from "./catalog-availability"
 
 const catalog: ModelCatalog = {
   source: "models.dev",
@@ -18,8 +19,9 @@ const catalog: ModelCatalog = {
       name: "OpenRouter",
       env: ["OPENROUTER_API_KEY"],
       models: [
-        { id: "anthropic/claude-sonnet", name: "Claude Sonnet", metadata: { contextWindowTokens: 200_000, toolCall: true } },
-        { id: "openai/gpt", name: "GPT", metadata: { contextWindowTokens: 128_000 } }
+        { id: "anthropic/claude-sonnet", name: "Claude Sonnet", metadata: { contextWindowTokens: 200_000, pricing: { promptUsdPerToken: 0.000_003, completionUsdPerToken: 0.000_015 }, toolCall: true } },
+        { id: "openai/gpt", name: "GPT", metadata: { contextWindowTokens: 128_000, pricing: { promptUsdPerToken: 0.000_002, completionUsdPerToken: 0.000_01 } } },
+        { id: "unpriced-model", metadata: {} }
       ]
     },
     {
@@ -31,13 +33,19 @@ const catalog: ModelCatalog = {
   ]
 }
 
+const availability: ProviderAvailabilities = {
+  openrouter: { status: "available" },
+  "private-gateway": { status: "unavailable", reason: "credential_missing" }
+}
+
 describe("provider catalog pages", () => {
   test("states known and custom provider requirements", () => {
-    const page = providersPageOf(catalog, { search: "gateway" })
+    const page = providersPageOf(catalog, availability, { search: "gateway" })
     expect(page.limit).toBe(DEFAULT_CATALOG_PAGE_LIMIT)
     expect(page.items.find((provider) => provider.id === "private-gateway")).toMatchObject({
       env: ["PRIVATE_MODEL_KEY"],
-      required: ["baseUrl", "protocol", "env"]
+      required: ["baseUrl", "protocol", "env"],
+      availability: { status: "unavailable", reason: "credential_missing" }
     })
     expect(page.items.find((provider) => provider.id === "cloudflare-ai-gateway")).toMatchObject({
       protocol: "openai-responses",
@@ -46,34 +54,108 @@ describe("provider catalog pages", () => {
   })
 
   test("states Bedrock region and endpoint requirements", () => {
-    expect(providersPageOf(catalog, { search: "bedrock" }).items[0]).toMatchObject({
+    expect(providersPageOf(catalog, availability, { search: "bedrock" }).items[0]).toMatchObject({
       id: "amazon-bedrock",
       protocol: "bedrock-converse",
       required: ["baseUrl", "env", "region"]
     })
   })
+
+  test("limits agent discovery to available providers", () => {
+    expect(providersPageOf(catalog, availability, { availability: "available" }).items.map((provider) => provider.id)).toEqual([
+      "openrouter"
+    ])
+  })
+
+  test("limits agent discovery to its effective model set", () => {
+    const models = {
+      allow: [{ provider: "openrouter", model_ids: ["openai/gpt"] }]
+    } as const
+    expect(providersPageOf(catalog, availability, { availability: "available", models }).items.map((provider) => provider.id)).toEqual([
+      "openrouter"
+    ])
+  })
 })
 
 describe("model catalog pages", () => {
   test("filters models and follows an opaque cursor", () => {
-    const first = modelsPageOf(catalog, { provider: "openrouter", limit: 1 })
+    const first = modelsPageOf(catalog, availability, { provider: "openrouter", limit: 1 })
     expect(first.items.map((model) => model.id)).toEqual(["anthropic/claude-sonnet"])
     expect(typeof first.next_cursor).toBe("string")
-    const second = modelsPageOf(catalog, { provider: "openrouter", limit: 1, cursor: first.next_cursor })
+    const second = modelsPageOf(catalog, availability, { provider: "openrouter", limit: 1, cursor: first.next_cursor })
     expect(second.items.map((model) => model.id)).toEqual(["openai/gpt"])
-    expect(second.next_cursor).toBeUndefined()
+    expect(typeof second.next_cursor).toBe("string")
+    const third = modelsPageOf(catalog, availability, { provider: "openrouter", limit: 1, cursor: second.next_cursor })
+    expect(third.items.map((model) => model.id)).toEqual(["unpriced-model"])
+    expect(third.next_cursor).toBeUndefined()
+  })
+
+  test("lists models from available providers", () => {
+    expect(modelsPageOf(catalog, availability, { availability: "available" }).items.map((model) => model.provider)).toEqual([
+      "openrouter",
+      "openrouter",
+      "openrouter"
+    ])
+  })
+
+  test("keeps the host catalog complete", () => {
+    expect(modelsPageOf(catalog, availability).items.map((model) => model.provider)).toEqual([
+      "openrouter",
+      "openrouter",
+      "openrouter",
+      "private-gateway"
+    ])
+  })
+
+  test("reports the policy used by the discovery surface", () => {
+    const policy = {
+      default: { provider: "openrouter", model_id: "openai/gpt" },
+      allow: [{ provider: "openrouter", model_ids: ["openai/gpt"] }]
+    } as const
+    expect(modelsPageOf(catalog, availability, { policy }).policy).toEqual(policy)
+    expect(providersPageOf(catalog, availability, { models: policy }).policy).toEqual(policy)
+  })
+
+  test("searches within the effective model set", () => {
+    expect(modelsPageOf(catalog, availability, {
+      models: { allow: [{ provider: "openrouter", model_ids: ["openai/gpt"] }] }
+    }).items.map((model) => `${model.provider}/${model.id}`)).toEqual(["openrouter/openai/gpt"])
   })
 
   test("searches model IDs and names without case sensitivity", () => {
-    expect(modelsPageOf(catalog, { search: "CLAUDE" }).items.map((model) => model.id)).toEqual([
+    expect(modelsPageOf(catalog, availability, { search: "CLAUDE" }).items.map((model) => model.id)).toEqual([
       "anthropic/claude-sonnet"
     ])
   })
 
+  test("sorts by a selected price before paging", () => {
+    const ascending = modelsPageOf(catalog, availability, {
+      sort: "completionUsdPerToken",
+      limit: 2,
+      availability: "available"
+    })
+    expect(ascending.items.map((model) => model.id)).toEqual(["openai/gpt", "anthropic/claude-sonnet"])
+    expect(typeof ascending.next_cursor).toBe("string")
+    const remaining = modelsPageOf(catalog, availability, {
+      sort: "completionUsdPerToken",
+      limit: 2,
+      cursor: ascending.next_cursor,
+      availability: "available"
+    })
+    expect(remaining.items.map((model) => model.id)).toEqual(["unpriced-model"])
+
+    expect(modelsPageOf(catalog, availability, {
+      availability: "available",
+      sort: "promptUsdPerToken",
+      order: "desc",
+      unpriced: "first"
+    }).items.map((model) => model.id)).toEqual(["unpriced-model", "anthropic/claude-sonnet", "openai/gpt"])
+  })
+
   test("rejects cursors used with another query or revision", () => {
-    const cursor = modelsPageOf(catalog, { provider: "openrouter", limit: 1 }).next_cursor
-    expect(() => modelsPageOf(catalog, { provider: "private-gateway", cursor })).toThrow("another query")
-    expect(() => modelsPageOf({ ...catalog, revision: "catalog-2" }, { provider: "openrouter", cursor })).toThrow(
+    const cursor = modelsPageOf(catalog, availability, { provider: "openrouter", limit: 1 }).next_cursor
+    expect(() => modelsPageOf(catalog, availability, { provider: "private-gateway", cursor })).toThrow("another query")
+    expect(() => modelsPageOf({ ...catalog, revision: "catalog-2" }, availability, { provider: "openrouter", cursor })).toThrow(
       "restart at revision"
     )
   })

--- a/apps/server/src/catalog-page.ts
+++ b/apps/server/src/catalog-page.ts
@@ -1,14 +1,35 @@
 import type {
+  CatalogAvailabilityFilter,
   ModelCatalog,
   ModelCatalogPage,
+  ModelCatalogPriceSort,
+  ModelCatalogSortOrder,
+  ModelCatalogUnpricedOrder,
   ProviderCatalogPage
 } from "@clavia/tardigrade-client/contract"
 import { MODEL_PROVIDER_CONNECTIONS } from "@clavia/tardigrade-model/directory"
+import { DEFAULT_MODEL_POLICY, modelAllowedBy, modelPolicyScopeOf, type ModelPolicy } from "tardie"
+import {
+  providerAvailabilityOf,
+  type ProviderAvailabilities
+} from "./catalog-availability"
 
 // DEFAULT_CATALOG_PAGE_LIMIT is the item count used when a catalog request states no limit.
 export const DEFAULT_CATALOG_PAGE_LIMIT = 50
 
+// DEFAULT_MODEL_CATALOG_SORT_ORDER is the price order used when a model query states a sort field.
+export const DEFAULT_MODEL_CATALOG_SORT_ORDER: ModelCatalogSortOrder = "asc"
+
+// DEFAULT_MODEL_CATALOG_UNPRICED_ORDER places models without the selected rate after priced models.
+export const DEFAULT_MODEL_CATALOG_UNPRICED_ORDER: ModelCatalogUnpricedOrder = "last"
+
+// DEFAULT_CATALOG_AVAILABILITY_FILTER keeps the host catalog complete when a caller states no availability filter.
+export const DEFAULT_CATALOG_AVAILABILITY_FILTER: CatalogAvailabilityFilter = "all"
+
 export interface CatalogPageQuery {
+  readonly availability?: CatalogAvailabilityFilter | undefined
+  readonly models?: ModelPolicy | undefined
+  readonly policy?: ModelPolicy | undefined
   readonly cursor?: string | undefined
   readonly limit?: number | undefined
   readonly search?: string | undefined
@@ -16,6 +37,9 @@ export interface CatalogPageQuery {
 
 export interface ModelCatalogPageQuery extends CatalogPageQuery {
   readonly provider?: string | undefined
+  readonly sort?: ModelCatalogPriceSort | undefined
+  readonly order?: ModelCatalogSortOrder | undefined
+  readonly unpriced?: ModelCatalogUnpricedOrder | undefined
 }
 
 interface CatalogCursor {
@@ -79,6 +103,7 @@ const pageOf = <A>(
     revision: catalog.revision,
     status: catalog.status,
     refreshed_at: catalog.refreshedAt,
+    policy: query.policy ?? query.models ?? DEFAULT_MODEL_POLICY,
     total: items.length,
     limit,
     ...(next < items.length ? { next_cursor: encoded({ revision: catalog.revision, offset: next, scope }) } : {}),
@@ -88,17 +113,25 @@ const pageOf = <A>(
 
 export const providersPageOf = (
   catalog: ModelCatalog,
+  availability: ProviderAvailabilities,
   query: CatalogPageQuery = {}
 ): ProviderCatalogPage => {
+  const availabilityFilter = query.availability ?? DEFAULT_CATALOG_AVAILABILITY_FILTER
   const search = normalized(query.search)
+  const modelScope = query.models === undefined ? "wide" : modelPolicyScopeOf([query.models])
   const discovered = new Map(catalog.providers.map((provider) => [provider.id, provider] as const))
-  const ids = [...new Set([...discovered.keys(), ...MODEL_PROVIDER_CONNECTIONS.map((provider) => provider.id)])].sort()
+  const ids = [...new Set([
+    ...discovered.keys(),
+    ...MODEL_PROVIDER_CONNECTIONS.map((provider) => provider.id),
+    ...Object.keys(availability)
+  ])].sort()
   const items = ids.map((id) => {
     const provider = discovered.get(id)
     const connection = MODEL_PROVIDER_CONNECTIONS.find((candidate) => candidate.id === id)
     return {
       id,
       name: provider?.name ?? connection?.name ?? id,
+      availability: providerAvailabilityOf(availability, id),
       ...(connection === undefined ? {} : { protocol: connection.protocol }),
       ...(connection?.baseUrl === undefined ? {} : { baseUrl: connection.baseUrl }),
       env: provider?.env ?? [],
@@ -110,20 +143,45 @@ export const providersPageOf = (
       ],
       optional: connection?.baseUrl === undefined ? [] : ["baseUrl"]
     }
-  }).filter((provider) => search.length === 0 || `${provider.id} ${provider.name}`.toLocaleLowerCase().includes(search))
-  return pageOf(catalog, items, query, `providers:${search}`)
+  }).filter((provider) => {
+    if (query.models === undefined || query.models.allow === "*") return true
+    return discovered.get(provider.id)?.models.some((model) =>
+      modelAllowedBy(query.models!, { provider: provider.id, model_id: model.id })
+    ) === true
+  }).filter((provider) => availabilityFilter === "all" || provider.availability.status === "available")
+    .filter((provider) => search.length === 0 || `${provider.id} ${provider.name}`.toLocaleLowerCase().includes(search))
+  return pageOf(catalog, items, query, `providers:${availabilityFilter}:${search}:${modelScope}`)
 }
 
 export const modelsPageOf = (
   catalog: ModelCatalog,
+  availability: ProviderAvailabilities,
   query: ModelCatalogPageQuery = {}
 ): ModelCatalogPage => {
+  const availabilityFilter = query.availability ?? DEFAULT_CATALOG_AVAILABILITY_FILTER
   const providerFilter = normalized(query.provider)
   const search = normalized(query.search)
+  const modelScope = query.models === undefined ? "wide" : modelPolicyScopeOf([query.models])
+  const sort = query.sort
+  const order = query.order ?? DEFAULT_MODEL_CATALOG_SORT_ORDER
+  const unpriced = query.unpriced ?? DEFAULT_MODEL_CATALOG_UNPRICED_ORDER
+  const identity = (model: { readonly provider: string; readonly id: string }): string => `${model.provider}/${model.id}`
   const items = catalog.providers
+    .filter((provider) => availabilityFilter === "all" || providerAvailabilityOf(availability, provider.id).status === "available")
     .filter((provider) => providerFilter.length === 0 || provider.id.toLocaleLowerCase() === providerFilter)
     .flatMap((provider) => provider.models.map((model) => ({ provider: provider.id, ...model })))
+    .filter((model) => query.models === undefined || modelAllowedBy(query.models, { provider: model.provider, model_id: model.id }))
     .filter((model) => search.length === 0 || `${model.id} ${model.name ?? ""}`.toLocaleLowerCase().includes(search))
-    .sort((left, right) => `${left.provider}/${left.id}`.localeCompare(`${right.provider}/${right.id}`))
-  return pageOf(catalog, items, query, `models:${providerFilter}:${search}`)
+    .sort((left, right) => {
+      if (sort === undefined) return identity(left).localeCompare(identity(right))
+      const leftRate = left.metadata.pricing?.[sort]
+      const rightRate = right.metadata.pricing?.[sort]
+      if (leftRate === undefined && rightRate !== undefined) return unpriced === "first" ? -1 : 1
+      if (leftRate !== undefined && rightRate === undefined) return unpriced === "first" ? 1 : -1
+      if (leftRate !== undefined && rightRate !== undefined && leftRate !== rightRate) {
+        return order === "asc" ? leftRate - rightRate : rightRate - leftRate
+      }
+      return identity(left).localeCompare(identity(right))
+    })
+  return pageOf(catalog, items, query, `models:${availabilityFilter}:${providerFilter}:${search}:${sort ?? "identity"}:${order}:${unpriced}:${modelScope}`)
 }

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -3,7 +3,13 @@ import {
   DEFAULT_MAX_CONCURRENT_LANES,
   driverPolicyOf
 } from "@clavia/tardigrade-host/driver"
-import { modelRefOf, type ModelRef } from "tardie"
+import {
+  DEFAULT_MODEL_POLICY,
+  modelAllowedBy,
+  modelPolicyOf,
+  modelRefOf,
+  type ModelPolicy
+} from "tardie"
 import { modelProtocolOf, type ModelProtocol } from "@clavia/tardigrade-model/directory"
 import { DEFAULT_MODEL_CATALOG_URL } from "@clavia/tardigrade-model/metadata"
 
@@ -53,8 +59,7 @@ export interface ModelProviderConfig {
 }
 
 // ModelConfig holds private provider connections and the reference used by the built-in actor.
-export interface ModelConfig {
-  readonly default: ModelRef | undefined
+export interface ModelConfig extends ModelPolicy {
   readonly providers: Readonly<Record<string, ModelProviderConfig>>
 }
 
@@ -133,6 +138,7 @@ const legacyModelError = (env: Env): Error | undefined => {
       [TARDIGRADE_CONFIG_VAR]: {
         models: {
           default: { provider, model_id },
+          allow: "*",
           providers: {
             [provider]: {
               baseUrl: text(env, "MODEL_BASE_URL") ?? "<base-url>",
@@ -155,7 +161,7 @@ const legacyModelError = (env: Env): Error | undefined => {
 export const modelConfigOf = (value: unknown): ModelConfig => {
   const source = recordOf(value)
   if (source === undefined) throw new Error("provider connection configuration must be a JSON object")
-  const unknownModelFields = Object.keys(source).filter((name) => name !== "default" && name !== "providers")
+  const unknownModelFields = Object.keys(source).filter((name) => name !== "default" && name !== "allow" && name !== "providers")
   if (unknownModelFields.length > 0) throw new Error(`models contains unknown fields: ${unknownModelFields.join(", ")}`)
   const providersSource = recordOf(source["providers"]) ?? {}
   const providers: Record<string, ModelProviderConfig> = {}
@@ -195,16 +201,26 @@ export const modelConfigOf = (value: unknown): ModelConfig => {
   const selectedValue = source["default"]
   const selected = modelRefOf(selectedValue)
   if (selectedValue !== undefined && selected === undefined) throw new Error("models.default must be { provider, model_id }")
+  const configured = Object.keys(providers).length > 0
+  if (configured && !("allow" in source)) throw new Error('models with providers must declare allow as "*" or an array')
+  if (configured && selected === undefined) throw new Error("models with providers must declare default { provider, model_id }")
+  const policy = modelPolicyOf({
+    ...(selected === undefined ? {} : { default: selected }),
+    allow: source["allow"] ?? "*"
+  })
   if (selected !== undefined && providers[selected.provider] === undefined) {
     throw new Error(`models.default names unconfigured provider ${JSON.stringify(selected.provider)}`)
   }
+  if (selected !== undefined && !modelAllowedBy(policy, selected)) {
+    throw new Error(`models.default ${selected.provider}/${selected.model_id} is excluded by models.allow`)
+  }
   return {
-    default: selected,
+    ...policy,
     providers
   }
 }
 
-// projectConfigOf reads Tardigrade settings from a Wrangler manifest.
+// projectConfigOf reads runnable Tardigrade settings from a Wrangler manifest.
 export const projectConfigOf = (value: unknown): ProjectConfig => {
   const source = recordOf(value)
   if (source === undefined) throw new Error("project configuration must be a JSON object")
@@ -212,14 +228,14 @@ export const projectConfigOf = (value: unknown): ProjectConfig => {
     throw new Error(`models must be nested under vars.${TARDIGRADE_CONFIG_VAR}`)
   }
   const varsValue = source["vars"]
-  if (varsValue === undefined) return { models: modelConfigOf({}) }
+  if (varsValue === undefined) return { models: modelConfigOf(DEFAULT_MODEL_POLICY) }
   const vars = recordOf(varsValue)
   if (vars === undefined) throw new Error("vars must be a JSON object")
   const configValue = vars[TARDIGRADE_CONFIG_VAR]
-  if (configValue === undefined) return { models: modelConfigOf({}) }
+  if (configValue === undefined) return { models: modelConfigOf(DEFAULT_MODEL_POLICY) }
   const config = recordOf(configValue)
   if (config === undefined) throw new Error(`${TARDIGRADE_CONFIG_VAR} must be a JSON object`)
-  return { models: modelConfigOf(config["models"] ?? {}) }
+  return { models: modelConfigOf(config["models"] ?? DEFAULT_MODEL_POLICY) }
 }
 
 const modelCredentialsFrom = (model: ModelConfig, env: Env): ModelCredentials => {
@@ -286,7 +302,7 @@ export const modelCatalogConfigOf = (env: Env): ModelCatalogConfig => ({
 // readConfig resolves project configuration and the environment into the value the process runs on.
 export const readConfig = (
   env: Env,
-  project: ProjectConfig = { models: { default: undefined, providers: {} } }
+  project: ProjectConfig = { models: { allow: "*", providers: {} } }
 ): ServerConfigValue => {
   const model = modelFrom(env, project)
   return {

--- a/apps/server/src/host.test.ts
+++ b/apps/server/src/host.test.ts
@@ -36,8 +36,12 @@ const briefOf = (trajectory: ReadonlyArray<Event>): string => {
 }
 
 const scripted = (request: InferRequest): Action => ({ kind: "complete", output: `ok: ${briefOf(request.trajectory)}` })
+const testModel = { provider: "test", model_id: "scripted" } as const
+const resolveTestModel = (model: { readonly provider: string; readonly model_id: string } = testModel) =>
+  ({ model, models: { default: model, allow: "*" as const } })
 
 const layerScripted: Layer.Layer<Infer> = Layer.succeed(Infer)({
+  resolve: resolveTestModel,
   react: (request: InferRequest) => Effect.succeed(scripted(request))
 })
 
@@ -75,6 +79,7 @@ const brief = (id: string, text = "hello") => ({ type: "MessageReceived", id, te
 describe("model selection", () => {
   const model = {
     default: { provider: "openrouter", model_id: "anthropic/claude-sonnet-4-6" },
+    allow: "*" as const,
     providers: {
       openrouter: {
         baseUrl: "https://openrouter.ai/api/v1",
@@ -168,6 +173,7 @@ describe("the threads service", () => {
     let peak = 0
     let calls = 0
     const concurrent = Layer.succeed(Infer)({
+      resolve: resolveTestModel,
       react: () => Effect.promise(async () => {
         active += 1
         peak = Math.max(peak, active)

--- a/apps/server/src/host.ts
+++ b/apps/server/src/host.ts
@@ -12,12 +12,16 @@ import type { Directory } from "@clavia/tardigrade-core/communication/directory"
 import { Ingress, ingressFrom } from "@clavia/tardigrade-host/communication/ingress"
 import type { Provider } from "@clavia/tardigrade-host/communication/provider"
 import {
+  applyModelPolicy,
   ACTOR_ARTIFACT_VERSION,
   ACTOR_NAME_PATTERN,
   Infer,
   actorMethodsOf,
+  intersectModelPolicies,
+  modelAllowedBy,
   type ActorMethods,
   type ModelRef,
+  type ModelPolicy,
   type ActorArtifactManifest,
   type Actor
 } from "tardie"
@@ -35,6 +39,8 @@ import {
 import { builtInActor, type ServerR } from "./actor"
 import { ServerConfig, type ModelConfig, type ModelCredentials, type ServerConfigValue } from "./config"
 import { ModelCatalogStore, type ModelCatalogState } from "./catalog"
+import { providerAvailabilitiesOf } from "./catalog-availability"
+import { modelsPageOf, providersPageOf } from "./catalog-page"
 import { DriverGauge } from "./driver-gauge"
 
 // The durable host, the assembly it runs, and the loop that drives it, behind one service. The
@@ -172,6 +178,9 @@ export const selectedModelFrom = (
 ): SelectedModel => {
   const selected = reference ?? config.default
   if (selected === undefined) throw new Error("the built-in actor has no model reference; run `tdg setup`")
+  if (!modelAllowedBy(config, selected)) {
+    throw new Error(`model ${selected.provider}/${selected.model_id} is excluded by the host model policy`)
+  }
   const provider = connectionFrom(config, credentials, selected)
   if (catalog.snapshot === undefined) {
     throw new Error(`model catalog metadata is unavailable for ${selected.provider}/${selected.model_id}; check the server startup logs`)
@@ -200,6 +209,7 @@ export const modelIsConfigured = (config: ServerConfigValue): boolean =>
   (() => {
     try {
       if (config.model.default === undefined) return false
+      if (!modelAllowedBy(config.model, config.model.default)) return false
       connectionFrom(config.model, config.modelCredentials, config.model.default)
       return true
     } catch {
@@ -215,11 +225,26 @@ const layerInferFrom = (config: ServerConfigValue, catalog: ModelCatalogState): 
       react: () => Effect.succeed(failed)
     })
   }
+  const availableModels = (): ModelPolicy => {
+    const snapshot = catalog.snapshot
+    if (snapshot === undefined) return { allow: [] }
+    const availability = providerAvailabilitiesOf(config.model, config.modelCredentials)
+    const configured: ModelPolicy = {
+      allow: snapshot.providers.flatMap((provider) =>
+        availability[provider.id]?.status === "available" && provider.models.length > 0
+          ? [{ provider: provider.id, model_ids: provider.models.map((model) => model.id) }]
+          : []
+      )
+    }
+    const authority = intersectModelPolicies([config.model, configured])
+    return { ...authority, ...(config.model.default === undefined ? {} : { default: config.model.default }) }
+  }
   return Layer.succeed(Infer, {
     resolve: (reference) => {
       const selected = selectedModelFrom(config.model, config.modelCredentials, catalog, reference)
       return {
-        model: reference,
+        model: { provider: selected.provider, model_id: selected.model_id },
+        models: availableModels(),
         contextWindowTokens: selected.contextWindowTokens,
         ...(selected.maxOutputTokens === undefined ? {} : { maxOutputTokens: selected.maxOutputTokens }),
         catalogRevision: selected.catalogRevision
@@ -497,13 +522,26 @@ const make = (options: ThreadsOptions) =>
     const runtimes = new Map<string, ActorRuntime>()
     const registry = yield* openBunActorRegistry<ActorSummary>({ file: config.db })
     const runRegistry = Effect.runPromiseWith(yield* Effect.context<never>())
+    const snapshot = catalog.snapshot
+    const availability = providerAvailabilitiesOf(config.model, config.modelCredentials)
+    const agentCatalog = snapshot === undefined
+      ? undefined
+      : {
+          providers: (query: Parameters<typeof providersPageOf>[2]) => {
+            const models = applyModelPolicy(config.model, query?.models ?? {})
+            return providersPageOf(snapshot, availability, { ...query, models, policy: models })
+          },
+          models: (query: Parameters<typeof modelsPageOf>[2]) => {
+            const models = applyModelPolicy(config.model, query?.models ?? {})
+            return modelsPageOf(snapshot, availability, { ...query, models, policy: models })
+          }
+        }
     const builtIn = modelIsConfigured(config)
       ? builtInActor({
-          provider: config.model.default!.provider,
-          default_model: config.model.default!.model_id,
-          contextWindowTokens: (model) => selectedModelFrom(config.model, config.modelCredentials, catalog, model).contextWindowTokens
+          contextWindowTokens: (model) => selectedModelFrom(config.model, config.modelCredentials, catalog, model).contextWindowTokens,
+          ...(agentCatalog === undefined ? {} : { catalog: agentCatalog })
         })
-      : builtInActor()
+      : builtInActor(agentCatalog === undefined ? {} : { catalog: agentCatalog })
     const root = resolve(config.actors)
     let mutations: Promise<void> = Promise.resolve()
     const exclusive = <A>(operation: () => Promise<A>): Promise<A> => {

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -81,7 +81,7 @@ describe("config", () => {
     expect(config.maxConcurrentLanes).toBe(DEFAULT_MAX_CONCURRENT_LANES)
     expect(config.token).toBeUndefined()
     expect(config.model).toEqual({
-      default: undefined,
+      allow: "*",
       providers: {}
     })
     expect(config.modelCredentials).toEqual({})
@@ -107,7 +107,7 @@ describe("config", () => {
     expect(config.actorData).toBe("/var/lib/actor-data")
     expect(config.maxConcurrentLanes).toBe(7)
     expect(config.token).toBe("secret")
-    expect(config.model).toEqual({ default: undefined, providers: {} })
+    expect(config.model).toEqual({ allow: "*", providers: {} })
     expect(config.modelCredentials).toEqual({})
     expect(config.catalog).toEqual({
       sourceUrl: "https://models.dev/api.json",
@@ -134,6 +134,7 @@ describe("config", () => {
     const project = projectConfigOf({
       vars: { TARDIGRADE_CONFIG: { models: {
         default: { provider: "openai", model_id: "gpt" },
+        allow: [{ provider: "openai", model_ids: ["gpt"] }],
         providers: {
           openai: {
             baseUrl: "https://api.openai.com/v1",
@@ -146,17 +147,18 @@ describe("config", () => {
     const config = readConfig({ OPENAI_API_KEY: "secret" }, project)
     expect(config.model).toMatchObject({
       default: { provider: "openai", model_id: "gpt" },
+      allow: [{ provider: "openai", model_ids: ["gpt"] }],
       providers: { openai: { protocol: "openai-responses" } }
     })
     expect(config.modelCredentials).toEqual({ OPENAI_API_KEY: "secret" })
     expect(() => projectConfigOf({
-      vars: { TARDIGRADE_CONFIG: { models: { providers: { openai: { apiKey: "must-not-live-here", env: ["OPENAI_API_KEY"] } } } } }
+      vars: { TARDIGRADE_CONFIG: { models: { allow: "*", providers: { openai: { apiKey: "must-not-live-here", env: ["OPENAI_API_KEY"] } } } } }
     })).toThrow("cannot contain apiKey")
     expect(() => projectConfigOf({
-      vars: { TARDIGRADE_CONFIG: { models: { providers: { openai: { baseUrl: "https://api.openai.com/v1", protocol: "openai-responses", env: ["bad-name"] } } } } }
+      vars: { TARDIGRADE_CONFIG: { models: { allow: "*", providers: { openai: { baseUrl: "https://api.openai.com/v1", protocol: "openai-responses", env: ["bad-name"] } } } } }
     })).toThrow("invalid name")
     expect(() => projectConfigOf({
-      vars: { TARDIGRADE_CONFIG: { models: { default: { provider: "missing", model_id: "gpt" }, providers: {} } } }
+      vars: { TARDIGRADE_CONFIG: { models: { default: { provider: "missing", model_id: "gpt" }, allow: "*", providers: {} } } }
     })).toThrow("unconfigured provider")
     expect(() => projectConfigOf({ models: {} })).toThrow("vars.TARDIGRADE_CONFIG")
   })

--- a/apps/voyager/dev/fixture.ts
+++ b/apps/voyager/dev/fixture.ts
@@ -86,7 +86,10 @@ const scripted = ({ trajectory }: InferRequest): Action => {
   }
 }
 
+const testModel = { provider: "test", model_id: "scripted" } as const
+
 const layerScripted: Layer.Layer<Infer> = Layer.succeed(Infer)({
+  resolve: (model = testModel) => ({ model, models: { default: model, allow: "*" } }),
   react: (request: InferRequest) => Effect.succeed(scripted(request))
 })
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -290,7 +290,6 @@ const plain = (text: string): CodeLine => ({ tokens: [token(text)] })
 const highlight = (capability: Capability, ...tokens: ReadonlyArray<CodeToken>): CodeLine => ({ tokens, capability })
 
 const start = (name: string): ReadonlyArray<CodeLine> => [
-  { tokens: [token("const", "red"), token(" model = { provider: "), token("\"openai\"", "blue"), token(", default_model: "), token("\"gpt-5.2\"", "blue"), token(" }")] },
   plain(""),
   { tokens: [token("export const", "red"), token(" " + name + " = "), token("actor", "purple"), token("({")] },
   { tokens: [token("  name: "), token("\"" + name + "\"", "blue"), token(",")] },
@@ -299,7 +298,7 @@ const start = (name: string): ReadonlyArray<CodeLine> => [
   { tokens: [token("    system", "purple"), token("("), token("\"Follow the evidence.\"", "blue"), token("),")] }
 ]
 
-const end: ReadonlyArray<CodeLine> = [plain("  ], model)]"), plain("})")]
+const end: ReadonlyArray<CodeLine> = [plain("  ])]"), plain("})")]
 
 const capabilityOptions: ReadonlyArray<CapabilityOption> = [
   { id: "memory", label: "Compaction" },
@@ -689,7 +688,7 @@ import { actor, agentMessageMethod, infer,
     system("Answer questions about the weather."),
     weather,
     nativeOutput
-  ], { provider: "openai", default_model: "gpt-5.2" })]
+  ])]
 })`}</code></pre>
             <aside><strong>components</strong><p>Pure functions over the log that compose instructions, tools, output, and policy.</p></aside>
           </div>
@@ -773,11 +772,6 @@ const instructions = system(
   "Investigate with code and delegate independent work."
 )
 
-const model = {
-  provider: "openrouter",
-  default_model: "anthropic/claude-sonnet-4.6"
-} as const
-
 const rlm = actor({
   name: "researcher",
   methods: agentMethods,
@@ -794,7 +788,7 @@ const rlm = actor({
       ], { authority: caller() }),
       compaction(),
       outputValidateOnce
-    ], model),
+    ]),
     budgetAuthority()
   ]
 })

--- a/bun.lock
+++ b/bun.lock
@@ -103,6 +103,9 @@
         "@clavia/tardigrade-host": "workspace:*",
         "effect": "4.0.0-rc.110",
       },
+      "devDependencies": {
+        "fast-check": "^4.9.0",
+      },
     },
     "packages/channels": {
       "name": "@clavia/tardigrade-channels",

--- a/docs/how-to/cli.md
+++ b/docs/how-to/cli.md
@@ -26,7 +26,7 @@ tdg call message '{"text":"read this repo and tell me what it does"}'
 | --- | --- |
 | `tdg init <name>` | Create an actor and configure its first provider connection |
 | `tdg setup` | Add provider connections, then choose the default model |
-| `tdg setup provider` | Add or update one provider connection |
+| `tdg setup provider` | Add or update one provider after initial setup |
 | `tdg setup default` | Choose the default model from configured providers |
 | `tdg lint <entry>` | Validate an actor's component and method seams |
 | `tdg build <entry>` | Build and validate an actor artifact |
@@ -67,7 +67,7 @@ A flag beats an environment variable, which beats `~/.tardigrade/config.json`, w
 | Model catalog cache | | `TARDIGRADE_MODEL_CATALOG_CACHE` | `.tardigrade/models.json` |
 | Provider credentials | | Variables named by each provider's `env` list | what interactive `tdg init` or `tdg setup` saved in `.dev.vars` |
 
-`tdg init` asks for the actor name when omitted, a provider connection, and a default model. Its target directory must be new. It creates an actor whose `infer` options match that selection, writes the public connection under `vars.TARDIGRADE_CONFIG` in `wrangler.jsonc` and `celld.jsonc`, and stores the credential in `.dev.vars` at mode 0600. A failed initialization removes the new target directory. Setup adds `.dev.vars*` to `.gitignore` when it stores a credential. It never prints the credential back. Run `tdg setup` inside the actor directory to add one or more provider connections, choose the default provider and model once, review the plan, and confirm the write. Existing providers remain available when the flow asks for the default. `tdg setup provider` changes connections without changing the default. Its declarative form accepts a provider name and a JSON connection object. The object names secret environment variables and does not contain or write their values. `tdg setup default` changes the default without writing credentials. Setup preserves unrelated platform settings, JSONC comments, local secret entries, and provider connections. `tdg dev` loads `.dev.vars`, then lets process environment values override it. It stores the actor's threads in `.tardigrade/actor.sqlite` under that directory, so keep the actor directory present while the server runs. A deployment uses its platform secret store. With no provider configured the server still boots and serves every read; it says so at boot and turns fail naming what is missing.
+`tdg init` asks for the actor name when omitted, a provider connection, and a default model. Its target directory must be new. It creates an actor that inherits the host model policy, writes the public connection under `vars.TARDIGRADE_CONFIG` in `wrangler.jsonc` and `celld.jsonc`, and stores the credential in `.dev.vars` at mode 0600. A failed initialization removes the new target directory. Setup adds `.dev.vars*` to `.gitignore` when it stores a credential. It never prints the credential back. Run `tdg setup` inside the actor directory to add one or more provider connections, choose the default provider and model once, review the plan, and confirm the write. Existing providers remain available when the flow asks for the default. The first provider and default are written together, so every configuration produced by the CLI can start a host. After that baseline exists, `tdg setup provider` changes connections without changing the default, and `tdg setup default` changes the default without writing credentials. Setup preserves unrelated platform settings, JSONC comments, local secret entries, and provider connections. `tdg dev` loads `.dev.vars`, then lets process environment values override it. It stores the actor's threads in `.tardigrade/actor.sqlite` under that directory, so keep the actor directory present while the server runs. A deployment uses its platform secret store. With no provider configured the server still boots and serves every read; it says so at boot and turns fail naming what is missing.
 
 An agent or CI job can avoid prompts by supplying the provider connection as JSON during initialization. The JSON names the credential environment variable and never contains its value:
 
@@ -78,15 +78,16 @@ tdg init researcher \
   --default-model anthropic/claude-sonnet-4.6
 ```
 
-Partial declarative initialization fails and lists the missing options. Declarative initialization does not read or write `OPENROUTER_API_KEY`; set it in the environment that runs the server. Agents and CI can add a connection and select it as the default in two focused commands:
+Partial declarative initialization fails and lists the missing options. Declarative initialization does not read or write `OPENROUTER_API_KEY`; set it in the environment that runs the server. Agents and CI can configure the first connection and default atomically:
 
 ```bash
-tdg setup provider openrouter '{"env":["OPENROUTER_API_KEY"]}'
-
-tdg setup default \
+tdg setup \
   --provider openrouter \
-  --model anthropic/claude-sonnet-4.6
+  --provider-config '{"env":["OPENROUTER_API_KEY"]}' \
+  --default-model anthropic/claude-sonnet-4.6
 ```
+
+Once a valid baseline exists, `tdg setup provider` adds or updates another connection and `tdg setup default` selects an allowed model from a configured provider.
 
 Known providers supply their standard protocol and endpoint. A provider whose connection needs more fields states them in the same object. Amazon Bedrock requires its gateway endpoint and AWS region:
 
@@ -106,6 +107,7 @@ tdg setup provider private-gateway '{"baseUrl":"https://models.example.com/v1","
     "TARDIGRADE_CONFIG": {
       "models": {
         "default": { "provider": "openrouter", "model_id": "anthropic/claude-sonnet-4.6" },
+        "allow": "*",
         "providers": {
           "openrouter": {
             "baseUrl": "https://openrouter.ai/api/v1",

--- a/docs/how-to/migrate.md
+++ b/docs/how-to/migrate.md
@@ -23,7 +23,7 @@ The current Vercel AI SDK agent surface includes [`ToolLoopAgent` and loop contr
 
 | Existing concern | Tardigrade home |
 | --- | --- |
-| `ToolLoopAgent`, `generateText`, `streamText`, or a manual model loop | `actor({ name, methods, components: [infer([...], { provider, default_model })] })` |
+| `ToolLoopAgent`, `generateText`, `streamText`, or a manual model loop | `actor({ name, methods, components: [infer([...])] })`; pass `models: { allow?, default? }` to narrow or override the host policy |
 | System instructions | `system(...)` |
 | Tool declarations and handlers | Package components mounted through `codeMode`, or fixed tools mounted through `toolList` |
 | `stopWhen`, maximum steps, and retry options | `budget`, `infer` policy, and domain components with explicit policy values |
@@ -60,7 +60,7 @@ Convert each structured result to `output({ name, schema })`. Send that contract
 
 ### Model binding
 
-Keep the baseline provider and model when the Tardigrade binding supports their transport. The built-in binding accepts OpenAI Responses, OpenAI-compatible chat completions, Anthropic Messages, and Bedrock Converse. Run `tdg setup` to add private provider connections and choose the default model. Use `tdg setup provider` or `tdg setup default` when the migration changes one concern. The server resolves model metadata from its catalog snapshot.
+Keep the baseline provider and model when the Tardigrade binding supports their transport. The built-in binding accepts OpenAI Responses, OpenAI-compatible chat completions, Anthropic Messages, and Bedrock Converse. Run `tdg setup` to write the first private provider connection and default model together. Once that baseline exists, use `tdg setup provider` or `tdg setup default` when the migration changes one concern. The server resolves model metadata from its catalog snapshot.
 
 List every existing model option and confirm that the selected binding represents it. A custom transport or required option belongs in an application-owned `Infer` layer and custom host. Do not silently drop a temperature, provider option, retry bound, output guarantee, or timeout that affects behavior.
 

--- a/docs/how-to/server.md
+++ b/docs/how-to/server.md
@@ -16,8 +16,8 @@ Base path `/v1`. Runtime routes address the actor mounted at the server origin. 
 
 | | |
 | --- | --- |
-| `GET /v1/providers` | Search and page provider setup requirements. `search`, `cursor`, `limit` |
-| `GET /v1/models` | Search and page public model metadata. `provider`, `search`, `cursor`, `limit` |
+| `GET /v1/providers` | Search and page provider setup requirements. The page reports the host model policy and default. `availability`, `search`, `cursor`, `limit` |
+| `GET /v1/models` | Search and page public model metadata. The page reports the host model policy and default. `availability`, `provider`, `search`, `sort`, `order`, `unpriced`, `cursor`, `limit` |
 | `GET /v1/metadata` | Read the mounted actor name and storage metadata |
 | `GET /v1/methods` | List methods with standalone input and output schemas |
 | `GET /v1/threads` | List threads |
@@ -74,7 +74,7 @@ Declared request failures are `application/problem+json`.
 | `TARDIGRADE_MODEL_CATALOG_TIMEOUT_MILLIS` | `10000`. Startup refresh timeout |
 | Provider credentials | Set each variable named by a provider's `env` list. Use deployment secrets on a hosted server |
 
-The server boots without a provider connection and serves every read; turns fail naming what is missing. An actor selects a configured provider and any model that provider exposes in the catalog. The built-in actor uses the configured default. Interactive `tdg setup` writes provider configuration under `vars.TARDIGRADE_CONFIG` in the generated platform manifests and local credentials to `.dev.vars`. The declarative `tdg setup provider <provider> <config>` command writes the connection and leaves secret values in the deployment environment. The `provider` and `default` subcommands change those concerns independently.
+The server boots without a provider connection and serves every read; turns fail naming what is missing. A `models` block with provider connections requires `allow` and `default`. The default must name a configured provider and belong to the allowed set. `allow` accepts `"*"` or provider selectors. Actors inherit this complete policy and may narrow its coordinates or select another allowed default. Interactive `tdg setup` writes provider configuration under `vars.TARDIGRADE_CONFIG` in the generated platform manifests and local credentials to `.dev.vars`. Its declarative form accepts `--provider`, `--provider-config`, and `--default-model` together. The CLI writes the first provider and default atomically. Once the host has a valid baseline, the `provider` and `default` subcommands update either concern while preserving runnable configuration.
 
 ```jsonc
 {
@@ -82,6 +82,7 @@ The server boots without a provider connection and serves every read; turns fail
     "TARDIGRADE_CONFIG": {
       "models": {
         "default": { "provider": "openrouter", "model_id": "anthropic/claude-sonnet-4.6" },
+        "allow": "*",
         "providers": {
           "openrouter": {
             "baseUrl": "https://openrouter.ai/api/v1",

--- a/e2e/actor/harness.ts
+++ b/e2e/actor/harness.ts
@@ -14,7 +14,12 @@ import {
 import type { Action } from "tardie/log/events"
 
 export const ROOT_LANE = "ag.root"
-export const TEST_MODEL = { provider: "test", default_model: "test-model" } as const
+export const TEST_MODEL = {
+  models: {
+    default: { provider: "test", model_id: "test-model" },
+    allow: "*"
+  }
+} as const
 
 export type Mind = (request: InferRequest, key?: string) => Promise<Action>
 

--- a/examples/quickstart/actor.ts
+++ b/examples/quickstart/actor.ts
@@ -6,7 +6,6 @@ import {
 
 // actorName is the stable name used by build, development, and deployment.
 const actorName = "researcher"
-const actorModel = { provider: "openai", default_model: "gpt-5.2" } as const
 
 // actorInstructions is the main place to describe the job and its expected answer.
 const actorInstructions = `
@@ -38,7 +37,7 @@ export default actor({
       compaction(),
       // outputValidateOnce validates one structured result when the endpoint supplies no native guarantee.
       outputValidateOnce
-    ], actorModel),
+    ]),
     budgetAuthority()
   ]
 })

--- a/examples/rlm-agent.ts
+++ b/examples/rlm-agent.ts
@@ -12,8 +12,6 @@ import { createBunHost } from "@clavia/tardigrade-bun/host"
 // values, so the model's system fragment lists them and the assembly's requirements carry their
 // needs (Router and Self for spawn; the spill store for workspace). The Bun host binds
 // all of those per lane.
-const actorModel = { provider: "openai", default_model: "gpt-5.2" } as const
-
 const rlm = actor({
   name: "researcher",
   methods: agentMethods,
@@ -21,14 +19,14 @@ const rlm = actor({
     budget([codeMode([agentsPackage(), workspacePackage()])]), // the per-turn code budget, inherited by spawned children
     compaction(), // bounded model context over long investigations
     outputValidateOnce // handles structured results without adding a retry
-  ], actorModel)]
+  ])]
 })
 
 const model = infer({
   baseUrl: "https://api.openai.com/v1",
   apiKey: process.env.OPENAI_API_KEY!,
-  provider: actorModel.provider,
-  model: actorModel.default_model,
+  provider: "openai",
+  model: "gpt-5.2",
   protocol: "openai-responses",
   contextWindowTokens: 400_000
 })

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -41,6 +41,9 @@
     "effect": "4.0.0-rc.110",
     "@clavia/tardigrade-host": "workspace:*"
   },
+  "devDependencies": {
+    "fast-check": "^4.9.0"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "bun test"

--- a/packages/agent/src/actor/message.test.ts
+++ b/packages/agent/src/actor/message.test.ts
@@ -5,7 +5,11 @@ import { agentMessageMethod, agentMethods } from "./message"
 
 const head = agentMessageMethod.event({
   id: "m1",
-  input: { text: "review it", input: { pull: 227 }, model: "openai/gpt-5.2" },
+  input: {
+    text: "review it",
+    input: { pull: 227 },
+    model: { provider: "openai", model_id: "gpt-5.2" }
+  },
   at: 1
 })
 
@@ -16,8 +20,22 @@ describe("agentMessageMethod", () => {
       id: "m1",
       text: "review it",
       input: { pull: 227 },
-      model: "openai/gpt-5.2",
+      model: { provider: "openai", model_id: "gpt-5.2" },
       at: 1
+    })
+    expect(agentMessageMethod.eventOf({
+      id: "m2",
+      input: {
+        text: "switch providers",
+        model: { provider: "openai", model_id: "gpt-5.6" }
+      },
+      at: 2
+    })).toEqual({
+      type: "MessageReceived",
+      id: "m2",
+      text: "switch providers",
+      model: { provider: "openai", model_id: "gpt-5.6" },
+      at: 2
     })
     expect(agentMethods).toEqual({ message: agentMessageMethod, requestBudget: requestBudgetMethod })
   })

--- a/packages/agent/src/actor/message.ts
+++ b/packages/agent/src/actor/message.ts
@@ -1,21 +1,59 @@
 import { Schema } from "effect"
-import { messageReceived } from "@clavia/tardigrade-core/communication/message"
+import { MessageReceived, messageReceived } from "@clavia/tardigrade-core/communication/message"
+import type { Event } from "@clavia/tardigrade-core/log/event"
 import { boundaryOf } from "../output/boundary"
 import { actorMethod, actorMethodsOf } from "@clavia/tardigrade-core/actor/method"
+import { turnEpochOf } from "@clavia/tardigrade-code/execution/turns"
 import { requestBudgetMethod } from "./budget"
+import { ModelRef } from "../inference/reference"
+import { ModelPolicy } from "../inference/access"
+import { turnFailed } from "../log/events"
 
 export const AgentMessageInput = Schema.Struct({
   text: Schema.String,
   input: Schema.optionalKey(Schema.Unknown),
-  model: Schema.optionalKey(Schema.NonEmptyString)
+  model: Schema.optionalKey(ModelRef)
 }).annotate({ identifier: "AgentMessageInput" })
 
 export type AgentMessageInput = typeof AgentMessageInput.Type
+
+// AgentMessageReceived is the durable input contract interpreted by the message method.
+export const AgentMessageReceived = Schema.Struct({
+  ...MessageReceived.fields,
+  model: Schema.optional(ModelRef),
+  models: Schema.optional(ModelPolicy)
+}).annotate({ identifier: "AgentMessageReceived" })
+
+const turnOf = (event: Event): string => String((event as { readonly id?: unknown }).id)
+
+const terminalKey = (event: Event, log: ReadonlyArray<Event>): string => {
+  const turn = turnOf(event)
+  const epoch = turnEpochOf(log, turn)
+  return epoch === 0 ? `tn:${turn}` : `tn:${turn}/${epoch}`
+}
 
 // agentMessageMethod exposes an agent turn as the generic message actor method.
 export const agentMessageMethod = actorMethod({
   input: AgentMessageInput,
   output: Schema.String,
+  durableInput: {
+    schema: AgentMessageReceived,
+    matches: (event) => event.type === "MessageReceived",
+    keyOf: ({ event, log }) => terminalKey(event, log),
+    reject: ({ event, log, error }, at) => {
+      const turn = turnOf(event)
+      const epoch = turnEpochOf(log, turn)
+      return turnFailed({
+        error: `invalid MessageReceived: ${error}; send a new corrected message`,
+        cause: "message_invalid",
+        attempts: 0,
+        attemptKey: `${turn}/message`,
+        turn,
+        ...(epoch === 0 ? {} : { epoch }),
+        at
+      })
+    }
+  },
   event: ({ id, input, at }) => messageReceived({
     id,
     text: input.text,

--- a/packages/agent/src/components/budget.test.ts
+++ b/packages/agent/src/components/budget.test.ts
@@ -19,7 +19,7 @@ import { nativeOutput } from "./native-output"
 import { toolList } from "./tool-list"
 import { agentKeys } from "../log/events"
 
-const TEST_MODEL = { provider: "test", default_model: "test-model" } as const
+const TEST_MODEL = { models: { default: { provider: "test", model_id: "test-model" }, allow: "*" } } as const
 
 const assembled = <R>(component: import("../runtime/composition").AgentComponent<R>) => actor({
   name: "test-agent",

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -16,7 +16,7 @@ import { actor, agentMethods, budget, codeMode, compaction, infer, nativeOutput,
 import type { AgentR } from "./runtime/turn"
 
 const ROOT_LANE = "ag.root"
-const TEST_MODEL = { provider: "test", default_model: "test-model" } as const
+const TEST_MODEL = { models: { default: { provider: "test", model_id: "test-model" }, allow: "*" } } as const
 
 // The headline: one ask, an emergent graph, one answer, library only.
 // The root's code spawns two children; the host births their lanes,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -36,6 +36,20 @@ export {
   type Render
 } from "./inference/reactor"
 export { ModelRef, modelRefOf } from "./inference/reference"
+export {
+  applyModelPolicy,
+  DEFAULT_MODEL_POLICY,
+  DEFAULT_MODEL_POLICY_OVERRIDE,
+  intersectModelPolicies,
+  modelAllowedBy,
+  ModelAllow,
+  ModelPolicy,
+  ModelPolicyOverride,
+  modelPolicyOf,
+  modelPolicyOverrideOf,
+  modelPolicyScopeOf,
+  ModelSelector
+} from "./inference/access"
 
 // The turn's declared final response: the contract a caller states, the profile a binding can
 // send unchanged, and the implementation that obtains it. `output` is the whole declarative
@@ -121,7 +135,14 @@ export { boundaryOf, outputOf, type Boundary } from "./output/boundary"
 
 // The spawn package: a value with no lane in it, so the assembly that mounts it and the host
 // that binds Router and Self per lane cannot disagree about placement (packages/agents.ts).
-export { agentsPackage, INLINE_OUTPUT_NAME, type SpawnOptions } from "./packages/agents"
+export {
+  agentsPackage,
+  INLINE_OUTPUT_NAME,
+  type AgentCatalog,
+  type AgentCatalogQuery,
+  type AgentModelCatalogQuery,
+  type SpawnOptions
+} from "./packages/agents"
 
 // The workspace the model reads its spilled values back through, and the optional SQL binding a
 // platform lights its third verb up with.

--- a/packages/agent/src/inference/access.properties.test.ts
+++ b/packages/agent/src/inference/access.properties.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test"
+import fc from "fast-check"
+import {
+  applyModelPolicy,
+  DEFAULT_MODEL_POLICY,
+  intersectModelPolicies,
+  modelAllowedBy,
+  modelPolicyOf,
+  type ModelPolicy
+} from "./access"
+import type { ModelRef } from "./reference"
+
+const coordinates: ReadonlyArray<ModelRef> = [
+  { provider: "openai", model_id: "large" },
+  { provider: "openai", model_id: "small" },
+  { provider: "anthropic", model_id: "sonnet" }
+]
+
+const coordinateKey = (model: ModelRef): string => `${model.provider}/${model.model_id}`
+
+const policyOf = (models: ReadonlyArray<ModelRef>, selected?: ModelRef): ModelPolicy => modelPolicyOf({
+  ...(selected === undefined ? {} : { default: selected }),
+  allow: models.map((model) => ({ provider: model.provider, model_ids: [model.model_id] }))
+})
+
+const selected = (policy: ModelPolicy): ReadonlyArray<string> =>
+  coordinates.filter((model) => modelAllowedBy(policy, model)).map(coordinateKey).sort()
+
+const policyArbitrary = fc.subarray([...coordinates]).map((models) => policyOf(models))
+
+const pointedPolicyArbitrary = fc.subarray([...coordinates], { minLength: 1 }).chain((models) =>
+  fc.constantFrom(...models).map((model) => policyOf(models, model))
+)
+
+const pointedOverrideArbitrary = pointedPolicyArbitrary.chain((incoming) =>
+  fc.constantFrom(...coordinates.filter((model) => modelAllowedBy(incoming, model)))
+    .map((nextDefault) => ({ incoming, nextDefault }))
+)
+
+describe("model policy set laws", () => {
+  test("wildcard is identity and an empty allowlist is empty", () => {
+    expect(selected(intersectModelPolicies([DEFAULT_MODEL_POLICY]))).toEqual(selected(DEFAULT_MODEL_POLICY))
+    expect(selected(intersectModelPolicies([{ allow: [] }]))).toEqual([])
+  })
+
+  test("selectors form a normalized union inside one policy", () => {
+    expect(modelPolicyOf({
+      allow: [
+        { provider: "openai", model_ids: ["small"] },
+        { provider: "anthropic", model_ids: "*" },
+        { provider: "openai", model_ids: ["large"] }
+      ]
+    })).toEqual({
+      allow: [
+        { provider: "anthropic", model_ids: "*" },
+        { provider: "openai", model_ids: ["large", "small"] }
+      ]
+    })
+  })
+
+  test("intersection is commutative and idempotent", () => {
+    fc.assert(fc.property(policyArbitrary, policyArbitrary, (left, right) => {
+      expect(selected(intersectModelPolicies([left, left]))).toEqual(selected(left))
+      expect(selected(intersectModelPolicies([left, right]))).toEqual(selected(intersectModelPolicies([right, left])))
+    }))
+  })
+
+  test("intersection is associative and contractive", () => {
+    fc.assert(fc.property(policyArbitrary, policyArbitrary, policyArbitrary, (left, middle, right) => {
+      const first = intersectModelPolicies([left, middle])
+      expect(selected(first).every((model) => selected(left).includes(model))).toBe(true)
+      expect(selected(intersectModelPolicies([first, right]))).toEqual(
+        selected(intersectModelPolicies([left, intersectModelPolicies([middle, right])]))
+      )
+    }))
+  })
+
+  test("an inherited default remains the point of every valid attenuation", () => {
+    fc.assert(fc.property(pointedPolicyArbitrary, fc.subarray([...coordinates]), (incoming, extra) => {
+      const retained = coordinates.filter((model) =>
+        modelAllowedBy(incoming, model) && (coordinateKey(model) === coordinateKey(incoming.default!) || extra.some((value) => coordinateKey(value) === coordinateKey(model)))
+      )
+      const effective = applyModelPolicy(incoming, { allow: policyOf(retained).allow })
+      expect(effective.default).toEqual(incoming.default)
+      expect(modelAllowedBy(effective, effective.default!)).toBe(true)
+      expect(selected(effective).every((model) => selected(incoming).includes(model))).toBe(true)
+    }))
+  })
+
+  test("a declared default remains inside the attenuated coordinate set", () => {
+    fc.assert(fc.property(pointedOverrideArbitrary, ({ incoming, nextDefault }) => {
+      const effective = applyModelPolicy(incoming, { default: nextDefault })
+      expect(effective.default).toEqual(nextDefault)
+      expect(modelAllowedBy(effective, effective.default!)).toBe(true)
+    }))
+  })
+})

--- a/packages/agent/src/inference/access.ts
+++ b/packages/agent/src/inference/access.ts
@@ -1,0 +1,184 @@
+import { Schema } from "effect"
+import { ModelRef, modelRefOf, type ModelRef as ModelRefType } from "./reference"
+
+const PolicyName = Schema.String.check(Schema.isTrimmed(), Schema.isNonEmpty())
+
+export const ModelSelector = Schema.Struct({
+  provider: PolicyName,
+  model_ids: Schema.Union([Schema.Literal("*"), Schema.Array(PolicyName).check(Schema.isNonEmpty())])
+})
+
+export interface ModelSelector {
+  readonly provider: string
+  readonly model_ids: "*" | ReadonlyArray<string>
+}
+
+export const ModelAllow = Schema.Union([Schema.Literal("*"), Schema.Array(ModelSelector)])
+export type ModelAllow = "*" | ReadonlyArray<ModelSelector>
+
+// ModelPolicy carries resolved coordinate authority. Future rule languages lower into this selector form before composition, so intersection remains the authority boundary.
+export const ModelPolicy = Schema.Struct({
+  default: Schema.optional(ModelRef),
+  allow: ModelAllow
+})
+
+export interface ModelPolicy {
+  readonly default?: ModelRefType
+  readonly allow: ModelAllow
+}
+
+export const ModelPolicyOverride = Schema.Struct({
+  default: Schema.optional(ModelRef),
+  allow: Schema.optional(ModelAllow)
+})
+
+export interface ModelPolicyOverride {
+  readonly default?: ModelRefType
+  readonly allow?: ModelAllow
+}
+
+// DEFAULT_MODEL_POLICY leaves model authority unchanged and selects no default for an unconfigured host.
+export const DEFAULT_MODEL_POLICY: ModelPolicy = { allow: "*" }
+
+// DEFAULT_MODEL_POLICY_OVERRIDE inherits model authority and its default.
+export const DEFAULT_MODEL_POLICY_OVERRIDE: ModelPolicyOverride = {}
+
+const recordOf = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : undefined
+
+const textOf = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined
+
+const selectorOf = (value: unknown, index: number): ModelSelector => {
+  const selector = recordOf(value)
+  if (selector === undefined) throw new Error(`model selector ${index} must be an object`)
+  const unknown = Object.keys(selector).filter((field) => field !== "provider" && field !== "model_ids")
+  if (unknown.length > 0) throw new Error(`model selector ${index} contains unknown fields: ${unknown.join(", ")}`)
+  const provider = textOf(selector["provider"])
+  if (provider === undefined) throw new Error(`model selector ${index} must declare provider`)
+  const rawModels = selector["model_ids"]
+  if (rawModels === "*") return { provider, model_ids: "*" }
+  if (!Array.isArray(rawModels) || rawModels.length === 0) {
+    throw new Error(`model selector ${index} model_ids must be "*" or a non-empty array`)
+  }
+  const modelIds = rawModels.map((value, modelIndex) => {
+    const model = textOf(value)
+    if (model === undefined) throw new Error(`model selector ${index} model_ids[${modelIndex}] must be a non-empty string`)
+    return model
+  })
+  return { provider, model_ids: [...new Set(modelIds)].sort() }
+}
+
+type ProviderModels = "*" | Set<string>
+
+// selectorMapOf lowers the current selector language into the set representation consumed by policy intersection. Query resolvers add syntax before this boundary and persist the normalized result.
+const selectorMapOf = (selectors: ReadonlyArray<ModelSelector>): Map<string, ProviderModels> => {
+  const providers = new Map<string, ProviderModels>()
+  for (const selector of selectors) {
+    const current = providers.get(selector.provider)
+    if (current === "*" || selector.model_ids === "*") {
+      providers.set(selector.provider, "*")
+    } else {
+      providers.set(selector.provider, new Set([...(current ?? []), ...selector.model_ids]))
+    }
+  }
+  return providers
+}
+
+const selectorsOf = (providers: ReadonlyMap<string, ProviderModels>): ReadonlyArray<ModelSelector> =>
+  [...providers.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([provider, models]) => ({ provider, model_ids: models === "*" ? "*" : [...models].sort() }))
+
+const allowOf = (rawAllow: unknown, required: boolean): ModelAllow | undefined => {
+  if (rawAllow === "*") return "*"
+  if (Array.isArray(rawAllow)) return selectorsOf(selectorMapOf(rawAllow.map(selectorOf)))
+  if (!required && rawAllow === undefined) return undefined
+  throw new Error(`model policy allow must be "*" or an array`)
+}
+
+// modelAllowedBy reports whether one reference belongs to a policy's selected set.
+export const modelAllowedBy = (policy: ModelPolicy, reference: ModelRefType): boolean =>
+  policy.allow === "*" || policy.allow.some((selector) =>
+    selector.provider === reference.provider &&
+    (selector.model_ids === "*" || selector.model_ids.includes(reference.model_id))
+  )
+
+// modelPolicyOf validates one policy and gives duplicate selectors a stable representation.
+export const modelPolicyOf = (value: unknown): ModelPolicy => {
+  if (value === undefined) return DEFAULT_MODEL_POLICY
+  const policy = recordOf(value)
+  if (policy === undefined) throw new Error("model policy must be an object")
+  const unknown = Object.keys(policy).filter((field) => field !== "default" && field !== "allow")
+  if (unknown.length > 0) throw new Error(`model policy contains unknown fields: ${unknown.join(", ")}`)
+  if (!("allow" in policy)) throw new Error('model policy must declare allow as "*" or an array')
+  const rawDefault = policy["default"]
+  const selected = modelRefOf(rawDefault)
+  if (rawDefault !== undefined && selected === undefined) throw new Error("model policy default must be { provider, model_id }")
+  const allow = allowOf(policy["allow"], true)!
+  const normalized: ModelPolicy = { ...(selected === undefined ? {} : { default: selected }), allow }
+  if (selected !== undefined && !modelAllowedBy(normalized, selected)) {
+    throw new Error(`model policy default ${selected.provider}/${selected.model_id} is excluded by allow`)
+  }
+  return normalized
+}
+
+// modelPolicyOverrideOf validates an optional downstream attenuation and default override.
+export const modelPolicyOverrideOf = (value: unknown): ModelPolicyOverride => {
+  if (value === undefined) return DEFAULT_MODEL_POLICY_OVERRIDE
+  const policy = recordOf(value)
+  if (policy === undefined) throw new Error("model policy override must be an object")
+  const unknown = Object.keys(policy).filter((field) => field !== "default" && field !== "allow")
+  if (unknown.length > 0) throw new Error(`model policy override contains unknown fields: ${unknown.join(", ")}`)
+  const rawDefault = policy["default"]
+  const selected = modelRefOf(rawDefault)
+  if (rawDefault !== undefined && selected === undefined) throw new Error("model policy override default must be { provider, model_id }")
+  const allow = allowOf(policy["allow"], false)
+  const normalized: ModelPolicyOverride = {
+    ...(selected === undefined ? {} : { default: selected }),
+    ...(allow === undefined ? {} : { allow })
+  }
+  if (selected !== undefined && allow !== undefined && !modelAllowedBy({ allow }, selected)) {
+    throw new Error(`model policy override default ${selected.provider}/${selected.model_id} is excluded by allow`)
+  }
+  return normalized
+}
+
+const intersectModels = (left: ProviderModels, right: ProviderModels): ProviderModels => {
+  if (left === "*") return right === "*" ? "*" : new Set(right)
+  if (right === "*") return new Set(left)
+  return new Set([...left].filter((model) => right.has(model)))
+}
+
+// intersectModelPolicies returns the authority shared by every layer (packages/core/tla/runtime/ModelPolicy.tla, ChildCannotWiden; HostCeiling).
+export const intersectModelPolicies = (policies: ReadonlyArray<ModelPolicy>): ModelPolicy => {
+  const explicit = policies.filter((policy) => policy.allow !== "*")
+  if (explicit.length === 0) return DEFAULT_MODEL_POLICY
+  let intersection = selectorMapOf(explicit[0]!.allow as ReadonlyArray<ModelSelector>)
+  for (const policy of explicit.slice(1)) {
+    const right = selectorMapOf(policy.allow as ReadonlyArray<ModelSelector>)
+    const next = new Map<string, ProviderModels>()
+    for (const [provider, models] of intersection) {
+      const other = right.get(provider)
+      if (other === undefined) continue
+      const shared = intersectModels(models, other)
+      if (shared === "*" || shared.size > 0) next.set(provider, shared)
+    }
+    intersection = next
+  }
+  return { allow: selectorsOf(intersection) }
+}
+
+// applyModelPolicy attenuates incoming authority and inherits or overrides its default (packages/core/tla/runtime/ModelPolicy.tla, ChildCannotWiden; DefaultAllowed).
+export const applyModelPolicy = (incoming: ModelPolicy, override: ModelPolicyOverride): ModelPolicy => {
+  const authority = intersectModelPolicies([incoming, { allow: override.allow ?? "*" }])
+  const selected = override.default ?? incoming.default
+  if (selected !== undefined && !modelAllowedBy(authority, selected)) {
+    throw new Error(`effective model policy excludes default ${selected.provider}/${selected.model_id}; supply an allowed default`)
+  }
+  return { ...authority, ...(selected === undefined ? {} : { default: selected }) }
+}
+
+// modelPolicyScopeOf returns a stable cursor scope for a policy intersection.
+export const modelPolicyScopeOf = (policies: ReadonlyArray<ModelPolicy>): string =>
+  JSON.stringify(intersectModelPolicies(policies).allow)

--- a/packages/agent/src/inference/reactor.ts
+++ b/packages/agent/src/inference/reactor.ts
@@ -19,6 +19,15 @@ import {
 } from "../output/contract"
 import type { ContextPolicy } from "../components/compaction"
 import { modelRefOf, type ModelRef } from "./reference"
+import {
+  applyModelPolicy,
+  DEFAULT_MODEL_POLICY,
+  DEFAULT_MODEL_POLICY_OVERRIDE,
+  modelAllowedBy,
+  modelPolicyOf,
+  type ModelPolicy,
+  type ModelPolicyOverride
+} from "./access"
 
 // The infer reactor: the model loop, and nothing else. A think is owed when the current turn
 // has no unanswered tool call and no terminal; serving marks the attempt, does inference, then
@@ -31,10 +40,10 @@ import { modelRefOf, type ModelRef } from "./reference"
 // output implementation the assembly mounts, not here (src/components/repair.ts, RepairPolicy).
 export interface InferPolicy {
   readonly giveUpAfter: number
-  readonly model?: ModelRef
+  readonly models: ModelPolicyOverride
 }
 
-export const DEFAULT_INFER_POLICY: InferPolicy = { giveUpAfter: 3 }
+export const DEFAULT_INFER_POLICY: InferPolicy = { giveUpAfter: 3, models: DEFAULT_MODEL_POLICY_OVERRIDE }
 
 // InferRequest is one attempt's whole context: the trajectory, and the render the assembly
 // derived for it (the system text, the tools the model is offered, and the implementation that
@@ -55,30 +64,32 @@ export interface InferRequest {
 
 export interface ModelResolution {
   readonly model: ModelRef
+  readonly models?: ModelPolicy
   readonly contextWindowTokens?: number
   readonly maxOutputTokens?: number
   readonly catalogRevision?: string
 }
 
-// selectedModelOf applies the visible model-selection order for one turn. A public message may
-// replace the model id while the assembly keeps its provider connection. Internal deliveries may
-// carry a complete model reference. Either durable request wins over the assembly default.
+// selectedModelOf applies the visible model-selection order for one turn. Message and policy references carry both provider and model identity (runtime/composition.test.ts, "the actor owns model selection").
 export const selectedModelOf = (
   head: Event,
   policy?: ModelRef
 ): ModelRef | undefined => {
   const selected = (head as { readonly model?: unknown }).model
-  const reference = modelRefOf(selected)
-  const model = typeof selected === "string" && selected.trim().length > 0 && policy !== undefined
-    ? { provider: policy.provider, model_id: selected.trim() }
-    : undefined
-  return reference ?? model ?? policy
+  return selected === undefined ? policy : modelRefOf(selected)
 }
 
 const resolvedModelOf = (events: ReadonlyArray<Event>): ModelRef | undefined => {
   const resolved = events.find((event) => event.type === "ModelResolved") as { readonly model?: unknown } | undefined
   return modelRefOf(resolved?.model)
 }
+
+const resolvedPolicyOf = (events: ReadonlyArray<Event>): ModelPolicy | undefined => {
+  const resolved = events.find((event) => event.type === "ModelResolved") as { readonly models?: unknown } | undefined
+  return resolved?.models === undefined ? undefined : modelPolicyOf(resolved.models)
+}
+
+class ModelSelectionError extends Error {}
 
 const epochStamp = (epoch: number): { readonly epoch?: number } =>
   epoch === 0 ? {} : { epoch }
@@ -96,7 +107,7 @@ export class Infer extends Context.Service<
   Infer,
   {
     readonly react: (request: InferRequest, key?: string) => Effect.Effect<Action>
-    readonly resolve?: (reference: ModelRef) => ModelResolution
+    readonly resolve?: (reference?: ModelRef) => ModelResolution
   }
 >()("agent/Infer") {}
 
@@ -313,30 +324,61 @@ export const inferReactorFor = (policy: Partial<InferPolicy>, render: Render): R
   if (slice.length === 0 || awaitingTool(slice) || terminated(slice)) return []
   const head = slice[0] as Event & { id?: unknown }
   const turn = String(head.id)
-  const trajectory = trajectoryOf(log)
   const resolvedModel = resolvedModelOf(slice)
-  const model = resolvedModel ?? selectedModelOf(head, policy.model)
-  if (model !== undefined && resolvedModel === undefined) {
+  const inheritedModels = modelPolicyOf((head as { readonly models?: unknown }).models)
+  const resolvedPolicy = resolvedPolicyOf(slice)
+  let policyError: string | undefined
+  let models = resolvedPolicy ?? inheritedModels
+  if (resolvedPolicy === undefined) {
+    try {
+      models = applyModelPolicy(inheritedModels, policy.models ?? DEFAULT_INFER_POLICY.models)
+    } catch (error) {
+      policyError = error instanceof Error ? error.message : String(error)
+    }
+  }
+  const trajectory = trajectoryOf(log)
+  const model = resolvedModel ?? selectedModelOf(head, models.default)
+  if (resolvedModel === undefined) {
     return [
       effect({
         key: `mr:${turn}`,
-        input: { turn, model },
+        input: { turn, model, models, policyError },
         act: (input) =>
           Effect.gen(function* () {
             const at = yield* Clock.currentTimeMillis
             const binding = yield* Infer
             return yield* Effect.try({
-              try: () => binding.resolve?.(input.model) ?? { model: input.model },
-              catch: (error) => error instanceof Error ? error.message : String(error)
+              try: () => {
+                if (input.policyError !== undefined) throw new ModelSelectionError(input.policyError)
+                if (input.model !== undefined && !modelAllowedBy(input.models, input.model)) {
+                  throw new ModelSelectionError(`model ${input.model.provider}/${input.model.model_id} is excluded by the effective model policy`)
+                }
+                const resolved = binding.resolve?.(input.model)
+                if (resolved === undefined) {
+                  if (input.model === undefined) {
+                    throw new ModelSelectionError("no model was selected; supply { provider, model_id } or configure a default")
+                  }
+                  return { model: input.model, models: input.models }
+                }
+                const models = applyModelPolicy(resolved.models ?? DEFAULT_MODEL_POLICY, input.models)
+                if (!modelAllowedBy(models, resolved.model)) {
+                  throw new ModelSelectionError(`model ${resolved.model.provider}/${resolved.model.model_id} is excluded by the effective model policy`)
+                }
+                return { ...resolved, models }
+              },
+              catch: (error) => ({
+                message: error instanceof Error ? error.message : String(error),
+                cause: error instanceof ModelSelectionError ? "model_selection" as const : "inference_error" as const
+              })
             }).pipe(Effect.match({
-              onSuccess: (resolved) => [modelResolved({ turn: input.turn, ...resolved, at })],
-              onFailure: (message) => [
+              onSuccess: (resolved) => [modelResolved({ turn: input.turn, ...resolved, models: resolved.models, at })],
+              onFailure: (failure) => [
                 turnFailed({
-                  error: message,
-                  cause: "inference_error",
+                  error: failure.message,
+                  cause: failure.cause,
                   attempts: 0,
                   attemptKey: `${input.turn}/model`,
-                  policy: { model: input.model },
+                  policy: { ...(input.model === undefined ? {} : { model: input.model }), models: input.models },
                   turn: input.turn,
                   at
                 })

--- a/packages/agent/src/log/events.ts
+++ b/packages/agent/src/log/events.ts
@@ -4,6 +4,7 @@ import type { Event } from "@clavia/tardigrade-core/log/event"
 import type { KeyFragment } from "@clavia/tardigrade-core/log"
 import type { Usage } from "../inference/usage"
 import { ModelRef, type ModelRef as ModelRefType } from "../inference/reference"
+import { ModelPolicy, type ModelPolicy as ModelPolicyType } from "../inference/access"
 
 // The agent's domain events. This alphabet belongs to the agent, and core never learns it: core
 // sees only the open envelope. The model responds by acting: its recorded decision is the
@@ -91,6 +92,7 @@ export const ModelResolved = Schema.Struct({
   type: Schema.Literal("ModelResolved"),
   turn: Schema.String,
   model: ModelRef,
+  models: Schema.optional(ModelPolicy),
   contextWindowTokens: Schema.optional(Schema.Finite),
   maxOutputTokens: Schema.optional(Schema.Finite),
   catalogRevision: Schema.optional(Schema.String),
@@ -121,8 +123,10 @@ export const TurnCompleted = Schema.Struct({
 })
 
 // TURN_FAILURE_CAUSES are the failure classes a turn ends in, each distinct because each has a
-// different remedy. `model` is a binding that reported nothing more specific; `inference_error`
-// and `inference_attempts_exhausted` are transport; `refused` is a provider that declined to
+// different remedy. `message_invalid` is an inbound event the agent cannot interpret;
+// `model_selection` needs a model reference or authority; `model` is a binding that reported
+// nothing more specific; `inference_error` and
+// `inference_attempts_exhausted` are transport; `refused` is a provider that declined to
 // answer and `truncated` is one cut at its output ceiling, neither of which a retry of the same
 // request fixes; `output_unsupported` is a contract the configured provider cannot obtain, found
 // before anything is spent; `output_contract_violation` is an endpoint that promised a native
@@ -130,6 +134,8 @@ export const TurnCompleted = Schema.Struct({
 // validate locally and fail on rather than correct; `output_repairs_exhausted` is the framework
 // correction loop spending its bound (src/output/contract.ts, OutputMode).
 export const TURN_FAILURE_CAUSES = [
+  "message_invalid",
+  "model_selection",
   "model",
   "inference_error",
   "inference_attempts_exhausted",
@@ -457,6 +463,7 @@ export const modelCalled = (
 export const modelResolved = (fields: {
   readonly turn: string
   readonly model: ModelRefType
+  readonly models: ModelPolicyType
   readonly contextWindowTokens?: number
   readonly maxOutputTokens?: number
   readonly catalogRevision?: string

--- a/packages/agent/src/packages/agents.test.ts
+++ b/packages/agent/src/packages/agents.test.ts
@@ -67,7 +67,84 @@ describe("agentsPackage", () => {
   test("the code contract keeps run terminal while escalation stays internal", () => {
     const system = codeSystemFor([agentsPackage()])
     expect(system).not.toContain("agents.continue")
-    expect(system).toContain("agents.run({text: string, background?: boolean, output?: unknown, budget?: number, escalatable?: boolean}) -> {output?: unknown, error?: string, dispatched?: boolean, callId?: string}")
+    expect(system).toContain("agents.providers({cursor?: string, search?: string, limit?: number})")
+    expect(system).toContain("agents.models({cursor?: string, search?: string, limit?: number, provider?: string, sort?: \"promptUsdPerToken\" | \"completionUsdPerToken\" | \"cachedPromptUsdPerToken\" | \"cacheWritePromptUsdPerToken\", order?: \"asc\" | \"desc\", unpriced?: \"first\" | \"last\"})")
+    expect(system).toContain("agents.run({text: string, background?: boolean, output?: unknown, model?: {provider: string, model_id: string}, budget?: number, escalatable?: boolean}) -> {output?: unknown, error?: string, dispatched?: boolean, callId?: string}")
+  })
+
+  test("catalog searches return the host API pages", async () => {
+    const providerQueries: unknown[] = []
+    const modelQueries: unknown[] = []
+    const providerPage = {
+      revision: "catalog-1",
+      status: "fresh",
+      refreshed_at: 1,
+      policy: { allow: "*" },
+      total: 1,
+      limit: 10,
+      items: [{ id: "openrouter", name: "OpenRouter", availability: { status: "available" }, env: ["OPENROUTER_API_KEY"], required: ["env"], optional: [] }]
+    }
+    const modelPage = {
+      revision: "catalog-1",
+      status: "fresh",
+      refreshed_at: 1,
+      policy: { allow: "*" },
+      total: 1,
+      limit: 10,
+      items: [{
+        provider: "openrouter",
+        id: "anthropic/claude-sonnet-4-6",
+        name: "Claude Sonnet",
+        metadata: {
+          contextWindowTokens: 200_000,
+          pricing: { promptUsdPerToken: 0.000_003, completionUsdPerToken: 0.000_015 }
+        }
+      }]
+    }
+    const pkg = agentsPackage({
+      catalog: {
+        providers: (query) => {
+          providerQueries.push(query)
+          return providerPage
+        },
+        models: (query) => {
+          modelQueries.push(query)
+          return modelPage
+        }
+      }
+    })
+    const sent: Array<Sent> = []
+    const providers = await Effect.runPromise(
+      pkg.methods.providers!({ search: "router", limit: 10 }, { callId: "providers" }).pipe(Effect.provide(env("mem:ag.root", sent)))
+    )
+    const models = await Effect.runPromise(
+      pkg.methods.models!({
+        provider: "openrouter",
+        search: "claude",
+        limit: 10,
+        sort: "completionUsdPerToken",
+        order: "asc",
+        unpriced: "last"
+      }, { callId: "models" }).pipe(Effect.provide(env("mem:ag.root", sent)))
+    )
+    expect(providerQueries).toEqual([{
+      search: "router",
+      limit: 10,
+      availability: "available",
+      models: { allow: "*" }
+    }])
+    expect(modelQueries).toEqual([{
+      search: "claude",
+      limit: 10,
+      provider: "openrouter",
+      availability: "available",
+      sort: "completionUsdPerToken",
+      order: "asc",
+      unpriced: "last",
+      models: { allow: "*" }
+    }])
+    expect(providers).toEqual(providerPage)
+    expect(models).toEqual(modelPage)
   })
 
   test("the default placement is the host's own sibling address", async () => {
@@ -112,11 +189,12 @@ describe("agentsPackage", () => {
     })
   })
 
-  test("the package fixes a child model outside the tool input", async () => {
+  test("a run selects a complete child model reference", async () => {
     const selected = { provider: "openrouter", model_id: "anthropic/claude-sonnet-4-6" } as const
+    const overridden = { provider: "openai", model_id: "gpt-5.6" } as const
     const sent: Array<Sent> = []
     const inherited = agentsPackage()
-    const fixed = agentsPackage({ model: selected })
+    const fixed = agentsPackage({ models: { default: selected, allow: "*" } })
     await Effect.runPromise(
       inherited.methods.run!({ text: "default pass", background: true }, { callId: "model-1" }).pipe(Effect.provide(env("mem:ag.root", sent)))
     )
@@ -125,12 +203,71 @@ describe("agentsPackage", () => {
     )
     expect(sent[0]!.event).not.toHaveProperty("model")
     expect(sent[1]!.event).toMatchObject({ model: selected })
-    const refused = await Effect.runPromise(
-      fixed.methods.run!({ text: "other", background: true, model: selected }, { callId: "model-3" }).pipe(Effect.provide(env("mem:ag.root", sent)))
+    await Effect.runPromise(
+      fixed.methods.run!({ text: "other", background: true, model: overridden }, { callId: "model-3" }).pipe(Effect.provide(env("mem:ag.root", sent)))
     )
-    expect(refused).toEqual({ error: "agents.run does not take model; configure agentsPackage({ model })" })
-    expect(sent).toHaveLength(2)
-    expect(codeSystemFor([fixed])).not.toContain("model:")
+    expect(sent[2]!.event).toMatchObject({ model: overridden })
+    expect(sent).toHaveLength(3)
+    expect(codeSystemFor([fixed])).toContain("model?: {provider: string, model_id: string}")
+  })
+
+  test("a child receives the parent and package model intersection", async () => {
+    const selected = { provider: "openai", model_id: "small" } as const
+    const parent: Event = {
+      type: "ModelResolved",
+      turn: "parent",
+      model: selected,
+      models: {
+        allow: [{ provider: "openai", model_ids: ["large", "small"] }]
+      },
+      at: 1
+    }
+    const pkg = agentsPackage({
+      models: {
+        default: selected,
+        allow: [
+          { provider: "openai", model_ids: ["small"] },
+          { provider: "anthropic", model_ids: "*" }
+        ]
+      }
+    })
+    const sent: Array<Sent> = []
+    await Effect.runPromise(
+      pkg.methods.run!({ text: "scout", background: true }, { callId: "narrow" }).pipe(
+        Effect.provide(env("mem:ag.root", sent, { "ag.root": [parent] }))
+      )
+    )
+    expect(sent[0]!.event).toMatchObject({
+      model: selected,
+      models: { allow: [{ provider: "openai", model_ids: ["small"] }] }
+    })
+  })
+
+  test("a package with no model override inherits the parent default", async () => {
+    const selected = { provider: "openai", model_id: "small" } as const
+    const parent: Event = {
+      type: "ModelResolved",
+      turn: "parent",
+      model: selected,
+      models: {
+        default: selected,
+        allow: [{ provider: "openai", model_ids: ["large", "small"] }]
+      },
+      at: 1
+    }
+    const sent: Array<Sent> = []
+    await Effect.runPromise(
+      agentsPackage().methods.run!({ text: "scout", background: true }, { callId: "inherit" }).pipe(
+        Effect.provide(env("mem:ag.root", sent, { "ag.root": [parent] }))
+      )
+    )
+    expect(sent[0]!.event).toMatchObject({
+      model: selected,
+      models: {
+        default: selected,
+        allow: [{ provider: "openai", model_ids: ["large", "small"] }]
+      }
+    })
   })
 
   test("a reply already on the lane answers without parking", async () => {

--- a/packages/agent/src/packages/agents.ts
+++ b/packages/agent/src/packages/agents.ts
@@ -15,12 +15,21 @@ import {
   type ActorId
 } from "@clavia/tardigrade-core/communication/endpoint"
 import { decodeOutput, outputFrom, type OutputContract } from "../output/contract"
-import { modelRefOf, type ModelRef } from "../inference/reference"
+import { modelRefOf } from "../inference/reference"
+import {
+  applyModelPolicy,
+  DEFAULT_MODEL_POLICY,
+  modelAllowedBy,
+  modelPolicyOf,
+  modelPolicyOverrideOf,
+  type ModelPolicy,
+  type ModelPolicyOverride
+} from "../inference/access"
 
-// The agents package: ad-hoc agents, reachable from code like any other package. One verb with a
-// delivery mode: `agents.run({text})` runs a fresh agent to quiescence and returns its terminal;
-// `agents.run({text, background: true})` delivers the brief and returns a pending handle, and
-// `agents.result({id})` awaits that handle's reply later.
+// agentsPackage provides model catalog discovery and ad-hoc agents. `agents.providers` and
+// `agents.models` search the available providers and models. `agents.run({text})` runs a fresh agent to
+// quiescence and returns its terminal; `agents.run({text, background: true})` delivers the brief
+// and returns a pending handle, and `agents.result({id})` awaits that handle's reply later.
 //
 // Every call is its own agent: the child's identity is the call's id, so a Promise.all of five
 // runs is five agents by construction, and no name exists to collide on. A persistent named
@@ -57,8 +66,10 @@ export interface SpawnOptions {
   // that declared it. A raw schema stays reachable and is preflighted instead (spawn.test.ts,
   // "the output a spawn asks for").
   readonly outputs?: Readonly<Record<string, OutputContract>>
-  // model is the fixed reference used by every child this package starts. An absent value leaves selection to the child actor's default.
-  readonly model?: ModelRef
+  // catalog supplies provider and model discovery to the package.
+  readonly catalog?: AgentCatalog
+  // models narrows inherited authority and may select a default for children started by this package.
+  readonly models?: ModelPolicyOverride
   readonly actorNameOf?: () => string | undefined
   readonly reserve?: (callId: string, want: number) => Promise<number>
   readonly shadowOf?: () => boolean
@@ -69,6 +80,29 @@ export interface SpawnOptions {
   readonly budget?: Partial<BudgetPolicy>
 }
 
+// AgentCatalogQuery selects a page of providers from the model catalog.
+export interface AgentCatalogQuery {
+  readonly availability?: "available"
+  readonly models?: ModelPolicy
+  readonly cursor?: string
+  readonly search?: string
+  readonly limit?: number
+}
+
+// AgentModelCatalogQuery selects a page of models from the model catalog.
+export interface AgentModelCatalogQuery extends AgentCatalogQuery {
+  readonly provider?: string
+  readonly sort?: "promptUsdPerToken" | "completionUsdPerToken" | "cachedPromptUsdPerToken" | "cacheWritePromptUsdPerToken"
+  readonly order?: "asc" | "desc"
+  readonly unpriced?: "first" | "last"
+}
+
+// AgentCatalog serves provider and model discovery pages.
+export interface AgentCatalog {
+  readonly providers: (query: AgentCatalogQuery) => unknown
+  readonly models: (query: AgentModelCatalogQuery) => unknown
+}
+
 const foregroundBoundarySchema = {
   type: "object",
   properties: {
@@ -77,9 +111,149 @@ const foregroundBoundarySchema = {
   }
 }
 
+const catalogQueryProperties = {
+  cursor: { type: "string", description: "the next_cursor returned by the previous page" },
+  search: { type: "string", description: "case-insensitive text matched against IDs and names" },
+  limit: { type: "integer", minimum: 1, description: "maximum items returned on this page" }
+}
+
+const catalogPageProperties = {
+  revision: { type: "string" },
+  status: { type: "string", enum: ["fresh", "cached"] },
+  refreshed_at: { type: "number" },
+  policy: {
+    type: "object",
+    properties: {
+      default: {
+        type: "object",
+        properties: { provider: { type: "string" }, model_id: { type: "string" } },
+        required: ["provider", "model_id"],
+        additionalProperties: false
+      },
+      allow: {
+        oneOf: [
+          { const: "*" },
+          {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                provider: { type: "string" },
+                model_ids: { oneOf: [{ const: "*" }, { type: "array", items: { type: "string" } }] }
+              },
+              required: ["provider", "model_ids"],
+              additionalProperties: false
+            }
+          }
+        ]
+      }
+    },
+    required: ["allow"],
+    additionalProperties: false
+  },
+  total: { type: "integer" },
+  limit: { type: "integer" },
+  next_cursor: { type: "string" }
+}
+
+const providerPageSchema = {
+  type: "object",
+  properties: {
+    ...catalogPageProperties,
+    items: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          name: { type: "string" },
+          availability: {
+            oneOf: [
+              {
+                type: "object",
+                properties: { status: { const: "available" } },
+                required: ["status"]
+              },
+              {
+                type: "object",
+                properties: {
+                  status: { const: "unavailable" },
+                  reason: { type: "string", enum: ["not_configured", "credential_missing"] }
+                },
+                required: ["status", "reason"]
+              }
+            ]
+          },
+          protocol: { type: "string" },
+          baseUrl: { type: "string" },
+          env: { type: "array", items: { type: "string" } },
+          required: { type: "array", items: { type: "string" } },
+          optional: { type: "array", items: { type: "string" } }
+        },
+        required: ["id", "name", "availability", "env", "required", "optional"]
+      }
+    },
+    error: { type: "string" }
+  }
+}
+
+const modelPageSchema = {
+  type: "object",
+  properties: {
+    ...catalogPageProperties,
+    items: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          provider: { type: "string" },
+          id: { type: "string" },
+          name: { type: "string" },
+          metadata: {
+            type: "object",
+            properties: {
+              contextWindowTokens: { type: "integer" },
+              maxOutputTokens: { type: "integer" },
+              pricing: {
+                type: "object",
+                properties: {
+                  promptUsdPerToken: { type: "number" },
+                  completionUsdPerToken: { type: "number" },
+                  cachedPromptUsdPerToken: { type: "number" },
+                  cacheWritePromptUsdPerToken: { type: "number" }
+                }
+              },
+              toolCall: { type: "boolean" },
+              structuredOutput: { type: "boolean" },
+              inputModalities: { type: "array", items: { type: "string" } },
+              outputModalities: { type: "array", items: { type: "string" } }
+            }
+          }
+        },
+        required: ["provider", "id", "metadata"]
+      }
+    },
+    error: { type: "string" }
+  }
+}
+
+const catalogQueryOf = (args: unknown): AgentCatalogQuery => {
+  const value = args as { readonly cursor?: unknown; readonly search?: unknown; readonly limit?: unknown } | undefined
+  return {
+    ...(typeof value?.cursor === "string" ? { cursor: value.cursor } : {}),
+    ...(typeof value?.search === "string" ? { search: value.search } : {}),
+    ...(typeof value?.limit === "number" ? { limit: value.limit } : {})
+  }
+}
+
 // sibling is the default placement: the child is a facet of the parent's own principal, named `ag.<callId>`. The address selects the target while ThreadCreated records its lineage (spawn.test.ts, "the default placement is the host's own sibling address"; tla/runtime/Thread.tla, CreationFirst).
 const sibling = (callId: string, self: ActorId): ActorId =>
   actorIdOf(self.actor, `ag.${callId}`)
+
+const inheritedModelsOf = (events: ReadonlyArray<{ readonly type: string }>): ModelPolicy => {
+  const resolved = [...events].reverse().find((event) => event.type === "ModelResolved") as { readonly models?: unknown } | undefined
+  return resolved?.models === undefined ? DEFAULT_MODEL_POLICY : modelPolicyOf(resolved.models)
+}
 
 export const agentsPackage = (
   options: SpawnOptions & { readonly place?: (callId: string, self: ActorId) => ActorId } = {}
@@ -91,27 +265,71 @@ export const agentsPackage = (
   const worldOf = options.worldOf ?? (() => undefined)
   const defaultBudget = budgetPolicyOf(options.budget).limit
   const outputs = options.outputs ?? {}
-  const model = options.model === undefined ? undefined : modelRefOf(options.model)
-  if (options.model !== undefined && model === undefined) {
-    throw new Error("agentsPackage model must be { provider, model_id }")
+  const catalog = options.catalog
+  const packageModels = modelPolicyOverrideOf(options.models)
+  const effectiveModelsOf = (events: ReadonlyArray<{ readonly type: string }>): ModelPolicy =>
+    applyModelPolicy(inheritedModelsOf(events), packageModels)
+  const effectiveModelsResultOf = (events: ReadonlyArray<{ readonly type: string }>):
+    | { readonly models: ModelPolicy }
+    | { readonly error: string } => {
+    try {
+      return { models: effectiveModelsOf(events) }
+    } catch (error) {
+      return { error: error instanceof Error ? error.message : String(error) }
+    }
   }
   const declared_ = Object.keys(outputs)
   return definePackage({
     name: "agents",
-    description: "Ad-hoc agents. run({text}) starts a fresh agent with the brief and waits for its terminal answer; add background: true for a long job, and result({id}) awaits the reply later. An escalatable child negotiates budget with its parent's requestBudget method while run remains pending.",
+    description: "Search known providers and available models, and run ad-hoc agents. providers() lists provider configuration requirements and availability. models() lists models from available providers with metadata and pricing; use provider to limit the search and sort to order a pricing field. run({text}) starts a fresh agent with the brief and waits for its terminal answer; add background: true for a long job, and result({id}) awaits the reply later. An escalatable child negotiates budget with its parent's requestBudget method while run remains pending.",
     annotations: {
+      providers: { readOnlyHint: true, openWorldHint: false },
+      models: { readOnlyHint: true, openWorldHint: false },
       run: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
       result: { readOnlyHint: true, openWorldHint: false }
     },
     docs: {
+      providers: {
+        description: "Search providers this agent may use. The page carries the effective model policy, including its default, plus connection requirements and no credential values.",
+        input: { type: "object", properties: catalogQueryProperties },
+        output: providerPageSchema
+      },
+      models: {
+        description: "Search models from available providers. The page carries the effective model policy, including its default. Set provider to search models within one provider. Each item carries metadata and pricing.",
+        input: {
+          type: "object",
+          properties: {
+            ...catalogQueryProperties,
+            provider: { type: "string", description: "exact provider ID" },
+            sort: {
+              type: "string",
+              enum: ["promptUsdPerToken", "completionUsdPerToken", "cachedPromptUsdPerToken", "cacheWritePromptUsdPerToken"],
+              description: "pricing field used to order models"
+            },
+            order: { type: "string", enum: ["asc", "desc"], description: "price order; defaults to asc" },
+            unpriced: { type: "string", enum: ["first", "last"], description: "placement of models without the selected price; defaults to last" }
+          }
+        },
+        output: modelPageSchema
+      },
       run: {
-        description: `Brief a fresh agent. \`output\` makes the result structured and parsed: the name of a declared contract${declared_.length === 0 ? " (this host declares none)" : ` (${declared_.join(", ")})`}, or a JSON schema of your own. \`budget\` caps the agent's tool calls: at the cap it answers with its best result, so a research agent can not run forever. \`background: true\` returns { callId } at once; result({id: callId}) awaits the reply later. \`escalatable: true\` lets the child call its parent's requestBudget method at the cap while this run remains pending for one terminal answer.`,
+        description: `Brief a fresh agent. \`output\` makes the result structured and parsed: the name of a declared contract${declared_.length === 0 ? " (this host declares none)" : ` (${declared_.join(", ")})`}, or a JSON schema of your own. \`model\` selects one configured provider and model for this child. \`budget\` caps the agent's tool calls: at the cap it answers with its best result, so a research agent can not run forever. \`background: true\` returns { callId } at once; result({id: callId}) awaits the reply later. \`escalatable: true\` lets the child call its parent's requestBudget method at the cap while this run remains pending for one terminal answer.`,
         input: {
           type: "object",
           properties: {
             text: { type: "string", description: "the brief" },
             background: { type: "boolean", description: "true: return { callId } at once, the reply arrives later via result()" },
             output: { description: "a declared contract's name, or a JSON schema for a structured answer" },
+            model: {
+              type: "object",
+              description: "the configured provider and provider-specific model ID",
+              properties: {
+                provider: { type: "string" },
+                model_id: { type: "string" }
+              },
+              required: ["provider", "model_id"],
+              additionalProperties: false
+            },
             budget: { type: "integer", description: "max tool calls before the agent must answer, a whole number of calls; keeps a research agent bounded" },
             escalatable: { type: "boolean", description: "true: at its budget the child may ask its parent's budget authority for more before answering" }
           },
@@ -140,6 +358,40 @@ export const agentsPackage = (
       }
     },
     methods: {
+      providers: (args) => Effect.gen(function* () {
+        if (catalog === undefined) return { error: "model catalog is unavailable" }
+        const log = yield* EventLog
+        const resolved = effectiveModelsResultOf(yield* log.read)
+        return "error" in resolved
+          ? resolved
+          : catalog.providers({ ...catalogQueryOf(args), availability: "available", models: resolved.models })
+      }),
+      models: (args) => Effect.gen(function* () {
+        if (catalog === undefined) return { error: "model catalog is unavailable" }
+        const log = yield* EventLog
+        const resolved = effectiveModelsResultOf(yield* log.read)
+        if ("error" in resolved) return resolved
+        const models = resolved.models
+        const query = catalogQueryOf(args)
+        const value = args as {
+          readonly provider?: unknown
+          readonly sort?: unknown
+          readonly order?: unknown
+          readonly unpriced?: unknown
+        } | undefined
+        const sort = value?.sort
+        const order = value?.order
+        const unpriced = value?.unpriced
+        return catalog.models({
+          ...query,
+          availability: "available",
+          models,
+          ...(typeof value?.provider === "string" ? { provider: value.provider } : {}),
+          ...(typeof sort === "string" ? { sort: sort as Exclude<AgentModelCatalogQuery["sort"], undefined> } : {}),
+          ...(typeof order === "string" ? { order: order as Exclude<AgentModelCatalogQuery["order"], undefined> } : {}),
+          ...(typeof unpriced === "string" ? { unpriced: unpriced as Exclude<AgentModelCatalogQuery["unpriced"], undefined> } : {})
+        })
+      }),
       run: (args, ctx) =>
         Effect.gen(function* () {
           // The three cross-lane privileges, read where the work happens: send, identity,
@@ -147,7 +399,8 @@ export const agentsPackage = (
           const router = yield* Router
           const source = yield* Self
           const log = yield* EventLog
-          const created = threadCreatedOf(yield* log.read)
+          const events = yield* log.read
+          const created = threadCreatedOf(events)
           if (created === undefined) {
             return yield* Effect.die(new Error(`thread ${formatActorId(source)} cannot spawn without ThreadCreated`))
           }
@@ -164,8 +417,13 @@ export const agentsPackage = (
           if (a?.output === undefined && a?.outputSchema !== undefined) {
             return { error: "agents.run takes the contract as `output`, not `outputSchema`" }
           }
-          if (a?.model !== undefined) {
-            return { error: "agents.run does not take model; configure agentsPackage({ model })" }
+          const resolved = effectiveModelsResultOf(events)
+          if ("error" in resolved) return resolved
+          const models = resolved.models
+          const selectedModel = a?.model === undefined ? models.default : modelRefOf(a.model)
+          if (a?.model !== undefined && selectedModel === undefined) return { error: "agents.run model must be { provider, model_id }" }
+          if (selectedModel !== undefined && !modelAllowedBy(models, selectedModel)) {
+            return { error: `agents.run model ${selectedModel.provider}/${selectedModel.model_id} is excluded by the effective model policy` }
           }
           const declaredOutput = outputAsked(a?.output, outputs, declared_)
           if ("error" in declaredOutput) return declaredOutput
@@ -206,7 +464,8 @@ export const agentsPackage = (
               id: ctx.callId,
               text,
               ...(outputDeclaration === undefined ? {} : { output: outputDeclaration }),
-              ...(model === undefined ? {} : { model }),
+              ...(selectedModel === undefined ? {} : { model: selectedModel }),
+              models,
               budget,
               ...(a?.escalatable === true ? { escalatable: true } : {}),
               ...(actor === undefined ? {} : { actor }),
@@ -227,7 +486,8 @@ export const agentsPackage = (
             id: ctx.callId,
             text,
             ...(outputDeclaration === undefined ? {} : { output: outputDeclaration }),
-            ...(model === undefined ? {} : { model }),
+            ...(selectedModel === undefined ? {} : { model: selectedModel }),
+            models,
             budget,
             ...(a?.escalatable === true ? { escalatable: true } : {}),
             ...(actor === undefined ? {} : { actor }),

--- a/packages/agent/src/runtime/composition.test.ts
+++ b/packages/agent/src/runtime/composition.test.ts
@@ -6,7 +6,7 @@ import type { Event } from "@clavia/tardigrade-core/log/event"
 import { EventLog, withWatermark } from "@clavia/tardigrade-core/log"
 import { Router } from "@clavia/tardigrade-core/communication/router"
 import { parseActorId } from "@clavia/tardigrade-core/communication/endpoint"
-import { Self, effect } from "@clavia/tardigrade-core/reconciliation"
+import { Self, effect, settleActor } from "@clavia/tardigrade-core/reconciliation"
 import { actor, composeComponents } from "@clavia/tardigrade-core/actor"
 import {
   CODE_VIEW_ALGEBRA,
@@ -26,7 +26,7 @@ import { system } from "../components/system"
 import { receive } from "./turn"
 import { Infer, NativeOutputSupport, selectedModelOf, type InferRequest } from "../inference/reactor"
 
-const TEST_MODEL = { provider: "test", default_model: "test-model" } as const
+const TEST_MODEL = { models: { default: { provider: "test", model_id: "test-model" }, allow: "*" } } as const
 
 const assembled = <R>(component: AgentComponent<R>) => actor({
   name: "test-agent",
@@ -94,14 +94,110 @@ describe("infer component", () => {
       provider: "vercel",
       model_id: "anthropic/claude-sonnet-4-6"
     })
-    expect(selectedModelOf({ ...message, model: "openai/gpt-5.2" } as Event, fallback)).toEqual({
-      provider: "cloudflare",
-      model_id: "openai/gpt-5.2"
-    })
     expect(selectedModelOf({ ...message, model: undefined } as Event, fallback)).toEqual(fallback)
   })
 
-  test("the selected model reaches the model binding", async () => {
+  test("a turn without any applicable default durably asks for a model reference", async () => {
+    let calls = 0
+    const mind = Layer.succeed(Infer, {
+      react: () => {
+        calls += 1
+        return Effect.succeed({ kind: "complete" as const, output: "done" })
+      }
+    })
+    const agent = assembled(infer([nativeOutput], {
+      models: {
+        allow: [{ provider: "openai", model_ids: ["large", "small"] }]
+      }
+    }))
+    const events = await run(
+      Effect.gen(function* () {
+        yield* receive(agent, { id: "m1", text: "choose" })
+        return yield* readLog
+      }),
+      Layer.mergeAll(memoryLog(), mind, noRouter, KeyValueStore.layerMemory)
+    )
+    expect(events.find((event) => event.type === "TurnFailed")).toMatchObject({
+      turn: "m1",
+      cause: "model_selection",
+      attempts: 0
+    })
+    expect(calls).toBe(0)
+  })
+
+  test("an actor with no model override inherits the host default", async () => {
+    const selected = { provider: "openai", model_id: "small" } as const
+    const seen: InferRequest[] = []
+    const mind = Layer.succeed(Infer, {
+      resolve: (model) => ({
+        model: model ?? selected,
+        models: {
+          default: selected,
+          allow: [{ provider: "openai", model_ids: ["large", "small"] }]
+        }
+      }),
+      react: (request: InferRequest) => {
+        seen.push(request)
+        return Effect.succeed({ kind: "complete" as const, output: "done" })
+      }
+    })
+    const agent = assembled(infer([nativeOutput]))
+    const events = await run(
+      Effect.gen(function* () {
+        yield* receive(agent, { id: "m1", text: "inherit" })
+        return yield* readLog
+      }),
+      Layer.mergeAll(memoryLog(), mind, noRouter, KeyValueStore.layerMemory)
+    )
+    expect(seen.map((request) => request.model)).toEqual([selected])
+    expect(events.find((event) => event.type === "ModelResolved")).toMatchObject({
+      model: selected,
+      models: {
+        default: selected,
+        allow: [{ provider: "openai", model_ids: ["large", "small"] }]
+      }
+    })
+  })
+
+  test("a historical model string durably fails its turn", async () => {
+    const seen: InferRequest[] = []
+    const mind = Layer.succeed(Infer, {
+      react: (request: InferRequest) => {
+        seen.push(request)
+        return Effect.succeed({ kind: "complete" as const, output: "done" })
+      }
+    })
+    const agent = assembled(infer([nativeOutput], TEST_MODEL))
+    const events = await run(
+      Effect.gen(function* () {
+        yield* settleActor(agent)
+        yield* receive(agent, {
+          id: "m2",
+          text: "continue",
+          model: { provider: "openai", model_id: "gpt-5.6" }
+        })
+        return yield* readLog
+      }),
+      Layer.mergeAll(memoryLog([{
+        type: "MessageReceived",
+        id: "m1",
+        text: "old",
+        model: "gpt-4o",
+        at: 1
+      }]), mind, noRouter, KeyValueStore.layerMemory)
+    )
+    expect(events.find((event) => event.type === "TurnFailed")).toMatchObject({
+      turn: "m1",
+      cause: "message_invalid",
+      attempts: 0
+    })
+    expect(seen.map((request) => request.model)).toEqual([
+      { provider: "openai", model_id: "gpt-5.6" }
+    ])
+    expect(events.at(-1)?.type).toBe("TurnCompleted")
+  })
+
+  test("each turn can select a provider without losing its conversation", async () => {
     const seen: InferRequest[] = []
     const mind = Layer.succeed(Infer, {
       react: (request: InferRequest) => {
@@ -116,27 +212,45 @@ describe("infer component", () => {
           model?.provider === "vercel" ? 200_000 : 100_000
       }),
       nativeOutput
-    ], { provider: "vercel", default_model: "anthropic/claude-sonnet-4-6" }))
+    ], {
+      models: {
+        default: { provider: "vercel", model_id: "anthropic/claude-sonnet-4-6" },
+        allow: "*"
+      }
+    }))
     const events = await run(
       Effect.gen(function* () {
         yield* receive(agent, {
           id: "m1",
-          text: "go",
-          model: "openai/gpt-5.2"
+          text: "first",
+          model: { provider: "vercel", model_id: "anthropic/claude-sonnet-4-6" }
+        })
+        yield* receive(agent, {
+          id: "m2",
+          text: "second",
+          model: { provider: "openai", model_id: "gpt-5.6" }
         })
         return yield* readLog
       }),
       Layer.mergeAll(memoryLog(), mind, noRouter, KeyValueStore.layerMemory)
     )
-    expect(seen[0]?.model).toEqual({ provider: "vercel", model_id: "openai/gpt-5.2" })
+    expect(seen.map((request) => request.model)).toEqual([
+      { provider: "vercel", model_id: "anthropic/claude-sonnet-4-6" },
+      { provider: "openai", model_id: "gpt-5.6" }
+    ])
     expect(seen[0]?.context?.contextWindowTokens).toBe(200_000)
-    expect(events.find((event) => event.type === "ModelResolved")).toMatchObject({
-      turn: "m1",
-      model: { provider: "vercel", model_id: "openai/gpt-5.2" }
-    })
-    expect(events.find((event) => event.type === "ModelCalled")).toMatchObject({
-      model: { provider: "vercel", model_id: "openai/gpt-5.2" }
-    })
+    expect(seen[1]?.context?.contextWindowTokens).toBe(100_000)
+    expect(seen[1]?.trajectory.filter((event) => event.type === "MessageReceived").map((event) =>
+      (event as { readonly id?: unknown }).id
+    )).toEqual(["m1", "m2"])
+    expect(events.filter((event) => event.type === "ModelResolved")).toMatchObject([
+      { turn: "m1", model: { provider: "vercel", model_id: "anthropic/claude-sonnet-4-6" } },
+      { turn: "m2", model: { provider: "openai", model_id: "gpt-5.6" } }
+    ])
+    expect(events.filter((event) => event.type === "ModelCalled")).toMatchObject([
+      { turn: "m1", model: { provider: "vercel", model_id: "anthropic/claude-sonnet-4-6" } },
+      { turn: "m2", model: { provider: "openai", model_id: "gpt-5.6" } }
+    ])
   })
 
   test("an assembly must declare one output strategy", () => {
@@ -255,7 +369,7 @@ describe("infer component", () => {
     const agent = assembled(infer([echoTable, later, nativeOutput], TEST_MODEL))
 
     expect(agent.components).toHaveLength(1)
-    expect(agent.reactors).toHaveLength(3)
+    expect(agent.reactors).toHaveLength(4)
     expect(() => renderOf([echoTable, later, nativeOutput], [{ type: "Ready" }])).toThrow('tool "echo" declared more than once')
   })
 

--- a/packages/agent/src/runtime/composition.ts
+++ b/packages/agent/src/runtime/composition.ts
@@ -14,7 +14,7 @@ import type { ToolSpec } from "../inference/request"
 import { fallbackOf, type OutputFallback } from "../output/contract"
 import { agentKeys } from "../log/events"
 import { inferReactorFor, type InferPolicy } from "../inference/reactor"
-import type { ModelRef } from "../inference/reference"
+import { modelPolicyOverrideOf, type ModelPolicyOverride } from "../inference/access"
 import { toolsReactorFrom, type Answer, type PendingCall } from "./tools"
 import type { ContextPolicy } from "../components/compaction"
 import type { AgentR } from "./turn"
@@ -211,11 +211,9 @@ const rootKeys = (children: KeyFragment | undefined): KeyFragment => {
   }
 }
 
-// InferOptions selects the provider connection and default model for an infer root. A message may
-// replace default_model for its turn, while provider remains assembly policy.
-export interface InferOptions extends Partial<Omit<InferPolicy, "model">> {
-  readonly provider: string
-  readonly default_model: string
+// InferOptions declares model authority and retry policy for an infer root.
+export interface InferOptions extends Partial<Omit<InferPolicy, "models">> {
+  readonly models?: ModelPolicyOverride
 }
 
 // infer composes an agent's child components and adds the model loop over their final view.
@@ -225,7 +223,7 @@ export const infer = <
   const Cs extends ReadonlyArray<AgentComponent<never> | AgentComponent<unknown>>
 >(
   components: Cs,
-  options: InferOptions
+  options: InferOptions = {}
 ): AgentComponent<AgentR | ComponentRequirements<Cs[number]>> => {
   type ComponentR = ComponentRequirements<Cs[number]>
   type R = AgentR | ComponentR
@@ -241,11 +239,9 @@ export const infer = <
   }
 
   renderView(viewOf([]))
-  if (options.provider.trim().length === 0) throw new Error("infer provider cannot be empty")
-  if (options.default_model.trim().length === 0) throw new Error("infer default_model cannot be empty")
-  const { provider, default_model, ...policy } = options
-  const model: ModelRef = { provider, model_id: default_model }
-  const inference = inferReactorFor({ ...policy, model }, (log) => renderView(viewOf(log))) as Reactor<R>
+  const { models: rawModels, ...policy } = options
+  const models = modelPolicyOverrideOf(rawModels)
+  const inference = inferReactorFor({ ...policy, models }, (log) => renderView(viewOf(log))) as Reactor<R>
   const dispatch = toolsReactorFrom(serve, (log, call) => offeredTools(log, call).map((tool) => tool.spec))
 
   return handles(agentMessageMethod, inheritComponentContract({

--- a/packages/agent/src/runtime/composition.types.test.ts
+++ b/packages/agent/src/runtime/composition.types.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../index"
 
 const accepts = <T>(_value: T): void => {}
-const TEST_MODEL = { provider: "test", default_model: "test-model" } as const
+const TEST_MODEL = { models: { default: { provider: "test", model_id: "test-model" }, allow: "*" } } as const
 
 const empty: AgentComponent = {
   name: "empty",
@@ -21,7 +21,7 @@ const empty: AgentComponent = {
   })
 }
 
-const nativeOnly = actor({ name: "native-only", methods: {}, components: [infer([empty, nativeOutput], TEST_MODEL)] })
+const nativeOnly = actor({ name: "native-only", methods: {}, components: [infer([empty, nativeOutput])] })
 const repaired = actor({ name: "repaired", methods: {}, components: [infer([empty, outputRepair], TEST_MODEL)] })
 
 type Requirements<A> = A extends Actor<infer R> ? R : never

--- a/packages/agent/src/runtime/turn.test.ts
+++ b/packages/agent/src/runtime/turn.test.ts
@@ -36,7 +36,7 @@ import {
   toolList
 } from "../index"
 
-const TEST_MODEL = { provider: "test", default_model: "test-model" } as const
+const TEST_MODEL = { models: { default: { provider: "test", model_id: "test-model" }, allow: "*" } } as const
 
 const assembled = <R>(component: AgentComponent<R>) => actor({
   name: "test-agent",
@@ -909,7 +909,7 @@ describe("the mind on a native surface", () => {
             nativeOutput
     ], TEST_MODEL))
     expect(mind.components).toHaveLength(1)
-    expect(mind.reactors).toHaveLength(3)
+    expect(mind.reactors).toHaveLength(4)
     const layers = Layer.mergeAll(
       memoryLog(),
       noRouter,

--- a/packages/agent/src/runtime/turn.ts
+++ b/packages/agent/src/runtime/turn.ts
@@ -10,6 +10,7 @@ import type { BudgetPolicy } from "../components/budget"
 import type { CompactionPolicy } from "../components/compaction"
 import type { CodePolicy } from "@clavia/tardigrade-code/execution/reactor"
 import type { WorkspacePolicy } from "@clavia/tardigrade-code/package/workspace"
+import type { ModelRef } from "../inference/reference"
 
 export { Infer } from "../inference/reactor"
 
@@ -43,7 +44,7 @@ export const receive = <R, T = unknown>(
     readonly id: string
     readonly text: string
     readonly input?: unknown
-    readonly model?: string
+    readonly model?: ModelRef
     readonly output?: OutputContract<T>
   }
 ): Effect.Effect<void, never, EventLog | R> =>

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -62,23 +62,32 @@ describe("the address a call goes to", () => {
       revision: "catalog-1",
       refreshed_at: 1,
       status: "fresh",
+      policy: { allow: "*" },
       total: 0,
       limit: 50,
       items: []
     })
     await makeActorClient({ baseUrl: "http://localhost:4111", fetch: stub }).models({
+      availability: "available",
       provider: "openrouter",
       search: "claude",
       cursor: "next",
-      limit: 25
+      limit: 25,
+      sort: "completionUsdPerToken",
+      order: "desc",
+      unpriced: "last"
     })
     const url = lastUrl()
     expect(url.pathname).toBe("/v1/models")
     expect(Object.fromEntries(url.searchParams)).toEqual({
+      availability: "available",
       provider: "openrouter",
       search: "claude",
       cursor: "next",
-      limit: "25"
+      limit: "25",
+      sort: "completionUsdPerToken",
+      order: "desc",
+      unpriced: "last"
     })
   })
 
@@ -87,6 +96,7 @@ describe("the address a call goes to", () => {
       revision: "catalog-1",
       refreshed_at: 1,
       status: "fresh",
+      policy: { allow: "*" },
       total: 0,
       limit: 50,
       items: []

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -12,6 +12,7 @@ import {
   type ActorMetadata,
   type ActorSummary,
   type Append,
+  type CatalogAvailabilityFilter,
   type ThreadNode,
   type ThreadSummary,
   type EventRow,
@@ -19,6 +20,9 @@ import {
   type MethodAccepted,
   type MethodSummary,
   type ModelCatalogPage,
+  type ModelCatalogPriceSort,
+  type ModelCatalogSortOrder,
+  type ModelCatalogUnpricedOrder,
   type ProviderCatalogPage,
   type Projections,
   type TurnView
@@ -100,10 +104,14 @@ export interface CatalogPageOptions {
   readonly cursor?: string | undefined
   readonly limit?: number | undefined
   readonly search?: string | undefined
+  readonly availability?: CatalogAvailabilityFilter | undefined
 }
 
 export interface ModelPageOptions extends CatalogPageOptions {
   readonly provider?: string | undefined
+  readonly sort?: ModelCatalogPriceSort | undefined
+  readonly order?: ModelCatalogSortOrder | undefined
+  readonly unpriced?: ModelCatalogUnpricedOrder | undefined
 }
 
 // What a caller states to follow a log: the tail's options, less the ones the client already holds.
@@ -232,11 +240,15 @@ const eventsQuery = (options: EventsOptions) => {
 }
 
 const catalogQuery = (options: ModelPageOptions) => {
-  const query: { cursor?: string; limit?: number; provider?: string; search?: string } = {}
+  const query: { availability?: CatalogAvailabilityFilter; cursor?: string; limit?: number; provider?: string; search?: string; sort?: ModelCatalogPriceSort; order?: ModelCatalogSortOrder; unpriced?: ModelCatalogUnpricedOrder } = {}
+  if (options.availability !== undefined) query.availability = options.availability
   if (options.cursor !== undefined) query.cursor = options.cursor
   if (options.limit !== undefined) query.limit = options.limit
   if (options.provider !== undefined) query.provider = options.provider
   if (options.search !== undefined) query.search = options.search
+  if (options.sort !== undefined) query.sort = options.sort
+  if (options.order !== undefined) query.order = options.order
+  if (options.unpriced !== undefined) query.unpriced = options.unpriced
   return query
 }
 

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -296,18 +296,49 @@ export const ModelCatalog = Schema.Struct({
 
 export type ModelCatalog = typeof ModelCatalog.Type
 
+export const ModelPolicySummary = Schema.Struct({
+  default: Schema.optionalKey(Schema.Struct({
+    provider: Schema.NonEmptyString,
+    model_id: Schema.NonEmptyString
+  })),
+  allow: Schema.Union([
+    Schema.Literal("*"),
+    Schema.Array(Schema.Struct({
+      provider: Schema.NonEmptyString,
+      model_ids: Schema.Union([Schema.Literal("*"), Schema.Array(Schema.NonEmptyString)])
+    }))
+  ])
+}).annotate({ identifier: "ModelPolicySummary" })
+
+export type ModelPolicySummary = typeof ModelPolicySummary.Type
+
 const CatalogPageFields = {
   revision: Schema.NonEmptyString,
   status: Schema.Literals(["fresh", "cached"]),
   refreshed_at: Schema.Finite,
+  policy: ModelPolicySummary,
   total: Schema.Int,
   limit: Schema.Int,
   next_cursor: Schema.optionalKey(Schema.String)
 }
 
+export const ProviderAvailability = Schema.Union([
+  Schema.Struct({ status: Schema.Literal("available") }),
+  Schema.Struct({
+    status: Schema.Literal("unavailable"),
+    reason: Schema.Literals(["not_configured", "credential_missing"])
+  })
+]).annotate({ identifier: "ProviderAvailability" })
+
+export type ProviderAvailability = typeof ProviderAvailability.Type
+
+export const CATALOG_AVAILABILITY_FILTERS = ["all", "available"] as const
+export type CatalogAvailabilityFilter = typeof CATALOG_AVAILABILITY_FILTERS[number]
+
 export const ProviderCatalogItem = Schema.Struct({
   id: Schema.NonEmptyString,
   name: Schema.NonEmptyString,
+  availability: ProviderAvailability,
   protocol: Schema.optionalKey(Schema.String),
   baseUrl: Schema.optionalKey(Schema.String),
   env: Schema.Array(Schema.String),
@@ -335,6 +366,21 @@ export const ModelCatalogPage = Schema.Struct({
 }).annotate({ identifier: "ModelCatalogPage" })
 
 export type ModelCatalogPage = typeof ModelCatalogPage.Type
+
+export const MODEL_CATALOG_PRICE_SORTS = [
+  "promptUsdPerToken",
+  "completionUsdPerToken",
+  "cachedPromptUsdPerToken",
+  "cacheWritePromptUsdPerToken"
+] as const
+
+export type ModelCatalogPriceSort = typeof MODEL_CATALOG_PRICE_SORTS[number]
+
+export const MODEL_CATALOG_SORT_ORDERS = ["asc", "desc"] as const
+export type ModelCatalogSortOrder = typeof MODEL_CATALOG_SORT_ORDERS[number]
+
+export const MODEL_CATALOG_UNPRICED_ORDERS = ["first", "last"] as const
+export type ModelCatalogUnpricedOrder = typeof MODEL_CATALOG_UNPRICED_ORDERS[number]
 
 export const ActorArtifact = Schema.Struct({
   manifest: Schema.Struct({
@@ -442,7 +488,8 @@ export const actorsGroup = HttpApiGroup.make("actors").add(
 const CatalogQuery = {
   search: Schema.optionalKey(Schema.String),
   cursor: Schema.optionalKey(Schema.String),
-  limit: Schema.optionalKey(Schema.Int)
+  limit: Schema.optionalKey(Schema.Int),
+  availability: Schema.optionalKey(Schema.Literals(CATALOG_AVAILABILITY_FILTERS))
 }
 
 // modelsGroup exposes paginated public provider and model discovery independently of private routes and credentials.
@@ -453,7 +500,13 @@ export const modelsGroup = HttpApiGroup.make("models").add(
     error: [ModelCatalogUnavailable.schema, InvalidRequest.schema]
   }),
   HttpApiEndpoint.get("models", "/v1/models", {
-    query: { ...CatalogQuery, provider: Schema.optionalKey(Schema.String) },
+    query: {
+      ...CatalogQuery,
+      provider: Schema.optionalKey(Schema.String),
+      sort: Schema.optionalKey(Schema.Literals(MODEL_CATALOG_PRICE_SORTS)),
+      order: Schema.optionalKey(Schema.Literals(MODEL_CATALOG_SORT_ORDERS)),
+      unpriced: Schema.optionalKey(Schema.Literals(MODEL_CATALOG_UNPRICED_ORDERS))
+    },
     success: ModelCatalogPage,
     error: [ModelCatalogUnavailable.schema, InvalidRequest.schema]
   })

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -24,7 +24,13 @@ export { isProblem, NO_ANSWER, problemOf, ProblemError } from "./problem"
 // The vocabulary's top level, and where the versioned routes live. A consumer that builds a URL by
 // hand reads them from here rather than spelling them again
 // (contract.ts).
-export { V1_PREFIX } from "./contract"
+export {
+  CATALOG_AVAILABILITY_FILTERS,
+  MODEL_CATALOG_PRICE_SORTS,
+  MODEL_CATALOG_SORT_ORDERS,
+  MODEL_CATALOG_UNPRICED_ORDERS,
+  V1_PREFIX
+} from "./contract"
 export { CLOSED, stream, streamUrl, type EventSourceLike, type Frame, type OpenEventSource, type StreamOptions } from "./stream"
 
 export type {
@@ -33,6 +39,7 @@ export type {
   ActorMetadata,
   ActorSummary,
   Append,
+  CatalogAvailabilityFilter,
   EventRow,
   Health,
   MethodAccepted,
@@ -40,6 +47,11 @@ export type {
   MethodState,
   ModelCatalog,
   ModelCatalogPage,
+  ModelCatalogPriceSort,
+  ModelCatalogSortOrder,
+  ModelCatalogUnpricedOrder,
+  ModelPolicySummary,
+  ProviderAvailability,
   ProviderCatalogPage,
   Problem,
   ThreadNode,

--- a/packages/core/src/actor/definition.ts
+++ b/packages/core/src/actor/definition.ts
@@ -13,6 +13,8 @@ import {
   methodCallKeys,
   methodResponseComponent,
   methodResponseKeys,
+  methodInputValidationComponents,
+  methodInputValidationTransitions,
   methodTimeoutComponent,
   methodTimeoutKeys,
   type ActorMethods
@@ -53,12 +55,25 @@ const fromOptions = <
   const methods = actorMethodsOf(options.methods)
   type R = ComponentRequirements<Components[number]> | Router | Self
   const components = options.components as ReadonlyArray<Component<unknown, R>>
-  const fragments = components.flatMap((component) => component.keys === undefined ? [] : [component.keys])
+  const inputValidation = methodInputValidationComponents(methods)
+  const fragments = [...inputValidation, ...components].flatMap((component) => component.keys === undefined ? [] : [component.keys])
   const responses = methodResponseComponent(methods)
   const contract = actorContractOf(methods, options.components as ReadonlyArray<Component<unknown, unknown>>)
+  const keyOf = composeKeys(...fragments, methodCallKeys, methodTimeoutKeys, methodResponseKeys)
+  const guarded = components.map((component) => {
+    const derive = reactorOf(component)
+    return (log: Parameters<typeof derive>[0]) => {
+      const recorded = new Set(log.flatMap((event) => {
+        const key = keyOf(event)
+        return key === undefined ? [] : [key]
+      }))
+      const invalid = methodInputValidationTransitions(methods, log).some((transition) => !recorded.has(transition.key))
+      return invalid ? [] : derive(log)
+    }
+  })
   const runtime = actorFromReactors<R>(
-    [...components.map(reactorOf), reactorOf(methodTimeoutComponent), reactorOf(responses)],
-    composeKeys(...fragments, methodCallKeys, methodTimeoutKeys, methodResponseKeys)
+    [...guarded, ...inputValidation.map(reactorOf), reactorOf(methodTimeoutComponent), reactorOf(responses)],
+    keyOf
   )
   return {
     ...runtime,

--- a/packages/core/src/actor/method/definition.ts
+++ b/packages/core/src/actor/method/definition.ts
@@ -15,11 +15,27 @@ export const actorMethodTimeoutOf = (timeoutMs: number | undefined): number => {
   return resolved
 }
 
+export interface InvalidDurableMethodInput {
+  readonly event: Event
+  readonly index: number
+  readonly log: ReadonlyArray<Event>
+  readonly error: string
+}
+
+// DurableMethodInput declares how a method recognizes and rejects an invocation already present in a log.
+export interface DurableMethodInput {
+  readonly schema: Schema.ConstraintDecoder<unknown>
+  readonly matches: (event: Event) => boolean
+  readonly keyOf: (input: InvalidDurableMethodInput) => string
+  readonly reject: (input: InvalidDurableMethodInput, at: number) => Event
+}
+
 // ActorMethodDeclaration is the erased shape a heterogeneous method table preserves. eventOf validates unknown input before constructing the durable event.
 export interface ActorMethodDeclaration {
   readonly input: Schema.ConstraintDecoder<unknown>
   readonly output: Schema.ConstraintDecoder<unknown>
   readonly timeoutMs: number
+  readonly durableInput?: DurableMethodInput
   readonly eventOf: (call: ActorMethodCall<unknown>) => Event
   readonly state: (events: ReadonlyArray<Event>, id: string) => ActorMethodState<unknown> | undefined
 }
@@ -32,6 +48,7 @@ export interface ActorMethodDefinition<
   readonly input: Input
   readonly output: Output
   readonly timeoutMs?: number
+  readonly durableInput?: DurableMethodInput
   readonly event: (call: ActorMethodCall<Input["Type"]>) => Event
   readonly state: (events: ReadonlyArray<Event>, id: string) => ActorMethodState<Output["Type"]> | undefined
 }

--- a/packages/core/src/actor/method/index.ts
+++ b/packages/core/src/actor/method/index.ts
@@ -9,8 +9,11 @@ export {
   type ActorMethodDefinition,
   type ActorMethodInput,
   type ActorMethodOutput,
-  type ActorMethods
+  type ActorMethods,
+  type DurableMethodInput,
+  type InvalidDurableMethodInput
 } from "./definition"
+export { methodInputValidationComponents, methodInputValidationTransitions } from "./validation"
 export type { ActorMethodCall, ActorMethodInvocation } from "./call"
 export {
   actorCall,

--- a/packages/core/src/actor/method/validation.ts
+++ b/packages/core/src/actor/method/validation.ts
@@ -1,0 +1,55 @@
+import { Schema } from "effect"
+import { intent } from "../../reconciliation"
+import type { Component } from "../component"
+import type { ActorMethods, InvalidDurableMethodInput } from "./definition"
+
+const errorOf = (
+  schema: Schema.ConstraintDecoder<unknown>,
+  value: unknown
+): string | undefined => {
+  try {
+    Schema.decodeUnknownSync(schema)(value)
+    return undefined
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error)
+  }
+}
+
+const transitionsFor = (
+  method: ActorMethods[string],
+  log: InvalidDurableMethodInput["log"]
+) => {
+  const contract = method.durableInput
+  if (contract === undefined) return []
+  return log.flatMap((event, index) => {
+    if (!contract.matches(event)) return []
+    const error = errorOf(contract.schema, event)
+    if (error === undefined) return []
+    const input: InvalidDurableMethodInput = { event, index, log, error }
+    return [intent({
+      key: contract.keyOf(input),
+      input,
+      events: (current, at) => [contract.reject(current, at)]
+    })]
+  })
+}
+
+// methodInputValidationTransitions derive every durable input rejection owed by a method table.
+export const methodInputValidationTransitions = (
+  methods: ActorMethods,
+  log: InvalidDurableMethodInput["log"]
+) => Object.values(methods).flatMap((method) => transitionsFor(method, log))
+
+// methodInputValidationComponents mount each method's durable input contract (packages/agent/src/runtime/composition.test.ts, "a historical model string durably fails its turn").
+export const methodInputValidationComponents = (
+  methods: ActorMethods
+): ReadonlyArray<Component<undefined>> => Object.entries(methods).flatMap(([name, method]) => {
+  if (method.durableInput === undefined) return []
+  return [{
+    name: `actor.method-input.${name}`,
+    derive: (log) => ({
+      view: undefined,
+      transitions: transitionsFor(method, log)
+    })
+  }]
+})

--- a/packages/core/tla/README.md
+++ b/packages/core/tla/README.md
@@ -17,6 +17,7 @@ The specifications describe the runtime and communication contracts independentl
 | `runtime/Driver` | Wake accounting, service, isolation, and bounded failure | `Driver.cfg`, `DriverLive.cfg`, `DriverIsolate.cfg`, `DriverPoisoned.cfg` | `DriverDrop.cfg` |
 | `runtime/Execution` | Mixed package completion and parked fiber release | `Execution.cfg` | `ExecutionReadyLeak.cfg` |
 | `runtime/Guard` | Terminal outcome remains singular across attempts | `Guard.cfg` | `GuardRace.cfg` |
+| `runtime/ModelPolicy` | Coordinate authority, complete host defaults, recursive attenuation, and selection | `ModelPolicy.cfg` | `ModelPolicyWiden.cfg` |
 | `runtime/Projection` | Prefix interpretation remains faithful | `Projection.cfg` | `ProjectionView.cfg` |
 | `runtime/Reconcile` | Derived keyed work commits, blocks, or settles | `Reconcile.cfg` | None |
 | `runtime/Replay` | Recorded answers remain bound to their questions | `Replay.cfg` | `ReplayTrust.cfg` |

--- a/packages/core/tla/runtime/ModelPolicy.cfg
+++ b/packages/core/tla/runtime/ModelPolicy.cfg
@@ -1,0 +1,14 @@
+\* ModelPolicy checks coordinate attenuation and total defaults against a finite provider and model space.
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  Actors = {"root", "first", "second"}
+  Root = "root"
+  NoActor = "none"
+INVARIANT TypeOK
+INVARIANT PolicyDefinition
+INVARIANT ChildCannotWiden
+INVARIANT HostCeiling
+INVARIANT DefaultAllowed
+INVARIANT SelectionRequiresAuthority
+INVARIANT DeniedAttemptFails

--- a/packages/core/tla/runtime/ModelPolicy.tla
+++ b/packages/core/tla/runtime/ModelPolicy.tla
@@ -1,0 +1,160 @@
+-------------------------- MODULE ModelPolicy --------------------------
+(* ModelPolicy models provider and model identities as coordinates, a complete host policy, recursive authority attenuation, default overrides, and explicit selection. *)
+
+EXTENDS FiniteSets, TLC
+
+CONSTANTS Actors, Root, NoActor
+
+(* CoordinateSpace is the normalized output of any selector or future query language. Policy composition depends only on these resolved coordinates. *)
+CoordinateSpace == {<<"openai", "large">>, <<"openai", "small">>, <<"anthropic", "sonnet">>}
+NoModel == <<"none", "none">>
+HostConfigured == CoordinateSpace
+HostAllowed == {<<"openai", "large">>, <<"openai", "small">>}
+HostDefault == <<"openai", "large">>
+HostAuthority == HostConfigured \cap HostAllowed
+AllowDeclarations == SUBSET CoordinateSpace
+DefaultDeclarations == CoordinateSpace \cup {NoModel}
+
+ASSUME Root \in Actors
+ASSUME HostConfigured \subseteq CoordinateSpace
+ASSUME HostAllowed \subseteq CoordinateSpace
+ASSUME HostDefault \in HostAuthority
+ASSUME NoModel \notin CoordinateSpace
+ASSUME NoActor \notin Actors
+
+(* AllowSet interprets omission and allow = "*" as the full coordinate space supplied by the caller. *)
+AllowSet(declared) == declared
+
+(* Attenuate intersects a layer's selector set with its incoming authority. *)
+Attenuate(incoming, declared) == incoming \cap AllowSet(declared)
+
+(* DefaultOf inherits the incoming default unless the layer declares another coordinate. *)
+DefaultOf(incoming, declared) == IF declared = NoModel THEN incoming ELSE declared
+
+VARIABLES active, parent, localAllow, localDefault, effective, defaults, attempted, selected, outcome
+
+vars == <<active, parent, localAllow, localDefault, effective, defaults, attempted, selected, outcome>>
+
+TypeOK ==
+  /\ active \subseteq Actors
+  /\ Root \in active
+  /\ parent \in [Actors -> Actors \cup {NoActor}]
+  /\ localAllow \in [Actors -> SUBSET CoordinateSpace]
+  /\ localDefault \in [Actors -> DefaultDeclarations]
+  /\ effective \in [Actors -> SUBSET CoordinateSpace]
+  /\ defaults \in [Actors -> DefaultDeclarations]
+  /\ attempted \in [Actors -> DefaultDeclarations]
+  /\ selected \in [Actors -> DefaultDeclarations]
+  /\ outcome \in [Actors -> {"pending", "selected", "failed"}]
+
+(* Init applies an optional root actor policy to the complete host policy. Invalid root policies produce no initial state. *)
+Init ==
+  \E declaredAllow \in AllowDeclarations, declaredDefault \in DefaultDeclarations:
+    LET rootAuthority == Attenuate(HostAuthority, declaredAllow)
+        rootDefault == DefaultOf(HostDefault, declaredDefault)
+    IN /\ rootDefault \in rootAuthority
+       /\ active = {Root}
+       /\ parent = [actor \in Actors |-> NoActor]
+       /\ localAllow = [actor \in Actors |-> IF actor = Root THEN AllowSet(declaredAllow) ELSE CoordinateSpace]
+       /\ localDefault = [actor \in Actors |-> IF actor = Root THEN declaredDefault ELSE NoModel]
+       /\ effective = [actor \in Actors |-> IF actor = Root THEN rootAuthority ELSE {}]
+       /\ defaults = [actor \in Actors |-> IF actor = Root THEN rootDefault ELSE NoModel]
+       /\ attempted = [actor \in Actors |-> NoModel]
+       /\ selected = [actor \in Actors |-> NoModel]
+       /\ outcome = [actor \in Actors |-> "pending"]
+
+(* Spawn intersects a child's optional selector with parent authority and resolves its optional default. The membership guard rejects a narrowing that excludes the resolved default. *)
+Spawn(child, source, declaredAllow, declaredDefault) ==
+  LET childAuthority == Attenuate(effective[source], declaredAllow)
+      childDefault == DefaultOf(defaults[source], declaredDefault)
+  IN /\ child \notin active
+     /\ source \in active
+     /\ declaredAllow \in AllowDeclarations
+     /\ declaredDefault \in DefaultDeclarations
+     /\ childDefault \in childAuthority
+     /\ active' = active \cup {child}
+     /\ parent' = [parent EXCEPT ![child] = source]
+     /\ localAllow' = [localAllow EXCEPT ![child] = AllowSet(declaredAllow)]
+     /\ localDefault' = [localDefault EXCEPT ![child] = declaredDefault]
+     /\ effective' = [effective EXCEPT ![child] = childAuthority]
+     /\ defaults' = [defaults EXCEPT ![child] = childDefault]
+     /\ UNCHANGED <<attempted, selected, outcome>>
+
+(* Attempt records an authorized coordinate or a durable rejection. *)
+Attempt(actor, coordinate) ==
+  /\ actor \in active
+  /\ outcome[actor] = "pending"
+  /\ coordinate \in CoordinateSpace
+  /\ attempted' = [attempted EXCEPT ![actor] = coordinate]
+  /\ IF coordinate \in effective[actor]
+     THEN /\ selected' = [selected EXCEPT ![actor] = coordinate]
+          /\ outcome' = [outcome EXCEPT ![actor] = "selected"]
+     ELSE /\ selected' = selected
+          /\ outcome' = [outcome EXCEPT ![actor] = "failed"]
+  /\ UNCHANGED <<active, parent, localAllow, localDefault, effective, defaults>>
+
+(* ResolveDefault selects the effective policy's distinguished coordinate. *)
+ResolveDefault(actor) == Attempt(actor, defaults[actor])
+
+Next ==
+  \/ \E child \in Actors, source \in Actors, declaredAllow \in AllowDeclarations, declaredDefault \in DefaultDeclarations:
+       Spawn(child, source, declaredAllow, declaredDefault)
+  \/ \E actor \in Actors, coordinate \in CoordinateSpace: Attempt(actor, coordinate)
+  \/ \E actor \in Actors: ResolveDefault(actor)
+
+Spec == Init /\ [][Next]_vars
+
+(* PolicyDefinition states that every actor is the intersection of its incoming authority and local selector, with an inherited or overridden default. *)
+PolicyDefinition ==
+  /\ effective[Root] = HostAuthority \cap localAllow[Root]
+  /\ defaults[Root] = DefaultOf(HostDefault, localDefault[Root])
+  /\ \A actor \in active \ {Root}:
+       /\ parent[actor] \in active
+       /\ effective[actor] = effective[parent[actor]] \cap localAllow[actor]
+       /\ defaults[actor] = DefaultOf(defaults[parent[actor]], localDefault[actor])
+
+(* ChildCannotWiden states that every child remains within its parent's authority. *)
+ChildCannotWiden ==
+  \A actor \in active \ {Root}: effective[actor] \subseteq effective[parent[actor]]
+
+(* HostCeiling states that every actor remains within the configured and allowed host coordinates. *)
+HostCeiling ==
+  \A actor \in active: effective[actor] \subseteq HostAuthority
+
+(* DefaultAllowed states that every active policy has a distinguished coordinate inside its authority. *)
+DefaultAllowed ==
+  \A actor \in active: defaults[actor] \in effective[actor]
+
+(* SelectionRequiresAuthority states that every selected coordinate belongs to the actor's effective set. *)
+SelectionRequiresAuthority ==
+  \A actor \in active: selected[actor] # NoModel => selected[actor] \in effective[actor]
+
+(* DeniedAttemptFails states that a denied coordinate terminates without selection. *)
+DeniedAttemptFails ==
+  \A actor \in active:
+    attempted[actor] # NoModel /\ attempted[actor] \notin effective[actor] => outcome[actor] = "failed" /\ selected[actor] = NoModel
+
+(* TrustSpawn replaces attenuation with a child's selector set. ModelPolicyWiden.cfg demonstrates the resulting authority amplification. *)
+TrustSpawn(child, source, declaredAllow, declaredDefault) ==
+  LET childAuthority == AllowSet(declaredAllow)
+      childDefault == DefaultOf(defaults[source], declaredDefault)
+  IN /\ child \notin active
+     /\ source \in active
+     /\ declaredAllow \in AllowDeclarations
+     /\ declaredDefault \in DefaultDeclarations
+     /\ childDefault \in childAuthority
+     /\ active' = active \cup {child}
+     /\ parent' = [parent EXCEPT ![child] = source]
+     /\ localAllow' = [localAllow EXCEPT ![child] = AllowSet(declaredAllow)]
+     /\ localDefault' = [localDefault EXCEPT ![child] = declaredDefault]
+     /\ effective' = [effective EXCEPT ![child] = childAuthority]
+     /\ defaults' = [defaults EXCEPT ![child] = childDefault]
+     /\ UNCHANGED <<attempted, selected, outcome>>
+
+TrustNext ==
+  \E child \in Actors, source \in Actors, declaredAllow \in AllowDeclarations, declaredDefault \in DefaultDeclarations:
+    TrustSpawn(child, source, declaredAllow, declaredDefault)
+
+TrustSpec == Init /\ [][TrustNext]_vars
+
+=============================================================================

--- a/packages/core/tla/runtime/ModelPolicyWiden.cfg
+++ b/packages/core/tla/runtime/ModelPolicyWiden.cfg
@@ -1,0 +1,8 @@
+\* ModelPolicyWiden proves that replacing attenuation lets a child add coordinates outside parent authority.
+SPECIFICATION TrustSpec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  Actors = {"root", "first", "second"}
+  Root = "root"
+  NoActor = "none"
+INVARIANT ChildCannotWiden

--- a/platform/cloudflare/src/config.test.ts
+++ b/platform/cloudflare/src/config.test.ts
@@ -4,7 +4,7 @@ import { structuredWorkerConfigOf } from "./config"
 
 describe("Worker configuration", () => {
   test("reads object and string bindings", () => {
-    const config = { models: { default: { provider: "openai", model_id: "gpt-5.2" } } }
+    const config = { models: { default: { provider: "openai", model_id: "gpt-5.2" }, allow: "*" } }
     expect(structuredWorkerConfigOf(config)).toEqual(config)
     expect(structuredWorkerConfigOf(JSON.stringify(config))).toEqual(config)
   })

--- a/platform/cloudflare/src/worker.ts
+++ b/platform/cloudflare/src/worker.ts
@@ -1,8 +1,14 @@
 import { DurableObject } from "cloudflare:workers"
 import { Clock, Context, Effect, Layer, Schema } from "effect"
 import { FetchHttpClient, HttpEffect, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
-import { actor, agentMethods, agentsPackage, budget, codeMode, compaction, fetchPackage, Infer, infer as inferAgent, outputValidateOnce, workspacePackage, type Actor, type ActorMethods, type ModelRef } from "tardie"
+import { actor, agentMethods, agentsPackage, applyModelPolicy, budget, codeMode, compaction, fetchPackage, Infer, infer as inferAgent, intersectModelPolicies, modelAllowedBy, outputValidateOnce, workspacePackage, type Actor, type ActorMethods, type ModelPolicy, type ModelRef } from "tardie"
 import type { Action } from "tardie/log/events"
+import {
+  CATALOG_AVAILABILITY_FILTERS,
+  MODEL_CATALOG_PRICE_SORTS,
+  MODEL_CATALOG_SORT_ORDERS,
+  MODEL_CATALOG_UNPRICED_ORDERS
+} from "@clavia/tardigrade-client/contract"
 import { infer } from "@clavia/tardigrade-model/model"
 import { DEFAULT_MODEL_CATALOG_URL } from "@clavia/tardigrade-model/metadata"
 import {
@@ -10,6 +16,7 @@ import {
   type ModelCatalogLoadPolicy,
   type ModelCatalogState
 } from "@clavia/tardigrade-server/catalog"
+import { providerAvailabilitiesOf } from "@clavia/tardigrade-server/catalog-availability"
 import { modelsPageOf, providersPageOf } from "@clavia/tardigrade-server/catalog-page"
 import { modelConfigOf, type ModelProviderConfig } from "@clavia/tardigrade-server/config"
 import { treeOf, type ThreadNode, type ThreadSummary } from "@clavia/tardigrade-server/projections"
@@ -84,7 +91,7 @@ interface CloudflareProvider extends ModelProviderConfig {
   readonly apiKey: string
 }
 
-interface CloudflareModels {
+interface CloudflareModels extends ModelPolicy {
   readonly default: ModelRef
   readonly providers: Readonly<Record<string, CloudflareProvider>>
 }
@@ -114,32 +121,59 @@ const modelsFrom = (env: Env): CloudflareModels | undefined => {
       apiKey: credentialFrom(env, name, provider.env)
     }
   }
-  return { default: parsed.default, providers }
+  return { default: parsed.default, allow: parsed.allow, providers }
 }
+
+const providerAvailabilityFrom = (env: Env) => {
+  const config = structuredWorkerConfigOf(env.TARDIGRADE_CONFIG)
+  const parsed = modelConfigOf(config?.["models"] ?? { allow: "*" })
+  const values = env as unknown as Readonly<Record<string, unknown>>
+  const credentials = Object.fromEntries(
+    Object.values(parsed.providers).flatMap((provider) => provider.env.flatMap((name) => {
+      const value = values[name]
+      return typeof value === "string" && value.trim().length > 0 ? [[name, value]] : []
+    }))
+  )
+  return providerAvailabilitiesOf(parsed, credentials)
+}
+
+const modelPolicyFrom = (env: Env): ModelPolicy => {
+  const config = structuredWorkerConfigOf(env.TARDIGRADE_CONFIG)
+  const parsed = modelConfigOf(config?.["models"] ?? { allow: "*" })
+  return { ...(parsed.default === undefined ? {} : { default: parsed.default }), allow: parsed.allow }
+}
+
+const providerAvailabilityFromModels = (models: CloudflareModels | undefined) => models === undefined
+  ? {}
+  : providerAvailabilitiesOf(models, Object.fromEntries(
+      Object.values(models.providers).flatMap((provider) => provider.env.map((name) => [name, provider.apiKey]))
+    ))
 
 const selectedModelFrom = (
   models: CloudflareModels,
   catalog: ModelCatalogState,
-  reference: ModelRef
+  reference?: ModelRef
 ) => {
-  const provider = models.providers[reference.provider]
-  if (provider === undefined) throw new Error(`provider ${JSON.stringify(reference.provider)} is not configured; update TARDIGRADE_CONFIG.models`)
+  const selected = reference ?? models.default
+  if (!modelAllowedBy(models, selected)) throw new Error(`model ${selected.provider}/${selected.model_id} is excluded by the host model policy`)
+  const provider = models.providers[selected.provider]
+  if (provider === undefined) throw new Error(`provider ${JSON.stringify(selected.provider)} is not configured; update TARDIGRADE_CONFIG.models`)
   if (catalog.snapshot === undefined) {
-    throw new Error(`model catalog metadata is unavailable for ${reference.provider}/${reference.model_id}; check the Worker logs`)
+    throw new Error(`model catalog metadata is unavailable for ${selected.provider}/${selected.model_id}; check the Worker logs`)
   }
-  const catalogProvider = catalog.snapshot.providers.find((candidate) => candidate.id === reference.provider)
+  const catalogProvider = catalog.snapshot.providers.find((candidate) => candidate.id === selected.provider)
   if (catalogProvider === undefined) {
-    throw new Error(`provider ${JSON.stringify(reference.provider)} is absent from model catalog revision ${JSON.stringify(catalog.snapshot.revision)}`)
+    throw new Error(`provider ${JSON.stringify(selected.provider)} is absent from model catalog revision ${JSON.stringify(catalog.snapshot.revision)}`)
   }
-  const model = catalogProvider.models.find((candidate) => candidate.id === reference.model_id)
+  const model = catalogProvider.models.find((candidate) => candidate.id === selected.model_id)
   if (model === undefined) {
-    throw new Error(`model ${reference.provider}/${reference.model_id} is absent from model catalog revision ${JSON.stringify(catalog.snapshot.revision)}`)
+    throw new Error(`model ${selected.provider}/${selected.model_id} is absent from model catalog revision ${JSON.stringify(catalog.snapshot.revision)}`)
   }
   const contextWindowTokens = model.metadata.contextWindowTokens
   if (contextWindowTokens === undefined) {
-    throw new Error(`model catalog has no context window for ${reference.provider}/${reference.model_id}`)
+    throw new Error(`model catalog has no context window for ${selected.provider}/${selected.model_id}`)
   }
-  return { reference, provider, metadata: model.metadata, contextWindowTokens, catalogRevision: catalog.snapshot.revision }
+  return { reference: selected, provider, metadata: model.metadata, contextWindowTokens, catalogRevision: catalog.snapshot.revision }
 }
 
 const modelLayer = (models: CloudflareModels | undefined, catalog: ModelCatalogState) => {
@@ -150,11 +184,24 @@ const modelLayer = (models: CloudflareModels | undefined, catalog: ModelCatalogS
       react: () => Effect.succeed(failed)
     })
   }
+  const availableModels = (): ModelPolicy => {
+    const snapshot = catalog.snapshot
+    if (snapshot === undefined) return { allow: [] }
+    const configured: ModelPolicy = {
+      allow: snapshot.providers.flatMap((provider) =>
+        models.providers[provider.id] !== undefined && provider.models.length > 0
+          ? [{ provider: provider.id, model_ids: provider.models.map((model) => model.id) }]
+          : []
+      )
+    }
+    return { ...intersectModelPolicies([models, configured]), default: models.default }
+  }
   return Layer.succeed(Infer, {
     resolve: (reference) => {
       const selected = selectedModelFrom(models, catalog, reference)
       return {
-        model: reference,
+        model: selected.reference,
+        models: availableModels(),
         contextWindowTokens: selected.contextWindowTokens,
         ...(selected.metadata.maxOutputTokens === undefined ? {} : { maxOutputTokens: selected.metadata.maxOutputTokens }),
         catalogRevision: selected.catalogRevision
@@ -224,14 +271,31 @@ function defaultAssemblyOf(
   models: CloudflareModels | undefined,
   catalog: ModelCatalogState
 ) {
-  const selected = models?.default ?? { provider: "unconfigured", model_id: "unconfigured" }
   const fireRatio = optionalRatio(env.TARDIGRADE_COMPACTION_FIRE_RATIO, "TARDIGRADE_COMPACTION_FIRE_RATIO")
   const keepRatio = optionalRatio(env.TARDIGRADE_COMPACTION_KEEP_RATIO, "TARDIGRADE_COMPACTION_KEEP_RATIO")
+  const snapshot = catalog.snapshot
+  const availability = providerAvailabilityFromModels(models)
+  const agentCatalog = snapshot === undefined
+    ? undefined
+    : {
+        providers: (query: Parameters<typeof providersPageOf>[2]) => {
+          const effective = applyModelPolicy(models ?? { allow: "*" }, query?.models ?? {})
+          return providersPageOf(snapshot, availability, { ...query, models: effective, policy: effective })
+        },
+        models: (query: Parameters<typeof modelsPageOf>[2]) => {
+          const effective = applyModelPolicy(models ?? { allow: "*" }, query?.models ?? {})
+          return modelsPageOf(snapshot, availability, { ...query, models: effective, policy: effective })
+        }
+      }
   return actor({
     name: DEFAULT_ACTOR_NAME,
     methods: agentMethods,
     components: [inferAgent([
-      budget([codeMode([agentsPackage(), workspacePackage(), fetchPackage()])]),
+      budget([codeMode([
+        agentsPackage(agentCatalog === undefined ? {} : { catalog: agentCatalog }),
+        workspacePackage(),
+        fetchPackage()
+      ])]),
       compaction({
         ...(models === undefined ? {} : {
           contextWindowTokens: (model: ModelRef | undefined) =>
@@ -241,10 +305,7 @@ function defaultAssemblyOf(
         ...(keepRatio === undefined ? {} : { keepRatio })
       }),
       outputValidateOnce
-    ], {
-      provider: selected.provider,
-      default_model: selected.model_id
-    })]
+    ])]
   })
 }
 
@@ -561,10 +622,21 @@ const catalogQueryOf = (request: HttpServerRequest.HttpServerRequest) => {
   const value = (name: string): string | undefined => query.get(name) ?? undefined
   const limit = value("limit")
   return {
+    availability: catalogChoiceOf(query.get("availability"), "availability", CATALOG_AVAILABILITY_FILTERS),
     cursor: value("cursor"),
     search: value("search"),
     ...(limit === undefined ? {} : { limit: Number(limit) })
   }
+}
+
+const catalogChoiceOf = <const Values extends ReadonlyArray<string>>(
+  raw: string | null,
+  name: string,
+  values: Values
+): Values[number] | undefined => {
+  if (raw === null) return undefined
+  if (values.includes(raw)) return raw as Values[number]
+  throw new Error(`catalog ${name} must be one of ${values.join(", ")}`)
 }
 
 const protectedRoute = <E, R>(
@@ -595,7 +667,10 @@ const routes = [
         if (catalog.snapshot === undefined) {
           throw new Error(catalog.refreshError ?? catalog.cacheError ?? "no validated model catalog is available")
         }
-        return providersPageOf(catalog.snapshot, catalogQueryOf(request))
+        return providersPageOf(catalog.snapshot, providerAvailabilityFrom(env), {
+          ...catalogQueryOf(request),
+          policy: modelPolicyFrom(env)
+        })
       },
       catch: (cause) => cause instanceof Error ? cause.message : String(cause)
     }).pipe(Effect.match({
@@ -615,14 +690,18 @@ const routes = [
           throw new Error(catalog.refreshError ?? catalog.cacheError ?? "no validated model catalog is available")
         }
         const query = new URL(request.url, "http://worker").searchParams
-        return modelsPageOf(catalog.snapshot, {
+        return modelsPageOf(catalog.snapshot, providerAvailabilityFrom(env), {
           ...catalogQueryOf(request),
-          provider: query.get("provider") ?? undefined
+          policy: modelPolicyFrom(env),
+          provider: query.get("provider") ?? undefined,
+          sort: catalogChoiceOf(query.get("sort"), "sort", MODEL_CATALOG_PRICE_SORTS),
+          order: catalogChoiceOf(query.get("order"), "order", MODEL_CATALOG_SORT_ORDERS),
+          unpriced: catalogChoiceOf(query.get("unpriced"), "unpriced", MODEL_CATALOG_UNPRICED_ORDERS)
         })
       },
       catch: (cause) => cause instanceof Error ? cause.message : String(cause)
     }).pipe(Effect.match({
-      onFailure: (error) => json({ error }, error.includes("catalog cursor") || error.includes("catalog limit") ? 400 : 503),
+      onFailure: (error) => json({ error }, error.startsWith("catalog ") ? 400 : 503),
       onSuccess: (page) => json(page)
     }))
   })),

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -768,13 +768,18 @@ export const infer = <const C extends ModelConfig>(config: C): Layer.Layer<Infer
   }
   const layer = Layer.succeed(Infer, {
     resolve: (reference) => {
-      if (reference.provider !== config.provider || reference.model_id !== config.model) {
+      const selected = reference ?? { provider: config.provider, model_id: config.model }
+      if (selected.provider !== config.provider || selected.model_id !== config.model) {
         throw new Error(
-          `model ${reference.provider}/${reference.model_id} is not bound; this host binds ${config.provider}/${config.model}`
+          `model ${selected.provider}/${selected.model_id} is not bound; this host binds ${config.provider}/${config.model}`
         )
       }
       return {
-        model: reference,
+        model: selected,
+        models: {
+          default: selected,
+          allow: [{ provider: selected.provider, model_ids: [selected.model_id] }]
+        },
         contextWindowTokens: config.contextWindowTokens,
         ...(config.maxOutputTokens === undefined ? {} : { maxOutputTokens: config.maxOutputTokens })
       }

--- a/tools/tla.ts
+++ b/tools/tla.ts
@@ -70,6 +70,8 @@ export const checks: ReadonlyArray<Check> = [
   counterexample("runtime", "Execution", "ExecutionReadyLeak.cfg", "Invariant ParkedAttemptReleases is violated"),
   pass("runtime", "Guard", "Guard.cfg"),
   counterexample("runtime", "Guard", "GuardRace.cfg", "Invariant NoDoubleOutcome is violated"),
+  pass("runtime", "ModelPolicy", "ModelPolicy.cfg"),
+  counterexample("runtime", "ModelPolicy", "ModelPolicyWiden.cfg", "Invariant ChildCannotWiden is violated"),
   pass("runtime", "Projection", "Projection.cfg"),
   counterexample("runtime", "Projection", "ProjectionView.cfg", "Invariant ViewFaithful is violated"),
   pass("runtime", "Reconcile", "Reconcile.cfg"),


### PR DESCRIPTION
## Summary

Adds provider and model catalog discovery to the host API and agents package. Catalog pages report provider availability, the effective model policy and default, filtering, pagination, and deterministic price sorting while keeping credential values private.

Requires complete `{ provider, model_id }` references across public messages and `agents.run`. Invalid durable message inputs append an actionable `TurnFailed`, including historical string model values, so a later corrected message can proceed normally.

Adds recursive model authority through `models: { default?, allow? }`. The host declares a complete provider, allow, and default policy. Actors and child agents inherit it, may attenuate its coordinate set, and may select a default inside their effective authority. CLI setup writes the first provider and default atomically.

Specifies the policy algebra in TLA+ and mirrors its set laws with fast-check properties. Future selector or query languages lower to normalized provider and model coordinates before policy composition.

## Verification

- `bun run gate`
- `bun run tla ModelPolicy`

Closes #277.
