### PR TITLE
feat(web): add site favicon

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#131514" />
     <meta name="description" content="Tardigrade is a TypeScript framework for durable, modular agents." />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" sizes="any" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="24" fill="#2450ff" />
+  <g fill="#fff" transform="translate(16 33) scale(.45714)">
+    <g transform="translate(-36 -62)">
+      <g transform="translate(320 0) scale(-1 1)">
+        <path d="M78 117 112 99v77c0 6-3 10-8 13l-21-11c-3-2-5-5-5-9Z" />
+        <path d="M120 95 154 81v96c0 6-3 10-8 13l-21-11c-3-2-5-5-5-9Z" />
+        <path d="M162 78c10-4 21-7 34-8v106c0 5-3 9-8 12l-21-11c-3-2-5-5-5-9Z" />
+        <path d="M204 70c12 1 23 4 34 8v90c0 4-2 7-5 9l-21 11c-5-3-8-7-8-12Z" />
+        <path d="m246 81 34 14v47l-34 14Z" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Adds an SVG favicon that reuses the Tardie mark in white on the site brand blue. This gives the web app a recognizable tab icon while keeping the asset sharp at different browser sizes.

Verification: `bun run build` in `apps/web`.