### PR TITLE
feat(cloudflare): expose application layers

### DIFF
--- a/platform/cloudflare/README.md
+++ b/platform/cloudflare/README.md
@@ -4,6 +4,33 @@ This binding mounts one actor definition into a named SQLite Durable Object. The
 
 Celld implements the Worker, SQLite Durable Object, alarm, and Worker Loader surfaces this binding uses. Code Mode uses JSON replay on Celld because its loaded Worker environment cannot carry capability stubs. The [Celld deployment guide](../../docs/how-to/celld.md) covers the generated manifest and node configuration.
 
+## Application services
+
+An actor can require an application Effect service. Pass `layersFor` to `cloudflareWorker` to build that service from the Worker environment and current lane. Tardigrade merges the returned layer with its model, HTTP, sandbox, event-log, and workspace layers. It constructs the application layer separately for each lane settlement, so mutable service state is shared only when the supplied Layer explicitly shares it.
+
+```ts
+import { Context, Effect, Layer } from "effect"
+import { ActorHost, cloudflareWorker, type CloudflareWorkerLayerContext, type Env as TardigradeEnv } from "tardie/cloudflare"
+
+interface Env extends TardigradeEnv {
+  readonly CUSTOMERS: D1Database
+}
+
+class CustomerStore extends Context.Service<
+  CustomerStore,
+  { readonly find: (id: string) => Effect.Effect<unknown> }
+>()("application/CustomerStore") {}
+
+export { ActorHost }
+export default cloudflareWorker(definition, {
+  layersFor: ({ env, lane }: CloudflareWorkerLayerContext<Env>) => Layer.succeed(CustomerStore, {
+    find: id => Effect.promise(() => env.CUSTOMERS.prepare("SELECT * FROM customers WHERE lane = ? AND id = ?").bind(lane, id).first())
+  })
+})
+```
+
+The callback may require Tardigrade's lane ports while constructing its layer. The returned Layer has a `never` error channel.
+
 ## Verify and deploy
 
 ```bash

--- a/platform/cloudflare/src/host.ts
+++ b/platform/cloudflare/src/host.ts
@@ -18,8 +18,8 @@ import { createLaneDriver, type DriverPolicy } from "@clavia/tardigrade-host/dri
 import type { HostPorts } from "@clavia/tardigrade-host/host"
 import { CloudflareEventStore, layerWorkspace } from "./storage"
 
-type CloudflarePorts = HostPorts | KeyValueStore.KeyValueStore
-type CloudflareLaneEnv<R> = Layer.Layer<Exclude<R, CloudflarePorts>, never, CloudflarePorts>
+export type CloudflarePorts = HostPorts | KeyValueStore.KeyValueStore
+export type CloudflareLaneEnv<R> = Layer.Layer<Exclude<R, CloudflarePorts>, never, CloudflarePorts>
 
 type LayersFor<R> = [Exclude<R, CloudflarePorts>] extends [never]
   ? { readonly layersFor?: (lane: string) => CloudflareLaneEnv<R> }

--- a/platform/cloudflare/src/index.ts
+++ b/platform/cloudflare/src/index.ts
@@ -3,6 +3,8 @@ export {
   cloudflareWorker,
   DEFAULT_CLOUDFLARE_MODEL_CATALOG_LOAD_POLICY,
   DEFAULT_CLOUDFLARE_MODEL_CATALOG_TIMEOUT_MILLIS,
+  type CloudflareWorkerLayerContext,
+  type CloudflareWorkerOptions,
   type Env
 } from "./worker"
 export { DEFAULT_ALARM_DELAY_MILLIS, DEFAULT_ALARM_POLICY, type AlarmPolicy } from "./alarm"

--- a/platform/cloudflare/src/worker.ts
+++ b/platform/cloudflare/src/worker.ts
@@ -1,6 +1,6 @@
 import { DurableObject } from "cloudflare:workers"
 import { Clock, Context, Effect, Layer, Schema } from "effect"
-import { FetchHttpClient, HttpEffect, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { FetchHttpClient, HttpClient, HttpEffect, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { actor, agentMethods, agentsPackage, applyModelPolicy, budget, codeMode, compaction, fetchPackage, Infer, infer as inferAgent, intersectModelPolicies, modelAllowedBy, outputValidateOnce, workspacePackage, type Actor, type ActorMethods, type ModelPolicy, type ModelRef } from "tardie"
 import type { Action } from "tardie/log/events"
 import {
@@ -37,7 +37,12 @@ import {
   type WorkerLoaderSandboxTransport
 } from "@clavia/tardigrade-worker-loader/sandbox"
 import { alarmPolicyOf, armAt, scheduledAlarmAt, type AlarmPolicy } from "./alarm"
-import { createCloudflareHost, type CloudflareHost } from "./host"
+import {
+  createCloudflareHost,
+  type CloudflareHost,
+  type CloudflareLaneEnv,
+  type CloudflarePorts
+} from "./host"
 import { layerCloudflareModelCatalogRepository } from "./catalog"
 import { structuredWorkerConfigOf } from "./config"
 
@@ -74,6 +79,7 @@ interface MountedActor {
   readonly name: string
   readonly actor: DefaultAssembly
   readonly methods: ActorMethods
+  readonly layersFor?: (context: CloudflareWorkerLayerContext<Env>) => CloudflareLaneEnv<never>
 }
 
 let mountedActor: MountedActor | undefined
@@ -455,7 +461,11 @@ export class ActorHost extends DurableObject<Env> {
       storage: this.ctx.storage,
       principal,
       actorFor: (lane) => threadOf(lane) === undefined ? undefined : selectedAssembly,
-      layersFor: () => Layer.mergeAll(modelLayer(models, catalog), FetchHttpClient.layer, sandboxLayer),
+      layersFor: (lane) => {
+        const framework = Layer.mergeAll(modelLayer(models, catalog), FetchHttpClient.layer, sandboxLayer)
+        const application = mountedActor?.layersFor?.({ env: this.env, lane })
+        return application === undefined ? framework : Layer.mergeAll(framework, application)
+      },
       routes: [remoteRoute],
       driver: driverPolicyOf({
         maxConcurrentLanes: positiveInteger(
@@ -820,17 +830,49 @@ const worker = {
   }
 } satisfies ExportedHandler<Env>
 
-// cloudflareWorker mounts a defined actor into the Worker and its Durable Object host (test/actor.workers.ts, "a mounted actor exposes durable methods").
-export const cloudflareWorker = <R, const Methods extends ActorMethods>(
-  definition: Actor<R, Methods>
-): ExportedHandler<Env> => {
+type CloudflareWorkerProvided = CloudflarePorts | Infer | HttpClient.HttpClient
+type CloudflareApplicationRequirements<R> = Exclude<R, CloudflareWorkerProvided>
+
+// CloudflareWorkerLayerContext exposes the Worker bindings and lane identity used to construct application services.
+export interface CloudflareWorkerLayerContext<WorkerEnv extends Env = Env> {
+  readonly env: WorkerEnv
+  readonly lane: string
+}
+
+type CloudflareWorkerLayersFor<R, WorkerEnv extends Env> = (
+  context: CloudflareWorkerLayerContext<WorkerEnv>
+) => CloudflareLaneEnv<CloudflareApplicationRequirements<R>>
+
+// CloudflareWorkerOptions supplies every actor requirement the Worker does not bind itself.
+export type CloudflareWorkerOptions<R, WorkerEnv extends Env = Env> =
+  [CloudflareApplicationRequirements<R>] extends [never]
+    ? { readonly layersFor?: CloudflareWorkerLayersFor<R, WorkerEnv> }
+    : { readonly layersFor: CloudflareWorkerLayersFor<R, WorkerEnv> }
+
+type CloudflareWorkerArguments<R, WorkerEnv extends Env> =
+  [CloudflareApplicationRequirements<R>] extends [never]
+    ? [options?: CloudflareWorkerOptions<R, WorkerEnv>]
+    : [options: CloudflareWorkerOptions<R, WorkerEnv>]
+
+// cloudflareWorker mounts a defined actor and its application layers into the Worker host (test/actor.workers.ts, "a mounted actor receives lane application services").
+export const cloudflareWorker = <
+  R,
+  const Methods extends ActorMethods,
+  WorkerEnv extends Env = Env
+>(
+  definition: Actor<R, Methods>,
+  ...[options]: CloudflareWorkerArguments<R, WorkerEnv>
+): ExportedHandler<WorkerEnv> => {
   mountedActor = {
     name: definition.name,
     actor: definition as unknown as DefaultAssembly,
-    methods: definition.methods
+    methods: definition.methods,
+    ...(options?.layersFor === undefined ? {} : {
+      layersFor: options.layersFor as unknown as (context: CloudflareWorkerLayerContext<Env>) => CloudflareLaneEnv<never>
+    })
   }
   deployedActor = definition.name
-  return worker
+  return worker as ExportedHandler<WorkerEnv>
 }
 
 export default worker

--- a/platform/cloudflare/test/actor.workers.ts
+++ b/platform/cloudflare/test/actor.workers.ts
@@ -11,9 +11,9 @@ const authorization = { authorization: "Bearer workers-test-token" }
 const actorStub = () => (env as Env).ACTORS.getByName("echo")
 const alarm = () => runInDurableObject(actorStub(), (_instance, state) => state.storage.getAlarm())
 
-const methodState = async (): Promise<unknown> => {
+const methodState = async (thread: string, call: string): Promise<unknown> => {
   for (let attempt = 0; attempt < 100; attempt++) {
-    const response = await SELF.fetch("http://test/v1/threads/root/methods/echo/calls/workers-smoke", {
+    const response = await SELF.fetch(`http://test/v1/threads/${thread}/methods/echo/calls/${call}`, {
       headers: authorization
     })
     const state = await response.json() as { readonly status?: unknown }
@@ -76,7 +76,7 @@ describe("cloudflare actor", () => {
     expect(accepted.status).toBe(202)
     expect(await accepted.json()).toEqual({ thread: "root", method: "echo", call: "workers-smoke" })
     expect(await alarm()).not.toBeNull()
-    expect(await methodState()).toEqual({ status: "completed", output: "Run in workerd." })
+    expect(await methodState("root", "workers-smoke")).toEqual({ status: "completed", output: "workers:ag.root:1:Run in workerd." })
     expect(await alarm()).toBeNull()
     const client = makeActorClient({
       baseUrl: "http://test",
@@ -86,7 +86,7 @@ describe("cloudflare actor", () => {
     expect(await client.invoke("root", "echo", { id: "workers-smoke", input: { text: "Run in workerd." } }))
       .toEqual({ thread: "root", method: "echo", call: "workers-smoke" })
     expect(await client.methodState("root", "echo", "workers-smoke"))
-      .toEqual({ status: "completed", output: "Run in workerd." })
+      .toEqual({ status: "completed", output: "workers:ag.root:1:Run in workerd." })
     const events = await SELF.fetch("http://test/v1/threads/root/events", { headers: authorization })
     expect((await events.json() as ReadonlyArray<{ readonly event: { readonly type: string } }>).map((row) => row.event.type)).toEqual([
       "ThreadCreated",
@@ -100,6 +100,24 @@ describe("cloudflare actor", () => {
     expect(await client.methods()).toEqual([expect.objectContaining({ name: "echo" })])
     expect(await client.list()).toEqual([expect.objectContaining({ id: "root", status: "settled" })])
     expect(await client.metadata()).toEqual({ name: "echo", storage: { kind: "durable-object" } })
+  })
+
+  test("a mounted actor receives lane application services", async () => {
+    const invoke = async (thread: string, call: string, text: string) => {
+      const accepted = await SELF.fetch(`http://test/v1/threads/${thread}/methods/echo/calls/${call}`, {
+        method: "PUT",
+        headers: { ...authorization, "content-type": "application/json" },
+        body: JSON.stringify({ text })
+      })
+      expect(accepted.status).toBe(202)
+      return methodState(thread, call)
+    }
+    const [first, second] = await Promise.all([
+      invoke("application-a", "application-a", "first"),
+      invoke("application-b", "application-b", "second")
+    ])
+    expect(first).toEqual({ status: "completed", output: "workers:ag.application-a:1:first" })
+    expect(second).toEqual({ status: "completed", output: "workers:ag.application-b:1:second" })
   })
 
   test("a durable object alarm terminates an overdue method call", async () => {

--- a/platform/cloudflare/test/fixture.worker.ts
+++ b/platform/cloudflare/test/fixture.worker.ts
@@ -1,7 +1,21 @@
-import { Effect, Schema } from "effect"
+import { Context, Effect, Layer, Schema } from "effect"
 import { actor, actorMethod } from "tardie"
 import { effect } from "@clavia/tardigrade-core/reconciliation"
-import { ActorHost, cloudflareWorker } from "../src/worker"
+import {
+  ActorHost,
+  cloudflareWorker,
+  type CloudflareWorkerLayerContext,
+  type Env
+} from "../src/worker"
+
+interface FixtureEnv extends Env {
+  readonly APPLICATION_PREFIX: string
+}
+
+class LaneApplication extends Context.Service<
+  LaneApplication,
+  { readonly prefix: string; readonly lane: string; calls: number }
+>()("test/LaneApplication") {}
 
 const echo = actorMethod({
   input: Schema.Struct({ text: Schema.String }),
@@ -42,14 +56,19 @@ const worker = cloudflareWorker(actor({
       return [effect({
         key: `echo-complete:${id}`,
         input: { id, text: String(request.text) },
-        act: (input) => Effect.promise(async () => {
-          await scheduler.wait(50)
-          return [{ type: "EchoCompleted", ...input }]
+        act: (input) => Effect.gen(function* () {
+          const application = yield* LaneApplication
+          application.calls += 1
+          yield* Effect.promise(() => scheduler.wait(50))
+          return [{ type: "EchoCompleted", ...input, text: `${application.prefix}:${application.lane}:${application.calls}:${input.text}` }]
         })
       })]
     }) })
   }]
-}))
+}), {
+  layersFor: ({ env, lane }: CloudflareWorkerLayerContext<FixtureEnv>) =>
+    Layer.succeed(LaneApplication, { prefix: env.APPLICATION_PREFIX, lane, calls: 0 })
+})
 
 export { ActorHost }
 export default worker

--- a/platform/cloudflare/tsconfig.test.json
+++ b/platform/cloudflare/tsconfig.test.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src/**/*.test.ts", "src/alarm.ts"]
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*.test.ts", "src/alarm.ts", "test/fixture.worker.ts"]
 }

--- a/platform/cloudflare/vitest.config.ts
+++ b/platform/cloudflare/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     wrangler: { configPath: "./test/wrangler.jsonc" },
     miniflare: {
       bindings: {
+        APPLICATION_PREFIX: "workers",
         TARDIGRADE_TOKEN: "workers-test-token",
         TARDIGRADE_ALARM_DELAY_MILLIS: "60000",
         TARDIGRADE_MODEL_CATALOG_URL: "https://models.test/catalog.json",


### PR DESCRIPTION
Exposes application Effect layers at the `cloudflareWorker()` composition boundary. The `layersFor` callback receives the Worker environment and lane identity, and its Layer is composed with Tardigrade model, HTTP, sandbox, event-log, and workspace services.

The type contract subtracts services supplied by the Worker from the actor requirements. Existing workers keep the optional second argument, while an actor with remaining application requirements must supply `layersFor`.

The workerd fixture requires a custom application service derived from a Worker binding and verifies that two concurrent lanes receive separate mutable state. All 58 gate tasks pass.

Closes #280.