### PR TITLE
docs(web): rebuild concepts page

### DIFF
--- a/apps/web/src/ActorDiagram.tsx
+++ b/apps/web/src/ActorDiagram.tsx
@@ -1,0 +1,66 @@
+import type { ReactElement } from "react"
+
+export const ActorDiagram = (): ReactElement => (
+  <svg
+    className="actor-diagram"
+    viewBox="0 0 720 640"
+    role="img"
+    aria-label="A caller interacts with an actor through methods. Methods append input events and expose call state. Components read the log, derive transitions, and interact with external services through effects whose outcomes return as events."
+  >
+    <defs>
+      <marker id="actor-diagram-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+        <path d="M0 0L8 4L0 8Z" />
+      </marker>
+    </defs>
+
+    <rect className="actor-diagram-boundary" x="80" y="102" width="560" height="430" />
+    <text className="actor-diagram-boundary-label" x="104" y="130">actor / researcher</text>
+
+    <g className="actor-diagram-node actor-diagram-external" transform="translate(260 18)">
+      <rect width="200" height="54" />
+      <text x="100" y="33">Caller</text>
+    </g>
+
+    <g className="actor-diagram-node" transform="translate(210 148)">
+      <rect width="300" height="68" />
+      <text className="actor-diagram-node-kind" x="18" y="22">methods</text>
+      <text className="actor-diagram-node-value" x="18" y="48">typed calls</text>
+    </g>
+
+    <g className="actor-diagram-log" transform="translate(170 270)">
+      <rect className="actor-diagram-log-frame" width="380" height="120" />
+      <text className="actor-diagram-node-kind" x="18" y="23">event log · audit-42</text>
+      <g transform="translate(18 42)">
+        <text x="0" y="12"><tspan>01</tspan><tspan x="34">MessageReceived</tspan></text>
+        <text x="190" y="12"><tspan>02</tspan><tspan x="224">ToolCalled</tspan></text>
+        <text x="0" y="42"><tspan>03</tspan><tspan x="34">ToolReturned</tspan></text>
+        <text x="190" y="42"><tspan>04</tspan><tspan x="224">TurnCompleted</tspan></text>
+      </g>
+    </g>
+
+    <g className="actor-diagram-node" transform="translate(210 444)">
+      <rect width="300" height="68" />
+      <text className="actor-diagram-node-kind" x="18" y="22">components</text>
+      <text className="actor-diagram-node-value" x="18" y="48">behavior</text>
+    </g>
+
+    <g className="actor-diagram-node actor-diagram-external" transform="translate(230 568)">
+      <rect width="260" height="54" />
+      <text x="130" y="33">External services</text>
+    </g>
+
+    <g className="actor-diagram-connectors" aria-hidden="true">
+      <path d="M360 72V148" />
+      <path d="M360 216V270" />
+      <path d="M360 390V444" />
+      <path d="M360 512V568" />
+    </g>
+
+    <g className="actor-diagram-edge-labels" aria-hidden="true">
+      <text x="380" y="92">call ↓ · result ↑</text>
+      <text x="380" y="246">input event ↓ · call state ↑</text>
+      <text x="380" y="420">events ↓ · transitions ↑</text>
+      <text x="380" y="548">effect ↓ · outcome ↑</text>
+    </g>
+  </svg>
+)

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useRef, useState, type ReactElement } from "react"
+import { ActorDiagram } from "./ActorDiagram"
 import { ComponentBridge } from "./ComponentBridge"
+import { ComponentDiagram } from "./ComponentDiagram"
 import { FlowOverlay } from "./FlowOverlay"
 import { IsometricEventLog } from "./IsometricEventLog"
+import { MethodDiagram } from "./MethodDiagram"
+import { TransitionLoop } from "./TransitionLoop"
 import { WorldGlobe } from "./WorldGlobe"
 
 const REPOSITORY = "https://github.com/clavia-labs/tardigrade"
@@ -71,13 +75,6 @@ const CopyIcon = (): ReactElement => (
 const CheckIcon = (): ReactElement => (
   <svg viewBox="0 0 24 24" aria-hidden="true">
     <path fill="none" stroke="currentColor" strokeLinecap="square" strokeLinejoin="miter" strokeWidth="1.8" d="m5 12.5 4.2 4.2L19 7" />
-  </svg>
-)
-
-const ConceptArrow = (): ReactElement => (
-  <svg className="concept-arrow" viewBox="0 0 96 24" aria-hidden="true">
-    <path d="M2 12H92" />
-    <path d="M84 5 92 12 84 19" />
   </svg>
 )
 
@@ -874,8 +871,9 @@ const ConceptsPage = (): ReactElement => (
 
         <section className="concept-section concept-section-actor">
           <div className="concept-copy">
-            <h2>Actor</h2>
-            <p>An actor is one durable event log and the components that interpret it. Methods append facts to the log. Components read those facts and decide what happens next.</p>
+            <h2>Actors</h2>
+            <p>The core primitive of Tardigrade is an actor. At a high level, an actor is an addressable entity with state and behavior. Its history is recorded as an append-only log of events, and its current state is derived from that log.</p>
+            <p>Methods let the world call an actor. Components read the log and derive transitions, the units of work that define how the actor responds.</p>
           </div>
           <div className="concept-interface">
             <span>interface</span>
@@ -885,81 +883,36 @@ const ConceptsPage = (): ReactElement => (
   components: Component[]
 })`}</pre>
           </div>
-          <div className="actor-concept-illustration" aria-label="An actor definition mounted beside its durable event log">
-            <div className="actor-concept-source">
-              <span>actor.ts</span>
-              <CodeSnippet label="actor example" code={`actor({
-  name: "researcher",
-  methods: { message },
-  components: [infer]
-})`} />
-            </div>
-            <div className="actor-concept-link" aria-hidden="true">
-              <svg viewBox="0 0 80 48">
-                <defs><marker id="actor-link-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto"><path d="M0 0 7 3.5 0 7Z" /></marker></defs>
-                <path d="M3 24H76" markerEnd="url(#actor-link-arrow)" />
-              </svg>
-              <span>mounts</span>
-            </div>
-            <div className="actor-concept-store-wrap">
-              <span>event store</span>
-              <div className="actor-concept-store">
-                <header><code>thread / audit-42</code></header>
-                <ol>
-                  <li data-tone="message"><span>01</span><code>MessageReceived</code></li>
-                  <li data-tone="tool"><span>02</span><code>ToolCalled</code></li>
-                  <li data-tone="return"><span>03</span><code>ToolReturned</code></li>
-                  <li data-tone="done"><span>04</span><code>TurnCompleted</code></li>
-                </ol>
-              </div>
-            </div>
-          </div>
+          <ActorDiagram />
         </section>
 
-        <section className="concept-section concept-section-methods">
+        <section className="concept-section concept-section-transitions">
           <div className="concept-copy">
-            <h2>Methods</h2>
-            <p>Methods are the actor's typed public API. A method defines the input event and how callers read pending, completed, or failed state from the log.</p>
+            <h2>Transitions</h2>
+            <p>A transition describes one unit of work enabled by the actor's log. The runtime executes enabled transitions and records their outcomes as new events.</p>
+            <p>Transitions come in two types. An intent proposes events without external work. An external effect interacts with the world and returns events that record its outcome. Each transition has a key, which lets the runtime determine whether its result is already in the log.</p>
           </div>
           <div className="concept-interface">
             <span>interface</span>
-            <pre>{`actorMethod({
-  input, output, timeoutMs?,
-  event(call): Event,
-  state(log, id): MethodState
-})`}</pre>
+            <pre>{`type Transition =
+  | { kind: "intent", key, events }
+  | { kind: "effect", key, act }`}</pre>
           </div>
-          <div className="methods-concept-illustration" aria-label="The world makes a typed method call that appends an event to the actor log">
-            <div className="methods-world">
-              <span>world</span>
-              <WorldGlobe />
-            </div>
-            <div className="methods-arrow"><ConceptArrow /></div>
-            <div className="typed-method-call">
-              <span>typed method</span>
-              <code>{`message({
-  text: "Find the evidence"
-})`}</code>
-            </div>
-            <div className="methods-arrow"><ConceptArrow /></div>
-            <div className="actor-concept-store-wrap methods-event-store">
-              <span>event log</span>
-              <div className="actor-concept-store">
-                <header><code>thread / audit-42</code></header>
-                <ol>
-                  <li data-tone="message"><span>01</span><code>MessageReceived</code><small>Find the evidence</small></li>
-                </ol>
-              </div>
-            </div>
+          <div className="transition-example-copy">
+            <h3>Example: a tool-calling agent</h3>
+            <p>A message starts inference. A tool call starts service work. Its result enables inference again. A final response completes the method call.</p>
           </div>
+          <div className="transition-loop-frame">
+            <TransitionLoop />
+          </div>
+          <p className="concept-bridge-copy">The actor runs enabled transitions until none remain, at which point it has settled. A component packages the logic that derives those transitions from the log.</p>
         </section>
 
         <section className="concept-section concept-section-components">
           <div className="concept-copy">
             <h2>Components</h2>
-            <p>A component is a pure function over the complete event log. It returns the view its parent consumes and the transitions that are due.</p>
-            <p>The log is the input. Components do not own hidden mutable state, so the same log always produces the same plan.</p>
-            <div className="concept-formula"><code>f(log)</code><span>→</span><code>{`{ view, transitions }`}</code></div>
+            <p>A component packages part of an actor's behavior as a named, pure function over the log. It derives two things. Its view is the value its parent component consumes. Its transitions describe the work currently enabled.</p>
+            <p>Given the same log, a component returns the same view and transitions without performing external work. External work stays inside effect transitions, which the runtime executes. Components can compose other components, so an actor's behavior can be assembled from smaller parts.</p>
           </div>
           <div className="concept-interface">
             <span>interface</span>
@@ -969,42 +922,30 @@ const ConceptsPage = (): ReactElement => (
   derive(log): { view, transitions }
 })`}</pre>
           </div>
+          <p className="concept-bridge-copy">In the tool-calling agent, an inference component derives the language model transition, while a tool component derives the service transition. Events in the shared log connect them: a model response enables the tool component, and a tool result enables the inference component again.</p>
           <div className="compaction-example-copy">
             <h3>Example: compaction</h3>
-            <p>At 104k tokens, the log has crossed the 80% threshold of a 128k window. Compaction keeps a 64k tail in the view and derives a summarization transition. When that work completes, it appends <code>CompactionCompleted</code> to the same log.</p>
+            <p>At 104k tokens, the log has crossed the 80% threshold of a 128k window. Compaction derives a transition that summarizes the older span. The transition appends <code>CompactionCompleted</code> to the log, and later model requests use its summary with a 64k-token tail. The full log remains unchanged.</p>
           </div>
-          <div className="compaction-flow" aria-label="Compaction derives a context view and a transition from the event log">
-            <div className="compaction-log">
-              <span>event log</span>
-              <div className="compaction-log-stack" aria-hidden="true">
-                <i /><i /><i /><i /><i />
-              </div>
-              <strong>104k tokens</strong>
-            </div>
-            <div className="compaction-flow-arrow" aria-hidden="true">→</div>
-            <div className="compaction-derive">
-              <span>component</span>
-              <code>compaction.derive(log)</code>
-              <dl>
-                <div><dt>window</dt><dd>128k</dd></div>
-                <div><dt>fire</dt><dd>80% · 102k</dd></div>
-                <div><dt>keep</dt><dd>50% · 64k</dd></div>
-              </dl>
-            </div>
-            <div className="compaction-flow-arrow" aria-hidden="true">→</div>
-            <div className="compaction-results">
-              <div>
-                <span>view</span>
-                <strong>Context policy</strong>
-                <p>Render a 64k-token tail after the latest checkpoint.</p>
-              </div>
-              <div>
-                <span>transition</span>
-                <strong>Summarization due</strong>
-                <p>Summarize the older history and append <code>CompactionCompleted</code>.</p>
-              </div>
-            </div>
+          <div className="component-diagram-frame"><ComponentDiagram /></div>
+          <p className="concept-bridge-copy">Components define this internal behavior. Methods expose it to callers.</p>
+        </section>
+
+        <section className="concept-section concept-section-methods">
+          <div className="concept-copy">
+            <h2>Methods</h2>
+            <p>Methods define the actor's callable interface. Each method declares input and output schemas, turns a valid call into an event, and derives the call's pending, completed, or failed state from the log.</p>
           </div>
+          <div className="concept-interface">
+            <span>interface</span>
+            <pre>{`actorMethod({
+  input, output, timeoutMs?,
+  event(call): Event,
+  state(log, id): MethodState
+})`}</pre>
+          </div>
+          <div className="method-diagram-frame"><MethodDiagram /></div>
+          <p className="concept-bridge-copy">For the tool-calling agent, the <code>message</code> method records the user's message. That event starts the transition loop. When the log contains a final response, the method returns its typed output. Each call has an identifier that links its input to its result and lets the log absorb duplicate deliveries.</p>
         </section>
 
       </article>

--- a/apps/web/src/ComponentDiagram.tsx
+++ b/apps/web/src/ComponentDiagram.tsx
@@ -1,0 +1,57 @@
+import type { ReactElement } from "react"
+
+export const ComponentDiagram = (): ReactElement => (
+  <svg
+    className="component-diagram"
+    viewBox="0 0 720 680"
+    role="img"
+    aria-label="A 104,000-token event log enables the compaction component to derive a summarization effect. The effect appends a CompactionCompleted event. Later model requests use its summary and a retained 64,000-token tail."
+  >
+    <defs>
+      <marker id="component-diagram-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+        <path d="M0 0L8 4L0 8Z" />
+      </marker>
+    </defs>
+
+    <g className="component-diagram-node" transform="translate(210 20)">
+      <rect width="300" height="86" />
+      <text className="component-diagram-kind" x="18" y="23">event log</text>
+      <text className="component-diagram-value" x="18" y="51">104k tokens</text>
+      <text className="component-diagram-detail" x="18" y="72">compaction threshold crossed</text>
+    </g>
+
+    <g className="component-diagram-component" transform="translate(160 158)">
+      <rect width="400" height="106" />
+      <text className="component-diagram-kind" x="20" y="25">component · compaction</text>
+      <text className="component-diagram-function" x="20" y="59">derive(log)</text>
+      <text className="component-diagram-detail" x="20" y="86">pure · observes the log</text>
+    </g>
+
+    <g className="component-diagram-node component-diagram-transition" transform="translate(210 318)">
+      <rect width="300" height="86" />
+      <text className="component-diagram-kind" x="18" y="23">effect transition</text>
+      <text className="component-diagram-value" x="18" y="51">summarize old span</text>
+      <text className="component-diagram-detail" x="18" y="72">runtime executes</text>
+    </g>
+
+    <g className="component-diagram-node" transform="translate(210 458)">
+      <rect width="300" height="86" />
+      <text className="component-diagram-kind" x="18" y="23">event · appended to log</text>
+      <text className="component-diagram-value" x="18" y="51">CompactionCompleted</text>
+      <text className="component-diagram-detail" x="18" y="72">summary and checkpoint recorded</text>
+    </g>
+
+    <g className="component-diagram-node component-diagram-view" transform="translate(180 598)">
+      <rect width="360" height="62" />
+      <text className="component-diagram-kind" x="18" y="22">next model context</text>
+      <text className="component-diagram-value" x="18" y="47">summary + 64k-token tail</text>
+    </g>
+
+    <g className="component-diagram-connectors" aria-hidden="true">
+      <path d="M360 106V158" />
+      <path d="M360 264V318" />
+      <path d="M360 404V458" />
+      <path d="M360 544V598" />
+    </g>
+  </svg>
+)

--- a/apps/web/src/MethodDiagram.tsx
+++ b/apps/web/src/MethodDiagram.tsx
@@ -1,0 +1,73 @@
+import type { ReactElement } from "react"
+
+export const MethodDiagram = (): ReactElement => (
+  <svg
+    className="method-diagram"
+    viewBox="0 0 720 776"
+    role="img"
+    aria-label="A caller makes a typed message call. The method validates it and appends a MessageReceived event. After the actor records TurnCompleted, the method derives a completed state and returns a typed result for the same call identifier."
+  >
+    <defs>
+      <marker id="method-diagram-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+        <path d="M0 0L8 4L0 8Z" />
+      </marker>
+    </defs>
+
+    <g className="method-diagram-node method-diagram-endpoint" transform="translate(180 10)">
+      <rect width="360" height="90" />
+      <text className="method-diagram-kind" x="18" y="23">typed call · audit-42</text>
+      <text className="method-diagram-value">
+        <tspan x="18" y="50">{`message({`}</tspan>
+        <tspan x="18" dy="21">{`  text: "Audit the deployment." })`}</tspan>
+      </text>
+    </g>
+
+    <g className="method-diagram-node method-diagram-method" transform="translate(180 130)">
+      <rect width="360" height="78" />
+      <text className="method-diagram-kind" x="18" y="23">method · message</text>
+      <text className="method-diagram-function" x="18" y="49">event(call)</text>
+      <text className="method-diagram-detail" x="172" y="49">validates typed input</text>
+    </g>
+
+    <g className="method-diagram-node" transform="translate(210 248)">
+      <rect width="300" height="78" />
+      <text className="method-diagram-kind" x="18" y="23">event · appended to log</text>
+      <text className="method-diagram-value" x="18" y="50">MessageReceived</text>
+      <text className="method-diagram-detail" x="182" y="50">call · audit-42</text>
+    </g>
+
+    <g className="method-diagram-loop" transform="translate(250 366)">
+      <rect width="220" height="54" />
+      <text x="110" y="22">actor runs transitions</text>
+      <text x="110" y="41">and records outcomes</text>
+    </g>
+
+    <g className="method-diagram-node" transform="translate(210 460)">
+      <rect width="300" height="78" />
+      <text className="method-diagram-kind" x="18" y="23">event · in the log</text>
+      <text className="method-diagram-value" x="18" y="50">TurnCompleted</text>
+      <text className="method-diagram-detail" x="166" y="50">call · audit-42</text>
+    </g>
+
+    <g className="method-diagram-node method-diagram-method" transform="translate(180 578)">
+      <rect width="360" height="78" />
+      <text className="method-diagram-kind" x="18" y="23">method · message</text>
+      <text className="method-diagram-function" x="18" y="50">state(log, "audit-42")</text>
+    </g>
+
+    <g className="method-diagram-node method-diagram-endpoint" transform="translate(180 696)">
+      <rect width="360" height="70" />
+      <text className="method-diagram-kind" x="18" y="23">typed result · audit-42</text>
+      <text className="method-diagram-value" x="18" y="50">completed({`{ output: string }`})</text>
+    </g>
+
+    <g className="method-diagram-connectors" aria-hidden="true">
+      <path d="M360 100V130" />
+      <path d="M360 208V248" />
+      <path d="M360 326V366" />
+      <path d="M360 420V460" />
+      <path d="M360 538V578" />
+      <path d="M360 656V696" />
+    </g>
+  </svg>
+)

--- a/apps/web/src/TransitionLoop.tsx
+++ b/apps/web/src/TransitionLoop.tsx
@@ -1,0 +1,55 @@
+import type { ReactElement } from "react"
+
+type NodeProps = {
+  readonly kind: "event" | "effect"
+  readonly label: string
+  readonly value: string
+  readonly x: number
+  readonly y: number
+  readonly width?: number
+}
+
+const Node = ({ kind, label, value, width = 260, x, y }: NodeProps): ReactElement => (
+  <g className={`transition-node transition-node-${kind}`} transform={`translate(${x} ${y})`}>
+    <rect width={width} height="68" />
+    <text className="transition-node-kind" x="14" y="22">{label}</text>
+    <text className="transition-node-value" x="14" y="49">{value}</text>
+  </g>
+)
+
+export const TransitionLoop = (): ReactElement => (
+  <svg className="transition-loop" viewBox="0 0 720 640" role="img" aria-label="A received message enables model inference. A tool call enables a service effect whose result enables inference again. A final response completes the method call and the actor settles.">
+    <defs>
+      <marker id="transition-loop-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+        <path d="M0 0L8 4L0 8Z" />
+      </marker>
+    </defs>
+
+    <g className="transition-paths" aria-hidden="true">
+      <path d="M210 98V150" />
+      <path d="M340 176C374 176 396 154 430 154" />
+      <path d="M540 188V250" />
+      <path d="M540 318V390" />
+      <path d="M430 424C378 424 392 236 340 202" />
+      <path d="M210 218V440" />
+      <path d="M210 508V562" />
+    </g>
+
+    <g className="transition-path-labels" aria-hidden="true">
+      <text x="374" y="144">tool call</text>
+      <text x="406" y="350">tool result</text>
+      <text x="230" y="342">final response</text>
+    </g>
+
+    <Node kind="event" label="event" value="MessageReceived" x={80} y={30} />
+    <Node kind="effect" label="effect transition" value="model.generate(log)" x={80} y={150} />
+    <Node kind="event" label="event" value="ToolCalled" x={430} y={120} width={220} />
+    <Node kind="effect" label="effect transition" value="service.call(...)" x={430} y={250} width={220} />
+    <Node kind="event" label="event" value="ToolReturned" x={430} y={390} width={220} />
+    <Node kind="event" label="event" value="TurnCompleted" x={80} y={440} />
+    <g className="transition-terminal" transform="translate(100 562)">
+      <rect width="220" height="50" />
+      <text x="110" y="30">settled</text>
+    </g>
+  </svg>
+)

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -434,10 +434,12 @@ h1 span { display: block; white-space: nowrap; }
 .rlm-parts p { margin: 8px 0 0; color: var(--ink-2); font-size: 14px; line-height: 1.5; }
 .concept-section { margin-top: 64px; padding-top: 44px; display: grid; grid-template-columns: minmax(0, .82fr) minmax(0, 1.18fr); gap: 42px; align-items: start; border-top: 1px dashed rgb(36 80 255 / 28%); }
 .concept-section-actor { margin-top: 0; padding-top: 0; grid-template-columns: 1fr; gap: 28px; border-top: 0; }
+.concept-section-transitions { grid-template-columns: 1fr; gap: 28px; }
 .concept-section-methods { grid-template-columns: 1fr; gap: 28px; }
 .concept-copy { min-width: 0; }
+.concept-section-transitions .concept-copy { max-width: 720px; }
 .guide-article .concept-copy h2 { margin: 0 0 16px; padding: 0; border: 0; font-size: 30px; }
-.concept-copy p { margin: 0; color: var(--ink-2); font-size: 15px; line-height: 1.6; }
+.concept-copy p { margin: 0; color: var(--ink-2); font-size: 17px; line-height: 1.62; }
 .concept-copy p + p { margin-top: 14px; }
 .concept-code { position: relative; min-width: 0; border: 1px solid rgb(36 80 255 / 38%); background: var(--surface); }
 .concept-code pre { margin: 0; padding: 20px 54px 20px 20px; overflow-x: auto; color: var(--ink); font-family: var(--mono); font-size: 12px; line-height: 1.7; }
@@ -449,6 +451,20 @@ h1 span { display: block; white-space: nowrap; }
 .concept-code button { position: absolute; top: 10px; right: 10px; width: 32px; height: 32px; display: grid; place-items: center; border: 1px solid rgb(36 80 255 / 30%); background: var(--surface); color: var(--moss-ink); cursor: pointer; transition: transform 140ms var(--ease-out), background-color 160ms ease; }
 .concept-code button:active { transform: scale(.96); }
 .concept-code button svg { width: 15px; height: 15px; }
+.actor-diagram { width: min(100%, 620px); height: auto; margin: 0 auto; overflow: visible; }
+.actor-diagram-boundary { fill: none; stroke: rgb(36 80 255 / 28%); stroke-width: 1; stroke-dasharray: 5 5; vector-effect: non-scaling-stroke; }
+.actor-diagram-boundary-label { fill: var(--moss-ink); font-family: var(--mono); font-size: 12px; letter-spacing: .06em; }
+.actor-diagram-node rect, .actor-diagram-log-frame { fill: transparent; stroke: rgb(36 80 255 / 42%); stroke-width: 1; vector-effect: non-scaling-stroke; }
+.actor-diagram-node:not(.actor-diagram-external) rect, .actor-diagram-log-frame { fill: var(--moss-wash); }
+.actor-diagram-external rect { stroke: rgb(36 80 255 / 28%); }
+.actor-diagram-external text { fill: var(--ink); font-family: var(--mono); font-size: 15px; text-anchor: middle; }
+.actor-diagram-node-kind { fill: var(--faint); font-family: var(--mono); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
+.actor-diagram-node-value { fill: var(--ink); font-family: var(--mono); font-size: 17px; }
+.actor-diagram-log g text { fill: var(--ink); font-family: var(--mono); font-size: 12px; }
+.actor-diagram-log g text tspan:first-child { fill: var(--faint); }
+.actor-diagram-connectors path { fill: none; stroke: rgb(36 80 255 / 62%); stroke-width: 1.25; marker-start: url(#actor-diagram-arrow); marker-end: url(#actor-diagram-arrow); vector-effect: non-scaling-stroke; }
+.actor-diagram marker path { fill: var(--moss-ink); }
+.actor-diagram-edge-labels { fill: var(--ink-2); font-family: var(--mono); font-size: 11px; }
 .actor-concept-illustration { min-width: 0; display: grid; grid-template-columns: minmax(150px, 1fr) 42px minmax(170px, 1.05fr); align-items: center; }
 .concept-section-actor .actor-concept-illustration { width: 100%; grid-template-columns: minmax(260px, .9fr) 80px minmax(300px, 1.1fr); }
 .actor-concept-source { min-width: 0; }
@@ -478,66 +494,59 @@ h1 span { display: block; white-space: nowrap; }
 .actor-concept-store li[data-tone="tool"] { border-left-color: var(--plum); background: var(--plum-wash); }
 .actor-concept-store li[data-tone="return"] { border-left-color: var(--run); background: var(--run-wash); }
 .actor-concept-store li[data-tone="done"] { border-left-color: var(--subagents); background: var(--subagents-wash); }
-.methods-concept-illustration { width: 100%; min-width: 0; padding: 28px 0 44px; display: grid; grid-template-columns: minmax(140px, .7fr) 56px minmax(240px, 1.25fr) 56px minmax(220px, 1fr); gap: 12px; align-items: center; }
-.methods-world, .typed-method-call, .methods-event-store { min-width: 0; }
-.methods-world { display: grid; justify-items: center; justify-self: center; }
-.methods-concept-illustration > .methods-arrow { width: 56px; }
-.methods-world > span, .typed-method-call > span { display: block; margin-bottom: 8px; color: var(--faint); font-family: var(--mono); font-size: 10px; letter-spacing: .08em; }
-.methods-world .world-globe { width: min(156px, 100%); }
-.methods-arrow { display: grid; place-items: center; color: var(--moss-ink); }
-.concept-arrow { width: 56px; height: 24px; overflow: visible; }
-.concept-arrow path { fill: none; stroke: currentColor; stroke-width: 1.4; stroke-linecap: round; stroke-linejoin: round; vector-effect: non-scaling-stroke; }
-.typed-method-call { border: 1px solid rgb(36 80 255 / 38%); background: var(--surface); }
-.typed-method-call > span { margin: 0; padding: 11px 14px; border-bottom: 1px dashed rgb(36 80 255 / 28%); }
-.typed-method-call > code { padding: 18px 20px; display: block; color: var(--moss-ink); font-family: var(--mono); font-size: 13px; line-height: 1.7; white-space: pre; }
-.methods-event-store .actor-concept-store li { min-height: 78px; }
-.methods-event-store .actor-concept-store li code { font-size: 12px; }
-.methods-event-store .actor-concept-store li small { font-size: 10px; }
 .concept-example-stack { min-width: 0; display: grid; gap: 10px; }
 .concept-call { padding: 12px 14px; overflow-x: auto; border: 1px solid rgb(36 80 255 / 30%); background: var(--moss-wash); color: var(--moss-ink); font-family: var(--mono); font-size: 11px; white-space: nowrap; }
-.concept-formula { width: fit-content; margin-top: 20px; display: flex; align-items: center; gap: 10px; color: rgb(36 80 255 / 62%); }
-.concept-formula code { padding: 8px 10px; border: 1px solid rgb(36 80 255 / 30%); background: var(--surface); color: var(--moss-ink); font-family: var(--mono); font-size: 12px; }
 .concept-interface { width: min(100%, 720px); display: grid; grid-template-columns: 88px minmax(0, 1fr); border: 1px solid rgb(36 80 255 / 38%); background: transparent; }
 .concept-interface > span { padding: 14px 12px; border-right: 1px dashed rgb(36 80 255 / 28%); color: var(--faint); font-family: var(--mono); font-size: 10px; letter-spacing: .08em; }
 .concept-interface pre { margin: 0; padding: 14px 16px; overflow-x: auto; color: var(--ink); font-family: var(--mono); font-size: 12px; line-height: 1.65; }
+.transition-example-copy { max-width: 720px; }
+.guide-article .transition-example-copy h3 { margin: 0 0 10px; color: var(--ink); font-size: 20px; }
+.transition-example-copy p, .concept-bridge-copy { margin: 0; color: var(--ink-2); font-size: 17px; line-height: 1.62; }
+.concept-bridge-copy { max-width: 800px; }
+.concept-bridge-copy code { color: var(--moss-ink); font-family: var(--mono); font-size: .9em; }
+.transition-loop-frame { width: 100%; overflow-x: auto; overscroll-behavior-inline: contain; }
+.transition-loop { min-width: 560px; width: min(100%, 680px); height: auto; margin: 0 auto; display: block; }
+.transition-paths path { fill: none; stroke: rgb(36 80 255 / 62%); stroke-width: 1.25; marker-end: url(#transition-loop-arrow); vector-effect: non-scaling-stroke; }
+.transition-loop marker path { fill: var(--moss-ink); }
+.transition-path-labels { fill: var(--faint); font-family: var(--mono); font-size: 9px; letter-spacing: .04em; }
+.transition-node rect { fill: transparent; stroke: rgb(36 80 255 / 38%); stroke-width: 1; vector-effect: non-scaling-stroke; }
+.transition-node-effect rect { fill: var(--moss-wash); stroke: var(--moss); }
+.transition-node text { font-family: var(--mono); }
+.transition-node-kind { fill: var(--faint); font-size: 10px; letter-spacing: .08em; text-transform: uppercase; }
+.transition-node-value { fill: var(--ink); font-size: 15px; }
+.transition-node-effect .transition-node-value { fill: var(--moss-ink); }
+.transition-terminal rect { fill: transparent; stroke: var(--subagents); stroke-width: 1; vector-effect: non-scaling-stroke; }
+.transition-terminal text { fill: var(--subagents); font-family: var(--mono); font-size: 10px; letter-spacing: .08em; text-anchor: middle; text-transform: uppercase; }
 .concept-section-components { grid-template-columns: 1fr; gap: 32px; }
 .concept-section-components .concept-copy { max-width: 720px; }
 .compaction-example-copy { max-width: 800px; }
 .guide-article .compaction-example-copy h3 { margin: 0 0 10px; color: var(--ink); font-size: 20px; }
-.compaction-example-copy p { margin: 0; color: var(--ink-2); font-size: 15px; line-height: 1.6; }
+.compaction-example-copy p { margin: 0; color: var(--ink-2); font-size: 17px; line-height: 1.62; }
 .compaction-example-copy code { color: var(--moss-ink); font-family: var(--mono); font-size: .9em; }
-.compaction-flow { width: 100%; min-width: 0; padding: 8px 0; display: grid; grid-template-columns: minmax(130px, .66fr) 52px minmax(220px, 1fr) 52px minmax(270px, 1.2fr); gap: 14px; align-items: center; }
-.compaction-log, .compaction-derive { min-width: 0; }
-.compaction-log > span, .compaction-derive > span, .compaction-results span { display: block; margin-bottom: 10px; color: var(--faint); font-family: var(--mono); font-size: 10px; letter-spacing: .08em; }
-.compaction-log-stack { display: grid; gap: 5px; }
-.compaction-log-stack i { height: 18px; display: block; border: 1px solid rgb(36 80 255 / 30%); background: var(--moss-wash); }
-.compaction-log-stack i:nth-child(2) { width: 92%; background: var(--plum-wash); }
-.compaction-log-stack i:nth-child(3) { width: 96%; background: var(--run-wash); }
-.compaction-log-stack i:nth-child(4) { width: 88%; background: var(--subagents-wash); }
-.compaction-log-stack i:nth-child(5) { width: 94%; background: var(--moss-wash); }
-.compaction-log strong { margin-top: 10px; display: block; color: var(--ink); font-family: var(--mono); font-size: 13px; font-weight: 500; }
-.compaction-flow-arrow { position: relative; height: 18px; color: var(--moss-ink); font-size: 0; }
-.compaction-flow-arrow::before { position: absolute; top: 8px; right: 2px; left: 2px; height: 1px; background: currentColor; content: ""; }
-.compaction-flow-arrow::after { position: absolute; top: 4px; right: 2px; width: 8px; height: 8px; border-top: 1px solid currentColor; border-right: 1px solid currentColor; content: ""; transform: rotate(45deg); }
-.compaction-derive { border: 1px solid rgb(36 80 255 / 38%); }
-.compaction-derive > span { margin: 0; padding: 10px 12px; border-bottom: 1px dashed rgb(36 80 255 / 28%); }
-.compaction-derive > code { padding: 16px 12px; display: block; color: var(--moss-ink); font-family: var(--mono); font-size: 13px; }
-.compaction-derive dl { margin: 0; border-top: 1px dashed rgb(36 80 255 / 28%); }
-.compaction-derive dl div { padding: 8px 12px; display: flex; justify-content: space-between; gap: 16px; }
-.compaction-derive dl div + div { border-top: 1px dashed rgb(36 80 255 / 18%); }
-.compaction-derive dt, .compaction-derive dd { margin: 0; font-family: var(--mono); font-size: 10px; }
-.compaction-derive dt { color: var(--faint); }
-.compaction-derive dd { color: var(--ink); }
-.compaction-results { min-width: 0; display: grid; grid-template-columns: 1fr; border: 1px solid rgb(36 80 255 / 38%); }
-.compaction-results > div { min-width: 0; padding: 15px; }
-.compaction-results > div + div { border-top: 1px dashed rgb(36 80 255 / 28%); }
-.compaction-results span { margin-bottom: 8px; }
-.compaction-results strong { display: block; color: var(--ink); font-size: 14px; }
-.compaction-results p { margin: 8px 0 0; color: var(--ink-2); font-size: 12px; line-height: 1.45; }
-.compaction-results p code { color: var(--moss-ink); font-family: var(--mono); font-size: 10px; }
-.concept-summary { margin-top: 64px; padding: 24px; border: 1px solid rgb(36 80 255 / 38%); background: var(--moss-wash); }
-.concept-summary strong { color: var(--moss-ink); font-family: var(--mono); font-size: 12px; font-weight: 500; }
-.concept-summary p { margin: 10px 0 0; color: var(--ink); font-size: 16px; line-height: 1.6; }
+.component-diagram-frame { width: 100%; overflow-x: auto; overscroll-behavior-inline: contain; }
+.component-diagram { min-width: 560px; width: min(100%, 680px); height: auto; margin: 0 auto; display: block; }
+.component-diagram-node rect, .component-diagram-component rect { fill: transparent; stroke: rgb(36 80 255 / 42%); stroke-width: 1; vector-effect: non-scaling-stroke; }
+.component-diagram-component rect, .component-diagram-transition rect, .component-diagram-view rect { stroke: var(--moss); }
+.component-diagram-component rect { fill: var(--moss-wash); }
+.component-diagram-kind { fill: var(--faint); font-family: var(--mono); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
+.component-diagram-value { fill: var(--ink); font-family: var(--mono); font-size: 16px; }
+.component-diagram-function { fill: var(--moss-ink); font-family: var(--mono); font-size: 19px; }
+.component-diagram-detail { fill: var(--ink-2); font-family: var(--mono); font-size: 11px; }
+.component-diagram-connectors path { fill: none; stroke: rgb(36 80 255 / 62%); stroke-width: 1.25; marker-end: url(#component-diagram-arrow); vector-effect: non-scaling-stroke; }
+.component-diagram marker path { fill: var(--moss-ink); }
+.method-diagram-frame { width: 100%; overflow-x: auto; overscroll-behavior-inline: contain; }
+.method-diagram { min-width: 560px; width: min(100%, 680px); height: auto; margin: 0 auto; display: block; }
+.method-diagram-node rect, .method-diagram-loop rect { fill: transparent; stroke: rgb(36 80 255 / 42%); stroke-width: 1; vector-effect: non-scaling-stroke; }
+.method-diagram-method rect, .method-diagram-endpoint rect { stroke: var(--moss); }
+.method-diagram-method rect { fill: var(--moss-wash); }
+.method-diagram-kind { fill: var(--faint); font-family: var(--mono); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
+.method-diagram-value { fill: var(--ink); font-family: var(--mono); font-size: 15px; }
+.method-diagram-function { fill: var(--moss-ink); font-family: var(--mono); font-size: 18px; }
+.method-diagram-detail { fill: var(--ink-2); font-family: var(--mono); font-size: 11px; }
+.method-diagram-loop rect { stroke-dasharray: 4 4; }
+.method-diagram-loop text { fill: var(--ink-2); font-family: var(--mono); font-size: 11px; text-anchor: middle; }
+.method-diagram-connectors path { fill: none; stroke: rgb(36 80 255 / 62%); stroke-width: 1.25; marker-end: url(#method-diagram-arrow); vector-effect: non-scaling-stroke; }
+.method-diagram marker path { fill: var(--moss-ink); }
 :focus-visible { outline: 2px solid var(--moss); outline-offset: 3px; }
 
 @media (hover: hover) and (pointer: fine) {
@@ -593,12 +602,7 @@ h1 span { display: block; white-space: nowrap; }
   .guide-deploy-commands { grid-template-columns: 1fr; }
   .cli-command-row { grid-template-columns: 1fr; gap: 6px; }
   .concept-section { grid-template-columns: 1fr; gap: 24px; }
-  .compaction-flow { padding: 8px 0; grid-template-columns: minmax(100px, .6fr) 34px minmax(180px, 1fr) 34px minmax(200px, 1.1fr); gap: 8px; }
   .concept-section-actor .actor-concept-illustration { grid-template-columns: minmax(220px, .9fr) 60px minmax(250px, 1.1fr); }
-  .methods-concept-illustration { width: 100%; margin-left: 0; grid-template-columns: 110px 32px minmax(160px, 1fr) 32px minmax(160px, .9fr); gap: 8px; transform: none; }
-  .methods-world .world-globe { width: 108px; }
-  .methods-concept-illustration > .methods-arrow { width: 32px; }
-  .methods-concept-illustration .concept-arrow { width: 32px; }
 }
 
 @media (max-width: 560px) {
@@ -627,20 +631,8 @@ h1 span { display: block; white-space: nowrap; }
   .rlm-parts > div:nth-child(even) { border-left: 0; }
   .rlm-parts > div + div { border-top: 1px dashed rgb(36 80 255 / 28%); }
   .concept-section { margin-top: 48px; padding-top: 36px; }
-  .compaction-flow { grid-template-columns: 1fr; gap: 10px; }
-  .compaction-flow-arrow { width: 18px; height: 30px; justify-self: center; transform: none; }
-  .compaction-flow-arrow::before { top: 2px; right: auto; bottom: 2px; left: 8px; width: 1px; height: auto; }
-  .compaction-flow-arrow::after { top: auto; right: auto; bottom: 2px; left: 4px; border-top: 0; border-right: 1px solid currentColor; border-bottom: 1px solid currentColor; transform: rotate(45deg); }
-  .compaction-results { grid-template-columns: 1fr; }
-  .compaction-results > div + div { border-top: 1px dashed rgb(36 80 255 / 28%); border-left: 0; }
   .actor-concept-illustration { grid-template-columns: 1fr; gap: 14px; }
   .concept-section-actor .actor-concept-illustration { grid-template-columns: 1fr; }
-  .methods-concept-illustration { grid-template-columns: 1fr; grid-template-rows: none; gap: 8px; }
-  .methods-world, .typed-method-call, .methods-event-store, .methods-concept-illustration > .methods-arrow:nth-child(2), .methods-concept-illustration > .methods-arrow:nth-child(4) { transform: none; }
-  .methods-world, .typed-method-call, .methods-event-store { grid-column: 1; grid-row: auto; }
-  .methods-world { width: 156px; justify-self: center; }
-  .methods-concept-illustration > .methods-arrow { position: static; width: auto; justify-self: center; }
-  .methods-arrow .concept-arrow { width: 34px; height: 28px; transform: rotate(90deg); }
   .actor-concept-link { grid-template-columns: 48px auto; justify-content: center; align-items: center; gap: 0; }
   .actor-concept-link svg { width: 48px; height: 48px; transform: rotate(90deg); }
   .actor-concept-link span { margin-left: -5px; }


### PR DESCRIPTION
Rewrites the concepts page so actors, transitions, components, and methods form one continuous mental model. The previous page mixed visual styles and left some relationships implicit, which made the actor loop harder to follow.

- Tightens the narrative and connects each concept to the next.
- Replaces the existing examples with consistent, responsive SVG diagrams.
- Clarifies transition execution, compaction order, and the durable method lifecycle.

Verified with `bun run gate`.