### PR TITLE
feat(models): observe inference deltas

### DIFF
--- a/apps/server/src/host.test.ts
+++ b/apps/server/src/host.test.ts
@@ -5,13 +5,15 @@ import type { ActorEnvelope } from "@clavia/tardigrade-core/communication/envelo
 import type { MessageReceived } from "@clavia/tardigrade-core/communication/message"
 import { Ingress } from "@clavia/tardigrade-host/ingress"
 import { RESERVED_ACTOR } from "@clavia/tardigrade-client/contract"
-import { Infer, type InferRequest } from "tardie"
+import { Infer, type InferDelta, type InferRequest, type InferenceObserver } from "tardie"
 import type { Action } from "tardie/log/events"
+import { modelAdapters, type ModelAdapter, type ModelAdapterRegistry } from "@clavia/tardigrade-model/adapter"
+import type { ModelCatalog } from "@clavia/tardigrade-client/contract"
 
 import { layerConfig, readConfig, ServerConfig } from "./config"
 import { Threads, layerThreads, selectedModelFrom } from "./host"
 import { DriverGauge } from "./driver-gauge"
-import { layerModelCatalogUnavailable } from "./catalog"
+import { layerModelCatalogUnavailable, layerModelCatalogValue, type ModelCatalogStore } from "./catalog"
 
 // Every case here opens a real store on disk and drives a real host, so it competes with every
 // other task in a parallel gate run. Bun's default per-test budget is tuned for a pure function and
@@ -56,8 +58,11 @@ const config = layerConfig(readConfig({
 const running = <A, E>(
   body: (threads: Context.Service.Shape<typeof Threads>) => Effect.Effect<A, E, DriverGauge | Ingress>,
   options: {
-    readonly infer?: Layer.Layer<Infer>
+    readonly infer?: Layer.Layer<Infer> | false
     readonly config?: Layer.Layer<ServerConfig>
+    readonly catalog?: Layer.Layer<ModelCatalogStore>
+    readonly inferenceObserver?: InferenceObserver
+    readonly modelAdapters?: ModelAdapterRegistry
   } = {}
 ): Promise<A> =>
   Effect.gen(function*() {
@@ -65,9 +70,11 @@ const running = <A, E>(
     return yield* body(threads)
   }).pipe(
     Effect.provide(Layer.provide(layerThreads({
-      infer: options.infer ?? layerScripted,
+      ...(options.infer === false ? {} : { infer: options.infer ?? layerScripted }),
+      ...(options.inferenceObserver === undefined ? {} : { inferenceObserver: options.inferenceObserver }),
+      ...(options.modelAdapters === undefined ? {} : { modelAdapters: options.modelAdapters }),
       providers: [{ name: "test", send: () => Effect.void }]
-    }), [options.config ?? config, layerModelCatalogUnavailable])),
+    }), [options.config ?? config, options.catalog ?? layerModelCatalogUnavailable])),
     Effect.scoped,
     Effect.runPromise
   ) as Promise<A>
@@ -273,6 +280,90 @@ describe("the threads service", () => {
       })
     )
     expect(types).toContain("TurnCompleted")
+  })
+
+  test("a Bun host observes text while its provider stream is active", async () => {
+    let release!: () => void
+    const released = new Promise<void>((resolve) => { release = resolve })
+    let observedFirst!: () => void
+    const first = new Promise<void>((resolve) => { observedFirst = resolve })
+    const deltas: InferDelta[] = []
+    const adapter: ModelAdapter = {
+      id: "test/streaming",
+      protocols: ["openai-chat-completions"],
+      start: () => ({
+        stream: {
+          async *[Symbol.asyncIterator]() {
+            yield { type: "TEXT_MESSAGE_START", messageId: "stream-1", role: "assistant", timestamp: 1 } as never
+            yield { type: "TEXT_MESSAGE_CONTENT", messageId: "stream-1", delta: "hel", timestamp: 2 } as never
+            await released
+            yield { type: "TEXT_MESSAGE_CONTENT", messageId: "stream-1", delta: "lo", timestamp: 3 } as never
+            yield { type: "TEXT_MESSAGE_END", messageId: "stream-1", timestamp: 4 } as never
+          }
+        }
+      })
+    }
+    const streamedModel = { provider: "test", model_id: "streamed" } as const
+    const streamedConfig = layerConfig(readConfig({
+      TARDIGRADE_DB: ":memory:",
+      TARDIGRADE_ACTORS: `/tmp/tardigrade-host-stream-${process.pid}`,
+      TEST_MODEL_KEY: "secret"
+    }, {
+      models: {
+        default: streamedModel,
+        allow: "*",
+        providers: {
+          test: {
+            baseUrl: "https://model.test/v1",
+            protocol: "openai-chat-completions",
+            env: ["TEST_MODEL_KEY"]
+          }
+        }
+      }
+    }))
+    const streamedCatalog: ModelCatalog = {
+      source: "models.dev",
+      revision: "stream-test",
+      refreshedAt: 1,
+      status: "fresh",
+      providers: [{
+        id: "test",
+        name: "Test",
+        env: ["TEST_MODEL_KEY"],
+        models: [{ id: "streamed", metadata: { contextWindowTokens: 8_192 } }]
+      }]
+    }
+
+    await running(
+      (threads) => Effect.gen(function*() {
+        yield* threads.append("stream", brief("stream-message"))
+        yield* Effect.promise(() => first)
+        const open = yield* threads.events("stream")
+        expect(open.some((event) => event.type === "TurnCompleted")).toBe(false)
+        expect(deltas.map((delta) => delta.text)).toEqual(["hel"])
+        release()
+        yield* threads.settled
+        const settled = yield* threads.events("stream")
+        expect(settled).toContainEqual(expect.objectContaining({ type: "TurnCompleted", output: "hello" }))
+      }),
+      {
+        infer: false,
+        config: streamedConfig,
+        catalog: layerModelCatalogValue(streamedCatalog),
+        modelAdapters: modelAdapters(adapter),
+        inferenceObserver: {
+          onDelta: (delta) => Effect.sync(() => {
+            deltas.push(delta)
+            if (delta.sequence === 0) observedFirst()
+          })
+        }
+      }
+    )
+
+    expect(deltas.map(({ thread, model, blockIndex, sequence, text }) => ({ thread, model, blockIndex, sequence, text }))).toEqual([
+      { thread: "ag.stream", model: streamedModel, blockIndex: 0, sequence: 0, text: "hel" },
+      { thread: "ag.stream", model: streamedModel, blockIndex: 0, sequence: 1, text: "lo" }
+    ])
   })
 
   test("list names every thread lane with its log", async () => {

--- a/apps/server/src/host.ts
+++ b/apps/server/src/host.ts
@@ -22,6 +22,7 @@ import {
   type ActorMethods,
   type ModelRef,
   type ModelPolicy,
+  type InferenceObserver,
   type ActorArtifactManifest,
   type Actor
 } from "tardie"
@@ -246,7 +247,8 @@ export const modelIsConfigured = (config: ServerConfigValue): boolean =>
 const layerInferFrom = (
   config: ServerConfigValue,
   catalog: ModelCatalogState,
-  adapters: ModelAdapterRegistry
+  adapters: ModelAdapterRegistry,
+  observer?: InferenceObserver
 ): Layer.Layer<Infer> => {
   if (Object.keys(config.model.providers).length === 0) {
     const failed: Action = { kind: "fail", error: MISSING_MODEL, failure: { cause: "inference_error", attempts: 1 } }
@@ -301,7 +303,7 @@ const layerInferFrom = (
         contextWindowTokens: selected.contextWindowTokens,
         ...(selected.maxOutputTokens === undefined ? {} : { maxOutputTokens: selected.maxOutputTokens }),
         ...(selected.pricing === undefined ? {} : { pricing: selected.pricing })
-      }, adapters)
+      }, adapters, observer === undefined ? {} : { observer })
       return Effect.flatMap(Infer, (model) => model.react(request, key)).pipe(Effect.provide(binding))
     })
   })
@@ -318,7 +320,7 @@ const layerLane = (
   adapters: ModelAdapterRegistry
 ) =>
   Layer.mergeAll(
-    options.infer ?? layerInferFrom(config, catalog, adapters),
+    options.infer ?? layerInferFrom(config, catalog, adapters, options.inferenceObserver),
     BunFileSystem.layer,
     BunPath.layer,
     FetchHttpClient.layer
@@ -331,6 +333,8 @@ export interface ThreadsOptions {
   readonly infer?: Layer.Layer<Infer>
   // modelAdapters replaces the host's protocol implementations and must cover every configured provider.
   readonly modelAdapters?: ModelAdapterRegistry
+  // inferenceObserver receives ephemeral normalized text outside the durable event log.
+  readonly inferenceObserver?: InferenceObserver
   // providers interpret replies whose durable inbound link targets an external provider instance.
   readonly providers?: ReadonlyArray<Provider>
   // actorRefresh watches the actor root and reconciles its artifacts after the stated debounce.
@@ -488,7 +492,7 @@ const runtimeOf = async (
   }
 }
 
-export type ActorThreadsOptions = Pick<ThreadsOptions, "infer" | "modelAdapters" | "providers">
+export type ActorThreadsOptions = Pick<ThreadsOptions, "infer" | "inferenceObserver" | "modelAdapters" | "providers">
 
 // layerActorThreads mounts one deployed definition as the runtime.
 export const layerActorThreads = (

--- a/docs/how-to/server.md
+++ b/docs/how-to/server.md
@@ -106,6 +106,24 @@ The server refreshes the public model catalog when it starts, validates the comp
 
 Catalog responses use cursor pagination. They include `revision`, `status`, `refreshed_at`, `total`, `limit`, `items`, and optional `next_cursor`. The default limit is `50` and callers can state another positive integer. Search is a case-insensitive substring over IDs and names. `GET /v1/models` also accepts an exact provider filter. Pass `next_cursor` with the same filters to continue. A cursor records the catalog revision and query, so a changed revision or filter returns 400 and the caller starts again without a cursor.
 
+## Live inference output
+
+An embedded Bun host can pass `inferenceObserver` to `layerThreads`. The observer receives normalized text after the provider adapter and before the final action is accumulated. Each delta names the actor, thread, turn, logical attempt, physical provider request, model, text block, and sequence. The host chooses its WebSocket, SSE, Redis, or pub/sub transport.
+
+```ts
+import { Effect } from "effect"
+import { layerThreads } from "tardie/server/host"
+
+const threads = layerThreads({
+  inferenceObserver: {
+    policy: { bufferCapacity: 128, deliveryTimeoutMs: 250 },
+    onDelta: (delta) => Effect.promise(() => liveOutput.publish(delta))
+  }
+})
+```
+
+The observer queue drops new deltas when it is full. Each accepted delivery has the configured timeout. Observer failure, timeout, and dropped deltas leave inference and the durable event log unchanged. A completed or failed turn remains authoritative. Replaying settled history emits no deltas. A recovery call that opens a new provider stream uses a fresh `physicalAttempt` under the same durable `logicalAttempt`. `DEFAULT_INFERENCE_OBSERVER_POLICY` exports the queue and timeout defaults.
+
 ## Clients
 
 `tardie/client` is generated from the same declaration this server implements, so `/openapi.json` and the client cannot drift from it.

--- a/packages/agent/src/components/compaction.test.ts
+++ b/packages/agent/src/components/compaction.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { Effect, Layer, Ref } from "effect"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import { EventLog, withWatermark } from "@clavia/tardigrade-core/log"
-import { actorFromReactors, send } from "@clavia/tardigrade-core/reconciliation"
+import { actorFromReactors, Self, send } from "@clavia/tardigrade-core/reconciliation"
 import { Infer } from "../inference/reactor"
 import { composeKeys } from "@clavia/tardigrade-core/log"
 import { messageKeys } from "@clavia/tardigrade-core/communication/message"
@@ -101,7 +101,7 @@ describe("the compaction measure and guard", () => {
   })
 })
 
-const mailbox = actorFromReactors<Infer | EventLog>([reactor], agentActorKeys)
+const mailbox = actorFromReactors<Infer | EventLog | Self>([reactor], agentActorKeys)
 
 describe("the compaction pass", () => {
   const run = async (initial: ReadonlyArray<Event>) => {
@@ -120,7 +120,8 @@ describe("the compaction pass", () => {
           briefed = String((trajectory[0] as { text?: unknown }).text ?? "")
           return Effect.succeed({ kind: "complete" as const, output: "covenants 1 through 13 extracted" })
         }
-      })
+      }),
+      Layer.succeed(Self, { actor: "test", thread: "compaction" })
     )
     await Effect.runPromise(
       send(mailbox, { type: "CompactionFired", at: 999 }).pipe(Effect.provide(layers)) as Effect.Effect<void>
@@ -215,12 +216,15 @@ describe("a projected repair is invisible to compaction as well as to the render
         return transition.act(transition.input as never)
       })).pipe(
         Effect.provide(
-          Layer.succeed(Infer, {
-            react: ({ trajectory }: { trajectory: ReadonlyArray<Event> }) => {
-              briefs.push(String((trajectory[0] as { text?: unknown }).text))
-              return Effect.succeed({ kind: "complete" as const, output: "summarized" })
-            }
-          })
+          Layer.mergeAll(
+            Layer.succeed(Infer, {
+              react: ({ trajectory }: { trajectory: ReadonlyArray<Event> }) => {
+                briefs.push(String((trajectory[0] as { text?: unknown }).text))
+                return Effect.succeed({ kind: "complete" as const, output: "summarized" })
+              }
+            }),
+            Layer.succeed(Self, { actor: "test", thread: "compaction" })
+          )
         )
       ) as unknown as Effect.Effect<ReadonlyArray<ReadonlyArray<Event>>>
     )

--- a/packages/agent/src/components/compaction.ts
+++ b/packages/agent/src/components/compaction.ts
@@ -1,5 +1,5 @@
 import { Clock, Effect } from "effect"
-import { effect, type Reactor } from "@clavia/tardigrade-core/reconciliation"
+import { effect, Self, type Reactor } from "@clavia/tardigrade-core/reconciliation"
 import { compactionCompleted } from "../log/events"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import { turnOf, turnView } from "@clavia/tardigrade-code/execution/turns"
@@ -346,7 +346,7 @@ const firedUncovered = (log: ReadonlyArray<Event>): boolean => {
 //
 // The policy this takes must be the one the render takes, or the guard measures a request the
 // model never sees (ContextPolicy above).
-export const compactionReactor = (policy: Partial<CompactionPolicy> = {}): Reactor<Infer> => (log) => {
+export const compactionReactor = (policy: Partial<CompactionPolicy> = {}): Reactor<Infer | Self> => (log) => {
   const model = modelResolutionOf(log).model
   const resolved = contextPolicyFrom(log, policy)
   // The projection runs first, so the guard, the cut, and the brief all read the history the
@@ -371,6 +371,7 @@ export const compactionReactor = (policy: Partial<CompactionPolicy> = {}): React
       },
       act: (input) =>
         Effect.gen(function* () {
+          const self = yield* Self
           const at = yield* Clock.currentTimeMillis
           const lines = input.span.map((e) => lineOf(e, resolved)).filter((l): l is string => l !== null)
           if (lines.length === 0) {
@@ -392,6 +393,7 @@ export const compactionReactor = (policy: Partial<CompactionPolicy> = {}): React
           const action = yield* (yield* Infer).react(
             {
               trajectory: [{ type: "MessageReceived", id: `compact-${input.keepFrom}`, text: brief, at }],
+              identity: { ...self, turn: `compact-${input.keepFrom}` },
               ...(model === undefined ? {} : { model }),
               system: "",
               tools: []
@@ -414,7 +416,7 @@ export const compactionReactor = (policy: Partial<CompactionPolicy> = {}): React
 
 // compaction derives one resolved context contribution and the transitions governed by the same
 // model-relative policy.
-export const compaction = (policy: Partial<CompactionPolicy> = {}): AgentComponent<Infer> => {
+export const compaction = (policy: Partial<CompactionPolicy> = {}): AgentComponent<Infer | Self> => {
   const reactor = compactionReactor(policy)
   return {
     name: "compaction",

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -148,6 +148,28 @@ describe("an assembled agent", () => {
     expect(mind.host.resting()).toBe(true)
   })
 
+  test("root and child inference requests carry their actor identity", async () => {
+    const seen: Array<{ readonly request: InferRequest; readonly key?: string }> = []
+    const mind = rlm(async (request, key) => {
+      seen.push({ request, ...(key === undefined ? {} : { key }) })
+      return scripted(request)
+    })
+    await mind.run("fan out and add")
+    expect(seen.some(({ request }) =>
+      request.identity.actor === "mem" &&
+      request.identity.thread === ROOT_LANE &&
+      request.identity.turn === "run-0"
+    )).toBe(true)
+    expect(new Set(seen.map(({ request }) => request.identity.thread))).toEqual(new Set([
+      ROOT_LANE,
+      "ag.t1.0",
+      "ag.t1.1"
+    ]))
+    for (const { request, key } of seen) {
+      expect(key?.startsWith(`${request.identity.turn}/infer/`)).toBe(true)
+    }
+  })
+
   test("an agent initialises from a log: history carries, new runs continue past it", async () => {
     // Run one agent to a settled state, carry its log into a fresh one: the seeded agent reads
     // the same history, and a new run serves without colliding with a recorded id.
@@ -162,6 +184,20 @@ describe("an assembled agent", () => {
     // Both turns live on one log: the carried terminal and the new one.
     expect(resumed.host.read(ROOT_LANE).filter((e) => e.type === "TurnCompleted")).toHaveLength(2)
     expect(resumed.host.resting()).toBe(true)
+  })
+
+  test("replay emits no inference", async () => {
+    const first = rlm(scripted)
+    await first.run("sum 1+2")
+    const carried = first.host.read(ROOT_LANE)
+    let calls = 0
+    const resumed = rlm(async (request) => {
+      calls += 1
+      return scripted(request)
+    }, [work()], carried)
+    await resumed.host.drive()
+    expect(calls).toBe(0)
+    expect(resumed.host.read(ROOT_LANE)).toEqual(carried)
   })
 
   test("a second run reuses the root lane as a genuinely fresh turn", async () => {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -37,6 +37,13 @@ export {
 } from "./inference/reactor"
 export { ModelRef, modelRefOf } from "./inference/reference"
 export {
+  DEFAULT_INFERENCE_OBSERVER_POLICY,
+  type InferDelta,
+  type InferenceIdentity,
+  type InferenceObserver,
+  type InferenceObserverPolicy
+} from "./inference/observer"
+export {
   applyModelPolicy,
   DEFAULT_MODEL_POLICY,
   DEFAULT_MODEL_POLICY_OVERRIDE,

--- a/packages/agent/src/inference/observer.ts
+++ b/packages/agent/src/inference/observer.ts
@@ -1,0 +1,37 @@
+import type { Effect } from "effect"
+import type { ModelRef } from "./reference"
+
+// InferenceIdentity identifies the actor turn that opened a logical model attempt (index.test.ts, "root and child inference requests carry their actor identity").
+export interface InferenceIdentity {
+  readonly actor: string
+  readonly thread: string
+  readonly turn: string
+}
+
+// InferDelta is ephemeral normalized text from one physical provider request. Sequence is zero-based within that request, so a consumer can detect a dropped delta (model.test.ts, "observes normalized text without changing the terminal action").
+export interface InferDelta extends InferenceIdentity {
+  readonly logicalAttempt: string
+  readonly physicalAttempt: string
+  readonly model: ModelRef
+  readonly blockIndex: number
+  readonly sequence: number
+  readonly text: string
+}
+
+// InferenceObserver receives ephemeral output outside the durable log. Failure and timeout discard that delivery without changing inference (model.test.ts, "observer failure and saturation leave inference unchanged").
+export interface InferenceObserver {
+  readonly onDelta: (delta: InferDelta) => Effect.Effect<void, Error>
+  readonly policy?: Partial<InferenceObserverPolicy>
+}
+
+// InferenceObserverPolicy bounds pending deliveries and each observer call.
+export interface InferenceObserverPolicy {
+  readonly bufferCapacity: number
+  readonly deliveryTimeoutMs: number
+}
+
+// DEFAULT_INFERENCE_OBSERVER_POLICY bounds best-effort delivery while each observer may override both fields.
+export const DEFAULT_INFERENCE_OBSERVER_POLICY: InferenceObserverPolicy = {
+  bufferCapacity: 64,
+  deliveryTimeoutMs: 100
+}

--- a/packages/agent/src/inference/reactor.ts
+++ b/packages/agent/src/inference/reactor.ts
@@ -1,6 +1,6 @@
 import { Cause, Clock, Context, Effect } from "effect"
 import { EventLog } from "@clavia/tardigrade-core/log"
-import { intent, effect, type Reactor } from "@clavia/tardigrade-core/reconciliation"
+import { intent, effect, Self, type Reactor } from "@clavia/tardigrade-core/reconciliation"
 import { modelCalled, modelResolved, outputRejected, textReturned, turnFailed } from "../log/events"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import type { Action } from "../log/events"
@@ -28,6 +28,7 @@ import {
   type ModelPolicy,
   type ModelPolicyOverride
 } from "./access"
+import type { InferenceIdentity } from "./observer"
 
 // The infer reactor: the model loop, and nothing else. A think is owed when the current turn
 // has no unanswered tool call and no terminal; serving marks the attempt, does inference, then
@@ -51,6 +52,7 @@ export const DEFAULT_INFER_POLICY: InferPolicy = { giveUpAfter: 3, models: DEFAU
 // about tools; the actor is the render's one owner.
 export interface InferRequest {
   readonly trajectory: ReadonlyArray<Event>
+  readonly identity: InferenceIdentity
   readonly model?: ModelRef
   readonly system: string
   readonly tools: ReadonlyArray<import("./request").ToolSpec>
@@ -318,7 +320,7 @@ export type Render = (log: ReadonlyArray<Event>) => {
   readonly output?: { readonly fallback: OutputFallback; readonly system?: string }
 }
 
-export const inferReactorFor = (policy: Partial<InferPolicy>, render: Render): Reactor<Infer | EventLog> => (log) => {
+export const inferReactorFor = (policy: Partial<InferPolicy>, render: Render): Reactor<Infer | EventLog | Self> => (log) => {
   const giveUpAfter = policy.giveUpAfter ?? DEFAULT_INFER_POLICY.giveUpAfter
   const slice = turnView(log)
   if (slice.length === 0 || awaitingTool(slice) || terminated(slice)) return []
@@ -514,6 +516,7 @@ export const inferReactorFor = (policy: Partial<InferPolicy>, render: Render): R
       act: (input) =>
         Effect.gen(function* () {
           const events = yield* EventLog
+          const self = yield* Self
           const at = yield* Clock.currentTimeMillis
           // The mark records the attempt BEFORE the inference, appended by the act itself: a
           // died attempt leaves its mark, the next derivation counts it, the bound holds.
@@ -531,7 +534,12 @@ export const inferReactorFor = (policy: Partial<InferPolicy>, render: Render): R
             })
           ])
           const action = yield* (yield* Infer)
-            .react({ trajectory: input.trajectory, ...(input.model === undefined ? {} : { model: input.model }), ...input.render }, input.attempt)
+            .react({
+              trajectory: input.trajectory,
+              identity: { ...self, turn: input.turn },
+              ...(input.model === undefined ? {} : { model: input.model }),
+              ...input.render
+            }, input.attempt)
             .pipe(
               Effect.catchCause((cause) =>
                 Cause.hasInterruptsOnly(cause)

--- a/platform/cloudflare/README.md
+++ b/platform/cloudflare/README.md
@@ -57,6 +57,29 @@ modelAdapters(anthropicAdapter, openAICompatibleAdapter)
 
 Amazon Bedrock is an optional peer dependency. Install its provider packages and register `bedrockAdapter` from `tardie/model/bedrock` when the host uses `bedrock-converse`.
 
+## Live inference output
+
+Pass `inferenceObserverFor` to observe normalized text while a provider stream is active. The factory receives the Worker environment and lane, so delivery can use a deployment binding. Deltas are ephemeral and carry actor, thread, turn, logical attempt, physical attempt, model, block, sequence, and text identity.
+
+```ts
+import { Effect } from "effect"
+import { ActorHost, cloudflareWorker, type CloudflareWorkerLayerContext, type Env as TardigradeEnv } from "tardie/cloudflare"
+
+interface Env extends TardigradeEnv {
+  readonly LIVE_OUTPUT: Queue
+}
+
+export { ActorHost }
+export default cloudflareWorker(definition, {
+  modelAdapters: modelAdapters(anthropicAdapter),
+  inferenceObserverFor: ({ env }: CloudflareWorkerLayerContext<Env>) => ({
+    onDelta: (delta) => Effect.promise(() => env.LIVE_OUTPUT.send(delta))
+  })
+})
+```
+
+Observer delivery uses the exported `DEFAULT_INFERENCE_OBSERVER_POLICY`. Supply `policy.bufferCapacity` and `policy.deliveryTimeoutMs` on the returned observer to override it. A full queue drops new deltas. Observer failure and timeout leave inference unchanged. The durable terminal event remains authoritative, and replaying settled history emits no deltas.
+
 ## Verify and deploy
 
 ```bash

--- a/platform/cloudflare/src/worker.ts
+++ b/platform/cloudflare/src/worker.ts
@@ -1,7 +1,7 @@
 import { DurableObject } from "cloudflare:workers"
 import { Clock, Context, Effect, Layer, Schema } from "effect"
 import { FetchHttpClient, HttpClient, HttpEffect, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
-import { actor, agentMethods, agentsPackage, applyModelPolicy, budget, codeMode, compaction, fetchPackage, Infer, infer as inferAgent, intersectModelPolicies, modelAllowedBy, outputValidateOnce, workspacePackage, type Actor, type ActorMethods, type ModelPolicy, type ModelRef } from "tardie"
+import { actor, agentMethods, agentsPackage, applyModelPolicy, budget, codeMode, compaction, fetchPackage, Infer, infer as inferAgent, intersectModelPolicies, modelAllowedBy, outputValidateOnce, workspacePackage, type Actor, type ActorMethods, type InferenceObserver, type ModelPolicy, type ModelRef } from "tardie"
 import type { Action } from "tardie/log/events"
 import {
   CATALOG_AVAILABILITY_FILTERS,
@@ -84,6 +84,7 @@ interface MountedActor {
   readonly actor: DefaultAssembly
   readonly methods: ActorMethods
   readonly modelAdapters: ModelAdapterRegistry
+  readonly inferenceObserverFor?: (context: CloudflareWorkerLayerContext<Env>) => InferenceObserver
   readonly layersFor?: (context: CloudflareWorkerLayerContext<Env>) => CloudflareLaneEnv<never>
 }
 
@@ -190,7 +191,8 @@ const selectedModelFrom = (
 const modelLayer = (
   models: CloudflareModels | undefined,
   catalog: ModelCatalogState,
-  adapters: ModelAdapterRegistry
+  adapters: ModelAdapterRegistry,
+  observer?: InferenceObserver
 ) => {
   if (models === undefined) {
     const failed: Action = { kind: "fail", error: "no model is configured", failure: { cause: "inference_error", attempts: 1 } }
@@ -235,7 +237,7 @@ const modelLayer = (
         contextWindowTokens: selectedModel.contextWindowTokens,
         ...(selectedModel.metadata.maxOutputTokens === undefined ? {} : { maxOutputTokens: selectedModel.metadata.maxOutputTokens }),
         ...(selectedModel.metadata.pricing === undefined ? {} : { pricing: selectedModel.metadata.pricing })
-      }, adapters)
+      }, adapters, observer === undefined ? {} : { observer })
       return Effect.flatMap(Infer, (model) => model.react(request, key)).pipe(Effect.provide(selected))
     }
   })
@@ -473,7 +475,8 @@ export class ActorHost extends DurableObject<Env> {
       principal,
       actorFor: (lane) => threadOf(lane) === undefined ? undefined : selectedAssembly,
       layersFor: (lane) => {
-        const framework = Layer.mergeAll(modelLayer(models, catalog, adapters), FetchHttpClient.layer, sandboxLayer)
+        const observer = mountedActor?.inferenceObserverFor?.({ env: this.env, lane })
+        const framework = Layer.mergeAll(modelLayer(models, catalog, adapters, observer), FetchHttpClient.layer, sandboxLayer)
         const application = mountedActor?.layersFor?.({ env: this.env, lane })
         return application === undefined ? framework : Layer.mergeAll(framework, application)
       },
@@ -860,10 +863,12 @@ export type CloudflareWorkerOptions<R, WorkerEnv extends Env = Env> =
     ? {
         readonly layersFor?: CloudflareWorkerLayersFor<R, WorkerEnv>
         readonly modelAdapters?: ModelAdapterRegistry
+        readonly inferenceObserverFor?: (context: CloudflareWorkerLayerContext<WorkerEnv>) => InferenceObserver
       }
     : {
         readonly layersFor: CloudflareWorkerLayersFor<R, WorkerEnv>
         readonly modelAdapters?: ModelAdapterRegistry
+        readonly inferenceObserverFor?: (context: CloudflareWorkerLayerContext<WorkerEnv>) => InferenceObserver
       }
 
 type CloudflareWorkerArguments<R, WorkerEnv extends Env> =
@@ -885,6 +890,9 @@ export const cloudflareWorker = <
     actor: definition as unknown as DefaultAssembly,
     methods: definition.methods,
     modelAdapters: options?.modelAdapters ?? modelAdapters(),
+    ...(options?.inferenceObserverFor === undefined ? {} : {
+      inferenceObserverFor: options.inferenceObserverFor as unknown as (context: CloudflareWorkerLayerContext<Env>) => InferenceObserver
+    }),
     ...(options?.layersFor === undefined ? {} : {
       layersFor: options.layersFor as unknown as (context: CloudflareWorkerLayerContext<Env>) => CloudflareLaneEnv<never>
     })

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -10,12 +10,17 @@ import {
   renderOf,
   repairFallback,
   VALIDATE_ONCE_FALLBACK,
-  NATIVE_MODE
+  NATIVE_MODE,
+  type InferDelta
 } from "tardie"
 
 // reqOf wraps a trajectory in the render the actor would derive: the code surface half.
 const surfaceRender = renderOf([codeMode(), nativeOutput], [])
-const reqOf = (trajectory: ReadonlyArray<Event>) => ({ trajectory, ...surfaceRender })
+const reqOf = (trajectory: ReadonlyArray<Event>) => ({
+  trajectory,
+  identity: { actor: "test", thread: "root", turn: "m1" },
+  ...surfaceRender
+})
 import { Infer } from "tardie"
 import {
   actionOf,
@@ -23,7 +28,8 @@ import {
   ladderOf,
   infer,
   retryAfterMsOf,
-  throttleDelayMs
+  throttleDelayMs,
+  type ModelInferOptions
 } from "./model"
 import {
   bedrockConverseTextAdapter as bedrockAdapter,
@@ -35,7 +41,7 @@ import {
 } from "./bedrock"
 import { anthropicAdapter } from "./anthropic"
 import { openAICompatibleAdapter } from "./openai"
-import { modelAdapters } from "./adapter"
+import { modelAdapters, type ModelAdapter } from "./adapter"
 import type { ModelConfig } from "./model"
 import type { ModelProtocol } from "./directory"
 import {
@@ -47,8 +53,10 @@ import type { Action } from "tardie/log/events"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 
 const testAdapters = modelAdapters(openAICompatibleAdapter, anthropicAdapter, registeredBedrockAdapter)
-const testInfer = <const C extends Omit<ModelConfig, "protocol" | "provider" | "contextWindowTokens"> & { readonly protocol?: ModelProtocol }>(config: C) =>
-  infer({ protocol: "openai-chat-completions", provider: "test", contextWindowTokens: 128_000, ...config }, testAdapters)
+const testInfer = <const C extends Omit<ModelConfig, "protocol" | "provider" | "contextWindowTokens"> & { readonly protocol?: ModelProtocol }>(
+  config: C,
+  options: ModelInferOptions = {}
+) => infer({ protocol: "openai-chat-completions", provider: "test", contextWindowTokens: 128_000, ...config }, testAdapters, options)
 
 // The model binding: the trajectory renders into the provider conversation, the streamed reply
 // decodes into one Action, and the whole loop round-trips through a fake OpenAI-compatible SSE
@@ -352,7 +360,11 @@ describe("infer end to end", () => {
       declared()
     )
     const action = (await Effect.runPromise(
-      Effect.flatMap(Infer, (model) => model.react({ trajectory: declared(), ...render })).pipe(
+      Effect.flatMap(Infer, (model) => model.react({
+        trajectory: declared(),
+        identity: { actor: "test", thread: "root", turn: "m1" },
+        ...render
+      })).pipe(
         Effect.provide(layer)
       ) as Effect.Effect<unknown>
     )) as Action
@@ -541,6 +553,132 @@ describe("infer end to end", () => {
       Effect.flatMap(Infer, (model) => model.react(reqOf(trajectory))).pipe(Effect.provide(layer)) as Effect.Effect<unknown>
     )
     expect(seen).toEqual(["m1/infer/0", null])
+  })
+})
+
+describe("ephemeral inference deltas", () => {
+  test("observes normalized text without changing the terminal action", async () => {
+    const deltas: InferDelta[] = []
+    const fetchImpl = (async () => sse([
+      { id: "stream-1", choices: [{ index: 0, delta: { role: "assistant", content: "hel" } }] },
+      { id: "stream-1", choices: [{ index: 0, delta: { content: "lo" } }] },
+      { id: "stream-1", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }
+    ])) as unknown as typeof globalThis.fetch
+    const layer = testInfer(
+      { baseUrl: "https://model.test/v1", apiKey: "k", model: "gpt-test", provider: "openai", fetch: fetchImpl },
+      {
+        observer: { onDelta: (delta) => Effect.sync(() => { deltas.push(delta) }) },
+        physicalAttemptId: () => "physical-1"
+      }
+    )
+    const action = await Effect.runPromise(
+      Effect.flatMap(Infer, (model) => model.react(reqOf([
+        { type: "MessageReceived", id: "m1", text: "go", at: 1 }
+      ]), "m1/infer/0")).pipe(Effect.provide(layer)) as Effect.Effect<Action>
+    )
+    expect(action).toMatchObject({ kind: "complete", output: "hello" })
+    expect(deltas).toEqual([
+      {
+        actor: "test",
+        thread: "root",
+        turn: "m1",
+        logicalAttempt: "m1/infer/0",
+        physicalAttempt: "physical-1",
+        model: { provider: "openai", model_id: "gpt-test" },
+        blockIndex: 0,
+        sequence: 0,
+        text: "hel"
+      },
+      {
+        actor: "test",
+        thread: "root",
+        turn: "m1",
+        logicalAttempt: "m1/infer/0",
+        physicalAttempt: "physical-1",
+        model: { provider: "openai", model_id: "gpt-test" },
+        blockIndex: 0,
+        sequence: 1,
+        text: "lo"
+      }
+    ])
+  })
+
+  test("a retried Bedrock attempt keeps the logical identity and changes the physical identity", async () => {
+    let starts = 0
+    let physical = 0
+    const deltas: InferDelta[] = []
+    const adapter: ModelAdapter = {
+      id: "test/bedrock",
+      protocols: ["bedrock-converse"],
+      start: () => {
+        const current = starts++
+        return {
+          stream: {
+            async *[Symbol.asyncIterator]() {
+              yield { type: "TEXT_MESSAGE_START", messageId: `b${current}`, role: "assistant", timestamp: 1 } as never
+              yield {
+                type: "TEXT_MESSAGE_CONTENT",
+                messageId: `b${current}`,
+                delta: current === 0 ? "discarded" : "winner",
+                timestamp: 2
+              } as never
+              if (current === 0) throw Object.assign(new Error("429 from Bedrock"), { status: 429 })
+              yield { type: "TEXT_MESSAGE_END", messageId: `b${current}`, timestamp: 3 } as never
+            }
+          }
+        }
+      }
+    }
+    const layer = infer({
+      baseUrl: "https://bedrock.test/us-east-1",
+      apiKey: "k",
+      model: "anthropic.claude-test",
+      protocol: "bedrock-converse",
+      provider: "bedrock",
+      contextWindowTokens: 128_000,
+      throttleRetryDelaysMs: [1],
+      sleep: async () => {}
+    }, modelAdapters(adapter), {
+      observer: { onDelta: (delta) => Effect.sync(() => { deltas.push(delta) }) },
+      physicalAttemptId: () => `physical-${physical++}`
+    })
+    const action = await Effect.runPromise(
+      Effect.flatMap(Infer, (model) => model.react(reqOf([
+        { type: "MessageReceived", id: "m1", text: "go", at: 1 }
+      ]), "m1/infer/0")).pipe(Effect.provide(layer)) as Effect.Effect<Action>
+    )
+    expect(action).toMatchObject({ kind: "complete", output: "winner" })
+    expect(deltas.map(({ logicalAttempt, physicalAttempt, text }) => ({ logicalAttempt, physicalAttempt, text }))).toEqual([
+      { logicalAttempt: "m1/infer/0", physicalAttempt: "physical-0", text: "discarded" },
+      { logicalAttempt: "m1/infer/0", physicalAttempt: "physical-1", text: "winner" }
+    ])
+  })
+
+  test("observer failure and saturation leave inference unchanged", async () => {
+    let deliveries = 0
+    const fetchImpl = (async () => sse([
+      ...Array.from({ length: 10 }, (_, index) => ({
+        id: "stream-2",
+        choices: [{ index: 0, delta: { content: String(index) } }]
+      })),
+      { id: "stream-2", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }
+    ])) as unknown as typeof globalThis.fetch
+    const layer = testInfer(
+      { baseUrl: "https://model.test/v1", apiKey: "k", model: "gpt-test", provider: "openai", fetch: fetchImpl },
+      {
+        observer: {
+          policy: { bufferCapacity: 1, deliveryTimeoutMs: 1 },
+          onDelta: () => deliveries++ === 0 ? Effect.die(new Error("observer offline")) : Effect.never
+        },
+        physicalAttemptId: () => "physical-saturated"
+      }
+    )
+    const action = await Effect.runPromise(
+      Effect.flatMap(Infer, (model) => model.react(reqOf([
+        { type: "MessageReceived", id: "m1", text: "go", at: 1 }
+      ]), "m1/infer/0")).pipe(Effect.provide(layer)) as Effect.Effect<Action>
+    )
+    expect(action).toMatchObject({ kind: "complete", output: "0123456789" })
   })
 })
 

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -1,4 +1,4 @@
-import { Clock, Effect, Layer, Random } from "effect"
+import { Cause, Clock, Effect, Fiber, Layer, Queue, Random, Stream } from "effect"
 import {
   StreamProcessor,
   type ModelMessage,
@@ -8,7 +8,15 @@ import {
   type Tool,
   type ToolCall
 } from "@tanstack/ai"
-import { Infer, NativeOutputSupport, type InferRequest } from "tardie"
+import {
+  DEFAULT_INFERENCE_OBSERVER_POLICY,
+  Infer,
+  NativeOutputSupport,
+  type InferDelta,
+  type InferRequest,
+  type InferenceObserver,
+  type InferenceObserverPolicy
+} from "tardie"
 import type { Action, AttemptEndpoint } from "tardie/log/events"
 import { assertSupportedBun } from "@clavia/tardigrade-bun/runtime"
 import { modelRequest, type AgentMessage, type ModelRequest, type ToolSpec } from "tardie/inference/request"
@@ -27,6 +35,15 @@ import type {
 } from "./adapter"
 
 export type { ModelConfig, StreamBounds } from "./adapter"
+
+// ModelInferOptions supplies ephemeral observation and the physical identity seam used by deterministic tests.
+export interface ModelInferOptions {
+  readonly observer?: InferenceObserver
+  readonly physicalAttemptId?: (logicalAttempt: string) => string
+}
+
+const randomPhysicalAttemptId = (logicalAttempt: string): string =>
+  `${logicalAttempt}/physical/${crypto.randomUUID()}`
 
 // The real model binding: one inference per react, streamed through a TanStack adapter and
 // decoded by their StreamProcessor. The reactors never learn this layer exists. Resilience is
@@ -406,6 +423,84 @@ const tapTokens = (
   }
 })
 
+interface DeltaDelivery {
+  readonly offer: (delta: InferDelta) => Effect.Effect<boolean>
+  readonly finish: Effect.Effect<void>
+}
+
+const observerPolicyOf = (observer: InferenceObserver): InferenceObserverPolicy => {
+  const policy = { ...DEFAULT_INFERENCE_OBSERVER_POLICY, ...observer.policy }
+  for (const [name, value] of Object.entries(policy)) {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw new Error(`inference observer ${name} must be a positive integer, got ${value}`)
+    }
+  }
+  return policy
+}
+
+// deltaDelivery decouples provider reads from host delivery with a dropping queue. Ending drains accepted deltas before the terminal action returns (model.test.ts, "observer failure and saturation leave inference unchanged").
+const deltaDelivery = (
+  observer: InferenceObserver,
+  policy: InferenceObserverPolicy
+): Effect.Effect<DeltaDelivery> =>
+  Effect.gen(function*() {
+    const queue = yield* Queue.dropping<InferDelta, Cause.Done>(policy.bufferCapacity)
+    const worker = yield* Stream.fromQueue(queue).pipe(
+      Stream.runForEach((delta) =>
+        Effect.suspend(() => observer.onDelta(delta)).pipe(
+          Effect.timeout(policy.deliveryTimeoutMs),
+          Effect.ignoreCause
+        )
+      ),
+      Effect.forkChild
+    )
+    return {
+      offer: (delta) => Queue.offer(queue, delta),
+      finish: Queue.end(queue).pipe(
+        Effect.andThen(Fiber.join(worker)),
+        Effect.ignoreCause
+      )
+    }
+  })
+
+// observed taps normalized text while preserving the stream consumed by the terminal accumulator.
+const observed = (
+  stream: AsyncIterable<StreamChunk>,
+  delivery: DeltaDelivery | undefined,
+  identity: InferRequest["identity"],
+  logicalAttempt: string | undefined,
+  physicalAttempt: string,
+  model: { readonly provider: string; readonly model_id: string }
+): AsyncIterable<StreamChunk> => {
+  if (delivery === undefined) return stream
+  if (logicalAttempt === undefined) throw new Error("an observed inference requires a logical attempt identity")
+  let blockIndex = -1
+  let sequence = 0
+  return Stream.fromAsyncIterable(stream, (cause) => cause).pipe(
+    Stream.tap((chunk) => {
+      if (chunk.type === "TEXT_MESSAGE_START") {
+        blockIndex += 1
+        return Effect.void
+      }
+      if (chunk.type !== "TEXT_MESSAGE_CONTENT" || typeof chunk.delta !== "string" || chunk.delta === "") {
+        return Effect.void
+      }
+      if (blockIndex < 0) blockIndex = 0
+      const delta: InferDelta = {
+        ...identity,
+        logicalAttempt,
+        physicalAttempt,
+        model,
+        blockIndex,
+        sequence: sequence++,
+        text: chunk.delta
+      }
+      return delivery.offer(delta).pipe(Effect.asVoid)
+    }),
+    Stream.toAsyncIterable
+  )
+}
+
 const withSpend = (action: Action, usage: Usage | undefined): Action =>
   usage === undefined ? action : { ...action, usage }
 
@@ -461,13 +556,15 @@ const spentOf = (parts: ReadonlyArray<Usage>, missed: boolean): Usage | undefine
 // infer provides NativeOutputSupport in its layer type only for a statically known native capability that accepts tools.
 export const infer = <const C extends ModelConfig>(
   config: C,
-  adapters: ModelAdapterRegistry
+  adapters: ModelAdapterRegistry,
+  options: ModelInferOptions = {}
 ): Layer.Layer<Infer | NativeOutputProvided<C>> => {
   assertSupportedBun()
   if (!Number.isSafeInteger(config.contextWindowTokens) || config.contextWindowTokens <= 0) {
     throw new Error(`contextWindowTokens must be a positive integer, got ${config.contextWindowTokens}`)
   }
   const selectedAdapter = adapters.resolve(config.protocol)
+  const observerPolicy = options.observer === undefined ? undefined : observerPolicyOf(options.observer)
   const sleep = config.sleep ?? realSleep
   const bounds: StreamBounds = {
     firstChunkMs: config.stream?.firstChunkMs ?? DEFAULT_STREAM_BOUNDS.firstChunkMs,
@@ -490,7 +587,10 @@ export const infer = <const C extends ModelConfig>(
     key: string | undefined,
     maxTokens: number,
     rung: number,
-    stats: { finish?: string }
+    stats: { finish?: string },
+    delivery: DeltaDelivery | undefined,
+    identity: InferRequest["identity"],
+    physicalAttempt: string
   ): Promise<Action> => {
     // Every consequence of a declared-output attempt names the mode it ran in, so replay reads a
     // recorded fact rather than re-deciding from a capability that may have changed since
@@ -544,7 +644,15 @@ export const infer = <const C extends ModelConfig>(
       return { usage, endpoint: endpointOf(config, wire), wire }
     }
     try {
-      const result = await new StreamProcessor().process(tapTokens(bounded(attempt.stream, bounds), held))
+      const normalized = observed(
+        tapTokens(bounded(attempt.stream, bounds), held),
+        delivery,
+        identity,
+        key,
+        physicalAttempt,
+        { provider: config.provider, model_id: config.model }
+      )
+      const result = await new StreamProcessor().process(normalized)
       const { usage, endpoint, wire } = await settle()
       stats.finish = attempt.finishReason?.() ?? result.finishReason ?? "stop"
       const stopClass = attempt.stopClass?.() ?? "ok"
@@ -632,6 +740,9 @@ export const infer = <const C extends ModelConfig>(
         yield* Effect.annotateCurrentSpan("gen_ai.output.mode", mode.name)
         yield* Effect.annotateCurrentSpan("gen_ai.output.native", mode.kind === "native")
       }
+      const delivery = options.observer === undefined || observerPolicy === undefined
+        ? undefined
+        : yield* deltaDelivery(options.observer, observerPolicy)
       const action = yield* Effect.promise<Action>(async () => {
         let rung = 0
         const parts: Usage[] = []
@@ -644,7 +755,11 @@ export const infer = <const C extends ModelConfig>(
           try {
             stats.rung = rung
             stats.attempts += 1
-            const action = await attemptOnce(req, mode, key, ladder[rung]!, rung, stats)
+            const logicalAttempt = key ?? request.identity.turn
+            const physicalAttempt = delivery === undefined
+              ? ""
+              : options.physicalAttemptId?.(logicalAttempt) ?? randomPhysicalAttemptId(logicalAttempt)
+            const action = await attemptOnce(req, mode, key, ladder[rung]!, rung, stats, delivery, request.identity, physicalAttempt)
             remember(action.usage, true)
             return served(withSpend(action, spentOf(parts, missed)), action.endpoint ?? endpointOf(config, undefined))
           } catch (e) {
@@ -718,7 +833,7 @@ export const infer = <const C extends ModelConfig>(
             await sleep(delay)
           }
         }
-      })
+      }).pipe(delivery === undefined ? (effect) => effect : Effect.ensuring(delivery.finish))
       // The wide-span discipline: everything a failure query filters by rides the one span.
       // Names follow the GenAI semantic conventions where they exist (registry, 2026).
       yield* Effect.annotateCurrentSpan("gen_ai.response.finish_reasons", [stats.finish ?? "unknown"])


### PR DESCRIPTION
## Summary

Hosts can observe normalized text while a physical provider request is active. Each ephemeral delta carries actor, thread, turn, logical attempt, physical attempt, selected model, block, sequence, and incremental text, so root and child output can be routed without provider wire parsing.

- Adds a Tardigrade-owned observer contract and complete inference caller identity.
- Uses Effect Stream and a bounded dropping queue with exported, overridable delivery policy.
- Exposes the shared observer contract through Bun `ThreadsOptions.inferenceObserver` and Cloudflare `inferenceObserverFor`, where the factory provides Worker bindings and lane context.
- Keeps deltas outside the event log. Terminal events remain authoritative and replay stays silent.
- Covers OpenAI-compatible output, Bedrock retries, root and child identity, replay, observer failure, timeout, saturation, and live delivery through a Bun host.

## Verification

- `bun run gate`

Closes #276