### PR TITLE
feat(cloudflare): isolate actor threads

### DIFF
--- a/platform/cloudflare/README.md
+++ b/platform/cloudflare/README.md
@@ -4,6 +4,20 @@ This binding mounts one actor definition into a named SQLite Durable Object. The
 
 Celld implements the Worker, SQLite Durable Object, alarm, and Worker Loader surfaces this binding uses. Code Mode uses JSON replay on Celld because its loaded Worker environment cannot carry capability stubs. The [Celld deployment guide](../../docs/how-to/celld.md) covers the generated manifest and node configuration.
 
+## Thread isolation
+
+Set `placement: "thread"` to give each actor thread a separate Durable Object, SQLite database, driver, alarm lifecycle, and isolate heap. The object name derives from the actor definition and thread identity. Actor delivery uses the complete `ActorId`, so a child thread routes to its own object even when it uses the same actor definition.
+
+```ts
+export { ActorHost }
+export default cloudflareWorker(definition, {
+  placement: "thread"
+})
+```
+
+The default `placement: "actor"` keeps all threads for one actor definition in one Durable Object. Actor-scoped placement supports `GET /v1/threads`. Thread-scoped placement returns status `400` for that actor-wide listing because Durable Object namespaces do not support object enumeration. Thread-specific method and event routes select the matching thread object.
+
+
 ## Application services
 
 An actor can require an application Effect service. Pass `layersFor` to `cloudflareWorker` to build that service from the Worker environment and current lane. Tardigrade merges the returned layer with its model, HTTP, sandbox, event-log, and workspace layers. It constructs the application layer separately for each lane settlement, so mutable service state is shared only when the supplied Layer explicitly shares it.

--- a/platform/cloudflare/src/host.ts
+++ b/platform/cloudflare/src/host.ts
@@ -35,6 +35,10 @@ export type CloudflareHostOptions<R> = {
   readonly pick?: (dirty: ReadonlySet<string>) => string
   readonly keyOf?: (event: Event) => string | undefined
 } & LayersFor<R>
+export interface CloudflareHostRouting {
+  readonly localThread: string | undefined
+}
+
 
 export interface CloudflareHost {
   readonly read: (lane: string) => Promise<ReadonlyArray<Event>>
@@ -59,7 +63,10 @@ const laneOf = (address: string): string => {
 }
 
 // createCloudflareHost binds one actor graph to Effect SQL over its Durable Object storage.
-export const createCloudflareHost = async <R = never>(options: CloudflareHostOptions<R>): Promise<CloudflareHost> => {
+export const createCloudflareHost = async <R = never>(
+  routing: CloudflareHostRouting,
+  options: CloudflareHostOptions<R>
+): Promise<CloudflareHost> => {
   const database = ManagedRuntime.make(SqliteClient.layer({ storage: options.storage }))
   const sql = await database.runPromise(SqliteClient.SqliteClient)
   const workspaceRuntime = ManagedRuntime.make(layerWorkspace(sql))
@@ -133,7 +140,16 @@ export const createCloudflareHost = async <R = never>(options: CloudflareHostOpt
     send: (_destination, envelope) => commitEffect(envelope.link.target, envelope.event, envelope.lineage, envelope.link, envelope.call)
   }
   const routes = [
-    directoryRoute(localTransport, mappedDirectory((id: ActorId) => id.actor === options.principal ? id : undefined), isActorEnvelope, (envelope) => envelope.link.target),
+    directoryRoute(
+      localTransport,
+      mappedDirectory((id: ActorId) =>
+        id.actor === options.principal && (routing.localThread === undefined || id.thread === routing.localThread)
+          ? id
+          : undefined
+      ),
+      isActorEnvelope,
+      (envelope) => envelope.link.target
+    ),
     directoryRoute(providerTransport, mappedDirectory<ProviderEndpoint, ProviderEndpoint>((endpoint) => endpoint), isProviderEnvelope, (envelope) => envelope.link.target),
     ...(options.routes ?? [])
   ]

--- a/platform/cloudflare/src/host.ts
+++ b/platform/cloudflare/src/host.ts
@@ -63,10 +63,22 @@ const laneOf = (address: string): string => {
 }
 
 // createCloudflareHost binds one actor graph to Effect SQL over its Durable Object storage.
-export const createCloudflareHost = async <R = never>(
+export function createCloudflareHost<R = never>(
+  options: CloudflareHostOptions<R>
+): Promise<CloudflareHost>
+export function createCloudflareHost<R = never>(
   routing: CloudflareHostRouting,
   options: CloudflareHostOptions<R>
-): Promise<CloudflareHost> => {
+): Promise<CloudflareHost>
+export async function createCloudflareHost<R = never>(
+  routingOrOptions: CloudflareHostRouting | CloudflareHostOptions<R>,
+  providedOptions?: CloudflareHostOptions<R>
+): Promise<CloudflareHost> {
+  const options = "storage" in routingOrOptions ? routingOrOptions : providedOptions
+  if (options === undefined) throw new Error("Cloudflare host options are required")
+  const routing = "storage" in routingOrOptions
+    ? { localThread: undefined }
+    : routingOrOptions
   const database = ManagedRuntime.make(SqliteClient.layer({ storage: options.storage }))
   const sql = await database.runPromise(SqliteClient.SqliteClient)
   const workspaceRuntime = ManagedRuntime.make(layerWorkspace(sql))

--- a/platform/cloudflare/src/worker.ts
+++ b/platform/cloudflare/src/worker.ts
@@ -70,10 +70,15 @@ export interface Env {
 
 const LANE_PREFIX = "ag."
 const laneOf = (thread: string): string => `${LANE_PREFIX}${thread}`
+const actorThreadOf = (thread: string): string => thread.startsWith(LANE_PREFIX) ? thread : laneOf(thread)
 const threadOf = (lane: string): string | undefined => lane.startsWith(LANE_PREFIX) ? lane.slice(LANE_PREFIX.length) : undefined
 
 const flattenThreads = (nodes: ReadonlyArray<ThreadNode>): ReadonlyArray<ThreadSummary> =>
   nodes.flatMap(({ children, ...summary }) => [summary, ...flattenThreads(children)])
+export type CloudflarePlacement = "actor" | "thread"
+
+const objectNameOf = (actor: string, thread: string | undefined, placement: CloudflarePlacement): string =>
+  placement === "thread" && thread !== undefined ? JSON.stringify([actor, thread]) : actor
 
 const DEFAULT_ACTOR_NAME = "default"
 
@@ -86,6 +91,7 @@ interface MountedActor {
   readonly modelAdapters: ModelAdapterRegistry
   readonly inferenceObserverFor?: (context: CloudflareWorkerLayerContext<Env>) => InferenceObserver
   readonly layersFor?: (context: CloudflareWorkerLayerContext<Env>) => CloudflareLaneEnv<never>
+  readonly placement: CloudflarePlacement
 }
 
 let mountedActor: MountedActor | undefined
@@ -348,6 +354,7 @@ export class ActorHost extends DurableObject<Env> {
   private catalogState: Promise<ModelCatalogState> | undefined
   private driving: Promise<void> | undefined
   private principal: string | undefined
+  private threadId: string | undefined
   private readonly alarmPolicy: AlarmPolicy
   private readonly sandboxCalls = new Map<
     string,
@@ -362,19 +369,35 @@ export class ActorHost extends DurableObject<Env> {
       : { recoveryDelayMillis: nonNegativeInteger(env.TARDIGRADE_ALARM_DELAY_MILLIS, 0, "TARDIGRADE_ALARM_DELAY_MILLIS") })
   }
 
-  async init(name: string): Promise<void> {
+  async init(name: string, thread?: string): Promise<void> {
     if (!deployed(name)) throw new Error(`actor ${JSON.stringify(name)} is not deployed`)
     this.ctx.storage.sql.exec("INSERT OR IGNORE INTO actor_meta (key, value) VALUES ('principal', ?)", name)
-    const principal = this.ctx.storage.sql.exec<{ value: string }>("SELECT value FROM actor_meta WHERE key = 'principal'").one().value
-    if (principal !== name) throw new Error("actor host name does not match its durable identity")
+    if (thread !== undefined) {
+      this.ctx.storage.sql.exec("INSERT OR IGNORE INTO actor_meta (key, value) VALUES ('thread', ?)", thread)
+    }
+    const principal = this.meta("principal")
+    const storedThread = this.meta("thread", false)
+    if (principal !== name) throw new Error("actor definition does not match the durable host identity")
+    if (storedThread !== thread) throw new Error("actor thread does not match the durable host identity")
     this.principal ??= principal
+    this.threadId ??= storedThread
+  }
+
+  private meta(key: string, required = true): string | undefined {
+    const row = this.ctx.storage.sql.exec<{ value: string }>(
+      "SELECT value FROM actor_meta WHERE key = ?",
+      key
+    ).toArray()[0]
+    if (row === undefined && required) throw new Error("actor host has not been initialized")
+    return row?.value
   }
 
   private name(): string {
-    if (this.principal !== undefined) return this.principal
-    const row = this.ctx.storage.sql.exec<{ value: string }>("SELECT value FROM actor_meta WHERE key = 'principal'").toArray()[0]
-    if (row === undefined) throw new Error("actor host has not been initialized")
-    return this.principal = row.value
+    return this.principal ??= this.meta("principal")!
+  }
+
+  private thread(): string | undefined {
+    return this.threadId ??= this.meta("thread", false)
   }
 
   async catalog(): Promise<ModelCatalogState> {
@@ -415,6 +438,11 @@ export class ActorHost extends DurableObject<Env> {
     const principal = this.name()
     const selectedAssembly = assemblyOf(principal, this.env, models, catalog)
     if (selectedAssembly === undefined) throw new Error(`actor ${JSON.stringify(principal)} is not deployed`)
+    const placement = mountedActor?.placement ?? "actor"
+    const currentThread = this.thread()
+    if (placement === "thread" && currentThread === undefined) {
+      throw new Error("thread-scoped actor host requires a thread identity")
+    }
     const sandboxCpuMs = optionalNonNegativeInteger(this.env.TARDIGRADE_SANDBOX_CPU_MILLIS, "TARDIGRADE_SANDBOX_CPU_MILLIS")
     const sandboxSubRequests = optionalNonNegativeInteger(
       this.env.TARDIGRADE_SANDBOX_SUBREQUESTS,
@@ -457,8 +485,9 @@ export class ActorHost extends DurableObject<Env> {
             : envelope.event
           return Effect.promise(async () => {
             if (!deployed(destination.actor)) throw new Error(`actor ${JSON.stringify(destination.actor)} is not deployed`)
-            const stub = this.env.ACTORS.getByName(destination.actor)
-            await stub.init(destination.actor)
+            const targetThread = placement === "thread" ? destination.thread : undefined
+            const stub = this.env.ACTORS.getByName(objectNameOf(destination.actor, targetThread, placement))
+            await stub.init(destination.actor, targetThread)
             await stub.deliver({ ...envelope, event })
           })
         })
@@ -466,11 +495,16 @@ export class ActorHost extends DurableObject<Env> {
     }
     const remoteRoute = directoryRoute(
       remoteTransport,
-      mappedDirectory((id: ActorId) => id.actor === principal ? undefined : id),
+      mappedDirectory((id: ActorId) => {
+        if (placement === "actor") return id.actor === principal ? undefined : id
+        return id.actor === principal && id.thread === currentThread ? undefined : id
+      }),
       isActorEnvelope,
       (envelope) => envelope.link.target
     )
-    return createCloudflareHost({
+    return createCloudflareHost(
+      { localThread: placement === "thread" ? currentThread : undefined },
+      {
       storage: this.ctx.storage,
       principal,
       actorFor: (lane) => threadOf(lane) === undefined ? undefined : selectedAssembly,
@@ -489,7 +523,8 @@ export class ActorHost extends DurableObject<Env> {
         )
       }),
       keyOf: selectedAssembly.keyOf
-    })
+      }
+    )
   }
 
   private host(): Promise<CloudflareHost> {
@@ -559,19 +594,33 @@ export class ActorHost extends DurableObject<Env> {
   }
 
   async append(thread: string, event: Event): Promise<void> {
+    const actorThread = actorThreadOf(thread)
+    const ownedThread = this.thread()
+    if (ownedThread !== undefined && ownedThread !== actorThread) {
+      throw new Error("request thread does not match actor host identity")
+    }
     const stamped = event.at === undefined ? { ...event, at: Date.now() } : event
     const host = await this.host()
-    await this.accept(host, () => host.stageRoot(host.self(laneOf(thread)), stamped))
+    await this.accept(host, () => host.stageRoot(host.self(actorThread), stamped))
   }
 
   async deliver(envelope: ActorEnvelope): Promise<void> {
-    if (envelope.link.target.actor !== this.name()) throw new Error("delivery target does not match actor host")
+    if (envelope.link.target.actor !== this.name()) throw new Error("delivery target does not match actor definition")
+    const ownedThread = this.thread()
+    if (ownedThread !== undefined && envelope.link.target.thread !== ownedThread) {
+      throw new Error("delivery target does not match actor thread")
+    }
     const host = await this.host()
     await this.accept(host, () => host.stage(envelope))
   }
 
   async events(thread: string): Promise<ReadonlyArray<Event>> {
-    return (await this.host()).read(laneOf(thread))
+    const actorThread = actorThreadOf(thread)
+    const ownedThread = this.thread()
+    if (ownedThread !== undefined && ownedThread !== actorThread) {
+      throw new Error("request thread does not match actor host identity")
+    }
+    return (await this.host()).read(actorThread)
   }
 
   async threads(): Promise<ReadonlyArray<ThreadSummary>> {
@@ -602,11 +651,14 @@ export class ActorHost extends DurableObject<Env> {
 
 const actorStub = async (
   env: Env,
-  name: string
+  name: string,
+  thread?: string
 ): Promise<DurableObjectStub<ActorHost> | undefined> => {
   if (!deployed(name)) return undefined
-  const stub = env.ACTORS.getByName(name)
-  await stub.init(name)
+  const placement = mountedActor?.placement ?? "actor"
+  const targetThread = placement === "thread" && thread !== undefined ? actorThreadOf(thread) : undefined
+  const stub = env.ACTORS.getByName(objectNameOf(name, targetThread, placement))
+  await stub.init(name, targetThread)
   return stub
 }
 
@@ -677,6 +729,9 @@ const protectedRoute = <E, R>(
 
 const routes = [
   HttpRouter.route("GET", "/healthz", Effect.gen(function* () {
+    if ((mountedActor?.placement ?? "actor") === "thread") {
+      return json({ status: "ready", actor: deployedActor })
+    }
     const env = yield* WorkerEnv
     return json(yield* Effect.promise(async () => (await actorStub(env, deployedActor))!.status()))
   })),
@@ -756,7 +811,7 @@ const routes = [
       const at = yield* Clock.currentTimeMillis
       const decoded = methodEventOf(method, { id: call, input, at })
       if ("error" in decoded) return json({ error: decoded.error }, 400)
-      const stub = yield* Effect.promise(() => actorStub(env, actor))
+      const stub = yield* Effect.promise(() => actorStub(env, actor, thread))
       if (stub === undefined) return json({ error: "actor is not deployed" }, 503)
       yield* Effect.promise(() => stub.append(thread, decoded.event))
       return json({ thread, method: methodName, call }, 202)
@@ -771,7 +826,7 @@ const routes = [
       const call = decodeURIComponent(params.call ?? "")
       const method = methodsOf(actor)?.[methodName]
       if (method === undefined) return json({ error: "unknown method" }, 404)
-      const stub = yield* Effect.promise(() => actorStub(env, actor))
+      const stub = yield* Effect.promise(() => actorStub(env, actor, thread))
       if (stub === undefined) return json({ error: "actor is not deployed" }, 503)
       const events = yield* Effect.promise(() => stub.events(thread)).pipe(
         Effect.map((value) => value as ReadonlyArray<Event>)
@@ -782,6 +837,9 @@ const routes = [
   )),
   HttpRouter.route("GET", "/v1/threads", protectedRoute((_request, env) =>
     Effect.gen(function* () {
+      if ((mountedActor?.placement ?? "actor") === "thread") {
+        return json({ error: "thread-scoped workers do not support actor-wide thread listing" }, 400)
+      }
       const stub = yield* Effect.promise(() => actorStub(env, deployedActor))
       if (stub === undefined) return json({ error: "actor is not deployed" }, 503)
       return json(yield* Effect.promise(() => stub.threads()))
@@ -792,7 +850,7 @@ const routes = [
       const params = yield* HttpRouter.params
       const actor = deployedActor
       const thread = decodeURIComponent(params.thread ?? "")
-      const stub = yield* Effect.promise(() => actorStub(env, actor))
+      const stub = yield* Effect.promise(() => actorStub(env, actor, thread))
       if (stub === undefined) return json({ error: "actor is not deployed" }, 503)
       const event = (yield* request.json.pipe(Effect.orElseSucceed(() => undefined))) as Event | undefined
       if (typeof event !== "object" || event === null || typeof event.type !== "string" || event.type === "") {
@@ -807,7 +865,7 @@ const routes = [
       const params = yield* HttpRouter.params
       const actor = deployedActor
       const thread = decodeURIComponent(params.thread ?? "")
-      const stub = yield* Effect.promise(() => actorStub(env, actor))
+      const stub = yield* Effect.promise(() => actorStub(env, actor, thread))
       if (stub === undefined) return json({ error: "actor is not deployed" }, 503)
       const url = new URL(request.url, "http://worker")
       const after = Number(url.searchParams.get("after") ?? 0)
@@ -856,10 +914,14 @@ export interface CloudflareWorkerLayerContext<WorkerEnv extends Env = Env> {
 type CloudflareWorkerLayersFor<R, WorkerEnv extends Env> = (
   context: CloudflareWorkerLayerContext<WorkerEnv>
 ) => CloudflareLaneEnv<CloudflareApplicationRequirements<R>>
+interface CloudflareWorkerPlacementOptions {
+  readonly placement?: CloudflarePlacement
+}
+
 
 // CloudflareWorkerOptions supplies every actor requirement the Worker does not bind itself.
 export type CloudflareWorkerOptions<R, WorkerEnv extends Env = Env> =
-  [CloudflareApplicationRequirements<R>] extends [never]
+  ([CloudflareApplicationRequirements<R>] extends [never]
     ? {
         readonly layersFor?: CloudflareWorkerLayersFor<R, WorkerEnv>
         readonly modelAdapters?: ModelAdapterRegistry
@@ -869,7 +931,8 @@ export type CloudflareWorkerOptions<R, WorkerEnv extends Env = Env> =
         readonly layersFor: CloudflareWorkerLayersFor<R, WorkerEnv>
         readonly modelAdapters?: ModelAdapterRegistry
         readonly inferenceObserverFor?: (context: CloudflareWorkerLayerContext<WorkerEnv>) => InferenceObserver
-      }
+      }) &
+  CloudflareWorkerPlacementOptions
 
 type CloudflareWorkerArguments<R, WorkerEnv extends Env> =
   [CloudflareApplicationRequirements<R>] extends [never]
@@ -890,6 +953,7 @@ export const cloudflareWorker = <
     actor: definition as unknown as DefaultAssembly,
     methods: definition.methods,
     modelAdapters: options?.modelAdapters ?? modelAdapters(),
+    placement: options?.placement ?? "actor",
     ...(options?.inferenceObserverFor === undefined ? {} : {
       inferenceObserverFor: options.inferenceObserverFor as unknown as (context: CloudflareWorkerLayerContext<Env>) => InferenceObserver
     }),

--- a/platform/cloudflare/test/actor.workers.ts
+++ b/platform/cloudflare/test/actor.workers.ts
@@ -8,8 +8,11 @@ import type { Env } from "../src/worker"
 import { layerCloudflareModelCatalogRepository } from "../src/catalog"
 
 const authorization = { authorization: "Bearer workers-test-token" }
-const actorStub = () => (env as Env).ACTORS.getByName("echo")
-const alarm = () => runInDurableObject(actorStub(), (_instance, state) => state.storage.getAlarm())
+const objectNameOf = (thread: string): string => JSON.stringify(["echo", `ag.${thread}`])
+const controlStub = () => (env as Env).ACTORS.getByName("echo")
+const actorStub = (thread: string) => (env as Env).ACTORS.getByName(objectNameOf(thread))
+const alarm = (thread: string) =>
+  runInDurableObject(actorStub(thread), (_instance, state) => state.storage.getAlarm())
 
 const methodState = async (thread: string, call: string): Promise<unknown> => {
   for (let attempt = 0; attempt < 100; attempt++) {
@@ -37,7 +40,7 @@ describe("cloudflare actor", () => {
         models: [{ id: "gpt-test", metadata: { contextWindowTokens: 128_000 } }]
       }]
     }
-    await runInDurableObject(actorStub(), async (_instance, state) => {
+    await runInDurableObject(controlStub(), async (_instance, state) => {
       const runtime = ManagedRuntime.make(layerCloudflareModelCatalogRepository(state.storage))
       try {
         const repository = await runtime.runPromise(ModelCatalogRepository)
@@ -75,9 +78,9 @@ describe("cloudflare actor", () => {
     })
     expect(accepted.status).toBe(202)
     expect(await accepted.json()).toEqual({ thread: "root", method: "echo", call: "workers-smoke" })
-    expect(await alarm()).not.toBeNull()
+    expect(await alarm("root")).not.toBeNull()
     expect(await methodState("root", "workers-smoke")).toEqual({ status: "completed", output: "workers:ag.root:1:Run in workerd." })
-    expect(await alarm()).toBeNull()
+    expect(await alarm("root")).toBeNull()
     const client = makeActorClient({
       baseUrl: "http://test",
       token: "workers-test-token",
@@ -94,11 +97,11 @@ describe("cloudflare actor", () => {
       "EchoCompleted"
     ])
     const health = await SELF.fetch("http://test/healthz")
-    expect(await health.json()).toEqual({ status: "resting", dirty: 0 })
+    expect(await health.json()).toEqual({ status: "ready", actor: "echo" })
     const threads = await SELF.fetch("http://test/v1/threads", { headers: authorization })
-    expect(await threads.json()).toEqual([expect.objectContaining({ id: "root", depth: 0, events: 3, status: "settled" })])
+    expect(threads.status).toBe(400)
+    expect(await threads.json()).toEqual({ error: "thread-scoped workers do not support actor-wide thread listing" })
     expect(await client.methods()).toEqual([expect.objectContaining({ name: "echo" })])
-    expect(await client.list()).toEqual([expect.objectContaining({ id: "root", status: "settled" })])
     expect(await client.metadata()).toEqual({ name: "echo", storage: { kind: "durable-object" } })
   })
 
@@ -118,11 +121,21 @@ describe("cloudflare actor", () => {
     ])
     expect(first).toEqual({ status: "completed", output: "workers:ag.application-a:1:first" })
     expect(second).toEqual({ status: "completed", output: "workers:ag.application-b:1:second" })
+    expect(actorStub("application-a").id.equals(actorStub("application-b").id)).toBe(false)
+    const firstLanes = await runInDurableObject(actorStub("application-a"), (_instance, state) =>
+      state.storage.sql.exec<{ lane: string }>("SELECT DISTINCT lane FROM events").toArray()
+    )
+    const secondLanes = await runInDurableObject(actorStub("application-b"), (_instance, state) =>
+      state.storage.sql.exec<{ lane: string }>("SELECT DISTINCT lane FROM events").toArray()
+    )
+    expect(firstLanes).toEqual([{ lane: "ag.application-a" }])
+    expect(secondLanes).toEqual([{ lane: "ag.application-b" }])
   })
 
   test("a durable object alarm terminates an overdue method call", async () => {
     const deadlineAt = Date.now() - 1
-    const stub = actorStub()
+    const stub = actorStub("timeout")
+    await stub.init("echo", "ag.timeout")
     await stub.append("timeout", {
       type: "CallDispatched",
       id: "overdue-1",
@@ -149,6 +162,6 @@ describe("cloudflare actor", () => {
       call: "overdue-1",
       deadlineAt
     }))
-    expect(await alarm()).toBeNull()
+    expect(await alarm("timeout")).toBeNull()
   })
 })

--- a/platform/cloudflare/test/fixture.worker.ts
+++ b/platform/cloudflare/test/fixture.worker.ts
@@ -66,6 +66,7 @@ const worker = cloudflareWorker(actor({
     }) })
   }]
 }), {
+  placement: "thread",
   layersFor: ({ env, lane }: CloudflareWorkerLayerContext<FixtureEnv>) =>
     Layer.succeed(LaneApplication, { prefix: env.APPLICATION_PREFIX, lane, calls: 0 })
 })


### PR DESCRIPTION
The Cloudflare adapter currently keys Durable Objects by actor definition name. Every root and child thread for one actor therefore shares a SQLite database, lane budget, alarm lifecycle, and isolate heap. On Celld, this prevents active threads from spreading across replicas and lets one thread affect unrelated sessions.

This PR implements the thread placement boundary requested in [#288](https://github.com/clavia-labs/tardigrade/issues/288).

- Add opt-in `placement: "thread"` and keep `placement: "actor"` as the default.
- Use `JSON.stringify([actorName, threadId])` as the collision-safe Durable Object name.
- Route actor delivery by the complete `ActorId`, so a child thread using the same actor definition is remote from its parent thread.
- Bind each thread object to one stored thread identity and reject cross-thread delivery or reads within that object.
- Keep provider catalogs, method metadata, and health checks independent of a user thread.
- Preserve the existing `createCloudflareHost(options)` API.

With thread placement, each thread gets an independent Durable Object process, SQLite database, lane driver, alarm lifecycle, workspace, and isolate heap. This gives Celld a separate placement unit for every root and child thread.

Actor-wide `GET /v1/threads` returns status `400` in thread mode because Durable Object namespaces cannot enumerate objects. This PR does not add the distributed tree index, explicit shared-world storage, or cross-object deadlock detection described in the broader issue. Those contracts can build on this placement primitive without changing object identity again.

<!-- pr-overview-images:start -->

## PR overview

<img alt="Thread-scoped Durable Object isolation" src="https://github.com/user-attachments/assets/7cd9fa5a-05df-4fc6-8849-582e0e7b6da2" />

<!-- pr-overview-images:end -->

## Verification

- `bun run gate` passed all 59 tasks on `63f0c97d38318b87783c526780ac1c6e3187b0dd`.
- `bun run --filter @clavia/tardigrade-cloudflare test:workers` passed 4 tests, including separate Durable Object identities and separate SQLite lanes for two concurrent threads.
- `bun run --filter @clavia/tardigrade-cloudflare typecheck` passed.
