### PR TITLE
fix(cloudflare): retain background actor reconciliation via ctx.waitUntil

### DIFF
--- a/platform/cloudflare/src/worker.ts
+++ b/platform/cloudflare/src/worker.ts
@@ -587,6 +587,10 @@ export class ActorHost extends DurableObject<Env> {
       }
     })()
     this.driving = driving
+    // Runtimes without facets (self-hosted workerd hosts such as celld) retire the request once its
+    // handler settles, which starves a detached drive; workerd runs it to completion, and registering
+    // the whole drive there holds the event open for its duration, so retain it only where needed.
+    if (this.ctx.facets === undefined) this.ctx.waitUntil(driving)
     void driving.finally(() => {
       if (this.driving === driving) this.driving = undefined
       if (!failed && host.work() > 0) this.kick(host)


### PR DESCRIPTION
[👾 omp · openrouter/z-ai/glm-5.3 · agency: directed · intent: fix celld background reconciliation starvation]

## Problem

On celld and other self-hosted workerd hosts that retire a Durable Object request once its handler settles, a detached background promise receives no further turns after the response returns. `ActorHost.kick()` starts `host.drive()` as a detached promise, so after `append()` or `deliver()` answers `202 Accepted`:

- the incoming event is durably staged, but reconciliation does not advance: method calls stay `pending`, prompts stall, and `this.driving` stays set because `driving.finally(...)` never runs, so later kicks return early;
- the only wake is the recovery alarm that `accept()` arms before answering (`DEFAULT_ALARM_DELAY_MILLIS`, 120 s by default), so on such runtimes every turn stalls up to the recovery delay.

Reproduced on celld v0.4.0 with the stock `tardie` cloudflare worker: an agent session records the prompt event and then stops; the session only advances when the recovery alarm fires. [denoland/celld#141](https://github.com/denoland/celld/issues/141) documents the same class for the Agents SDK fire-and-forget `runFiber`, where `ctx.waitUntil` is the sanctioned workaround.

Cloudflare's runtime is not affected: Durable Objects remain active while there is ongoing work or pending I/O, [`waitUntil` is documented as having no effect](https://developers.cloudflare.com/durable-objects/api/state/#waituntil) in Durable Objects, and this repo's workerd tests pass on `main` with the detached drive.

## Fix

Retain the drive on the event only where the runtime needs it:

```ts
this.driving = driving
if (this.ctx.facets === undefined) this.ctx.waitUntil(driving)
```

`ctx.facets` is the marker: workerd implements facets (`DurableObjectFacets` in `@cloudflare/workers-types`), while celld [does not define `ctx.facets`](https://github.com/denoland/celld/blob/main/docs/cloudflare-compat.md). On workerd the code path stays identical to `main`. On strict runtimes the drive registers with `ctx.waitUntil` and continues past the answer.

The registration must stay conditional. Registering the whole drive on workerd couples the Durable Object event to the drive chain: the alarm that terminates an overdue method call can no longer be delivered while the event stays open, and on the GitHub runner every test in `test/actor.workers.ts` grew from sub-second to 3–8 s and timed out at the 5 s limit (two red gate runs: [33224048409](https://github.com/clavia-labs/tardigrade/actions/runs/33224048409), [33225317207](https://github.com/clavia-labs/tardigrade/actions/runs/33225317207)). If maintainers prefer a first-class switch over the `facets` marker (for example an explicit host capability or a config flag), I am happy to rework.

## Tests

- `platform/cloudflare` workers suite (vitest-pool-workers, pinned workerd): typecheck and lint clean; 5 consecutive full-suite runs green locally, including cold-cache, fresh-install, and two-core-contention conditions, plus 10× isolated runs of each alarm-sensitive test.
- A `runInDurableObject` probe confirms the pinned workerd build exposes `ctx.facets` on `ActorHost`, so the registration is skipped there; celld's compatibility documentation states `ctx.facets` is not defined.
- Gate on this branch: [33225941986](https://github.com/clavia-labs/tardigrade/actions/runs/33225941986) — green.

Not yet verified end-to-end on celld; the registration path there follows the workaround shape documented in [denoland/celld#141](https://github.com/denoland/celld/issues/141).
