### PR TITLE
fix(ci): ignore web releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ name: publish
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "apps/web/**"
   workflow_dispatch:
     inputs:
       dry-run:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,8 @@
   "packages": {
     ".": {
       "component": "tardigrade",
-      "changelog-path": "packages/agent/CHANGELOG.md"
+      "changelog-path": "packages/agent/CHANGELOG.md",
+      "exclude-paths": ["apps/web"]
     }
   }
 }


### PR DESCRIPTION
## Summary

The publish workflow skips pushes that only change apps/web. Release Please also excludes apps/web commits from the tardigrade component.

## Reason

The web app is absent from the npm artifact. A web-only fix currently opens a package release PR and can publish another release candidate while a release PR is pending.

## Verification

- bun run gate --only=lint
- release-please config parsed as JSON
- publish workflow parsed as YAML
- git diff --check