### PR TITLE
refactor(agent): collapse model resolution

### DIFF
--- a/packages/agent/src/components/compaction.ts
+++ b/packages/agent/src/components/compaction.ts
@@ -83,21 +83,12 @@ const ratio = (value: number, name: string): number => {
   return value
 }
 
-// modelResolutionOf returns the latest model facts recorded by infer for the open thread.
-const modelResolutionOf = (log: ReadonlyArray<Event>): {
-  readonly model: ModelRef | undefined
-  readonly contextWindowTokens: number | undefined
-} => {
-  let model: ModelRef | undefined
-  let contextWindowTokens: number | undefined
-  for (const event of log) {
-    if (event.type !== "ModelResolved") continue
-    const selected = modelRefOf((event as { readonly model?: unknown }).model)
-    if (selected !== undefined) model = selected
-    const window = (event as { readonly contextWindowTokens?: unknown }).contextWindowTokens
-    if (typeof window === "number") contextWindowTokens = window
-  }
-  return { model, contextWindowTokens }
+// selectedModelOf returns the open turn's explicit selection or the latest model actually called.
+const selectedModelOf = (log: ReadonlyArray<Event>): ModelRef | undefined => {
+  const open = turnView(log)
+  if (open.length > 0) return modelRefOf((open[0] as { readonly model?: unknown }).model)
+  const called = [...log].reverse().find((event) => event.type === "ModelCalled") as { readonly model?: unknown } | undefined
+  return modelRefOf(called?.model)
 }
 
 // contextPolicyOf resolves the model-relative policy into the absolute thresholds used by the
@@ -139,15 +130,7 @@ export const contextPolicyOf = (
 const contextPolicyFrom = (
   log: ReadonlyArray<Event>,
   policy: Partial<CompactionPolicy>
-): ContextPolicy => {
-  const selection = modelResolutionOf(log)
-  return contextPolicyOf(
-    selection.contextWindowTokens === undefined
-      ? policy
-      : { ...policy, contextWindowTokens: selection.contextWindowTokens },
-    selection.model
-  )
-}
+): ContextPolicy => contextPolicyOf(policy, selectedModelOf(log))
 
 // resolvedContextPolicyOf fills a partial absolute policy at the render boundary. Components
 // normally contribute every field after resolving their model-relative policy.
@@ -351,7 +334,7 @@ const firedUncovered = (log: ReadonlyArray<Event>): boolean => {
 // The policy this takes must be the one the render takes, or the guard measures a request the
 // model never sees (ContextPolicy above).
 export const compactionReactor = (policy: Partial<CompactionPolicy> = {}): Reactor<Infer | Self> => (log) => {
-  const model = modelResolutionOf(log).model
+  const model = selectedModelOf(log)
   const resolved = contextPolicyFrom(log, policy)
   // The projection runs first, so the guard, the cut, and the brief all read the history the
   // model reads. A corrected exchange the render hides can neither trigger a paid pass nor leak

--- a/packages/agent/src/inference/reactor.ts
+++ b/packages/agent/src/inference/reactor.ts
@@ -1,7 +1,7 @@
 import { Cause, Clock, Context, Effect } from "effect"
 import { EventLog } from "@clavia/tardigrade-core/log"
 import { intent, effect, Self, type Reactor } from "@clavia/tardigrade-core/reconciliation"
-import { modelCalled, modelResolved, outputRejected, textReturned, turnFailed } from "../log/events"
+import { modelCalled, outputRejected, textReturned, turnFailed } from "../log/events"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import type { Action } from "../log/events"
 import { trajectoryOf, turnEpochOf, turnView } from "@clavia/tardigrade-code/execution/turns"
@@ -66,10 +66,8 @@ export interface InferRequest {
 
 export interface ModelResolution {
   readonly model: ModelRef
+  // models is the interpreter's current authority for validating this call. It is not recorded.
   readonly models?: ModelPolicy
-  readonly contextWindowTokens?: number
-  readonly maxOutputTokens?: number
-  readonly catalogRevision?: string
 }
 
 // selectedModelOf applies the visible model-selection order for one turn. Message and policy references carry both provider and model identity (runtime/composition.test.ts, "the actor owns model selection").
@@ -81,17 +79,31 @@ export const selectedModelOf = (
   return selected === undefined ? policy : modelRefOf(selected)
 }
 
-const resolvedModelOf = (events: ReadonlyArray<Event>): ModelRef | undefined => {
-  const resolved = events.find((event) => event.type === "ModelResolved") as { readonly model?: unknown } | undefined
-  return modelRefOf(resolved?.model)
-}
-
-const resolvedPolicyOf = (events: ReadonlyArray<Event>): ModelPolicy | undefined => {
-  const resolved = events.find((event) => event.type === "ModelResolved") as { readonly models?: unknown } | undefined
-  return resolved?.models === undefined ? undefined : modelPolicyOf(resolved.models)
-}
-
 class ModelSelectionError extends Error {}
+
+const resolvedModelFor = (
+  resolve: ((reference?: ModelRef) => ModelResolution) | undefined,
+  reference: ModelRef | undefined,
+  models: ModelPolicy,
+  policyError: string | undefined
+): ModelRef => {
+  if (policyError !== undefined) throw new ModelSelectionError(policyError)
+  if (reference !== undefined && !modelAllowedBy(models, reference)) {
+    throw new ModelSelectionError(`model ${reference.provider}/${reference.model_id} is excluded by the effective model policy`)
+  }
+  const resolved = resolve?.(reference)
+  if (resolved === undefined) {
+    if (reference === undefined) {
+      throw new ModelSelectionError("no model was selected; supply { provider, model_id } or configure a default")
+    }
+    return reference
+  }
+  const allowed = applyModelPolicy(resolved.models ?? DEFAULT_MODEL_POLICY, models)
+  if (!modelAllowedBy(allowed, resolved.model)) {
+    throw new ModelSelectionError(`model ${resolved.model.provider}/${resolved.model.model_id} is excluded by the effective model policy`)
+  }
+  return resolved.model
+}
 
 const epochStamp = (epoch: number): { readonly epoch?: number } =>
   epoch === 0 ? {} : { epoch }
@@ -274,7 +286,6 @@ const diedAttempts = (turn: ReadonlyArray<Event>, epoch: number): number => {
   for (let i = turn.length - 1; i >= 0; i--) {
     const event = turn[i]!
     if (event.type === "ModelCalled" && Number((event as { epoch?: unknown }).epoch ?? 0) === epoch) n += 1
-    else if (event.type === "ModelResolved") continue
     else break
   }
   return n
@@ -328,72 +339,20 @@ export const inferReactorFor = (policy: Partial<InferPolicy>, render: Render): R
   const head = slice[0] as Event & { id?: unknown }
   const turn = String(head.id)
   const epoch = turnEpochOf(log, turn)
-  const resolvedModel = resolvedModelOf(slice)
   const inheritedModels = modelPolicyOf((head as { readonly models?: unknown }).models)
-  const resolvedPolicy = resolvedPolicyOf(slice)
   let policyError: string | undefined
-  let models = resolvedPolicy ?? inheritedModels
-  if (resolvedPolicy === undefined) {
-    try {
-      models = applyModelPolicy(inheritedModels, policy.models ?? DEFAULT_INFER_POLICY.models)
-    } catch (error) {
-      policyError = error instanceof Error ? error.message : String(error)
-    }
-  }
-  const trajectory = trajectoryOf(log)
-  const model = resolvedModel ?? selectedModelOf(head, models.default)
-  if (resolvedModel === undefined) {
-    return [
-      effect({
-        key: `mr:${turn}`,
-        invocation: { method: "message", id: turn, epoch },
-        input: { turn, model, models, policyError },
-        act: (input) =>
-          Effect.gen(function* () {
-            const at = yield* Clock.currentTimeMillis
-            const binding = yield* Infer
-            return yield* Effect.try({
-              try: () => {
-                if (input.policyError !== undefined) throw new ModelSelectionError(input.policyError)
-                if (input.model !== undefined && !modelAllowedBy(input.models, input.model)) {
-                  throw new ModelSelectionError(`model ${input.model.provider}/${input.model.model_id} is excluded by the effective model policy`)
-                }
-                const resolved = binding.resolve?.(input.model)
-                if (resolved === undefined) {
-                  if (input.model === undefined) {
-                    throw new ModelSelectionError("no model was selected; supply { provider, model_id } or configure a default")
-                  }
-                  return { model: input.model, models: input.models }
-                }
-                const models = applyModelPolicy(resolved.models ?? DEFAULT_MODEL_POLICY, input.models)
-                if (!modelAllowedBy(models, resolved.model)) {
-                  throw new ModelSelectionError(`model ${resolved.model.provider}/${resolved.model.model_id} is excluded by the effective model policy`)
-                }
-                return { ...resolved, models }
-              },
-              catch: (error) => ({
-                message: error instanceof Error ? error.message : String(error),
-                cause: error instanceof ModelSelectionError ? "model_selection" as const : "inference_error" as const
-              })
-            }).pipe(Effect.match({
-              onSuccess: (resolved) => [modelResolved({ turn: input.turn, ...resolved, models: resolved.models, at })],
-              onFailure: (failure) => [
-                turnFailed({
-                  error: failure.message,
-                  cause: failure.cause,
-                  attempts: 0,
-                  attemptKey: `${input.turn}/model`,
-                  policy: { ...(input.model === undefined ? {} : { model: input.model }), models: input.models },
-                  turn: input.turn,
-                  at
-                })
-              ]
-            }))
-          })
-      })
-    ]
+  let models = inheritedModels
+  try {
+    models = applyModelPolicy(inheritedModels, policy.models ?? DEFAULT_INFER_POLICY.models)
+  } catch (error) {
+    policyError = error instanceof Error ? error.message : String(error)
   }
   const died = diedAttempts(slice, epoch)
+  const prior = died === 0
+    ? undefined
+    : [...slice].reverse().find((event) => event.type === "ModelCalled") as { readonly model?: unknown } | undefined
+  const trajectory = trajectoryOf(log)
+  const model = modelRefOf(prior?.model) ?? selectedModelOf(head, models.default)
   const marks = slice.filter((e) => e.type === "ModelCalled").length
   const modelFailures = log.filter(
     (event) =>
@@ -503,7 +462,9 @@ export const inferReactorFor = (policy: Partial<InferPolicy>, render: Render): R
         ordinal: marks,
         trajectory,
         model,
-        render: rendered,
+        models,
+        policyError,
+        log,
         // The declared policy, stamped on the ask: the contract's identity and the fallback the
         // assembly mounted. The mode the attempt actually ran in is the binding's to report, and
         // it lands on the consequence (events.ts, OutputPolicy; completionOf above).
@@ -522,27 +483,53 @@ export const inferReactorFor = (policy: Partial<InferPolicy>, render: Render): R
           const events = yield* EventLog
           const self = yield* Self
           const at = yield* Clock.currentTimeMillis
+          const binding = yield* Infer
+          const selection = yield* Effect.try({
+            try: () => resolvedModelFor(binding.resolve, input.model, input.models, input.policyError),
+            catch: (error) => ({
+              message: error instanceof Error ? error.message : String(error),
+              cause: error instanceof ModelSelectionError ? "model_selection" as const : "inference_error" as const
+            })
+          }).pipe(Effect.match({
+            onFailure: (failure) => ({ failure }),
+            onSuccess: (selected) => ({ selected })
+          }))
+          if ("failure" in selection) {
+            return [
+              turnFailed({
+                error: selection.failure.message,
+                cause: selection.failure.cause,
+                attempts: 0,
+                attemptKey: `${input.turn}/model`,
+                policy: input.model === undefined ? null : { model: input.model },
+                turn: input.turn,
+                ...epochStamp(input.epoch),
+                at
+              })
+            ]
+          }
+          const selected = selection.selected
           // The mark records the attempt BEFORE the inference, appended by the act itself: a
           // died attempt leaves its mark, the next derivation counts it, the bound holds.
           // callId is the provider idempotency key (shared across retries of one logical
           // attempt); ordinal is the occurrence the dedup key reads.
-          yield* events.append([
-            modelCalled({
-              callId: input.attempt,
-              ...(input.model === undefined ? {} : { model: input.model }),
-              ordinal: input.ordinal,
-              ...(input.stamp === undefined ? {} : { output: input.stamp }),
-              turn: input.turn,
-              ...epochStamp(input.epoch),
-              at
-            })
-          ])
-          const action = yield* (yield* Infer)
+          const mark = modelCalled({
+            callId: input.attempt,
+            model: selected,
+            ordinal: input.ordinal,
+            ...(input.stamp === undefined ? {} : { output: input.stamp }),
+            turn: input.turn,
+            ...epochStamp(input.epoch),
+            at
+          })
+          yield* events.append([mark])
+          const actualRender = render([...input.log, mark])
+          const action = yield* binding
             .react({
               trajectory: input.trajectory,
               identity: { ...self, turn: input.turn },
-              ...(input.model === undefined ? {} : { model: input.model }),
-              ...input.render
+              model: selected,
+              ...actualRender
             }, input.attempt, signal)
             .pipe(
               Effect.catchCause((cause) =>

--- a/packages/agent/src/log/events.ts
+++ b/packages/agent/src/log/events.ts
@@ -5,7 +5,6 @@ import type { KeyFragment } from "@clavia/tardigrade-core/log"
 import { CancellationRequested } from "@clavia/tardigrade-core/actor/method"
 import type { Usage } from "../inference/usage"
 import { ModelRef, type ModelRef as ModelRefType } from "../inference/reference"
-import { ModelPolicy, type ModelPolicy as ModelPolicyType } from "../inference/access"
 
 // The agent's domain events compose with core actor input and control events. The model responds
 // by acting: its recorded decision is the consequence event it emits, and the prose it emits
@@ -77,6 +76,7 @@ export const ToolReturned = Schema.Struct({
 export const ModelCalled = Schema.Struct({
   type: Schema.Literal("ModelCalled"),
   callId: Schema.String,
+  // model is the concrete selection for this provider effect. It remains optional for earlier logs.
   model: Schema.optional(ModelRef),
   // The occurrence: distinct per physical attempt, the dedup key's scope. callId stays the
   // provider idempotency key, shared across retries of one logical attempt.
@@ -86,18 +86,6 @@ export const ModelCalled = Schema.Struct({
   output: Schema.optional(OutputPolicy),
   epoch: Schema.optional(Schema.Finite),
   turn: Schema.optional(Schema.String),
-  at: Schema.Finite
-})
-
-// ModelResolved records the model reference and catalog limits used by one turn.
-export const ModelResolved = Schema.Struct({
-  type: Schema.Literal("ModelResolved"),
-  turn: Schema.String,
-  model: ModelRef,
-  models: Schema.optional(ModelPolicy),
-  contextWindowTokens: Schema.optional(Schema.Finite),
-  maxOutputTokens: Schema.optional(Schema.Finite),
-  catalogRevision: Schema.optional(Schema.String),
   at: Schema.Finite
 })
 
@@ -333,7 +321,6 @@ export const BudgetDenied = Schema.Struct({
 
 export const AgentEvent = Schema.Union([
   MessageReceived,
-  ModelResolved,
   ModelCalled,
   TextReturned,
   ToolCalled,
@@ -422,8 +409,6 @@ export const agentKeys: KeyFragment = {
         // repetition that evidences died attempts is preserved. A mark predating the ordinal
         // lands unkeyed, which the folds tolerate.
         return v.ordinal === undefined ? undefined : `mc:${String(v.turn)}/${String(v.ordinal)}`
-      case "ModelResolved":
-        return `mr:${String(v.turn)}`
       case "BudgetExhausted":
         // The wall's occurrence is the ceiling it fired at: a grant raises it, so a second
         // crossing keys anew.
@@ -476,17 +461,6 @@ export const modelCalled = (
     }
   } & EpochStamp
 ): Event => ({ type: "ModelCalled", ...fields }) as Event
-
-export const modelResolved = (fields: {
-  readonly turn: string
-  readonly model: ModelRefType
-  readonly models: ModelPolicyType
-  readonly contextWindowTokens?: number
-  readonly maxOutputTokens?: number
-  readonly catalogRevision?: string
-  readonly at: number
-}): Event =>
-  ({ type: "ModelResolved", ...fields }) as Event
 
 export const textReturned = (fields: { readonly text: string } & Stamp): Event =>
   ({ type: "TextReturned", ...fields }) as Event

--- a/packages/agent/src/packages/agents.test.ts
+++ b/packages/agent/src/packages/agents.test.ts
@@ -253,9 +253,9 @@ describe("agentsPackage", () => {
   test("a child receives the parent and package model intersection", async () => {
     const selected = { provider: "openai", model_id: "small" } as const
     const parent: Event = {
-      type: "ModelResolved",
-      turn: "parent",
-      model: selected,
+      type: "MessageReceived",
+      id: "parent",
+      text: "delegate",
       models: {
         allow: [{ provider: "openai", model_ids: ["large", "small"] }]
       },
@@ -285,9 +285,9 @@ describe("agentsPackage", () => {
   test("a package with no model override inherits the parent default", async () => {
     const selected = { provider: "openai", model_id: "small" } as const
     const parent: Event = {
-      type: "ModelResolved",
-      turn: "parent",
-      model: selected,
+      type: "MessageReceived",
+      id: "parent",
+      text: "delegate",
       models: {
         default: selected,
         allow: [{ provider: "openai", model_ids: ["large", "small"] }]

--- a/packages/agent/src/packages/agents.ts
+++ b/packages/agent/src/packages/agents.ts
@@ -6,7 +6,9 @@ import {
   type ActorInvocationContext
 } from "@clavia/tardigrade-core/actor"
 import { EventLog } from "@clavia/tardigrade-core/log"
+import type { Event } from "@clavia/tardigrade-core/log/event"
 import { definePackage, type Package } from "@clavia/tardigrade-code/package/definition"
+import { turnView } from "@clavia/tardigrade-code/execution/turns"
 import { budgetPolicyOf, type BudgetPolicy } from "../components/budget"
 import { Park } from "@clavia/tardigrade-code/execution/errors"
 import { boundaryId } from "@clavia/tardigrade-core/communication/message"
@@ -289,9 +291,9 @@ const childClaimOf = (
   }
 }
 
-const inheritedModelsOf = (events: ReadonlyArray<{ readonly type: string }>): ModelPolicy => {
-  const resolved = [...events].reverse().find((event) => event.type === "ModelResolved") as { readonly models?: unknown } | undefined
-  return resolved?.models === undefined ? DEFAULT_MODEL_POLICY : modelPolicyOf(resolved.models)
+const inheritedModelsOf = (events: ReadonlyArray<Event>): ModelPolicy => {
+  const head = turnView(events)[0] as { readonly models?: unknown } | undefined
+  return head?.models === undefined ? DEFAULT_MODEL_POLICY : modelPolicyOf(head.models)
 }
 
 export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self | EventLog> => {
@@ -303,9 +305,9 @@ export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self
   const outputs = options.outputs ?? {}
   const catalog = options.catalog
   const packageModels = modelPolicyOverrideOf(options.models)
-  const effectiveModelsOf = (events: ReadonlyArray<{ readonly type: string }>): ModelPolicy =>
+  const effectiveModelsOf = (events: ReadonlyArray<Event>): ModelPolicy =>
     applyModelPolicy(inheritedModelsOf(events), packageModels)
-  const effectiveModelsResultOf = (events: ReadonlyArray<{ readonly type: string }>):
+  const effectiveModelsResultOf = (events: ReadonlyArray<Event>):
     | { readonly models: ModelPolicy }
     | { readonly error: string } => {
     try {

--- a/packages/agent/src/runtime/composition.test.ts
+++ b/packages/agent/src/runtime/composition.test.ts
@@ -150,13 +150,42 @@ describe("infer component", () => {
       Layer.mergeAll(memoryLog(), mind, noRouter, KeyValueStore.layerMemory)
     )
     expect(seen.map((request) => request.model)).toEqual([selected])
-    expect(events.find((event) => event.type === "ModelResolved")).toMatchObject({
-      model: selected,
-      models: {
-        default: selected,
-        allow: [{ provider: "openai", model_ids: ["large", "small"] }]
+    const called = events.find((event) => event.type === "ModelCalled")
+    expect(called).toMatchObject({ model: selected })
+    expect(called).not.toHaveProperty("models")
+  })
+
+  test("a died attempt retries the model recorded by ModelCalled", async () => {
+    const recorded = { provider: "openai", model_id: "small" } as const
+    const current = { provider: "openai", model_id: "large" } as const
+    const seen: InferRequest[] = []
+    const mind = Layer.succeed(Infer, {
+      resolve: (model) => ({ model: model ?? current, models: { default: current, allow: "*" } }),
+      react: (request: InferRequest) => {
+        seen.push(request)
+        return Effect.succeed({ kind: "complete" as const, output: "done" })
       }
     })
+    const agent = assembled(infer([nativeOutput], { models: { default: current, allow: "*" } }))
+    const events = await run(
+      Effect.gen(function* () {
+        yield* settleActor(agent)
+        return yield* readLog
+      }),
+      Layer.mergeAll(
+        memoryLog([
+          { type: "MessageReceived", id: "m1", text: "retry", at: 1 },
+          { type: "ModelCalled", callId: "m1/infer/0", model: recorded, ordinal: 0, turn: "m1", at: 2 }
+        ]),
+        mind,
+        noRouter,
+        KeyValueStore.layerMemory
+      )
+    )
+    expect(seen.map((request) => request.model)).toEqual([recorded])
+    expect(events.filter((event) => event.type === "ModelCalled").map((event) =>
+      (event as { readonly model?: unknown }).model
+    )).toEqual([recorded, recorded])
   })
 
   test("a historical model string durably fails its turn", async () => {
@@ -243,10 +272,6 @@ describe("infer component", () => {
     expect(seen[1]?.trajectory.filter((event) => event.type === "MessageReceived").map((event) =>
       (event as { readonly id?: unknown }).id
     )).toEqual(["m1", "m2"])
-    expect(events.filter((event) => event.type === "ModelResolved")).toMatchObject([
-      { turn: "m1", model: { provider: "vercel", model_id: "anthropic/claude-sonnet-4-6" } },
-      { turn: "m2", model: { provider: "openai", model_id: "gpt-5.6" } }
-    ])
     expect(events.filter((event) => event.type === "ModelCalled")).toMatchObject([
       { turn: "m1", model: { provider: "vercel", model_id: "anthropic/claude-sonnet-4-6" } },
       { turn: "m2", model: { provider: "openai", model_id: "gpt-5.6" } }

--- a/packages/agent/src/runtime/turn.test.ts
+++ b/packages/agent/src/runtime/turn.test.ts
@@ -151,7 +151,6 @@ describe("the agent with execute as the only tool", () => {
     )
     expect(events.map((e) => e.type)).toEqual([
       "MessageReceived",
-      "ModelResolved",
       "ModelCalled",
       "ToolCalled",
       "CodeDispatched",
@@ -164,8 +163,8 @@ describe("the agent with execute as the only tool", () => {
       "ModelCalled",
       "TurnCompleted"
     ])
-    expect(events[5]).toMatchObject({ callId: "t1.0", name: "zohorecruit.insert_record" })
-    expect(events[9]).toMatchObject({ result: { jd_record_id: "jd-91", hits: 3 } })
+    expect(events[4]).toMatchObject({ callId: "t1.0", name: "zohorecruit.insert_record" })
+    expect(events[8]).toMatchObject({ result: { jd_record_id: "jd-91", hits: 3 } })
     expect(spies).toEqual({ insert: 1, search: 1 })
     expect(count.calls).toBe(2)
     expect(rootReactor(events)).toHaveLength(0)
@@ -372,7 +371,6 @@ describe("the agent with execute as the only tool", () => {
     )
     expect(events.map((e) => e.type)).toEqual([
       "MessageReceived",
-      "ModelResolved",
       "ModelCalled",
       "TurnCompleted"
     ])
@@ -934,7 +932,6 @@ describe("the mind on a native surface", () => {
     )
     expect(events.map((e) => e.type)).toEqual([
       "MessageReceived",
-      "ModelResolved",
       "ModelCalled",
       "ToolCalled",
       "ToolReturned",


### PR DESCRIPTION
## Summary

Model selection and authority resolution now remain interpreter-time work. Each provider attempt records its concrete selected model in `ModelCalled` before inference begins, and a died attempt reads that model when it retries.

The `ModelResolved` event and its expanded policy payload are removed. Compaction reads the open turn or latest call model, while catalog tools and child calls derive authority from the explicit `MessageReceived.models` attenuation.

This keeps event growth independent of the interpreter catalog size while preserving replay, retry, and child-authority behavior.

Closes #306.