### PR TITLE
feat(agent): select compaction model

### DIFF
--- a/packages/agent/src/components/compaction.test.ts
+++ b/packages/agent/src/components/compaction.test.ts
@@ -15,7 +15,8 @@ import {
   contextPolicyOf,
   estimateTokens,
   keepFromIndex,
-  suffixOf
+  suffixOf,
+  type CompactionPolicy
 } from "./compaction"
 
 // Compaction is a pure machine: a guard fires at a resolved tool round when the rendered suffix
@@ -101,12 +102,12 @@ describe("the compaction measure and guard", () => {
   })
 })
 
-const mailbox = actorFromReactors<Infer | EventLog | Self>([reactor], agentActorKeys)
-
 describe("the compaction pass", () => {
-  const run = async (initial: ReadonlyArray<Event>) => {
+  const run = async (initial: ReadonlyArray<Event>, policy: Partial<CompactionPolicy> = TEST_POLICY) => {
     const ref = Ref.makeUnsafe<ReadonlyArray<Event>>(initial)
     let briefed = ""
+    let model: unknown
+    const actor = actorFromReactors<Infer | EventLog | Self>([compactionReactor(policy)], agentActorKeys)
     const layers = Layer.mergeAll(
       Layer.succeed(
         EventLog,
@@ -116,17 +117,18 @@ describe("the compaction pass", () => {
         })
       ),
       Layer.succeed(Infer, {
-        react: ({ trajectory }: { trajectory: ReadonlyArray<Event> }) => {
+        react: ({ trajectory, model: selected }: { trajectory: ReadonlyArray<Event>; model?: unknown }) => {
           briefed = String((trajectory[0] as { text?: unknown }).text ?? "")
+          model = selected
           return Effect.succeed({ kind: "complete" as const, output: "covenants 1 through 13 extracted" })
         }
       }),
       Layer.succeed(Self, { actor: "test", instance: "main", thread: "compaction" })
     )
     await Effect.runPromise(
-      send(mailbox, { type: "CompactionFired", at: 999 }).pipe(Effect.provide(layers)) as Effect.Effect<void>
+      send(actor, { type: "CompactionFired", at: 999 }).pipe(Effect.provide(layers)) as Effect.Effect<void>
     )
-    return { log: await Effect.runPromise(Ref.get(ref)), briefed: () => briefed }
+    return { log: await Effect.runPromise(Ref.get(ref)), briefed: () => briefed, model: () => model }
   }
 
   test("a fire summarizes and checkpoints down to a KEEP-token tail, mid-turn", async () => {
@@ -144,6 +146,13 @@ describe("the compaction pass", () => {
     expect(estimateTokens(suffixOf(log))).toBeLessThanOrEqual(TEST_CONTEXT.keepTokens + 2 * roundTokens)
     expect(briefed()).toContain("extract the covenants")
     expect(briefed()).toContain("run 1")
+  })
+
+  test("a pass can select its model", async () => {
+    const selected = { provider: "test", model_id: "compact" } as const
+    const { log, model } = await run(openTurn(16), { ...TEST_POLICY, model: selected })
+    expect(model()).toEqual(selected)
+    expect(log.find((event) => event.type === "CompactionCompleted")).toMatchObject({ model: selected })
   })
 
   test("the cut lands on a boundary: a kept tail opens with a call, its return beside it", async () => {

--- a/packages/agent/src/components/compaction.ts
+++ b/packages/agent/src/components/compaction.ts
@@ -62,6 +62,7 @@ export interface CompactionPolicy {
   readonly fireRatio: number
   readonly keepRatio: number
   readonly summaryLineCap: number
+  readonly model?: ModelRef
 }
 
 export const DEFAULT_COMPACTION_POLICY: CompactionPolicy = {
@@ -334,7 +335,7 @@ const firedUncovered = (log: ReadonlyArray<Event>): boolean => {
 // The policy this takes must be the one the render takes, or the guard measures a request the
 // model never sees (ContextPolicy above).
 export const compactionReactor = (policy: Partial<CompactionPolicy> = {}): Reactor<Infer | Self> => (log) => {
-  const model = selectedModelOf(log)
+  const model = policy.model ?? selectedModelOf(log)
   const resolved = contextPolicyFrom(log, policy)
   // The projection runs first, so the guard, the cut, and the brief all read the history the
   // model reads. A corrected exchange the render hides can neither trigger a paid pass nor leak
@@ -352,6 +353,7 @@ export const compactionReactor = (policy: Partial<CompactionPolicy> = {}): React
         keepFrom: cut.keepFrom,
         summary: prior.summary,
         span,
+        ...(model === undefined ? {} : { model }),
         contextWindowTokens: resolved.contextWindowTokens,
         fireTokens: resolved.fireTokens,
         keepTokens: resolved.keepTokens
@@ -377,11 +379,15 @@ export const compactionReactor = (policy: Partial<CompactionPolicy> = {}): React
             lines.join("\n")
           ].join("\n\n")
           // A summarize attempt offers no tools: the only sane action is a completion.
-          const action = yield* (yield* Infer).react(
+          const infer = yield* Infer
+          const summaryModel = input.model === undefined
+            ? undefined
+            : infer.resolve?.(input.model).model ?? input.model
+          const action = yield* infer.react(
             {
               trajectory: [{ type: "MessageReceived", id: `compact-${input.keepFrom}`, text: brief, at }],
               identity: { ...self, turn: `compact-${input.keepFrom}` },
-              ...(model === undefined ? {} : { model }),
+              ...(summaryModel === undefined ? {} : { model: summaryModel }),
               system: "",
               tools: []
             },
@@ -394,6 +400,7 @@ export const compactionReactor = (policy: Partial<CompactionPolicy> = {}): React
             contextWindowTokens: input.contextWindowTokens,
             fireTokens: input.fireTokens,
             keepTokens: input.keepTokens,
+            ...(summaryModel === undefined ? {} : { model: summaryModel }),
             at
           })]
         })

--- a/packages/agent/src/log/events.ts
+++ b/packages/agent/src/log/events.ts
@@ -570,6 +570,7 @@ export const compactionCompleted = (
     readonly contextWindowTokens: number
     readonly fireTokens: number
     readonly keepTokens: number
+    readonly model?: ModelRefType
     readonly at: number
   }
 ): Event => ({ type: "CompactionCompleted", ...fields }) as Event


### PR DESCRIPTION
## Summary

`compaction({ model })` selects the model used to summarize history. The configured reference is captured in the durable effect input and resolved through the host before inference.

`CompactionCompleted` records the resolved model beside the applied context policy and summary. When the option is absent, compaction continues to use the current turn model.

The main turn model still determines the context window and compaction thresholds because those values describe the history being bounded.