### PR TITLE
fix(cli): default actor name

### DIFF
--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -22,7 +22,7 @@ import { modelCatalogConfigOf, type ModelConfig } from "@clavia/tardigrade-serve
 import { buildActor, buildSummary, DEFAULT_BUILD_DIRECTORY, lintActor, lintSummary, loadBuiltActor } from "./build"
 import { readFileConfig, readProjectConfig, resolveRemote, resolveServer } from "./config"
 import { availableDevPort, DEFAULT_MIN_PORT, DEV_URL_HOST, dev, openBrowser } from "./dev"
-import { DEFAULT_ACTOR_ENTRY, defaultInitDirectory, initActor, initSummary, terminalColorsEnabled } from "./init"
+import { DEFAULT_ACTOR_ENTRY, DEFAULT_INIT_ACTOR_NAME, defaultInitDirectory, initActor, initSummary, terminalColorsEnabled } from "./init"
 import { withLoader } from "./loader"
 import { resolveModelLock, writeModelLock } from "./model-lock"
 import {
@@ -467,6 +467,7 @@ export const initCommand = Command.make("init", {
     const name = declaredName ?? (canAsk()
       ? yield* Prompt.text({
         message: "Actor name",
+        default: DEFAULT_INIT_ACTOR_NAME,
         validate: (value) => {
           const candidate = value.trim()
           return ACTOR_NAME_PATTERN.test(candidate)

--- a/apps/cli/src/init.test.ts
+++ b/apps/cli/src/init.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { buildActor } from "./build"
 import { CELLD_PROJECT_CONFIG_PATH } from "./celld"
 import { CLOUDFLARE_MODEL_CATALOG_MIGRATION } from "@clavia/tardigrade-cloudflare/catalog-migration"
-import { DEFAULT_ACTOR_ENTRY, DEFAULT_CATALOG_MIGRATION, DEFAULT_MODEL_LOCK, DEFAULT_PACKAGE_MANIFEST, DEFAULT_WORKER_ENTRY, defaultInitDirectory, initActor, initSummary, terminalColorsEnabled } from "./init"
+import { DEFAULT_ACTOR_ENTRY, DEFAULT_CATALOG_MIGRATION, DEFAULT_INIT_ACTOR_NAME, DEFAULT_MODEL_LOCK, DEFAULT_PACKAGE_MANIFEST, DEFAULT_WORKER_ENTRY, defaultInitDirectory, initActor, initSummary, terminalColorsEnabled } from "./init"
 
 let root = ""
 afterEach(async () => {
@@ -18,6 +18,10 @@ const temporaryRoot = async (): Promise<string> => {
 }
 
 describe("initActor", () => {
+  test("uses a visible quickstart name", () => {
+    expect(DEFAULT_INIT_ACTOR_NAME).toBe("my-agent")
+  })
+
   test("creates a buildable named quickstart", async () => {
     const cwd = await temporaryRoot()
     const initialized = await initActor("reviewer", { cwd, now: new Date("2026-08-24T00:00:00Z"), packageVersion: "0.7.1-test" })

--- a/apps/cli/src/init.ts
+++ b/apps/cli/src/init.ts
@@ -12,6 +12,7 @@ import { callCommand, shellWord } from "./workflow"
 import { emptyModelLock, MODEL_LOCK_FILE, type ModelLock } from "./model-lock"
 
 export const DEFAULT_ACTOR_ENTRY = "actor.ts"
+export const DEFAULT_INIT_ACTOR_NAME = "my-agent"
 export const DEFAULT_WORKER_ENTRY = "worker.ts"
 export const DEFAULT_PACKAGE_MANIFEST = "package.json"
 export const DEFAULT_MODEL_LOCK = MODEL_LOCK_FILE


### PR DESCRIPTION
Adds `my-agent` as the visible default for the interactive `tdg init` actor-name prompt. Pressing Enter now creates the quickstart project without requiring a name to be typed. The exported `DEFAULT_INIT_ACTOR_NAME` keeps the CLI default visible to consumers and tests.

Tests: `bun test apps/cli/src/init.test.ts` and `bun run --cwd apps/cli typecheck`.