### PR TITLE
feat(cli): add actor templates

### DIFF
--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -393,6 +393,7 @@ describe("parsing", () => {
 
       expect(ran.failed).toBe(false)
       expect(actor).toContain("infer([")
+      expect(actor).toContain('name: "get_weather"')
       expect(config).toContain('"provider": "openrouter"')
       expect(config).toContain('"model_id": "anthropic/claude-sonnet-4-6"')
       expect(ran.recorded.installed).toEqual([directory])
@@ -417,6 +418,7 @@ describe("parsing", () => {
     expect(devHelp).toContain("--max-concurrent-threads")
     const initHelp = (await drive(["init", "--help"])).lines.join("\n")
     expect(initHelp).toContain("--dir")
+    expect(initHelp).toContain("--template")
     for (const flag of ["--provider", "--provider-config", "--default-model"]) {
       expect(initHelp).toContain(flag)
     }

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -25,6 +25,7 @@ import { availableDevPort, DEFAULT_MIN_PORT, DEV_URL_HOST, dev, openBrowser } fr
 import { DEFAULT_ACTOR_ENTRY, DEFAULT_INIT_ACTOR_NAME, defaultInitDirectory, initActor, initSummary, terminalColorsEnabled } from "./init"
 import { withLoader } from "./loader"
 import { resolveModelLock, writeModelLock } from "./model-lock"
+import { DEFAULT_INIT_TEMPLATE, INIT_TEMPLATES } from "./template"
 import {
   defaultModelFrom,
   defaultSetupJson,
@@ -456,6 +457,10 @@ export const initCommand = Command.make("init", {
     Flag.withDescription("The directory to create. Defaults to a directory named after the actor."),
     Flag.optional
   ),
+  template: Flag.choice("template", INIT_TEMPLATES).pipe(
+    Flag.withDescription(`The actor template. Defaults to ${DEFAULT_INIT_TEMPLATE}.`),
+    Flag.withDefault(DEFAULT_INIT_TEMPLATE)
+  ),
   provider: setupProvider,
   providerConfig: setupProviderConfig,
   defaultModel: setupDefaultModel,
@@ -498,6 +503,7 @@ export const initCommand = Command.make("init", {
       try: () => initActor(name, {
         cwd: cli.cwd,
         ...(directory === undefined ? {} : { directory }),
+        template: flags.template,
         modelProtocol: answers.protocol,
         modelLock
       }),

--- a/apps/cli/src/init.test.ts
+++ b/apps/cli/src/init.test.ts
@@ -105,6 +105,13 @@ describe("initActor", () => {
     expect(initialized.entry).toBe(join(cwd, "actors", "custom", DEFAULT_ACTOR_ENTRY))
   })
 
+  test("writes the stated actor template", async () => {
+    const cwd = await temporaryRoot()
+    const initialized = await initActor("reviewer", { cwd, template: "rlm" })
+
+    expect(await readFile(initialized.entry, "utf8")).toContain("codeMode([")
+  })
+
 })
 
 describe("initSummary", () => {

--- a/apps/cli/src/init.ts
+++ b/apps/cli/src/init.ts
@@ -5,7 +5,7 @@ import { CLOUDFLARE_MODEL_CATALOG_MIGRATION } from "@clavia/tardigrade-cloudflar
 import type { ModelProtocol } from "@clavia/tardigrade-model/directory"
 
 import { CELLD_PROJECT_CONFIG_PATH, celldConfigOf } from "./celld"
-import { actorTemplate } from "./template"
+import { actorTemplate, type InitTemplate } from "./template"
 import type { SetupAnswers, SetupFiles } from "./setup"
 import { versionIn } from "./version"
 import { callCommand, shellWord } from "./workflow"
@@ -26,6 +26,7 @@ export interface InitActorOptions {
   readonly packageVersion?: string
   readonly modelProtocol?: ModelProtocol
   readonly modelLock?: ModelLock
+  readonly template?: InitTemplate
 }
 
 export interface InitializedActor {
@@ -119,7 +120,10 @@ export const initActor = async (name: string, options: InitActorOptions): Promis
   const packageManifest = resolve(directory, DEFAULT_PACKAGE_MANIFEST)
   const modelLock = resolve(directory, DEFAULT_MODEL_LOCK)
   const catalogMigration = resolve(directory, DEFAULT_CATALOG_MIGRATION)
-  const source = await actorTemplate({ name })
+  const source = await actorTemplate({
+    name,
+    ...(options.template === undefined ? {} : { template: options.template })
+  })
   const manifestSource = manifestTemplate(name, options.now ?? new Date())
   const packageVersion = options.packageVersion ?? await versionIn(import.meta.url)
   if (packageVersion.endsWith("-unknown")) throw new Error("cannot determine the installed Tardigrade version")

--- a/apps/cli/src/template.test.ts
+++ b/apps/cli/src/template.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { buildActor } from "./build"
-import { actorTemplate, renderActorTemplate } from "./template"
+import { actorTemplate, DEFAULT_INIT_TEMPLATE, INIT_TEMPLATES, renderActorTemplate } from "./template"
 
 let root = ""
 
@@ -20,13 +20,23 @@ const build = async (source: string) => {
 }
 
 describe("actorTemplate", () => {
-  test("builds a named actor with the useful local reach", async () => {
+  test("builds the quickstart template by default", async () => {
     const source = await actorTemplate({ name: "reviewer" })
     const built = await build(source)
 
     expect(built.manifest.name).toBe("reviewer")
+    expect(DEFAULT_INIT_TEMPLATE).toBe("quickstart")
+    expect(INIT_TEMPLATES).toEqual(["quickstart", "rlm"])
     expect(source).toContain('const actorName = "reviewer"')
     expect(source).toContain("infer([")
+    expect(source).toContain('name: "get_weather"')
+  })
+
+  test("builds the RLM template", async () => {
+    const source = await actorTemplate({ name: "reviewer", template: "rlm" })
+    const built = await build(source)
+
+    expect(built.manifest.name).toBe("reviewer")
     expect(source).toContain("You are ${actorName}, a focused research agent.")
     expect(source).toContain("filesPackage()")
     expect(source).toContain("fetchPackage()")
@@ -55,7 +65,7 @@ describe("actorTemplate", () => {
 
   test("refuses a template without its editable fields", () => {
     expect(() => renderActorTemplate("export default {}", { name: "reviewer" })).toThrow(
-      "quickstart template must contain one actorName declaration"
+      "actor template must contain one actorName declaration"
     )
   })
 })

--- a/apps/cli/src/template.test.ts
+++ b/apps/cli/src/template.test.ts
@@ -38,7 +38,6 @@ describe("actorTemplate", () => {
 
     expect(built.manifest.name).toBe("reviewer")
     expect(source).toContain("You are ${actorName}, a focused research agent.")
-    expect(source).toContain("filesPackage()")
     expect(source).toContain("fetchPackage()")
     expect(source).toContain("agentsPackage()")
     expect(source).toContain("workspacePackage()")

--- a/apps/cli/src/template.ts
+++ b/apps/cli/src/template.ts
@@ -6,11 +6,17 @@ import { fileURLToPath } from "node:url"
 export interface ActorTemplateOptions {
   readonly name: string
   readonly instructions?: string
+  readonly template?: InitTemplate
 }
 
-export const INSTALLED_ACTOR_TEMPLATE = "../../examples/quickstart/actor.ts"
-export const REPO_ACTOR_TEMPLATE = "../../../examples/quickstart/actor.ts"
-export const ACTOR_TEMPLATE_CANDIDATES: ReadonlyArray<string> = [INSTALLED_ACTOR_TEMPLATE, REPO_ACTOR_TEMPLATE]
+export const INIT_TEMPLATES = ["quickstart", "rlm"] as const
+export type InitTemplate = typeof INIT_TEMPLATES[number]
+export const DEFAULT_INIT_TEMPLATE: InitTemplate = "quickstart"
+
+export const actorTemplateCandidates = (template: InitTemplate): ReadonlyArray<string> => [
+  `../../examples/${template}/actor.ts`,
+  `../../../examples/${template}/actor.ts`
+]
 
 const templateLiteralOf = (value: string): string =>
   value
@@ -20,7 +26,7 @@ const templateLiteralOf = (value: string): string =>
 
 const replaceExactlyOnce = (source: string, pattern: RegExp, replacement: string, field: string): string => {
   const matches = source.match(pattern)
-  if (matches === null || matches.length !== 1) throw new Error(`quickstart template must contain one ${field}`)
+  if (matches === null || matches.length !== 1) throw new Error(`actor template must contain one ${field}`)
   return source.replace(pattern, replacement)
 }
 
@@ -56,7 +62,7 @@ export const loadActorTemplate = async (candidates: ReadonlyArray<string>): Prom
 
 export const actorTemplate = async (
   options: ActorTemplateOptions,
-  candidates: ReadonlyArray<string> = ACTOR_TEMPLATE_CANDIDATES.map((candidate) =>
+  candidates: ReadonlyArray<string> = actorTemplateCandidates(options.template ?? DEFAULT_INIT_TEMPLATE).map((candidate) =>
     fileURLToPath(new URL(candidate, import.meta.url))
   )
 ): Promise<string> => renderActorTemplate(await loadActorTemplate(candidates), options)

--- a/examples/quickstart/actor.ts
+++ b/examples/quickstart/actor.ts
@@ -1,43 +1,51 @@
-import {
-  actor, agentMethods, agentsPackage, budget, budgetAuthority, caller, codeMode,
-  compaction, fetchPackage, filesPackage, infer,
-  outputValidateOnce, system, workspacePackage
-} from "tardie"
+import type { AgentComponent, AgentTool } from "tardie"
+import { actor, agentMessageMethod, infer, nativeOutput, system } from "tardie"
 
-// actorName is the stable name used by build, development, and deployment.
-const actorName = "researcher"
+const actorName = "weather-agent"
 
-// actorInstructions is the main place to describe the job and its expected answer.
 const actorInstructions = `
-You are ${actorName}, a focused research agent.
-
-Investigate the user's request carefully.
-Use project files as evidence.
-Delegate independent research when it helps.
-Return a concise answer with concrete findings.
+Answer questions about the weather.
+Use the weather tool for current conditions.
 `.trim()
+
+const serveWeather: AgentTool["serve"] = (call, _log, answer) => {
+  const city = typeof call.arguments === "object" && call.arguments !== null && "city" in call.arguments
+    ? String(call.arguments.city)
+    : "unknown"
+  return [answer({ city, temperature: 21, unit: "celsius" })]
+}
+
+const weather: AgentComponent = {
+  name: "weather",
+  derive: () => ({
+    view: {
+      system: [],
+      tools: [{
+        spec: {
+          name: "get_weather",
+          description: "Get the current weather for a city",
+          inputSchema: {
+            type: "object",
+            properties: { city: { type: "string" } },
+            required: ["city"],
+            additionalProperties: false
+          }
+        },
+        serve: serveWeather
+      }],
+      context: [],
+      output: []
+    },
+    transitions: []
+  })
+}
 
 export default actor({
   name: actorName,
-  // methods declares the typed calls this actor accepts.
-  methods: agentMethods,
-  // components carry implementation and output requirements into the host type.
-  components: [
-    infer([
-      system(actorInstructions),
-      // budget scopes the tool-call limit to the codeMode subtree.
-      budget([
-        // codeMode gives the model one code tool over the package components listed here.
-        codeMode([
-          // codeMode package components grant access to files, HTTP, child agents, and saved results.
-          filesPackage(), fetchPackage(), agentsPackage(), workspacePackage()
-        ])
-      ], { authority: caller() }),
-      // compaction summarizes older context when a long turn outgrows its context window.
-      compaction(),
-      // outputValidateOnce validates one structured result when the endpoint supplies no native guarantee.
-      outputValidateOnce
-    ]),
-    budgetAuthority()
-  ]
+  methods: { message: agentMessageMethod },
+  components: [infer([
+    system(actorInstructions),
+    weather,
+    nativeOutput
+  ])]
 })

--- a/examples/rlm/actor.ts
+++ b/examples/rlm/actor.ts
@@ -10,7 +10,7 @@ const actorInstructions = `
 You are ${actorName}, a focused research agent.
 
 Investigate the user's request carefully.
-Use project files as evidence.
+Use fetched sources and delegated reports as evidence.
 Delegate independent research when it helps.
 Return a concise answer with concrete findings.
 `.trim()

--- a/examples/rlm/actor.ts
+++ b/examples/rlm/actor.ts
@@ -1,0 +1,34 @@
+import {
+  actor, agentMethods, agentsPackage, budget, budgetAuthority, caller, codeMode,
+  compaction, fetchPackage, filesPackage, infer,
+  outputValidateOnce, system, workspacePackage
+} from "tardie"
+
+const actorName = "researcher"
+
+const actorInstructions = `
+You are ${actorName}, a focused research agent.
+
+Investigate the user's request carefully.
+Use project files as evidence.
+Delegate independent research when it helps.
+Return a concise answer with concrete findings.
+`.trim()
+
+export default actor({
+  name: actorName,
+  methods: agentMethods,
+  components: [
+    infer([
+      system(actorInstructions),
+      budget([
+        codeMode([
+          filesPackage(), fetchPackage(), agentsPackage(), workspacePackage()
+        ])
+      ], { authority: caller() }),
+      compaction(),
+      outputValidateOnce
+    ]),
+    budgetAuthority()
+  ]
+})

--- a/examples/rlm/actor.ts
+++ b/examples/rlm/actor.ts
@@ -1,6 +1,6 @@
 import {
   actor, agentMethods, agentsPackage, budget, budgetAuthority, caller, codeMode,
-  compaction, fetchPackage, filesPackage, infer,
+  compaction, fetchPackage, infer,
   outputValidateOnce, system, workspacePackage
 } from "tardie"
 
@@ -23,7 +23,7 @@ export default actor({
       system(actorInstructions),
       budget([
         codeMode([
-          filesPackage(), fetchPackage(), agentsPackage(), workspacePackage()
+          fetchPackage(), agentsPackage(), workspacePackage()
         ])
       ], { authority: caller() }),
       compaction(),

--- a/knip.json
+++ b/knip.json
@@ -12,7 +12,7 @@
       "entry": [
         "tools/*.ts",
         "examples/*.ts",
-        "examples/quickstart/*.ts"
+        "examples/*/*.ts"
       ],
       "project": [
         "tools/**/*.ts",

--- a/tools/publish.ts
+++ b/tools/publish.ts
@@ -2,6 +2,7 @@ import { cp, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "n
 import { tmpdir } from "node:os"
 import { isAbsolute, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
+import { INIT_TEMPLATES } from "../apps/cli/src/template"
 
 type PkgJson = {
   readonly name: string
@@ -55,8 +56,6 @@ const STAGED_ASSETS = "ui"
 const STAGED_EXAMPLES = "examples"
 
 const VOYAGER_SOURCE = "apps/voyager/dist"
-const QUICKSTART_SOURCE = "examples/quickstart"
-
 const VOYAGER_BUILD = ["bun", "run", "--cwd", "apps/voyager", "build"]
 
 const npmMin = { maj: 11, min: 5, patch: 1 } as const
@@ -199,7 +198,9 @@ try {
     cp(join(root, "LICENSE"), join(stage, "LICENSE")),
     cp(join(root, "README.md"), join(stage, "README.md")),
     cp(join(root, VOYAGER_SOURCE), join(stage, STAGED_ASSETS), { recursive: true }),
-    cp(join(root, QUICKSTART_SOURCE), join(stage, STAGED_EXAMPLES, "quickstart"), { recursive: true }),
+    ...INIT_TEMPLATES.map((template) =>
+      cp(join(root, "examples", template), join(stage, STAGED_EXAMPLES, template), { recursive: true })
+    ),
     ...packages.map(async (source) => {
       await cp(join(root, source.dir, "src"), join(stage, "src", source.namespace), {
         recursive: true,


### PR DESCRIPTION
Adds `quickstart` and `rlm` actor templates to `tdg init --template`. `quickstart` is the default and creates the weather agent used by the guide. `rlm` preserves the code-mode researcher.

Both editable actor sources live under `examples/<template>/actor.ts`. The release packager stages the registered templates so the installed CLI reads the same sources as the repository.

Tests: `bun run gate`.