### PR TITLE
fix(cli): explain missing project

### DIFF
--- a/apps/cli/src/commands.test.ts
+++ b/apps/cli/src/commands.test.ts
@@ -811,6 +811,20 @@ describe("failures", () => {
 })
 
 describe("dev asks only where someone can answer", () => {
+  test("an empty directory points to initialization", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "tdg-dev-empty-"))
+    try {
+      const ran = await drive(["dev", "--no-open"], { cwd })
+
+      expect(ran.failed).toBe(true)
+      expect(failureText(ran)).toContain("no Tardigrade project found")
+      expect(failureText(ran)).toContain("tdg init")
+      expect(failureText(ran)).toContain("tdg dev")
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  })
+
   // A boot inside CI, a container, or a script has nobody to answer a prompt, so it takes the
   // notice and serves anyway. The terminal check is what separates the two (commands.ts, canAsk).
   test("says what is missing when stdin is not a terminal", () => {

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -606,6 +606,11 @@ export const devCommand = Command.make("dev", {
 }, (flags) =>
   Effect.gen(function*() {
     const cli = yield* Cli
+    if (!existsSync(resolve(cli.cwd, DEFAULT_ACTOR_ENTRY))) {
+      return yield* userErrorOf(
+        `no Tardigrade project found in ${cli.cwd}. Run \`tdg init\`, enter the created project directory, then run \`tdg dev\` again.`
+      )
+    }
     const localSecrets = yield* readSetupEnv(cli.cwd)
     const runtimeEnv = runtimeEnvironmentOf(cli.env, localSecrets)
     const project = yield* Effect.mapError(readProjectConfig(cli.cwd, runtimeEnv), userErrorOf)

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -608,7 +608,7 @@ export const devCommand = Command.make("dev", {
     const cli = yield* Cli
     if (!existsSync(resolve(cli.cwd, DEFAULT_ACTOR_ENTRY))) {
       return yield* userErrorOf(
-        `no Tardigrade project found in ${cli.cwd}. Run \`tdg init\`, enter the created project directory, then run \`tdg dev\` again.`
+        `no Tardigrade project found in ${cli.cwd}. Run \`tdg init\`, navigate to the created project directory, then run \`tdg dev\` again.`
       )
     }
     const localSecrets = yield* readSetupEnv(cli.cwd)


### PR DESCRIPTION
Checks for `actor.ts` before `tdg dev` reads configuration, prompts for model setup, or starts a build. An empty directory now points the user to `tdg init`, the created project directory, and the next `tdg dev` command.

Tests: `bun test apps/cli/src/commands.test.ts` and `bun run --cwd apps/cli typecheck`.