### PR TITLE
ci(web): deploy with Vercel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,28 @@ jobs:
       # silently resolving something different from what everyone else installed.
       - run: bun install --frozen-lockfile
       - run: bun run gate
+
+  deploy-web:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: production
+      url: https://tardigrade.sh
+    env:
+      VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: canary
+      - run: bun install --frozen-lockfile
+      - run: bun install --global vercel@latest
+      - run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: apps/web
+      - run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: apps/web
+      - run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: apps/web


### PR DESCRIPTION
Deploys the web app to Vercel after the main CI gate succeeds. The job pulls production settings, builds within `apps/web`, and uploads the prebuilt output. The GitHub production environment links to `https://tardigrade.sh`; `tardie.ai` remains attached to the Vercel project.

`VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` are configured as repository variables. Deployment also requires the `VERCEL_TOKEN` repository secret.

Verified with a local Vercel production pull and build.