### PR TITLE
fix(ci): target Vercel preset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
               > .vercel/project.json
         working-directory: apps/web
       - run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          NITRO_PRESET: vercel
         working-directory: apps/web
       - run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
         working-directory: apps/web


### PR DESCRIPTION
Sets the Nitro build preset explicitly for the Vercel production job. Without Vercel system environment variables, Nitro selects `node-server`, writes `.output`, and makes Vercel look for a missing `dist` directory.

Verified with an empty local Vercel cache, API-generated project settings, and a complete production build into `.vercel/output`.