### PR TITLE
test(agent): stabilize refinement property

### DIFF
--- a/packages/agent/src/runtime/refinement.properties.test.ts
+++ b/packages/agent/src/runtime/refinement.properties.test.ts
@@ -296,5 +296,5 @@ describe("agent projection refinement", () => {
       const incremental = infer(components, INFER_OPTIONS) as Component<AgentView, unknown>
       assertAgentRefinement(completeAgent(components, INFER_OPTIONS), incremental, log)
     }), { numRuns: 100 })
-  })
+  }, { timeout: 15_000 })
 })


### PR DESCRIPTION
The composed agent refinement property checks 100 generated histories. It can exceed Bun's default five-second timeout on busy CI runners even when the property holds.

Give only this test a 15-second timeout. This preserves all 100 generated runs and keeps the default timeout for the rest of the suite.