### PR TITLE
docs(web): refine public introduction

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -59,12 +59,6 @@ const GuideIcon = (): ReactElement => (
   </svg>
 )
 
-const ConsoleIcon = (): ReactElement => (
-  <svg viewBox="0 0 24 24" aria-hidden="true">
-    <path fill="none" stroke="currentColor" strokeLinecap="square" strokeWidth="1.6" d="M3.5 5.5h17v13h-17zM7 10l2 2-2 2m5 0h4" />
-  </svg>
-)
-
 const MoonIcon = (): ReactElement => (
   <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 15.2A8.5 8.5 0 0 1 8.8 4 8.5 8.5 0 1 0 20 15.2Z" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.7" /></svg>
 )
@@ -530,7 +524,6 @@ const SiteFooter = (): ReactElement => {
         <Link className="footer-brand" to="/" aria-label="Tardigrade home"><Mark /><span>Tardigrade</span></Link>
         <nav className="footer-links" aria-label="Footer navigation">
           <Link to="/docs/$" params={{ _splat: "quickstart" }}><GuideIcon />Quickstart</Link>
-          <Link to="/console"><ConsoleIcon />Console</Link>
           <a href={REPOSITORY} rel="noreferrer" target="_blank"><Github />GitHub</a>
           <a href="https://discord.gg/Z74jwRxz4k" rel="noreferrer" target="_blank"><Discord />Discord</a>
           <ThemeToggle />
@@ -545,7 +538,6 @@ export const SiteShell = ({ children, pathname }: { readonly children: ReactNode
   const headerRef = useRef<HTMLElement>(null)
   const menuButtonRef = useRef<HTMLButtonElement>(null)
   const docs = pathname.startsWith("/docs")
-  const consolePage = pathname === "/console"
 
   useEffect(() => {
     if (!mobileMenuOpen) return
@@ -580,7 +572,6 @@ export const SiteShell = ({ children, pathname }: { readonly children: ReactNode
           <Link className="guide-link" to="/docs" aria-current={docs ? "page" : undefined}>Docs</Link>
         </div>
         <div className="nav-actions">
-          <Link className="console-link" to="/console" aria-current={consolePage ? "page" : undefined}>Console</Link>
           <a className="github-link" href={REPOSITORY} aria-label="Tardigrade on GitHub" rel="noreferrer" target="_blank"><Github /></a>
           <button className="mobile-menu-trigger" type="button" aria-controls="mobile-navigation" aria-expanded={mobileMenuOpen} ref={menuButtonRef} onClick={() => setMobileMenuOpen((open) => !open)}>
             <MenuIcon />
@@ -591,7 +582,6 @@ export const SiteShell = ({ children, pathname }: { readonly children: ReactNode
       <div className="mobile-nav-panel" data-open={mobileMenuOpen} id="mobile-navigation" aria-hidden={!mobileMenuOpen} inert={!mobileMenuOpen ? true : undefined}>
         <nav className="mobile-nav-panel-inner" aria-label="Mobile navigation">
           <div className="mobile-nav-primary">
-            <Link className="mobile-nav-console" to="/console" aria-current={consolePage ? "page" : undefined}><ConsoleIcon />Console</Link>
             <div className="mobile-nav-sections">
               <Link to="/docs" aria-current={docs ? "page" : undefined}>Docs</Link>
             </div>

--- a/docs/site/Why.mdx
+++ b/docs/site/Why.mdx
@@ -49,13 +49,15 @@ const runAgent = async (
 }
 ```
 
-It doesn't seem like a problem initially, but as you add more stateful conditions (permissions, budgets, budgets and permissions for subagents), it starts to add up. It is not obvious which part of your code led to a specific agent behavior, nor how they interact with each other.
+It doesn't seem like a problem initially, but as you add more stateful conditions (permissions, budgets, *budgets and permissions for subagents*), it starts to add up.
+
+It is not obvious which part of your code led to a specific agent behavior, nor how they interact with each other.
 
 ### A composable way to author behavior
 
-Tardigrade grew out of the realization that an agent harness isn't very different from a traditional user interface. Just like how traditional user interfaces help humans interact with the digital world, agent harnesses help agents interact with the physical world. Once you frame it this way, it become a rendering problem and the frontend community had already solved for this!&#x20;
+Tardigrade grew out of the realization that an agent harness is similar to a user interface. User interfaces help humans interact with the digital world. Agent harnesses help agents interact with the real world. Framed this way, authoring a harness becomes a rendering problem, and frontend developers already know how to solve it.
 
-React defined the user interface as a component tree, and each component was a function of state. Similarly, Tardigrade defines an agent harness as a composition of components, and each component is a state machine, with state as projections from an immutable event log.
+React defined the user interface as a component tree, and each component as a function of state. Similarly, Tardigrade defines an agent harness as a composition of components, and each component is a state machine, with state as projections from an immutable event log.
 
 <InterfaceComparisonDiagram />
 
@@ -65,7 +67,7 @@ If you asked me to compress Tardigrade's single most important insight, it is th
 
 <Math expression="\text{behavior} = f(\text{immutable event log})" />
 
-If you can describe the behavior you want to see in simple english, you should be able to define it as a function of the event log. An agent harness could then be viewed as a composition of such behaviors.
+If you can describe the behavior you want to see in simple English, you should be able to define it as a function of the event log. An agent harness could then be viewed as a composition of such behaviors.
 
 <div className="harness-diagram-frame">
   <HarnessDiagram />
@@ -73,9 +75,11 @@ If you can describe the behavior you want to see in simple english, you should b
 
 ### Example: Compaction
 
-For example, let's take compaction. In simple english, you could describe compaction as follows:
+For example, let's take compaction. In simple English, you could describe compaction as follows:
 
-> When the token count of the conversation sent to inference reaches a certain threshold, use a language model to summarize part of the conversation. Append the summary to the event log as `CompactionCompleted`. For each subsequent model call, attach the summary and a tail of the conversation.
+> **When** the token count of the conversation sent to a model reaches a certain threshold, use a model to summarize part of the conversation.
+>
+> **Then**, append the summary to the event log in a `CompactionCompleted` event. For subsequent model calls, send the summary and the retained part of the conversation.
 
 As a state machine written over the event log, it looks like this:
 
@@ -133,4 +137,4 @@ Tardigrade composes behavior by reconciling the transitions enabled by each comp
 ComponentDefinition<State, View, Requirements>
 ```
 
-We can extend this approach to build subagents, codemode, recursive language models and so on. Your imagination is the limit here! Continue to the [Quickstart](/docs/quickstart) to start building.
+We can compose this approach into complex behaviors such as subagents, codemode, and recursive language models. Continue to the [Quickstart](/docs/quickstart) to start building.


### PR DESCRIPTION
Clarify why agent behavior becomes difficult to trace as stateful policies accumulate. Connect agent harnesses to the component model more directly, and describe compaction as a simple when-and-then behavior over the event log.

Hide the unfinished Console from public navigation while keeping its route available for direct development access.