### PR TITLE
fix(web): prefer html for crawlers

### DIFF
--- a/apps/web/src/docs/accept.test.ts
+++ b/apps/web/src/docs/accept.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+
+import { wantsMarkdown } from "./accept"
+
+describe("docs content negotiation", () => {
+  test("ambiguous clients receive HTML", () => {
+    expect(wantsMarkdown(null)).toBe(false)
+    expect(wantsMarkdown("*/*")).toBe(false)
+    expect(wantsMarkdown("text/html,application/xhtml+xml,*/*;q=0.8")).toBe(false)
+  })
+
+  test("explicit Markdown preferences receive Markdown", () => {
+    expect(wantsMarkdown("text/markdown")).toBe(true)
+    expect(wantsMarkdown("text/markdown,text/html;q=0.5")).toBe(true)
+  })
+
+  test("unsupported media types are refused", () => {
+    expect(wantsMarkdown("application/json")).toBeUndefined()
+  })
+})

--- a/apps/web/src/docs/accept.ts
+++ b/apps/web/src/docs/accept.ts
@@ -1,0 +1,30 @@
+type MediaRange = {
+  readonly index: number
+  readonly quality: number
+  readonly subtype: string
+  readonly type: string
+}
+
+const mediaRanges = (header: string | null): ReadonlyArray<MediaRange> => (header ?? "*/*").split(",").flatMap((entry, index) => {
+  const [media = "", ...parameters] = entry.trim().toLowerCase().split(";")
+  const [type, subtype, extra] = media.split("/")
+  if (type === undefined || type.length === 0 || subtype === undefined || subtype.length === 0 || extra !== undefined) return []
+  const qualityParameter = parameters.map((parameter) => parameter.trim()).find((parameter) => parameter.startsWith("q="))
+  const quality = qualityParameter === undefined ? 1 : Number(qualityParameter.slice(2))
+  return [{ index, quality: Number.isFinite(quality) && quality >= 0 && quality <= 1 ? quality : 0, subtype, type }]
+})
+
+const qualityFor = (ranges: ReadonlyArray<MediaRange>, type: string, subtype: string): number => {
+  const matches = ranges.filter((range) => (range.type === "*" || range.type === type) && (range.subtype === "*" || range.subtype === subtype))
+  if (matches.length === 0) return 0
+  const specificity = (range: MediaRange): number => Number(range.type !== "*") + Number(range.subtype !== "*")
+  return [...matches].sort((left, right) => specificity(right) - specificity(left) || left.index - right.index)[0]?.quality ?? 0
+}
+
+export const wantsMarkdown = (header: string | null): boolean | undefined => {
+  const ranges = mediaRanges(header)
+  const markdown = qualityFor(ranges, "text", "markdown")
+  const html = qualityFor(ranges, "text", "html")
+  if (markdown === 0 && html === 0) return undefined
+  return markdown > html
+}

--- a/apps/web/src/docs/response.server.ts
+++ b/apps/web/src/docs/response.server.ts
@@ -1,3 +1,4 @@
+import { wantsMarkdown } from "./accept"
 import { DEFAULT_DOC_CACHE_CONTROL } from "./cache"
 import { docAt } from "./load"
 import { docSource } from "./source.server"
@@ -6,41 +7,10 @@ type DocsResponseOptions = {
   readonly cacheControl?: string
 }
 
-type MediaRange = {
-  readonly index: number
-  readonly quality: number
-  readonly subtype: string
-  readonly type: string
-}
-
 const markdownPath = (pathname: string): string | undefined => {
   if (pathname.endsWith(".mdx")) return pathname.slice(0, -4)
   if (pathname.endsWith(".md")) return pathname.slice(0, -3)
   return undefined
-}
-
-const mediaRanges = (header: string | null): ReadonlyArray<MediaRange> => (header ?? "*/*").split(",").flatMap((entry, index) => {
-  const [media = "", ...parameters] = entry.trim().toLowerCase().split(";")
-  const [type, subtype, extra] = media.split("/")
-  if (type === undefined || type.length === 0 || subtype === undefined || subtype.length === 0 || extra !== undefined) return []
-  const qualityParameter = parameters.map((parameter) => parameter.trim()).find((parameter) => parameter.startsWith("q="))
-  const quality = qualityParameter === undefined ? 1 : Number(qualityParameter.slice(2))
-  return [{ index, quality: Number.isFinite(quality) && quality >= 0 && quality <= 1 ? quality : 0, subtype, type }]
-})
-
-const qualityFor = (ranges: ReadonlyArray<MediaRange>, type: string, subtype: string): number => {
-  const matches = ranges.filter((range) => (range.type === "*" || range.type === type) && (range.subtype === "*" || range.subtype === subtype))
-  if (matches.length === 0) return 0
-  const specificity = (range: MediaRange): number => Number(range.type !== "*") + Number(range.subtype !== "*")
-  return [...matches].sort((left, right) => specificity(right) - specificity(left) || left.index - right.index)[0]?.quality ?? 0
-}
-
-const wantsMarkdown = (request: Request): boolean | undefined => {
-  const ranges = mediaRanges(request.headers.get("accept"))
-  const markdown = qualityFor(ranges, "text", "markdown")
-  const html = qualityFor(ranges, "text", "html")
-  if (markdown === 0 && html === 0) return undefined
-  return markdown >= html
 }
 
 const responseBody = (request: Request, value: string): string | undefined => request.method === "HEAD" ? undefined : value
@@ -49,7 +19,7 @@ export const docsResponse = (request: Request, options: DocsResponseOptions = {}
   if (request.method !== "GET" && request.method !== "HEAD") return undefined
   const pathname = new URL(request.url).pathname
   const explicitPath = markdownPath(pathname)
-  const preference = explicitPath === undefined ? wantsMarkdown(request) : true
+  const preference = explicitPath === undefined ? wantsMarkdown(request.headers.get("accept")) : true
   if (preference === false) return undefined
   if (preference === undefined) return new Response(responseBody(request, "Not acceptable\n"), { status: 406, headers: { "content-type": "text/plain; charset=utf-8", vary: "Accept" } })
   const doc = docAt(explicitPath ?? pathname)

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -10,6 +10,7 @@
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "types": ["bun", "vite/client"],
     "paths": { "@docs/*": ["../../docs/site/*"] },
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/knip.json
+++ b/knip.json
@@ -83,6 +83,7 @@
     },
     "apps/web": {
       "entry": [
+        "src/**/*.test.ts",
         "../../docs/site/**/*.mdx"
       ],
       "project": [

--- a/tools/gate.ts
+++ b/tools/gate.ts
@@ -73,6 +73,7 @@ const tasks: ReadonlyArray<Task> = [
   { id: "test:platform-cloudflare:workers", cwd: platformPkg("cloudflare"), cmd: ["bun", "run", "test:workers"] },
   { id: "test:platform-worker-loader:workers", cwd: platformPkg("worker-loader"), cmd: ["bun", "run", "test:workers"] },
   ...apps.map((name) => ({ id: `test:app-${name}`, cwd: appPkg(name), cmd: ["bun", "test"] })),
+  { id: "test:app-web", cwd: appPkg("web"), cmd: ["bun", "test"] },
   { id: "test:e2e", cwd: e2e, cmd: ["bun", "test"] },
   { id: "bundle:platform-cloudflare", cwd: platformPkg("cloudflare"), cmd: ["bun", "run", "bundle"] },
   { id: "bundle:model-adapters", cmd: ["bun", "run", "tools/model-adapter-bundles.ts"] },


### PR DESCRIPTION
## Summary

Makes implicit documentation URLs prefer HTML when a client sends an ambiguous `Accept` header such as `*/*`. Social preview crawlers can now read the Open Graph and Twitter image metadata instead of receiving raw Markdown. Explicit Markdown requests and `.md` or `.mdx` paths continue to return Markdown.

Adds focused content-negotiation tests and includes web tests in the repository gate.

## Verification

- `bun run gate`
- Verified `Accept: */*` returns HTML with `og:image` and `twitter:image`
- Verified `Accept: text/markdown` returns Markdown