### PR TITLE
feat(web): improve docs interactions

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,11 +14,13 @@
   },
   "dependencies": {
     "@mdx-js/react": "^3.1.1",
+    "@phosphor-icons/react": "^2.1.10",
     "@tanstack/react-router": "1.170.32",
     "@tanstack/react-start": "1.168.49",
     "katex": "^0.18.5",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7"
+    "react-dom": "^19.2.7",
+    "simple-icons": "13.21.0"
   },
   "devDependencies": {
     "@mdx-js/rollup": "^3.1.1",

--- a/apps/web/src/docs/Docs.tsx
+++ b/apps/web/src/docs/Docs.tsx
@@ -1,6 +1,8 @@
 import { MDXProvider } from "@mdx-js/react"
+import { ArrowSquareOut, CaretDown, ChatCircleDots } from "@phosphor-icons/react"
 import { Link } from "@tanstack/react-router"
-import { Fragment, type ReactElement } from "react"
+import { Fragment, useEffect, useRef, useState, type ReactElement } from "react"
+import { siClaude, siOpenai } from "simple-icons/icons"
 
 import { CheckIcon, CopyIcon, useCopy } from "../ui/copy"
 import { mdxComponents } from "./components"
@@ -16,18 +18,60 @@ const CopyMarkdownButton = ({ markdown }: { readonly markdown: string }): ReactE
   )
 }
 
-const Sidebar = ({ current }: { readonly current: Doc }): ReactElement => {
+const BrandIcon = ({ path }: { readonly path: string }): ReactElement => (
+  <svg className="ask-ai-provider-icon" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d={path} /></svg>
+)
+
+const assistantPrompt = (markdown: string): string => `Use the following Tardigrade documentation as context. Help me understand or apply it.\n\n<documentation>\n${markdown}\n</documentation>`
+
+const AskAiButton = ({ markdown }: { readonly markdown: string }): ReactElement => {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (!open) return
+    const closeOutside = (event: PointerEvent): void => {
+      if (event.target instanceof Node && !rootRef.current?.contains(event.target)) setOpen(false)
+    }
+    const closeOnEscape = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") setOpen(false)
+    }
+    document.addEventListener("pointerdown", closeOutside)
+    document.addEventListener("keydown", closeOnEscape)
+    return () => {
+      document.removeEventListener("pointerdown", closeOutside)
+      document.removeEventListener("keydown", closeOnEscape)
+    }
+  }, [open])
+  const openAssistant = (url: string): void => {
+    void navigator.clipboard.writeText(assistantPrompt(markdown))
+    window.open(url, "_blank", "noopener,noreferrer")
+    setOpen(false)
+  }
   return (
-    <aside className="guide-sidebar">
-      {docSections.map(([section, pages], sectionIndex) => (
-        <Fragment key={section}>
-          <span className={sectionIndex === 0 ? undefined : "guide-sidebar-section"}>{section}</span>
-          {pages.map((page) => <Link to="/docs/$" params={{ _splat: page.frontmatter.route.slice("/docs/".length) }} aria-current={page === current ? "page" : undefined} key={page.frontmatter.route}>{page.frontmatter.title}</Link>)}
-        </Fragment>
-      ))}
-    </aside>
+    <div className="ask-ai" ref={rootRef}>
+      <button className="ask-ai-trigger" type="button" aria-expanded={open} aria-haspopup="true" onClick={() => setOpen((current) => !current)}>
+        <ChatCircleDots className="ask-ai-trigger-icon" aria-hidden="true" /><span>Ask</span><CaretDown className="ask-ai-trigger-caret" aria-hidden="true" />
+      </button>
+      {open ? (
+        <div className="ask-ai-menu">
+          <button type="button" onClick={() => openAssistant("https://chatgpt.com/")}><BrandIcon path={siOpenai.path} /><span><strong>ChatGPT</strong><small>Copy context and open</small></span><ArrowSquareOut aria-hidden="true" /></button>
+          <button type="button" onClick={() => openAssistant("https://claude.ai/new")}><BrandIcon path={siClaude.path} /><span><strong>Claude</strong><small>Copy context and open</small></span><ArrowSquareOut aria-hidden="true" /></button>
+        </div>
+      ) : null}
+    </div>
   )
 }
+
+const Sidebar = ({ current }: { readonly current: Doc }): ReactElement => (
+  <aside className="guide-sidebar">
+    {docSections.map(([section, pages], sectionIndex) => (
+      <Fragment key={section}>
+        <span className={sectionIndex === 0 ? undefined : "guide-sidebar-section"}>{section}</span>
+        {pages.map((page) => <Link to="/docs/$" params={{ _splat: page.frontmatter.route.slice("/docs/".length) }} aria-current={page === current ? "page" : undefined} key={page.frontmatter.route}>{page.frontmatter.title}</Link>)}
+      </Fragment>
+    ))}
+  </aside>
+)
 
 export const DocsPage = ({ pathname }: { readonly pathname: string }): ReactElement | undefined => {
   const doc = docAt(pathname)
@@ -40,7 +84,7 @@ export const DocsPage = ({ pathname }: { readonly pathname: string }): ReactElem
         <article className={`guide-article${frontmatter.articleClass === undefined ? "" : ` ${frontmatter.articleClass}`}`}>
           <div className="guide-heading">
             <div><h1>{frontmatter.title}</h1>{frontmatter.hideDescription === true ? null : <p className="guide-intro">{frontmatter.description}</p>}</div>
-            <CopyMarkdownButton markdown={doc.markdown} />
+            <div className="guide-heading-actions"><CopyMarkdownButton markdown={doc.markdown} /><AskAiButton markdown={doc.markdown} /></div>
           </div>
           <div className="guide-divider" />
           <MDXProvider components={mdxComponents}><Content /></MDXProvider>

--- a/apps/web/src/docs/components/diagrams/TrajectoryBranchesDiagram.tsx
+++ b/apps/web/src/docs/components/diagrams/TrajectoryBranchesDiagram.tsx
@@ -12,27 +12,44 @@ const trajectoryPoints = [
 ] as const
 
 export const TrajectoryBranchesDiagram = (): ReactElement => (
-  <svg className="trajectory-branches-diagram" viewBox="0 0 720 208" role="img" aria-label="Possible agent trajectories" aria-describedby="trajectory-branches-description">
-    <desc id="trajectory-branches-description">One current state branches into more possible trajectories as the operating horizon grows.</desc>
-    <g className="trajectory-branches-paths">
-      <path d="M32 112C96 92 116 44 194 55S322 29 410 48S548 20 684 28" />
-      <path d="M32 112C102 99 130 78 206 86S340 69 434 82S568 52 694 68" />
-      <path d="M32 112C112 108 152 116 226 102S358 91 456 110S590 90 682 102" />
-      <path className="trajectory-branches-lead" d="M32 112C112 112 182 128 258 118S410 132 500 124S602 126 692 122" />
-      <path d="M32 112C108 122 142 154 224 146S350 166 438 150S570 158 680 164" />
-      <path d="M32 112C96 130 122 186 208 174S340 190 430 180S564 205 694 194" />
-      <path d="M32 112C110 124 176 72 264 80S418 152 520 142S628 176 690 176" />
-      <path d="M32 112C106 110 150 198 274 190S450 110 582 138S650 146 700 144" />
-    </g>
-    <g className="trajectory-branches-nodes">
-      <rect className="trajectory-branches-origin" x="27.5" y="107.5" width="9" height="9" />
-      {trajectoryPoints.map(([x, y], index) => (
-        <rect key={`${x}-${y}`} x={x - (index % 3 === 2 ? 3.5 : 2.5)} y={y - (index % 3 === 2 ? 3.5 : 2.5)} width={index % 3 === 2 ? 7 : 5} height={index % 3 === 2 ? 7 : 5} />
-      ))}
-    </g>
-    <g className="trajectory-branches-horizon" aria-hidden="true">
-      <text x="24" y="12">NOW</text>
-      <text x="696" y="12" textAnchor="end">LONGER HORIZON</text>
-    </g>
-  </svg>
+  <div className="trajectory-branches-viewport">
+    <div className="trajectory-branches-horizon-labels" aria-hidden="true"><span>NOW</span><span>LONGER HORIZON</span></div>
+    <svg className="trajectory-branches-diagram trajectory-branches-diagram-desktop" viewBox="0 0 720 208" role="img" aria-label="Possible agent trajectories" aria-describedby="trajectory-branches-description">
+      <desc id="trajectory-branches-description">One current state branches into more possible trajectories as the operating horizon grows.</desc>
+      <g className="trajectory-branches-paths">
+        <path d="M32 112C96 92 116 44 194 55S322 29 410 48S548 20 684 28" />
+        <path d="M32 112C102 99 130 78 206 86S340 69 434 82S568 52 694 68" />
+        <path d="M32 112C112 108 152 116 226 102S358 91 456 110S590 90 682 102" />
+        <path className="trajectory-branches-lead" d="M32 112C112 112 182 128 258 118S410 132 500 124S602 126 692 122" />
+        <path d="M32 112C108 122 142 154 224 146S350 166 438 150S570 158 680 164" />
+        <path d="M32 112C96 130 122 186 208 174S340 190 430 180S564 205 694 194" />
+        <path d="M32 112C110 124 176 72 264 80S418 152 520 142S628 176 690 176" />
+        <path d="M32 112C106 110 150 198 274 190S450 110 582 138S650 146 700 144" />
+      </g>
+      <g className="trajectory-branches-nodes">
+        <rect className="trajectory-branches-origin" x="27.5" y="107.5" width="9" height="9" />
+        {trajectoryPoints.map(([x, y], index) => (
+          <rect key={`${x}-${y}`} x={x - (index % 3 === 2 ? 3.5 : 2.5)} y={y - (index % 3 === 2 ? 3.5 : 2.5)} width={index % 3 === 2 ? 7 : 5} height={index % 3 === 2 ? 7 : 5} />
+        ))}
+      </g>
+    </svg>
+    <svg className="trajectory-branches-diagram trajectory-branches-diagram-mobile" viewBox="0 0 360 208" role="img" aria-label="Possible agent trajectories" aria-describedby="trajectory-branches-mobile-description">
+      <desc id="trajectory-branches-mobile-description">One current state branches into five possible trajectories as the operating horizon grows.</desc>
+      <g className="trajectory-branches-paths">
+        <path d="M24 112C78 92 106 38 172 52S292 24 388 36" />
+        <path d="M24 112C84 100 126 76 196 84S302 64 388 76" />
+        <path className="trajectory-branches-lead" d="M24 112C90 112 150 126 218 116S304 118 388 108" />
+        <path d="M24 112C86 126 130 158 190 146S288 158 388 170" />
+        <path d="M24 112C74 148 116 190 202 178S300 196 388 190" />
+      </g>
+      <g className="trajectory-branches-nodes">
+        <rect className="trajectory-branches-origin" x="19.5" y="107.5" width="9" height="9" />
+        <rect x="169.5" y="49.5" width="5" height="5" />
+        <rect x="193.5" y="81.5" width="5" height="5" />
+        <rect x="214.5" y="112.5" width="7" height="7" />
+        <rect x="187.5" y="143.5" width="5" height="5" />
+        <rect x="199.5" y="175.5" width="5" height="5" />
+      </g>
+    </svg>
+  </div>
 )

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -329,12 +329,19 @@ h1 span { display: block; white-space: nowrap; }
 .trajectory-nodes { fill: var(--bg); stroke: rgb(var(--accent-rgb) / 52%); stroke-width: 1; vector-effect: non-scaling-stroke; }
 .trajectory-nodes rect:last-child { fill: var(--moss-wash); stroke: var(--moss); }
 .trajectory-exit { fill: none; stroke: var(--moss); stroke-width: 1; vector-effect: non-scaling-stroke; }
-.trajectory-branches-diagram { width: 100%; height: auto; margin: 22px 0 30px; display: block; overflow: visible; }
+.trajectory-branches-viewport { position: relative; width: 100%; margin: 22px 0 30px; overflow: hidden; container-type: inline-size; }
+.trajectory-branches-diagram { width: 100%; height: auto; display: block; overflow: visible; }
+.trajectory-branches-diagram-mobile { display: none; }
 .trajectory-branches-paths { fill: none; stroke: rgb(var(--accent-rgb) / 30%); stroke-width: 1; vector-effect: non-scaling-stroke; }
 .trajectory-branches-paths .trajectory-branches-lead { stroke: var(--moss); stroke-width: 1.25; }
 .trajectory-branches-nodes { fill: var(--bg); stroke: rgb(var(--accent-rgb) / 52%); stroke-width: 1; vector-effect: non-scaling-stroke; }
 .trajectory-branches-nodes .trajectory-branches-origin { fill: var(--moss-wash); stroke: var(--moss); }
-.trajectory-branches-horizon text { fill: var(--faint); font-family: var(--mono); font-size: 9px; letter-spacing: .08em; }
+.trajectory-branches-horizon-labels { position: absolute; z-index: 1; top: 0; right: 3.333%; left: 3.333%; display: flex; justify-content: space-between; color: var(--faint); font-family: var(--mono); font-size: 9px; letter-spacing: .08em; pointer-events: none; }
+@container (max-width: 640px) {
+  .trajectory-branches-diagram-desktop { display: none; }
+  .trajectory-branches-diagram-mobile { display: block; }
+  .trajectory-branches-horizon-labels { right: 12px; left: 12px; }
+}
 .behavior-trajectory-diagram { width: min(100%, 720px); height: auto; margin: -8px 0 26px; display: block; overflow: visible; }
 .behavior-trajectory-path { fill: none; stroke: rgb(var(--accent-rgb) / 38%); stroke-width: 1; vector-effect: non-scaling-stroke; }
 .behavior-trajectory-direction { fill: none; stroke: var(--moss); stroke-width: 1.25; vector-effect: non-scaling-stroke; }
@@ -402,9 +409,23 @@ h1 span { display: block; white-space: nowrap; }
 .guide-heading { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 24px; align-items: start; }
 .guide-article h1 { max-width: none; margin: 0; font-size: clamp(36px, 4.2vw, 48px); font-weight: 600; letter-spacing: -.045em; }
 .guide-intro { margin: 20px 0 0; color: var(--ink-2); font-size: 18px; }
-.copy-markdown { min-height: 44px; margin-top: 4px; padding: 11px 15px; display: inline-flex; align-items: center; gap: 10px; border: 1px solid rgb(var(--accent-rgb) / 38%); background: transparent; color: var(--ink-2); cursor: pointer; font-family: var(--mono); font-size: 14px; transition: color 160ms ease; }
+.guide-heading-actions { margin-top: 4px; display: flex; align-items: flex-start; gap: 8px; }
+.copy-markdown { min-height: 44px; padding: 11px 15px; display: inline-flex; align-items: center; gap: 10px; border: 1px solid rgb(var(--accent-rgb) / 38%); background: transparent; color: var(--ink-2); cursor: pointer; font-family: var(--mono); font-size: 14px; transition: color 160ms ease, transform 120ms var(--ease-out); }
 .copy-markdown svg { width: 20px; height: 20px; color: var(--moss-ink); }
-@media (hover: hover) and (pointer: fine) { .copy-markdown:hover { color: var(--ink); } }
+.copy-markdown:active, .ask-ai-trigger:active, .ask-ai-menu button:active { transform: scale(.97); }
+.ask-ai { position: relative; }
+.ask-ai-trigger { min-height: 44px; padding: 11px 13px; display: inline-flex; align-items: center; gap: 8px; border: 1px solid rgb(var(--accent-rgb) / 38%); background: transparent; color: var(--ink-2); cursor: pointer; font-family: var(--mono); font-size: 14px; white-space: nowrap; transition: color 160ms ease, transform 120ms var(--ease-out); }
+.ask-ai-trigger-icon { width: 19px; height: 19px; color: var(--moss-ink); }
+.ask-ai-trigger-caret { width: 13px; height: 13px; color: var(--faint); transition: transform 160ms var(--ease-out); }
+.ask-ai-trigger[aria-expanded="true"] .ask-ai-trigger-caret { transform: rotate(180deg); }
+.ask-ai-menu { position: absolute; z-index: 12; top: calc(100% + 6px); right: 0; width: 230px; padding: 5px; border: 1px solid var(--hair); background: var(--surface); box-shadow: 0 14px 32px rgb(16 21 33 / 14%); }
+.ask-ai-menu button { width: 100%; padding: 10px; display: grid; grid-template-columns: 20px minmax(0, 1fr) 15px; align-items: center; gap: 10px; border: 0; background: transparent; color: var(--ink); cursor: pointer; text-align: left; transition: background-color 120ms ease, transform 120ms var(--ease-out); }
+.ask-ai-menu button > span { display: grid; gap: 2px; }
+.ask-ai-menu strong { font-family: var(--display); font-size: 14px; font-weight: 550; }
+.ask-ai-menu small { color: var(--faint); font-family: var(--mono); font-size: 9px; }
+.ask-ai-menu button > svg:last-child { width: 15px; height: 15px; color: var(--faint); }
+.ask-ai-provider-icon { width: 18px; height: 18px; color: var(--ink-2); }
+@media (hover: hover) and (pointer: fine) { .copy-markdown:hover, .ask-ai-trigger:hover { color: var(--ink); } .ask-ai-menu button:hover { background: var(--sunken); } }
 .guide-divider { margin: 24px 0 44px; border-top: 1px dashed rgb(var(--accent-rgb) / 28%); }
 .guide-article > p:not(.guide-intro) { max-width: 720px; margin: 0; color: var(--ink); font-size: 17px; line-height: 1.62; }
 .guide-article > p:not(.guide-intro) + p:not(.guide-intro) { margin-top: 18px; }
@@ -748,6 +769,9 @@ h1 span { display: block; white-space: nowrap; }
   .guide-article > p:not(.guide-intro) { font-size: 16px; }
   .copy-markdown { width: 44px; padding: 11px; justify-content: center; }
   .copy-markdown span { display: none; }
+  .guide-heading-actions { gap: 6px; }
+  .ask-ai-trigger { width: 44px; padding: 11px; justify-content: center; }
+  .ask-ai-trigger span, .ask-ai-trigger-caret { display: none; }
   .behavior-trajectory-annotation text { font-size: 18px; }
   .interface-comparison { padding: 16px; }
   :is(.actor-diagram, .transition-loop, .component-diagram, .harness-diagram, .primitive-diagram, .method-diagram) { width: 100%; }

--- a/bun.lock
+++ b/bun.lock
@@ -73,11 +73,13 @@
       "version": "0.0.1",
       "dependencies": {
         "@mdx-js/react": "^3.1.1",
+        "@phosphor-icons/react": "^2.1.10",
         "@tanstack/react-router": "1.170.32",
         "@tanstack/react-start": "1.168.49",
         "katex": "^0.18.5",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
+        "simple-icons": "13.21.0",
       },
       "devDependencies": {
         "@mdx-js/rollup": "^3.1.1",
@@ -1351,6 +1353,8 @@
     "sharp": ["sharp@0.35.2", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.4" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.2", "@img/sharp-darwin-x64": "0.35.2", "@img/sharp-freebsd-wasm32": "0.35.2", "@img/sharp-libvips-darwin-arm64": "1.3.1", "@img/sharp-libvips-darwin-x64": "1.3.1", "@img/sharp-libvips-linux-arm": "1.3.1", "@img/sharp-libvips-linux-arm64": "1.3.1", "@img/sharp-libvips-linux-ppc64": "1.3.1", "@img/sharp-libvips-linux-riscv64": "1.3.1", "@img/sharp-libvips-linux-s390x": "1.3.1", "@img/sharp-libvips-linux-x64": "1.3.1", "@img/sharp-libvips-linuxmusl-arm64": "1.3.1", "@img/sharp-libvips-linuxmusl-x64": "1.3.1", "@img/sharp-linux-arm": "0.35.2", "@img/sharp-linux-arm64": "0.35.2", "@img/sharp-linux-ppc64": "0.35.2", "@img/sharp-linux-riscv64": "0.35.2", "@img/sharp-linux-s390x": "0.35.2", "@img/sharp-linux-x64": "0.35.2", "@img/sharp-linuxmusl-arm64": "0.35.2", "@img/sharp-linuxmusl-x64": "0.35.2", "@img/sharp-webcontainers-wasm32": "0.35.2", "@img/sharp-win32-arm64": "0.35.2", "@img/sharp-win32-ia32": "0.35.2", "@img/sharp-win32-x64": "0.35.2" } }, "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "simple-icons": ["simple-icons@13.21.0", "", {}, "sha512-LI5pVJPBv6oc79OMsffwb6kEqnmB8P1Cjg1crNUlhsxPETQ5UzbCKQdxU+7MW6+DD1qfPkla/vSKlLD4IfyXpQ=="],
 
     "smol-toml": ["smol-toml@1.8.0", "", {}, "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ=="],
 

--- a/docs/site/Why.mdx
+++ b/docs/site/Why.mdx
@@ -8,7 +8,7 @@ sectionOrder: 1
 order: 2
 ---
 
-Building an agent can be challenging, especially as the horizon over which they operate is ever expanding. Tasks get harder, behaviors become harder to reason about, and the harnesses we build around our agents get ever more complex.
+Building an agent can be challenging, especially as they operate over longer horizons. Tasks get harder, behaviors become harder to reason about, and the harnesses we build around our agents get ever more complex.
 
 <TrajectoryBranchesDiagram />
 
@@ -52,9 +52,9 @@ It is not obvious which parts of your code led to a specific agent behavior or h
 
 Tardigrade grew out of the realization that an agent harness is very similar to a user interface.
 
-User interfaces help humans interact with the digital world. Agent harnesses help agents interact with the real world. Framed this way, authoring a harness becomes a rendering problem, and the frontend community has already solved it!
+User interfaces help humans interact with the digital world. Harnesses help agents interact with the real world. Framed this way, authoring a harness becomes a rendering problem, and the frontend community has already solved it!
 
-[React](https://react.dev/) defines a user interface as a component tree, with each component as a function of state. Similarly, Tardigrade defines an agent harness as a composition of behaviors. Each behavior is a state machine whose state is a projection of an immutable event log.
+[React](https://react.dev/) defines a user interface as a component tree, with each component as a function of state. Similarly, Tardigrade defines an agent harness as a composition of components that define behavior. Each component is a state machine whose state is a projection of an immutable event log.
 
 <InterfaceComparisonDiagram />
 
@@ -78,7 +78,7 @@ If you can describe the behavior you want to see based on what has happened, you
 
 For example, take compaction. A model's context window is bounded, but conversations can be unbounded. At some point, you are going to hit a limit. Compaction is a workaround to have a continuous conversation thread despite this constraint.
 
-You could describe it as follows:
+You could describe a typical compaction strategy as follows:
 
 > **When** the conversation sent to a model reaches a certain token threshold, use a model to summarize part of the conversation.
 >


### PR DESCRIPTION
Adds an Ask menu to documentation pages so readers can copy the current page context and open ChatGPT or Claude in one action. The existing Markdown copy action now uses source bundled with the page, which removes its network delay.

The trajectory illustration switches to a simpler five-path composition when its container is narrow. This keeps the branching idea legible in mobile layouts and split panes. The Why page also includes the revised horizon, harness, component, and compaction wording.

Verification:

- `bun run gate`
- `bun run gate --only=lint:docs`