### PR TITLE
docs(web): swarm scale copy

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -579,7 +579,7 @@ const Scalability = (): ReactElement => (
     <div className="scalability-inner">
       <div className="scalability-copy">
         <h2>Scalable.</h2>
-        <p>Every agent can run as a durable object. Scale from a single agent to an entire civilisation.</p>
+        <p>Every agent can run as a durable object. Scale from a single agent to swarms of agents.</p>
       </div>
       <ScalabilityGrid />
     </div>

--- a/docs/site/Welcome.mdx
+++ b/docs/site/Welcome.mdx
@@ -39,7 +39,7 @@ Tardigrade is a TypeScript framework for building modular agents around an immut
 <div className="welcome-feature">
   <div className="welcome-feature-copy">
     <h3>Scalable</h3>
-    <p>Every agent can run as a durable object. Scale from a single agent to an entire civilisation.</p>
+    <p>Every agent can run as a durable object. Scale from a single agent to swarms of agents.</p>
   </div>
   <ServerlessDiagram />
 </div>


### PR DESCRIPTION
Swaps the scalability line on the landing page and Welcome doc to describe swarms of agents instead of an entire civilisation.

- landing page (App.tsx) scalability copy
- Welcome.mdx scalability copy