### PR TITLE
docs(web): fix stale init commands

### DIFF
--- a/docs/site/examples/rlm.mdx
+++ b/docs/site/examples/rlm.mdx
@@ -70,6 +70,6 @@ const rlm = actor({
 
 ## Start from the quickstart
 
-Initialize a project, then replace its actor assembly with this RLM.
+Initialize a project with the RLM template to get this assembly directly.
 
-<Command value="tdg init researcher" label="Initialize the RLM project" />
+<Command value="tdg init researcher --template rlm" label="Initialize the RLM project" />

--- a/docs/site/quickstart.mdx
+++ b/docs/site/quickstart.mdx
@@ -28,7 +28,7 @@ bun add -g tardie@latest
 Now, use the [Tardie CLI](/docs/cli) to create a new `my-agent` directory and configure a language model provider.
 
 ```bash variant="single"
-tdg init --template quickstart
+tdg init my-agent --template quickstart
 ```
 
 After the setup, you should see the following files:


### PR DESCRIPTION
Verified the quickstart and RLM example against a fresh tdg install and hit two commands that no longer match the CLI.

- quickstart.mdx: `tdg init --template quickstart` fails without a name argument, since name is positional and only prompted in an interactive terminal; made it `tdg init my-agent --template quickstart` to match the directory name the rest of the guide assumes
- rlm.mdx: `tdg init researcher` pointed at the manual "replace its actor assembly" flow, but the CLI now ships a native `--template rlm` that generates this exact assembly directly; updated the command and lead-in text to use it
- confirmed both commands against the published `tardie` CLI (0.20.0) and `bun run gate --only=lint:docs`