### PR TITLE
fix(cloudflare): commit deadline cancellation atomically

### DIFF
--- a/packages/core/src/interaction/timeout.test.ts
+++ b/packages/core/src/interaction/timeout.test.ts
@@ -132,6 +132,59 @@ describe("method alarms", () => {
     }])
   })
 
+  test("one crossing projects every crossed invocation", () => {
+    const work = legacyActorMethod({
+      input: Schema.String,
+      output: Schema.String,
+      event: ({ invocation, at }) => ({
+        type: "WorkStarted",
+        id: invocation.id,
+        call: { invocation, deadlineAt: 40 },
+        at
+      }),
+      state: () => ({ status: "pending" }),
+      cancellation: {
+        state: () => "running",
+        event: (request, at) => ({ type: "WorkCancelled", id: request.invocation.id, at })
+      }
+    })
+    const first = { method: "work", id: "work-1", epoch: 0 } as const
+    const second = { method: "work", id: "work-2", epoch: 0 } as const
+    const started = (invocation: { readonly method: "work"; readonly id: string; readonly epoch: 0 }, deadlineAt: number) => ({
+      type: "WorkStarted",
+      id: invocation.id,
+      call: { invocation, deadlineAt },
+      at: 1
+    } as Event)
+    const log = [started(first, 40), started(second, 45)]
+    expect(deadlineCancellationEventsAt(log, { work }, 44)).toEqual([{
+      type: "CancellationRequested",
+      request: "deadline/work/work-1/0/40",
+      invocation: first,
+      cause: "deadline",
+      deadlineAt: 40,
+      at: 44
+    }])
+    expect(deadlineCancellationEventsAt(log, { work }, 50)).toEqual([
+      {
+        type: "CancellationRequested",
+        request: "deadline/work/work-1/0/40",
+        invocation: first,
+        cause: "deadline",
+        deadlineAt: 40,
+        at: 50
+      },
+      {
+        type: "CancellationRequested",
+        request: "deadline/work/work-2/0/45",
+        invocation: second,
+        cause: "deadline",
+        deadlineAt: 45,
+        at: 50
+      }
+    ])
+  })
+
   test("a settled or terminal deadline projects no cancellation", () => {
     const work = legacyActorMethod({
       input: Schema.String,

--- a/packages/core/src/interaction/timeout.test.ts
+++ b/packages/core/src/interaction/timeout.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "bun:test"
 import type { Event } from "@clavia/tardigrade-core/event"
-import { alarmFired, earliestDeadlineOf, methodDeadlineCancellationDerivation, methodTimeoutKeys, methodTimeoutDerivation } from "./timeout"
+import {
+  alarmFired,
+  deadlineCancellationsAt,
+  deadlineCancellationEventsAt,
+  earliestDeadlineOf,
+  methodDeadlineCancellationDerivation,
+  methodTimeoutKeys,
+  methodTimeoutDerivation
+} from "./timeout"
 import { legacyActorMethod } from "../actor/method-compat"
 import { Schema } from "effect"
 
@@ -87,6 +95,122 @@ describe("method alarms", () => {
       deadlineAt: 40,
       at: 43
     }])
+  })
+
+  test("a crossed deadline projects its cancellation at the observed time", () => {
+    const work = legacyActorMethod({
+      input: Schema.String,
+      output: Schema.String,
+      event: ({ invocation, at }) => ({
+        type: "WorkStarted",
+        id: invocation.id,
+        call: { invocation, deadlineAt: 40 },
+        at
+      }),
+      state: () => ({ status: "pending" }),
+      cancellation: {
+        state: () => "running",
+        event: (request, at) => ({ type: "WorkCancelled", id: request.invocation.id, at })
+      }
+    })
+    const invocation = { method: "work", id: "work-1", epoch: 0 } as const
+    const started = {
+      type: "WorkStarted",
+      id: "work-1",
+      call: { invocation, deadlineAt: 40 },
+      at: 1
+    } as Event
+    expect(deadlineCancellationsAt([started], { work }, 39)).toEqual([])
+    expect(deadlineCancellationsAt([started], { work }, 40)).toEqual([{ invocation, deadlineAt: 40 }])
+    expect(deadlineCancellationEventsAt([started], { work }, 40)).toEqual([{
+      type: "CancellationRequested",
+      request: "deadline/work/work-1/0/40",
+      invocation,
+      cause: "deadline",
+      deadlineAt: 40,
+      at: 40
+    }])
+  })
+
+  test("a settled or terminal deadline projects no cancellation", () => {
+    const work = legacyActorMethod({
+      input: Schema.String,
+      output: Schema.String,
+      event: ({ invocation, at }) => ({
+        type: "WorkStarted",
+        id: invocation.id,
+        call: { invocation, deadlineAt: 40 },
+        at
+      }),
+      state: (events, invocation) => events.some((event) =>
+        event.type === "WorkCompleted" && String((event as { readonly id?: unknown }).id) === invocation.id
+      ) ? { status: "completed", output: "done" } : { status: "pending" },
+      cancellation: {
+        state: (events, invocation) => events.some((event) =>
+          event.type === "WorkCompleted" && String((event as { readonly id?: unknown }).id) === invocation.id
+        ) ? "terminal" : "running",
+        event: (request, at) => ({ type: "WorkCancelled", id: request.invocation.id, at })
+      }
+    })
+    const invocation = { method: "work", id: "work-1", epoch: 0 } as const
+    const started = {
+      type: "WorkStarted",
+      id: "work-1",
+      call: { invocation, deadlineAt: 40 },
+      at: 1
+    } as Event
+    const requested = [{
+      type: "CancellationRequested",
+      request: "deadline/work/work-1/0/40",
+      invocation,
+      cause: "deadline",
+      deadlineAt: 40,
+      at: 40
+    } as Event]
+    expect(deadlineCancellationEventsAt([started, ...requested], { work }, 41)).toEqual([])
+    const completed = [{ type: "WorkCompleted", id: "work-1", at: 20 } as Event]
+    expect(deadlineCancellationEventsAt([started, ...completed], { work }, 41)).toEqual([])
+    expect(deadlineCancellationEventsAt([started], {}, 41)).toEqual([])
+  })
+
+  test("a crossed deadline projects its cancellation before and after commit", () => {
+    const work = legacyActorMethod({
+      input: Schema.String,
+      output: Schema.String,
+      event: ({ invocation, at }) => ({
+        type: "WorkStarted",
+        id: invocation.id,
+        call: { invocation, deadlineAt: 40 },
+        at
+      }),
+      state: () => ({ status: "pending" }),
+      cancellation: {
+        state: () => "running",
+        event: (request, at) => ({ type: "WorkCancelled", id: request.invocation.id, at })
+      }
+    })
+    const invocation = { method: "work", id: "work-1", epoch: 0 } as const
+    const started = {
+      type: "WorkStarted",
+      id: "work-1",
+      call: { invocation, deadlineAt: 40 },
+      at: 1
+    } as Event
+    const alarmed = [started, alarmFired({ scheduledFor: 40, at: 43 })]
+    const transition = methodDeadlineCancellationDerivation({ work })(alarmed)[0]
+    expect(transition?.kind).toBe("intent")
+    if (transition?.kind !== "intent") return
+    expect(transition.events(transition.input, 43)).toEqual([{
+      type: "CancellationRequested",
+      request: "deadline/work/work-1/0/40",
+      invocation,
+      cause: "deadline",
+      deadlineAt: 40,
+      at: 43
+    }])
+    const committed = [...alarmed, ...deadlineCancellationEventsAt(alarmed, { work }, 43)]
+    expect(methodDeadlineCancellationDerivation({ work })(committed)).toEqual([])
+    expect(deadlineCancellationEventsAt(committed, { work }, 44)).toEqual([])
   })
 
   test("an alarm crossing produces one caller timeout without reading a clock", () => {

--- a/packages/core/src/interaction/timeout.test.ts
+++ b/packages/core/src/interaction/timeout.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./timeout"
 import { legacyActorMethod } from "../actor/method-compat"
 import { initialMethodStates, reduceMethodStates } from "./state"
+import type { ActorMethods } from "../actor/method"
 import { Schema } from "effect"
 
 const dispatched = (
@@ -30,6 +31,43 @@ const dispatched = (
   deadlineAt,
   at
 })
+
+// One cancellable work method backs the selection and legacy-recovery properties: its invocation
+// runs until a WorkCompleted record settles it, and only a running invocation accepts cancellation.
+const work = legacyActorMethod({
+  input: Schema.String,
+  output: Schema.String,
+  event: ({ invocation, at }) => ({
+    type: "WorkStarted",
+    id: invocation.id,
+    call: { invocation, deadlineAt: 40 },
+    at
+  }),
+  state: (events, invocation) => events.some((event) =>
+    event.type === "WorkCompleted" && String((event as { readonly id?: unknown }).id) === invocation.id
+  ) ? { status: "completed", output: "done" } : { status: "pending" },
+  cancellation: {
+    state: (events, invocation) => events.some((event) =>
+      event.type === "WorkCompleted" && String((event as { readonly id?: unknown }).id) === invocation.id
+    ) ? "terminal" : "running",
+    event: (request, at) => ({ type: "WorkCancelled", id: request.invocation.id, at })
+  }
+})
+const workMethods: ActorMethods = { work }
+const startedWork = (id: string, deadlineAt = 40, at = 1): Event => ({
+  type: "WorkStarted",
+  id,
+  call: { invocation: { method: "work", id, epoch: 0 }, deadlineAt },
+  at
+} as Event)
+const deadlineCancellation = (id: string, deadlineAt: number, at: number): Event => ({
+  type: "CancellationRequested",
+  request: `deadline/work/${id}/0/${deadlineAt}`,
+  invocation: { method: "work", id, epoch: 0 },
+  cause: "deadline",
+  deadlineAt,
+  at
+} as Event)
 
 describe("method alarms", () => {
   test("an alarm fact states its schedule and observed firing time", () => {
@@ -58,258 +96,76 @@ describe("method alarms", () => {
       }
     ]
     expect(earliestDeadlineOf(log)).toBe(20)
+    expect(earliestDeadlineOf([startedWork("work-1")], workMethods)).toBe(40)
+    expect(earliestDeadlineOf([startedWork("work-1"), { type: "WorkCompleted", id: "work-1", at: 20 } as Event], workMethods))
+      .toBeUndefined()
   })
 
-  test("an accepted invocation deadline requests method cancellation", () => {
-    const work = legacyActorMethod({
-      input: Schema.String,
-      output: Schema.String,
-      event: ({ invocation, at }) => ({
-        type: "WorkStarted",
-        id: invocation.id,
-        call: { invocation, deadlineAt: 40 },
-        at
-      }),
-      state: (events, invocation) => events.some((event) =>
-        event.type === "WorkCompleted" && String((event as { readonly id?: unknown }).id) === invocation.id
-      ) ? { status: "completed", output: "done" } : { status: "pending" },
-      cancellation: {
-        state: () => "running",
-        event: (request, at) => ({ type: "WorkCancelled", id: request.invocation.id, at })
-      }
-    })
-    const invocation = { method: "work", id: "work-1", epoch: 0 } as const
-    const log: ReadonlyArray<Event> = [
-      { type: "WorkStarted", id: "work-1", call: { invocation, deadlineAt: 40 }, at: 1 } as Event,
-      { type: "AlarmFired", scheduledFor: 40, at: 43 } as Event
-    ]
-    expect(earliestDeadlineOf(log.slice(0, 1))).toBe(40)
-    expect(earliestDeadlineOf([
-      log[0]!,
-      { type: "WorkCompleted", id: "work-1", at: 20 } as Event
-    ], { work })).toBeUndefined()
-    const transition = methodDeadlineCancellationDerivation({ work })(log)[0]
-    expect(transition?.kind).toBe("intent")
-    if (transition?.kind !== "intent") return
-    expect(transition.events(transition.input, 43)).toEqual([{
-      type: "CancellationRequested",
-      request: "deadline/work/work-1/0/40",
-      invocation,
-      cause: "deadline",
-      deadlineAt: 40,
-      at: 43
-    }])
-  })
-
-  test("a crossed deadline projects its cancellation at the observed time", () => {
-    const work = legacyActorMethod({
-      input: Schema.String,
-      output: Schema.String,
-      event: ({ invocation, at }) => ({
-        type: "WorkStarted",
-        id: invocation.id,
-        call: { invocation, deadlineAt: 40 },
-        at
-      }),
-      state: () => ({ status: "pending" }),
-      cancellation: {
-        state: () => "running",
-        event: (request, at) => ({ type: "WorkCancelled", id: request.invocation.id, at })
-      }
-    })
-    const invocation = { method: "work", id: "work-1", epoch: 0 } as const
-    const started = {
-      type: "WorkStarted",
-      id: "work-1",
-      call: { invocation, deadlineAt: 40 },
-      at: 1
-    } as Event
-    expect(deadlineCancellationsAt([started], { work }, 39)).toEqual([])
-    expect(deadlineCancellationsAt([started], { work }, 40)).toEqual([{ invocation, deadlineAt: 40 }])
-    expect(deadlineCancellationEventsAt([started], { work }, 40)).toEqual([{
-      type: "CancellationRequested",
-      request: "deadline/work/work-1/0/40",
-      invocation,
-      cause: "deadline",
-      deadlineAt: 40,
-      at: 40
-    }])
-  })
-
-  test("one crossing projects every crossed invocation", () => {
-    const work = legacyActorMethod({
-      input: Schema.String,
-      output: Schema.String,
-      event: ({ invocation, at }) => ({
-        type: "WorkStarted",
-        id: invocation.id,
-        call: { invocation, deadlineAt: 40 },
-        at
-      }),
-      state: () => ({ status: "pending" }),
-      cancellation: {
-        state: () => "running",
-        event: (request, at) => ({ type: "WorkCancelled", id: request.invocation.id, at })
-      }
-    })
-    const first = { method: "work", id: "work-1", epoch: 0 } as const
-    const second = { method: "work", id: "work-2", epoch: 0 } as const
-    const started = (invocation: { readonly method: "work"; readonly id: string; readonly epoch: 0 }, deadlineAt: number) => ({
-      type: "WorkStarted",
-      id: invocation.id,
-      call: { invocation, deadlineAt },
-      at: 1
-    } as Event)
-    const log = [started(first, 40), started(second, 45)]
-    expect(deadlineCancellationEventsAt(log, { work }, 44)).toEqual([{
-      type: "CancellationRequested",
-      request: "deadline/work/work-1/0/40",
-      invocation: first,
-      cause: "deadline",
-      deadlineAt: 40,
-      at: 44
-    }])
-    expect(deadlineCancellationEventsAt(log, { work }, 50)).toEqual([
+  test("cancellation selection projects one cancellation from an eligible invocation", () => {
+    const completed = { type: "WorkCompleted", id: "work-1", at: 20 } as Event
+    const cases: ReadonlyArray<{
+      readonly name: string
+      readonly log: ReadonlyArray<Event>
+      readonly at: number
+      readonly expected: ReadonlyArray<Event>
+      readonly methods?: ActorMethods
+    }> = [
       {
-        type: "CancellationRequested",
-        request: "deadline/work/work-1/0/40",
-        invocation: first,
-        cause: "deadline",
-        deadlineAt: 40,
-        at: 50
+        name: "overdue, running, and cancellable",
+        log: [startedWork("work-1")],
+        at: 40,
+        expected: [deadlineCancellation("work-1", 40, 40)]
       },
+      { name: "deadline still in the future", log: [startedWork("work-1")], at: 39, expected: [] },
+      { name: "already settled", log: [startedWork("work-1"), completed], at: 41, expected: [] },
       {
-        type: "CancellationRequested",
-        request: "deadline/work/work-2/0/45",
-        invocation: second,
-        cause: "deadline",
-        deadlineAt: 45,
-        at: 50
+        name: "cancellation already requested",
+        log: [startedWork("work-1"), deadlineCancellation("work-1", 40, 40)],
+        at: 41,
+        expected: []
+      },
+      { name: "method does not support cancellation", log: [startedWork("work-1")], methods: {}, at: 41, expected: [] },
+      {
+        name: "every crossed invocation",
+        log: [startedWork("work-1"), startedWork("work-2", 45)],
+        at: 50,
+        expected: [deadlineCancellation("work-1", 40, 50), deadlineCancellation("work-2", 45, 50)]
       }
+    ]
+    expect(deadlineCancellationsAt([startedWork("work-1")], workMethods, 40)).toEqual([
+      { invocation: { method: "work", id: "work-1", epoch: 0 }, deadlineAt: 40 }
     ])
+    for (const current of cases) {
+      expect(deadlineCancellationEventsAt(current.log, current.methods ?? workMethods, current.at), current.name)
+        .toEqual(current.expected)
+    }
   })
 
-  test("a settled or terminal deadline projects no cancellation", () => {
-    const work = legacyActorMethod({
-      input: Schema.String,
-      output: Schema.String,
-      event: ({ invocation, at }) => ({
-        type: "WorkStarted",
-        id: invocation.id,
-        call: { invocation, deadlineAt: 40 },
-        at
-      }),
-      state: (events, invocation) => events.some((event) =>
-        event.type === "WorkCompleted" && String((event as { readonly id?: unknown }).id) === invocation.id
-      ) ? { status: "completed", output: "done" } : { status: "pending" },
-      cancellation: {
-        state: (events, invocation) => events.some((event) =>
-          event.type === "WorkCompleted" && String((event as { readonly id?: unknown }).id) === invocation.id
-        ) ? "terminal" : "running",
-        event: (request, at) => ({ type: "WorkCancelled", id: request.invocation.id, at })
-      }
-    })
-    const invocation = { method: "work", id: "work-1", epoch: 0 } as const
-    const started = {
-      type: "WorkStarted",
-      id: "work-1",
-      call: { invocation, deadlineAt: 40 },
-      at: 1
-    } as Event
-    const requested = [{
-      type: "CancellationRequested",
-      request: "deadline/work/work-1/0/40",
-      invocation,
-      cause: "deadline",
-      deadlineAt: 40,
-      at: 40
-    } as Event]
-    expect(deadlineCancellationEventsAt([started, ...requested], { work }, 41)).toEqual([])
-    const completed = [{ type: "WorkCompleted", id: "work-1", at: 20 } as Event]
-    expect(deadlineCancellationEventsAt([started, ...completed], { work }, 41)).toEqual([])
-    expect(deadlineCancellationEventsAt([started], {}, 41)).toEqual([])
-  })
-
-  test("a crossed deadline projects its cancellation before and after commit", () => {
-    const work = legacyActorMethod({
-      input: Schema.String,
-      output: Schema.String,
-      event: ({ invocation, at }) => ({
-        type: "WorkStarted",
-        id: invocation.id,
-        call: { invocation, deadlineAt: 40 },
-        at
-      }),
-      state: () => ({ status: "pending" }),
-      cancellation: {
-        state: () => "running",
-        event: (request, at) => ({ type: "WorkCancelled", id: request.invocation.id, at })
-      }
-    })
-    const invocation = { method: "work", id: "work-1", epoch: 0 } as const
-    const started = {
-      type: "WorkStarted",
-      id: "work-1",
-      call: { invocation, deadlineAt: 40 },
-      at: 1
-    } as Event
-    const alarmed = [started, alarmFired({ scheduledFor: 40, at: 43 })]
-    const transition = methodDeadlineCancellationDerivation({ work })(alarmed)[0]
-    expect(transition?.kind).toBe("intent")
-    if (transition?.kind !== "intent") return
-    expect(transition.events(transition.input, 43)).toEqual([{
-      type: "CancellationRequested",
-      request: "deadline/work/work-1/0/40",
-      invocation,
-      cause: "deadline",
-      deadlineAt: 40,
-      at: 43
-    }])
-    const committed = [...alarmed, ...deadlineCancellationEventsAt(alarmed, { work }, 43)]
-    expect(methodDeadlineCancellationDerivation({ work })(committed)).toEqual([])
-    expect(deadlineCancellationEventsAt(committed, { work }, 44)).toEqual([])
-  })
-
-  test("two alarms crossing one deadline project one cancellation", () => {
-    const work = legacyActorMethod({
-      input: Schema.String,
-      output: Schema.String,
-      event: ({ invocation, at }) => ({
-        type: "WorkStarted",
-        id: invocation.id,
-        call: { invocation, deadlineAt: 40 },
-        at
-      }),
-      state: () => ({ status: "pending" }),
-      cancellation: {
-        state: () => "running",
-        event: (request, at) => ({ type: "WorkCancelled", id: request.invocation.id, at })
-      }
-    })
-    const invocation = { method: "work", id: "work-1", epoch: 0 } as const
-    const started = {
-      type: "WorkStarted",
-      id: "work-1",
-      call: { invocation, deadlineAt: 40 },
-      at: 1
-    } as Event
+  test("legacy recovery derives an alarm's missing cancellation exactly once", () => {
     const log = [
-      started,
+      startedWork("work-1"),
       alarmFired({ scheduledFor: 40, at: 43 }),
       alarmFired({ scheduledFor: 40, at: 50 })
     ]
-    const complete = methodDeadlineCancellationDerivation({ work })(log)
+    const complete = methodDeadlineCancellationDerivation(workMethods)(log)
     expect(complete).toHaveLength(1)
     expect(complete.map((transition) => transition.key))
-      .toEqual([`cx:${JSON.stringify([invocation.method, invocation.id, invocation.epoch])}`])
-    let methodStates = initialMethodStates({ work })
+      .toEqual([`cx:${JSON.stringify(["work", "work-1", 0])}`])
+    const transition = complete[0]
+    expect(transition?.kind).toBe("intent")
+    if (transition?.kind !== "intent") return
+    expect(transition.events(transition.input, 50)).toEqual([deadlineCancellation("work-1", 40, 50)])
+    let methodStates = initialMethodStates(workMethods)
     let timeoutState = initialMethodTimeoutState()
     for (const event of log) {
-      methodStates = reduceMethodStates({ work }, methodStates, event)
+      methodStates = reduceMethodStates(workMethods, methodStates, event)
       timeoutState = reduceMethodTimeoutState(timeoutState, event)
     }
-    expect(methodTimeoutTransitions({ work }, methodStates, timeoutState).map((transition) => transition.key))
+    expect(methodTimeoutTransitions(workMethods, methodStates, timeoutState).map((transition) => transition.key))
       .toEqual(complete.map((transition) => transition.key))
+    const committed = [...log, ...deadlineCancellationEventsAt(log, workMethods, 50)]
+    expect(methodDeadlineCancellationDerivation(workMethods)(committed)).toEqual([])
+    expect(deadlineCancellationEventsAt(committed, workMethods, 51)).toEqual([])
   })
 
   test("an alarm crossing produces one caller timeout without reading a clock", () => {

--- a/packages/core/src/interaction/timeout.test.ts
+++ b/packages/core/src/interaction/timeout.test.ts
@@ -31,8 +31,6 @@ const dispatched = (
   at
 })
 
-// One cancellable work method backs the selection and legacy-recovery properties: its invocation
-// runs until a WorkCompleted record settles it, and only a running invocation accepts cancellation.
 const work = legacyActorMethod({
   input: Schema.String,
   output: Schema.String,

--- a/packages/core/src/interaction/timeout.test.ts
+++ b/packages/core/src/interaction/timeout.test.ts
@@ -5,11 +5,15 @@ import {
   deadlineCancellationsAt,
   deadlineCancellationEventsAt,
   earliestDeadlineOf,
+  initialMethodTimeoutState,
   methodDeadlineCancellationDerivation,
+  methodTimeoutDerivation,
   methodTimeoutKeys,
-  methodTimeoutDerivation
+  methodTimeoutTransitions,
+  reduceMethodTimeoutState
 } from "./timeout"
 import { legacyActorMethod } from "../actor/method-compat"
+import { initialMethodStates, reduceMethodStates } from "./state"
 import { Schema } from "effect"
 
 const dispatched = (
@@ -264,6 +268,48 @@ describe("method alarms", () => {
     const committed = [...alarmed, ...deadlineCancellationEventsAt(alarmed, { work }, 43)]
     expect(methodDeadlineCancellationDerivation({ work })(committed)).toEqual([])
     expect(deadlineCancellationEventsAt(committed, { work }, 44)).toEqual([])
+  })
+
+  test("two alarms crossing one deadline project one cancellation", () => {
+    const work = legacyActorMethod({
+      input: Schema.String,
+      output: Schema.String,
+      event: ({ invocation, at }) => ({
+        type: "WorkStarted",
+        id: invocation.id,
+        call: { invocation, deadlineAt: 40 },
+        at
+      }),
+      state: () => ({ status: "pending" }),
+      cancellation: {
+        state: () => "running",
+        event: (request, at) => ({ type: "WorkCancelled", id: request.invocation.id, at })
+      }
+    })
+    const invocation = { method: "work", id: "work-1", epoch: 0 } as const
+    const started = {
+      type: "WorkStarted",
+      id: "work-1",
+      call: { invocation, deadlineAt: 40 },
+      at: 1
+    } as Event
+    const log = [
+      started,
+      alarmFired({ scheduledFor: 40, at: 43 }),
+      alarmFired({ scheduledFor: 40, at: 50 })
+    ]
+    const complete = methodDeadlineCancellationDerivation({ work })(log)
+    expect(complete).toHaveLength(1)
+    expect(complete.map((transition) => transition.key))
+      .toEqual([`cx:${JSON.stringify([invocation.method, invocation.id, invocation.epoch])}`])
+    let methodStates = initialMethodStates({ work })
+    let timeoutState = initialMethodTimeoutState()
+    for (const event of log) {
+      methodStates = reduceMethodStates({ work }, methodStates, event)
+      timeoutState = reduceMethodTimeoutState(timeoutState, event)
+    }
+    expect(methodTimeoutTransitions({ work }, methodStates, timeoutState).map((transition) => transition.key))
+      .toEqual(complete.map((transition) => transition.key))
   })
 
   test("an alarm crossing produces one caller timeout without reading a clock", () => {

--- a/packages/core/src/interaction/timeout.test.ts
+++ b/packages/core/src/interaction/timeout.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test"
 import type { Event } from "@clavia/tardigrade-core/event"
 import {
   alarmFired,
-  deadlineCancellationsAt,
   deadlineCancellationEventsAt,
   earliestDeadlineOf,
   initialMethodTimeoutState,
@@ -132,9 +131,6 @@ describe("method alarms", () => {
         expected: [deadlineCancellation("work-1", 40, 50), deadlineCancellation("work-2", 45, 50)]
       }
     ]
-    expect(deadlineCancellationsAt([startedWork("work-1")], workMethods, 40)).toEqual([
-      { invocation: { method: "work", id: "work-1", epoch: 0 }, deadlineAt: 40 }
-    ])
     for (const current of cases) {
       expect(deadlineCancellationEventsAt(current.log, current.methods ?? workMethods, current.at), current.name)
         .toEqual(current.expected)

--- a/packages/core/src/interaction/timeout.ts
+++ b/packages/core/src/interaction/timeout.ts
@@ -142,7 +142,7 @@ const deadlineCancellationTransition = (invocation: InvocationRef, deadlineAt: n
   })]
 })
 
-// deadlineCancellationsAt projects the invocation deadlines an observed time has crossed into the same cancellation targets the caller path uses (timeout.test.ts, "a crossed deadline projects its cancellation at the observed time"; cancellation.test.ts, "the core event and key identify the target invocation independently of its requester").
+// deadlineCancellationsAt projects the invocation deadlines an observed time has crossed into the same cancellation targets the caller path uses (timeout.test.ts, "cancellation selection projects one cancellation from an eligible invocation"; cancellation.test.ts, "the core event and key identify the target invocation independently of its requester").
 export const deadlineCancellationsAt = (
   log: ReadonlyArray<Event>,
   methods: ActorMethods,
@@ -162,7 +162,7 @@ export const deadlineCancellationsAt = (
   })
 }
 
-// deadlineCancellationEventsAt constructs the durable cancellation requests one observed crossing commits alongside its alarm fact (timeout.test.ts, "one crossing projects every crossed invocation"; test/actor.workers.ts, "an alarm commits its deadline cancellation atomically").
+// deadlineCancellationEventsAt constructs the durable cancellation requests one observed crossing commits alongside its alarm fact (timeout.test.ts, "cancellation selection projects one cancellation from an eligible invocation"; test/actor.workers.ts, "an alarm commits its deadline cancellation atomically").
 export const deadlineCancellationEventsAt = (
   log: ReadonlyArray<Event>,
   methods: ActorMethods,
@@ -189,7 +189,7 @@ export const methodTimeoutDerivation: CompleteTransitionDerivation = (log) => {
   })
 }
 
-// methodDeadlineCancellationDerivation projects one deadline cancellation per invocation a recorded alarm crossed, for logs written before the alarm handler committed them (timeout.test.ts, "a crossed deadline projects its cancellation before and after commit"; timeout.test.ts, "two alarms crossing one deadline project one cancellation").
+// methodDeadlineCancellationDerivation projects one deadline cancellation per invocation a recorded alarm crossed, for logs written before the alarm handler committed them (timeout.test.ts, "legacy recovery derives an alarm's missing cancellation exactly once").
 export const methodDeadlineCancellationDerivation = (methods: ActorMethods): CompleteTransitionDerivation => (log) => {
   const latestAlarmAt = alarmsOf(log).reduce<number | undefined>(
     (latest, alarm) => latest === undefined ? alarm.at : Math.max(latest, alarm.at),

--- a/packages/core/src/interaction/timeout.ts
+++ b/packages/core/src/interaction/timeout.ts
@@ -52,7 +52,7 @@ const dispatchesOf = (log: ReadonlyArray<Event>): ReadonlyArray<RecordedDispatch
   return dispatch === undefined ? [] : [dispatch]
 })
 
-export interface InvocationDeadline {
+interface InvocationDeadline {
   readonly invocation: InvocationRef
   readonly deadlineAt: number
 }
@@ -143,7 +143,7 @@ const deadlineCancellationTransition = (invocation: InvocationRef, deadlineAt: n
 })
 
 // deadlineCancellationsAt projects the invocation deadlines an observed time has crossed into the same cancellation targets the caller path uses (timeout.test.ts, "cancellation selection projects one cancellation from an eligible invocation"; cancellation.test.ts, "the core event and key identify the target invocation independently of its requester").
-export const deadlineCancellationsAt = (
+const deadlineCancellationsAt = (
   log: ReadonlyArray<Event>,
   methods: ActorMethods,
   at: number

--- a/packages/core/src/interaction/timeout.ts
+++ b/packages/core/src/interaction/timeout.ts
@@ -142,7 +142,7 @@ const deadlineCancellationTransition = (invocation: InvocationRef, deadlineAt: n
   })]
 })
 
-// deadlineCancellationsAt projects the invocation deadlines an observed time has crossed into the same cancellation targets the caller path uses (timeout.test.ts, "cancellation selection projects one cancellation from an eligible invocation"; cancellation.test.ts, "the core event and key identify the target invocation independently of its requester").
+// deadlineCancellationsAt selects crossed deadlines for running cancellable invocations (timeout.test.ts, "cancellation selection projects one cancellation from an eligible invocation").
 const deadlineCancellationsAt = (
   log: ReadonlyArray<Event>,
   methods: ActorMethods,
@@ -162,7 +162,7 @@ const deadlineCancellationsAt = (
   })
 }
 
-// deadlineCancellationEventsAt constructs the durable cancellation requests one observed crossing commits alongside its alarm fact (timeout.test.ts, "cancellation selection projects one cancellation from an eligible invocation"; test/actor.workers.ts, "an alarm commits its deadline cancellation atomically").
+// deadlineCancellationEventsAt constructs durable requests for selected deadline cancellations (test/actor.workers.ts, "an alarm commits its deadline cancellation atomically").
 export const deadlineCancellationEventsAt = (
   log: ReadonlyArray<Event>,
   methods: ActorMethods,
@@ -189,7 +189,7 @@ export const methodTimeoutDerivation: CompleteTransitionDerivation = (log) => {
   })
 }
 
-// methodDeadlineCancellationDerivation projects one deadline cancellation per invocation a recorded alarm crossed, for logs written before the alarm handler committed them (timeout.test.ts, "legacy recovery derives an alarm's missing cancellation exactly once").
+// methodDeadlineCancellationDerivation repairs missing cancellations from recorded alarms (timeout.test.ts, "legacy recovery derives an alarm's missing cancellation exactly once").
 export const methodDeadlineCancellationDerivation = (methods: ActorMethods): CompleteTransitionDerivation => (log) => {
   const latestAlarmAt = alarmsOf(log).reduce<number | undefined>(
     (latest, alarm) => latest === undefined ? alarm.at : Math.max(latest, alarm.at),

--- a/packages/core/src/interaction/timeout.ts
+++ b/packages/core/src/interaction/timeout.ts
@@ -142,7 +142,7 @@ const deadlineCancellationTransition = (invocation: InvocationRef, deadlineAt: n
   })]
 })
 
-// deadlineCancellationsAt projects the invocation deadlines an observed time has crossed into the same cancellation targets the caller path uses.
+// deadlineCancellationsAt projects the invocation deadlines an observed time has crossed into the same cancellation targets the caller path uses (timeout.test.ts, "a crossed deadline projects its cancellation at the observed time"; cancellation.test.ts, "the core event and key identify the target invocation independently of its requester").
 export const deadlineCancellationsAt = (
   log: ReadonlyArray<Event>,
   methods: ActorMethods,
@@ -162,7 +162,7 @@ export const deadlineCancellationsAt = (
   })
 }
 
-// deadlineCancellationEventsAt constructs the durable cancellation requests one observed crossing commits alongside its alarm fact.
+// deadlineCancellationEventsAt constructs the durable cancellation requests one observed crossing commits alongside its alarm fact (timeout.test.ts, "one crossing projects every crossed invocation"; test/actor.workers.ts, "an alarm commits its deadline cancellation atomically").
 export const deadlineCancellationEventsAt = (
   log: ReadonlyArray<Event>,
   methods: ActorMethods,
@@ -189,13 +189,17 @@ export const methodTimeoutDerivation: CompleteTransitionDerivation = (log) => {
   })
 }
 
-// methodDeadlineCancellationDerivation projects the deadline cancellations a recorded alarm crossed, for logs written before the alarm handler committed them (timeout.test.ts, "a crossed deadline projects its cancellation before and after commit").
-export const methodDeadlineCancellationDerivation = (methods: ActorMethods): CompleteTransitionDerivation => (log) =>
-  alarmsOf(log).flatMap((alarm) =>
-    deadlineCancellationsAt(log, methods, alarm.at).map(({ invocation, deadlineAt }) =>
-      deadlineCancellationTransition(invocation, deadlineAt)
-    )
-  )
+// methodDeadlineCancellationDerivation projects one deadline cancellation per invocation a recorded alarm crossed, for logs written before the alarm handler committed them (timeout.test.ts, "a crossed deadline projects its cancellation before and after commit"; timeout.test.ts, "two alarms crossing one deadline project one cancellation").
+export const methodDeadlineCancellationDerivation = (methods: ActorMethods): CompleteTransitionDerivation => (log) => {
+  const alarms = alarmsOf(log)
+  return invocationDeadlinesOf(log).flatMap(({ invocation, deadlineAt }) => {
+    const alarm = alarmFor(alarms, deadlineAt)
+    if (alarm === undefined) return []
+    return deadlineCancellationsAt(log, methods, alarm.at)
+      .filter((target) => invocationKey(target.invocation) === invocationKey(invocation) && target.deadlineAt === deadlineAt)
+      .map((target) => deadlineCancellationTransition(target.invocation, target.deadlineAt))
+  })
+}
 
 /** @deprecated Use methodTimeoutDerivation. This compatibility name describes a complete-history transition derivation. */
 export const methodTimeoutReactor: CompleteTransitionDerivation = (log) => methodTimeoutDerivation(log)

--- a/packages/core/src/interaction/timeout.ts
+++ b/packages/core/src/interaction/timeout.ts
@@ -10,7 +10,7 @@ import { type ActorInvocationContext, invocationKey, sameInvocation, type Invoca
 
 import { recordedDispatchOf, terminalInvocationRefOf, terminalStorageKey, type RecordedDispatch } from "./records-compat"
 
-import { cancellationStateOf, initialMethodStates, reduceMethodStates } from "./state"
+import { cancellationStateOf, initialMethodStates, reduceMethodStates, type ActorMethodView } from "./state"
 import { type ActorMethods } from "../actor/method"
 
 export interface AlarmFiredFields {
@@ -52,7 +52,7 @@ const dispatchesOf = (log: ReadonlyArray<Event>): ReadonlyArray<RecordedDispatch
   return dispatch === undefined ? [] : [dispatch]
 })
 
-interface InvocationDeadline {
+export interface InvocationDeadline {
   readonly invocation: InvocationRef
   readonly deadlineAt: number
 }
@@ -142,6 +142,42 @@ const deadlineCancellationTransition = (invocation: InvocationRef, deadlineAt: n
   })]
 })
 
+// deadlineCancellationsAt projects the invocation deadlines an observed time has crossed into the same cancellation targets the caller path uses.
+export const deadlineCancellationsAt = (
+  log: ReadonlyArray<Event>,
+  methods: ActorMethods,
+  at: number
+): ReadonlyArray<InvocationDeadline> => {
+  const views = new Map<string, ActorMethodView<unknown>>()
+  return invocationDeadlinesOf(log).flatMap(({ invocation, deadlineAt }) => {
+    if (deadlineAt > at) return []
+    const method = methods[invocation.method]
+    if (method === undefined || method.cancellation === undefined || invocationSettled(log, invocation)) return []
+    let view = views.get(invocation.method)
+    if (view === undefined) {
+      view = replayProjection(method.projection, log)
+      views.set(invocation.method, view)
+    }
+    return cancellationStateOf(method, view, invocation) !== "running" ? [] : [{ invocation, deadlineAt }]
+  })
+}
+
+// deadlineCancellationEventsAt constructs the durable cancellation requests one observed crossing commits alongside its alarm fact.
+export const deadlineCancellationEventsAt = (
+  log: ReadonlyArray<Event>,
+  methods: ActorMethods,
+  at: number
+): ReadonlyArray<Event> =>
+  deadlineCancellationsAt(log, methods, at).map(({ invocation, deadlineAt }) =>
+    cancellationRequested({
+      request: `deadline/${invocation.method}/${invocation.id}/${invocation.epoch}/${deadlineAt}`,
+      invocation,
+      cause: "deadline",
+      deadlineAt,
+      at
+    })
+  )
+
 // methodTimeoutDerivation turns alarm facts into method terminals without reading a clock.
 export const methodTimeoutDerivation: CompleteTransitionDerivation = (log) => {
   const terminal = terminalCalls(log)
@@ -153,19 +189,13 @@ export const methodTimeoutDerivation: CompleteTransitionDerivation = (log) => {
   })
 }
 
-// methodDeadlineCancellationDerivation turns an accepted invocation deadline into the same durable cancellation used by callers.
-export const methodDeadlineCancellationDerivation = (methods: ActorMethods): CompleteTransitionDerivation => (log) => {
-  const alarms = alarmsOf(log)
-  return invocationDeadlinesOf(log).flatMap(({ invocation, deadlineAt }) => {
-    const cancellation = methods[invocation.method]?.cancellation
-    if (cancellation === undefined || invocationSettled(log, invocation)) return []
-    const alarm = alarmFor(alarms, deadlineAt)
-    const method = methods[invocation.method]
-    if (alarm === undefined || method === undefined ||
-      cancellationStateOf(method, replayProjection(method.projection, log), invocation) !== "running") return []
-    return [deadlineCancellationTransition(invocation, deadlineAt)]
-  })
-}
+// methodDeadlineCancellationDerivation projects the deadline cancellations a recorded alarm crossed, for logs written before the alarm handler committed them (timeout.test.ts, "a crossed deadline projects its cancellation before and after commit").
+export const methodDeadlineCancellationDerivation = (methods: ActorMethods): CompleteTransitionDerivation => (log) =>
+  alarmsOf(log).flatMap((alarm) =>
+    deadlineCancellationsAt(log, methods, alarm.at).map(({ invocation, deadlineAt }) =>
+      deadlineCancellationTransition(invocation, deadlineAt)
+    )
+  )
 
 /** @deprecated Use methodTimeoutDerivation. This compatibility name describes a complete-history transition derivation. */
 export const methodTimeoutReactor: CompleteTransitionDerivation = (log) => methodTimeoutDerivation(log)

--- a/packages/core/src/interaction/timeout.ts
+++ b/packages/core/src/interaction/timeout.ts
@@ -191,14 +191,13 @@ export const methodTimeoutDerivation: CompleteTransitionDerivation = (log) => {
 
 // methodDeadlineCancellationDerivation projects one deadline cancellation per invocation a recorded alarm crossed, for logs written before the alarm handler committed them (timeout.test.ts, "a crossed deadline projects its cancellation before and after commit"; timeout.test.ts, "two alarms crossing one deadline project one cancellation").
 export const methodDeadlineCancellationDerivation = (methods: ActorMethods): CompleteTransitionDerivation => (log) => {
-  const alarms = alarmsOf(log)
-  return invocationDeadlinesOf(log).flatMap(({ invocation, deadlineAt }) => {
-    const alarm = alarmFor(alarms, deadlineAt)
-    if (alarm === undefined) return []
-    return deadlineCancellationsAt(log, methods, alarm.at)
-      .filter((target) => invocationKey(target.invocation) === invocationKey(invocation) && target.deadlineAt === deadlineAt)
-      .map((target) => deadlineCancellationTransition(target.invocation, target.deadlineAt))
-  })
+  const latestAlarmAt = alarmsOf(log).reduce<number | undefined>(
+    (latest, alarm) => latest === undefined ? alarm.at : Math.max(latest, alarm.at),
+    undefined
+  )
+  if (latestAlarmAt === undefined) return []
+  return deadlineCancellationsAt(log, methods, latestAlarmAt)
+    .map(({ invocation, deadlineAt }) => deadlineCancellationTransition(invocation, deadlineAt))
 }
 
 /** @deprecated Use methodTimeoutDerivation. This compatibility name describes a complete-history transition derivation. */

--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -106,7 +106,6 @@ const options = (path: string): BunHostOptions<never> => ({
   keyOf
 })
 
-// Both bun deadline properties drive one cancellable hold actor.
 const hasHoldEvent = (events: ReadonlyArray<Event>, type: string, id: string): boolean =>
   events.some((event) => event.type === type && String((event as { readonly id?: unknown }).id) === id)
 const hold = actorMethod({
@@ -518,7 +517,6 @@ describe("the bun host", () => {
     expect(alarm.pending).toEqual([50])
     expect(h.work()).toBe(0)
 
-    // A rejected cancellation insert aborts the whole batch, alarm fact included, and leaves the driver unmarked.
     const threadDb = new Database(bunThreadDatabasePath(path, "caller"))
     threadDb.exec(`CREATE TRIGGER reject_deadline_cancellation
       BEFORE INSERT ON events
@@ -531,7 +529,6 @@ describe("the bun host", () => {
     expect(h.work()).toBe(0)
     expect(alarm.pending).toEqual([])
 
-    // The aborted batch left the deadline uncrossed, so a clean retry commits alarm fact and cancellation together.
     await h.wake("caller")
     expect(alarm.pending).toEqual([50])
     threadDb.exec("DROP TRIGGER reject_deadline_cancellation")
@@ -553,7 +550,6 @@ describe("the bun host", () => {
     const path = freshPath()
     const alarm = new ManualAlarmScheduler()
     const h = await deadlineHost(path, alarm)
-    // A log written before the atomic alarm commits: the alarm fact landed, its cancellation did not.
     await h.seed("caller", [
       created("caller"),
       heldInvocation(),

--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -3,9 +3,10 @@ import { Database } from "bun:sqlite"
 import { existsSync, mkdtempSync, readFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { Effect, Layer, Tracer } from "effect"
+import { Effect, Layer, Schema, Tracer } from "effect"
 import type { KeyValueStore } from "effect/unstable/persistence"
 import type { Event } from "@clavia/tardigrade-core/log/event"
+import { actor, actorMethod, component } from "@clavia/tardigrade-core/actor"
 import { effect } from "@clavia/tardigrade-core/effect"
 import { actorFromProjections, type Actor } from "@clavia/tardigrade-core/runtime"
 import { completeTransitionProjection, type ErasedTransitionProjection } from "@clavia/tardigrade-core/transition"
@@ -453,6 +454,109 @@ describe("the bun host", () => {
     expect(recoveredAlarm.pending).toEqual([])
     expect(await recovered.resting()).toBe(true)
     await recovered.close()
+  })
+
+  test("an alarm commits its deadline cancellation atomically", async () => {
+    const path = freshPath()
+    interface HoldState {
+      readonly requests: ReadonlySet<string>
+      readonly cancelled: ReadonlySet<string>
+    }
+    const initialHoldState = (): HoldState => ({ requests: new Set(), cancelled: new Set() })
+    const stepHoldState = (hold: HoldState, event: Event): HoldState => {
+      const id = String((event as { readonly id?: unknown }).id ?? "")
+      if (event.type === "HoldRequested" && !hold.requests.has(id)) {
+        return { ...hold, requests: new Set(hold.requests).add(id) }
+      }
+      if (event.type === "HoldCancelled" && !hold.cancelled.has(id)) {
+        return { ...hold, cancelled: new Set(hold.cancelled).add(id) }
+      }
+      return hold
+    }
+    const hold = actorMethod({
+      input: Schema.Struct({ text: Schema.String }),
+      output: Schema.String,
+      event: ({ invocation, input, at }) => ({ type: "HoldRequested", id: invocation.id, text: input.text, at }),
+      projection: {
+        initial: initialHoldState,
+        step: stepHoldState,
+        output: (hold: HoldState) => ({
+          currentEpoch: () => 0,
+          invocationState: (invocation) => !hold.requests.has(invocation.id) ? undefined
+            : hold.cancelled.has(invocation.id)
+              ? { status: "cancelled" as const, cause: "deadline" as const }
+              : { status: "pending" as const }
+        })
+      },
+      cancellation: {
+        event: (cancellation, at) => ({ type: "HoldCancelled", id: cancellation.invocation.id, at })
+      }
+    })
+    const holdComponent = component<HoldState, undefined>({
+      name: "hold",
+      keys: {
+        prefixes: ["hold-request:", "hold-cancel:"],
+        keyOf: (event) => {
+          if (event.type === "HoldRequested") return `hold-request:${String((event as { readonly id?: unknown }).id)}`
+          if (event.type === "HoldCancelled") return `hold-cancel:${String((event as { readonly id?: unknown }).id)}`
+          return undefined
+        }
+      },
+      initial: initialHoldState,
+      step: stepHoldState,
+      output: () => ({ view: undefined, transitions: [] })
+    })
+    const holdActor = actor({ name: "echo", methods: { hold }, components: [holdComponent] })
+    const alarm = new ManualAlarmScheduler()
+    const h = await createBunHost({
+      database: path,
+      actorFor: () => holdActor,
+      keyOf: holdActor.keyOf,
+      alarm
+    })
+    await h.seed("caller", [
+      created("caller"),
+      {
+        type: "HoldRequested",
+        id: "hold-1",
+        text: "held",
+        call: { invocation: { method: "hold", id: "hold-1", epoch: 0 }, deadlineAt: 50 },
+        at: 1
+      } as Event
+    ])
+    await h.recover()
+    expect(alarm.pending).toEqual([50])
+    expect(h.work()).toBe(0)
+
+    // A rejected cancellation insert aborts the whole batch, alarm fact included, and leaves the driver unmarked.
+    const threadDb = new Database(bunThreadDatabasePath(path, "caller"))
+    threadDb.exec(`CREATE TRIGGER reject_deadline_cancellation
+      BEFORE INSERT ON events
+      WHEN NEW.key LIKE 'cx:%'
+      BEGIN SELECT RAISE(ABORT, 'reject deadline cancellation'); END`)
+    await expect(alarm.advanceTo(60)).rejects.toThrow()
+    const rejected = await h.read("caller")
+    expect(rejected.filter((event) => event.type === "AlarmFired")).toEqual([])
+    expect(rejected.filter((event) => event.type === "CancellationRequested")).toEqual([])
+    expect(h.work()).toBe(0)
+    expect(alarm.pending).toEqual([])
+
+    // The aborted batch left the deadline uncrossed, so a clean retry commits alarm fact and cancellation together.
+    await h.wake("caller")
+    expect(alarm.pending).toEqual([50])
+    threadDb.exec("DROP TRIGGER reject_deadline_cancellation")
+    await alarm.advanceTo(60)
+
+    const committed = await h.read("caller")
+    const alarmAt = committed.findIndex((event) => event.type === "AlarmFired")
+    const cancellationAt = committed.findIndex((event) => event.type === "CancellationRequested")
+    expect(alarmAt).toBeGreaterThanOrEqual(0)
+    expect(cancellationAt).toBeGreaterThan(alarmAt)
+    expect(committed.some((event) => event.type === "HoldCancelled")).toBe(true)
+    expect(await h.resting()).toBe(true)
+    expect(h.work()).toBe(0)
+    await h.close()
+    threadDb.close()
   })
 
   test("threads names every thread the log holds", async () => {

--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -106,6 +106,58 @@ const options = (path: string): BunHostOptions<never> => ({
   keyOf
 })
 
+// Both bun deadline properties drive one hold actor: a cancellable method whose invocation cancels
+// on record, so the atomic and alarm-only-repair tests share its fixture.
+interface HoldState {
+  readonly requests: ReadonlySet<string>
+  readonly cancelled: ReadonlySet<string>
+}
+const initialHoldState = (): HoldState => ({ requests: new Set(), cancelled: new Set() })
+const stepHoldState = (hold: HoldState, event: Event): HoldState => {
+  const id = String((event as { readonly id?: unknown }).id ?? "")
+  if (event.type === "HoldRequested" && !hold.requests.has(id)) {
+    return { ...hold, requests: new Set(hold.requests).add(id) }
+  }
+  if (event.type === "HoldCancelled" && !hold.cancelled.has(id)) {
+    return { ...hold, cancelled: new Set(hold.cancelled).add(id) }
+  }
+  return hold
+}
+const hold = actorMethod({
+  input: Schema.Struct({ text: Schema.String }),
+  output: Schema.String,
+  event: ({ invocation, input, at }) => ({ type: "HoldRequested", id: invocation.id, text: input.text, at }),
+  projection: {
+    initial: initialHoldState,
+    step: stepHoldState,
+    output: (hold: HoldState) => ({
+      currentEpoch: () => 0,
+      invocationState: (invocation) => !hold.requests.has(invocation.id) ? undefined
+        : hold.cancelled.has(invocation.id)
+          ? { status: "cancelled" as const, cause: "deadline" as const }
+          : { status: "pending" as const }
+    })
+  },
+  cancellation: {
+    event: (cancellation, at) => ({ type: "HoldCancelled", id: cancellation.invocation.id, at })
+  }
+})
+const holdComponent = component<HoldState, undefined>({
+  name: "hold",
+  keys: {
+    prefixes: ["hold-request:", "hold-cancel:"],
+    keyOf: (event) => {
+      if (event.type === "HoldRequested") return `hold-request:${String((event as { readonly id?: unknown }).id)}`
+      if (event.type === "HoldCancelled") return `hold-cancel:${String((event as { readonly id?: unknown }).id)}`
+      return undefined
+    }
+  },
+  initial: initialHoldState,
+  step: stepHoldState,
+  output: () => ({ view: undefined, transitions: [] })
+})
+const holdActor = actor({ name: "echo", methods: { hold }, components: [holdComponent] })
+
 describe("the bun host", () => {
   test("root creation awaits the configured reservation and reuses it on later messages", async () => {
     const requests: string[] = []
@@ -458,55 +510,6 @@ describe("the bun host", () => {
 
   test("an alarm commits its deadline cancellation atomically", async () => {
     const path = freshPath()
-    interface HoldState {
-      readonly requests: ReadonlySet<string>
-      readonly cancelled: ReadonlySet<string>
-    }
-    const initialHoldState = (): HoldState => ({ requests: new Set(), cancelled: new Set() })
-    const stepHoldState = (hold: HoldState, event: Event): HoldState => {
-      const id = String((event as { readonly id?: unknown }).id ?? "")
-      if (event.type === "HoldRequested" && !hold.requests.has(id)) {
-        return { ...hold, requests: new Set(hold.requests).add(id) }
-      }
-      if (event.type === "HoldCancelled" && !hold.cancelled.has(id)) {
-        return { ...hold, cancelled: new Set(hold.cancelled).add(id) }
-      }
-      return hold
-    }
-    const hold = actorMethod({
-      input: Schema.Struct({ text: Schema.String }),
-      output: Schema.String,
-      event: ({ invocation, input, at }) => ({ type: "HoldRequested", id: invocation.id, text: input.text, at }),
-      projection: {
-        initial: initialHoldState,
-        step: stepHoldState,
-        output: (hold: HoldState) => ({
-          currentEpoch: () => 0,
-          invocationState: (invocation) => !hold.requests.has(invocation.id) ? undefined
-            : hold.cancelled.has(invocation.id)
-              ? { status: "cancelled" as const, cause: "deadline" as const }
-              : { status: "pending" as const }
-        })
-      },
-      cancellation: {
-        event: (cancellation, at) => ({ type: "HoldCancelled", id: cancellation.invocation.id, at })
-      }
-    })
-    const holdComponent = component<HoldState, undefined>({
-      name: "hold",
-      keys: {
-        prefixes: ["hold-request:", "hold-cancel:"],
-        keyOf: (event) => {
-          if (event.type === "HoldRequested") return `hold-request:${String((event as { readonly id?: unknown }).id)}`
-          if (event.type === "HoldCancelled") return `hold-cancel:${String((event as { readonly id?: unknown }).id)}`
-          return undefined
-        }
-      },
-      initial: initialHoldState,
-      step: stepHoldState,
-      output: () => ({ view: undefined, transitions: [] })
-    })
-    const holdActor = actor({ name: "echo", methods: { hold }, components: [holdComponent] })
     const alarm = new ManualAlarmScheduler()
     const h = await createBunHost({
       database: path,
@@ -557,6 +560,42 @@ describe("the bun host", () => {
     expect(h.work()).toBe(0)
     await h.close()
     threadDb.close()
+  })
+
+  test("an alarm-only log repairs its missing cancellation", async () => {
+    const path = freshPath()
+    const alarm = new ManualAlarmScheduler()
+    const h = await createBunHost({
+      database: path,
+      actorFor: () => holdActor,
+      keyOf: holdActor.keyOf,
+      alarm
+    })
+    // A log written before the atomic alarm commits: the alarm fact landed, its cancellation did not.
+    await h.seed("caller", [
+      created("caller"),
+      {
+        type: "HoldRequested",
+        id: "hold-1",
+        text: "held",
+        call: { invocation: { method: "hold", id: "hold-1", epoch: 0 }, deadlineAt: 50 },
+        at: 1
+      } as Event,
+      { type: "AlarmFired", scheduledFor: 50, at: 60 } as Event
+    ])
+    await h.recover()
+    const repaired = await h.read("caller")
+    expect(repaired.filter((event) => event.type === "CancellationRequested")).toHaveLength(1)
+    expect(repaired.find((event) => event.type === "CancellationRequested")).toMatchObject({
+      request: "deadline/hold/hold-1/0/50",
+      cause: "deadline"
+    })
+    expect(repaired.some((event) => event.type === "HoldCancelled")).toBe(true)
+    expect(await h.resting()).toBe(true)
+    expect(alarm.pending).toEqual([])
+    await h.drive()
+    expect((await h.read("caller")).filter((event) => event.type === "CancellationRequested")).toHaveLength(1)
+    await h.close()
   })
 
   test("threads names every thread the log holds", async () => {

--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -8,7 +8,7 @@ import type { KeyValueStore } from "effect/unstable/persistence"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import { actor, actorMethod, component } from "@clavia/tardigrade-core/actor"
 import { effect } from "@clavia/tardigrade-core/effect"
-import { actorFromProjections, type Actor } from "@clavia/tardigrade-core/runtime"
+import { actorFromProjections, actorRuntimeOf, type Actor } from "@clavia/tardigrade-core/runtime"
 import { completeTransitionProjection, type ErasedTransitionProjection } from "@clavia/tardigrade-core/transition"
 import { methodTimeoutKeys, methodTimeoutDerivation } from "@clavia/tardigrade-core/interaction/timeout"
 import { formatThreadAddress, parseThreadAddress } from "@clavia/tardigrade-core/transport/endpoint"
@@ -106,34 +106,20 @@ const options = (path: string): BunHostOptions<never> => ({
   keyOf
 })
 
-// Both bun deadline properties drive one hold actor: a cancellable method whose invocation cancels
-// on record, so the atomic and alarm-only-repair tests share its fixture.
-interface HoldState {
-  readonly requests: ReadonlySet<string>
-  readonly cancelled: ReadonlySet<string>
-}
-const initialHoldState = (): HoldState => ({ requests: new Set(), cancelled: new Set() })
-const stepHoldState = (hold: HoldState, event: Event): HoldState => {
-  const id = String((event as { readonly id?: unknown }).id ?? "")
-  if (event.type === "HoldRequested" && !hold.requests.has(id)) {
-    return { ...hold, requests: new Set(hold.requests).add(id) }
-  }
-  if (event.type === "HoldCancelled" && !hold.cancelled.has(id)) {
-    return { ...hold, cancelled: new Set(hold.cancelled).add(id) }
-  }
-  return hold
-}
+// Both bun deadline properties drive one cancellable hold actor.
+const hasHoldEvent = (events: ReadonlyArray<Event>, type: string, id: string): boolean =>
+  events.some((event) => event.type === type && String((event as { readonly id?: unknown }).id) === id)
 const hold = actorMethod({
   input: Schema.Struct({ text: Schema.String }),
   output: Schema.String,
   event: ({ invocation, input, at }) => ({ type: "HoldRequested", id: invocation.id, text: input.text, at }),
   projection: {
-    initial: initialHoldState,
-    step: stepHoldState,
-    output: (hold: HoldState) => ({
+    initial: () => [] as ReadonlyArray<Event>,
+    step: (events, event) => [...events, event],
+    output: (events) => ({
       currentEpoch: () => 0,
-      invocationState: (invocation) => !hold.requests.has(invocation.id) ? undefined
-        : hold.cancelled.has(invocation.id)
+      invocationState: (invocation) => !hasHoldEvent(events, "HoldRequested", invocation.id) ? undefined
+        : hasHoldEvent(events, "HoldCancelled", invocation.id)
           ? { status: "cancelled" as const, cause: "deadline" as const }
           : { status: "pending" as const }
     })
@@ -142,7 +128,7 @@ const hold = actorMethod({
     event: (cancellation, at) => ({ type: "HoldCancelled", id: cancellation.invocation.id, at })
   }
 })
-const holdComponent = component<HoldState, undefined>({
+const holdComponent = component<undefined, undefined>({
   name: "hold",
   keys: {
     prefixes: ["hold-request:", "hold-cancel:"],
@@ -152,11 +138,26 @@ const holdComponent = component<HoldState, undefined>({
       return undefined
     }
   },
-  initial: initialHoldState,
-  step: stepHoldState,
+  initial: () => undefined,
+  step: () => undefined,
   output: () => ({ view: undefined, transitions: [] })
 })
 const holdActor = actor({ name: "echo", methods: { hold }, components: [holdComponent] })
+const holdRuntime = actorRuntimeOf(holdActor)
+const heldInvocation = (deadlineAt = 50): Event => ({
+  type: "HoldRequested",
+  id: "hold-1",
+  text: "held",
+  call: { invocation: { method: "hold", id: "hold-1", epoch: 0 }, deadlineAt },
+  at: 1
+}) as Event
+const deadlineHost = (path: string, alarm: ManualAlarmScheduler) => createBunHost({
+  database: path,
+  actorFor: () => holdActor,
+  keyOf: holdRuntime.keyOf,
+  alarm
+})
+const eventsOf = (events: ReadonlyArray<Event>, type: string) => events.filter((event) => event.type === type)
 
 describe("the bun host", () => {
   test("root creation awaits the configured reservation and reuses it on later messages", async () => {
@@ -511,22 +512,8 @@ describe("the bun host", () => {
   test("an alarm commits its deadline cancellation atomically", async () => {
     const path = freshPath()
     const alarm = new ManualAlarmScheduler()
-    const h = await createBunHost({
-      database: path,
-      actorFor: () => holdActor,
-      keyOf: holdActor.keyOf,
-      alarm
-    })
-    await h.seed("caller", [
-      created("caller"),
-      {
-        type: "HoldRequested",
-        id: "hold-1",
-        text: "held",
-        call: { invocation: { method: "hold", id: "hold-1", epoch: 0 }, deadlineAt: 50 },
-        at: 1
-      } as Event
-    ])
+    const h = await deadlineHost(path, alarm)
+    await h.seed("caller", [created("caller"), heldInvocation()])
     await h.recover()
     expect(alarm.pending).toEqual([50])
     expect(h.work()).toBe(0)
@@ -539,8 +526,8 @@ describe("the bun host", () => {
       BEGIN SELECT RAISE(ABORT, 'reject deadline cancellation'); END`)
     await expect(alarm.advanceTo(60)).rejects.toThrow()
     const rejected = await h.read("caller")
-    expect(rejected.filter((event) => event.type === "AlarmFired")).toEqual([])
-    expect(rejected.filter((event) => event.type === "CancellationRequested")).toEqual([])
+    expect(eventsOf(rejected, "AlarmFired")).toEqual([])
+    expect(eventsOf(rejected, "CancellationRequested")).toEqual([])
     expect(h.work()).toBe(0)
     expect(alarm.pending).toEqual([])
 
@@ -565,27 +552,16 @@ describe("the bun host", () => {
   test("an alarm-only log repairs its missing cancellation", async () => {
     const path = freshPath()
     const alarm = new ManualAlarmScheduler()
-    const h = await createBunHost({
-      database: path,
-      actorFor: () => holdActor,
-      keyOf: holdActor.keyOf,
-      alarm
-    })
+    const h = await deadlineHost(path, alarm)
     // A log written before the atomic alarm commits: the alarm fact landed, its cancellation did not.
     await h.seed("caller", [
       created("caller"),
-      {
-        type: "HoldRequested",
-        id: "hold-1",
-        text: "held",
-        call: { invocation: { method: "hold", id: "hold-1", epoch: 0 }, deadlineAt: 50 },
-        at: 1
-      } as Event,
+      heldInvocation(),
       { type: "AlarmFired", scheduledFor: 50, at: 60 } as Event
     ])
     await h.recover()
     const repaired = await h.read("caller")
-    expect(repaired.filter((event) => event.type === "CancellationRequested")).toHaveLength(1)
+    expect(eventsOf(repaired, "CancellationRequested")).toHaveLength(1)
     expect(repaired.find((event) => event.type === "CancellationRequested")).toMatchObject({
       request: "deadline/hold/hold-1/0/50",
       cause: "deadline"
@@ -594,7 +570,7 @@ describe("the bun host", () => {
     expect(await h.resting()).toBe(true)
     expect(alarm.pending).toEqual([])
     await h.drive()
-    expect((await h.read("caller")).filter((event) => event.type === "CancellationRequested")).toHaveLength(1)
+    expect(eventsOf(await h.read("caller"), "CancellationRequested")).toHaveLength(1)
     await h.close()
   })
 

--- a/platform/bun/src/host.ts
+++ b/platform/bun/src/host.ts
@@ -19,7 +19,7 @@ import type { ThreadAllocation } from "@clavia/tardigrade-core/actor/allocation"
 import { formatThreadAddress, parseThreadAddress, type ThreadAddress, type ProviderEndpoint } from "@clavia/tardigrade-core/transport/endpoint"
 import type { Link } from "@clavia/tardigrade-core/transport/link"
 import { actorEventKeyOf, actorThreadsOf, type ActorThreadRecord, type ThreadRegistered, type ThreadRequested } from "@clavia/tardigrade-core/actor"
-import { alarmFired, earliestDeadlineOf } from "@clavia/tardigrade-core/interaction/timeout"
+import { alarmFired, deadlineCancellationEventsAt, earliestDeadlineOf } from "@clavia/tardigrade-core/interaction/timeout"
 import { methodIngressKeyOf } from "@clavia/tardigrade-core/interaction/invocation"
 import { type ActorMethods } from "@clavia/tardigrade-core/actor/method"
 import {
@@ -595,7 +595,12 @@ export const createBunHost = async <R = never>(options: BunHostOptions<R>): Prom
       const active = await runtimeOf(thread)
       if (active.alarm?.deadlineAt !== deadlineAt) return
       delete active.alarm
-      await appendTo(thread, [alarmFired({ scheduledFor: deadlineAt, at })])
+      // The alarm callback commits the alarm fact and the deadline cancellations it crossed in one append, so the batch lands whole or not at all (host.test.ts, "an alarm commits its deadline cancellation atomically").
+      const log = await active.runtime.runPromise(active.store.read)
+      await appendTo(thread, [
+        alarmFired({ scheduledFor: deadlineAt, at }),
+        ...(methods === undefined ? [] : deadlineCancellationEventsAt(log, methods, at))
+      ])
       driver.mark(thread)
       await drive()
     })

--- a/platform/bun/src/host.ts
+++ b/platform/bun/src/host.ts
@@ -595,7 +595,7 @@ export const createBunHost = async <R = never>(options: BunHostOptions<R>): Prom
       const active = await runtimeOf(thread)
       if (active.alarm?.deadlineAt !== deadlineAt) return
       delete active.alarm
-      // The alarm callback commits the alarm fact and the deadline cancellations it crossed in one append, so the batch lands whole or not at all (host.test.ts, "an alarm commits its deadline cancellation atomically").
+      // synchronizeAlarm commits each alarm with its crossed deadline cancellations (host.test.ts, "an alarm commits its deadline cancellation atomically").
       const log = await active.runtime.runPromise(active.store.read)
       await appendTo(thread, [
         alarmFired({ scheduledFor: deadlineAt, at }),

--- a/platform/cloudflare/src/host.ts
+++ b/platform/cloudflare/src/host.ts
@@ -230,7 +230,7 @@ export async function createCloudflareThreadHost<R = never>(options: CloudflareT
   const nextMethodDeadline = async (): Promise<number | undefined> => {
     return earliestDeadlineOf(await Effect.runPromise(events.read), methods)
   }
-  // recordAlarm commits the alarm fact and the deadline cancellations it crossed in one append (test/actor.workers.ts, "an alarm commits its deadline cancellation atomically").
+  // recordAlarm commits each alarm with its crossed deadline cancellations (test/actor.workers.ts, "an alarm commits its deadline cancellation atomically").
   const recordAlarm = async (at: number): Promise<void> => {
     const log = await Effect.runPromise(events.read)
     const deadline = earliestDeadlineOf(log, methods)

--- a/platform/cloudflare/src/host.ts
+++ b/platform/cloudflare/src/host.ts
@@ -12,7 +12,7 @@ import { ThreadAllocator, reserveRootThread } from "@clavia/tardigrade-core/acto
 import { initializingThreadAllocator } from "@clavia/tardigrade-host/allocation"
 import { formatThreadAddress, type ThreadAddress, type ProviderEndpoint } from "@clavia/tardigrade-core/transport/endpoint"
 import type { Link } from "@clavia/tardigrade-core/transport/link"
-import { alarmFired, earliestDeadlineOf } from "@clavia/tardigrade-core/interaction/timeout"
+import { alarmFired, deadlineCancellationEventsAt, earliestDeadlineOf } from "@clavia/tardigrade-core/interaction/timeout"
 import { methodIngressKeyOf } from "@clavia/tardigrade-core/interaction/invocation"
 import { type ActorMethods } from "@clavia/tardigrade-core/actor/method"
 import {
@@ -230,12 +230,16 @@ export async function createCloudflareThreadHost<R = never>(options: CloudflareT
   const nextMethodDeadline = async (): Promise<number | undefined> => {
     return earliestDeadlineOf(await Effect.runPromise(events.read), methods)
   }
+  // recordAlarm commits the alarm fact and the deadline cancellations it crossed in one append (test/actor.workers.ts, "an alarm commits its deadline cancellation atomically").
   const recordAlarm = async (at: number): Promise<void> => {
-    const deadline = earliestDeadlineOf(await Effect.runPromise(events.read), methods)
+    const log = await Effect.runPromise(events.read)
+    const deadline = earliestDeadlineOf(log, methods)
     if (deadline !== undefined && deadline <= at) {
-      const result = await Effect.runPromise(events.append([alarmFired({ scheduledFor: deadline, at })]))
+      const result = await Effect.runPromise(store.append([
+        alarmFired({ scheduledFor: deadline, at }),
+        ...(methods === undefined ? [] : deadlineCancellationEventsAt(log, methods, at))
+      ]))
       if (result.appended > 0) driver.mark(options.thread)
-      await Effect.runPromise(syncCommit(result))
     } else {
       await options.storage.sync()
     }

--- a/platform/cloudflare/test/actor.workers.ts
+++ b/platform/cloudflare/test/actor.workers.ts
@@ -48,6 +48,74 @@ const methodState = async (thread: string, call: string): Promise<unknown> => {
   return undefined
 }
 
+// Both deadline properties drive one hold actor: a cancellable method whose invocation completes or
+// cancels on record, so the atomic and stale-snapshot tests share its fixture.
+interface HoldState {
+  readonly requests: ReadonlySet<string>
+  readonly completed: ReadonlySet<string>
+  readonly cancelled: ReadonlySet<string>
+}
+const initialHoldState = (): HoldState => ({ requests: new Set(), completed: new Set(), cancelled: new Set() })
+const stepHoldState = (hold: HoldState, event: Event): HoldState => {
+  const id = String((event as { readonly id?: unknown }).id ?? "")
+  if (event.type === "HoldRequested" && !hold.requests.has(id)) {
+    return { ...hold, requests: new Set(hold.requests).add(id) }
+  }
+  if (event.type === "HoldCompleted" && !hold.completed.has(id)) {
+    return { ...hold, completed: new Set(hold.completed).add(id) }
+  }
+  if (event.type === "HoldCancelled" && !hold.cancelled.has(id)) {
+    return { ...hold, cancelled: new Set(hold.cancelled).add(id) }
+  }
+  return hold
+}
+const hold = actorMethod({
+  input: Schema.Struct({ text: Schema.String }),
+  output: Schema.String,
+  event: ({ invocation, input, at }) => ({ type: "HoldRequested", id: invocation.id, text: input.text, at }),
+  projection: {
+    initial: initialHoldState,
+    step: stepHoldState,
+    output: (hold: HoldState) => ({
+      currentEpoch: () => 0,
+      invocationState: (invocation) => !hold.requests.has(invocation.id) ? undefined
+        : hold.cancelled.has(invocation.id)
+          ? { status: "cancelled" as const, cause: "deadline" as const }
+          : hold.completed.has(invocation.id)
+            ? { status: "completed" as const, output: "done" }
+            : { status: "pending" as const }
+    })
+  },
+  cancellation: {
+    event: (cancellation, at) => ({ type: "HoldCancelled", id: cancellation.invocation.id, at })
+  }
+})
+const holdComponent = component<HoldState, undefined>({
+  name: "hold",
+  keys: {
+    prefixes: ["hold-request:", "hold-complete:", "hold-cancel:"],
+    keyOf: (event) => {
+      if (event.type === "HoldRequested") return `hold-request:${String((event as { readonly id?: unknown }).id)}`
+      if (event.type === "HoldCompleted") return `hold-complete:${String((event as { readonly id?: unknown }).id)}`
+      if (event.type === "HoldCancelled") return `hold-cancel:${String((event as { readonly id?: unknown }).id)}`
+      return undefined
+    }
+  },
+  initial: initialHoldState,
+  step: stepHoldState,
+  output: () => ({ view: undefined, transitions: [] })
+})
+const holdDeadlineActor = actor({ name: "echo", methods: { hold }, components: [holdComponent] })
+const deadlineThreadHost = (state: DurableObjectState, thread: string) =>
+  createCloudflareThreadHost({
+    storage: state.storage,
+    actorName: "echo",
+    actorInstance: "main",
+    thread,
+    actor: holdDeadlineActor,
+    keyOf: holdDeadlineActor.keyOf
+  })
+
 beforeAll(async () => {
   const db = (env as Env).CATALOG_DB
   const statements = (env as Env & { readonly CATALOG_MIGRATION: string }).CATALOG_MIGRATION
@@ -280,63 +348,7 @@ describe("cloudflare actor", () => {
 
   test("an alarm commits its deadline cancellation atomically", async () => {
     const result = await runInDurableObject(threadStub("deadline-atomicity"), async (_instance, state) => {
-      interface HoldState {
-        readonly requests: ReadonlySet<string>
-        readonly cancelled: ReadonlySet<string>
-      }
-      const initialHoldState = (): HoldState => ({ requests: new Set(), cancelled: new Set() })
-      const stepHoldState = (hold: HoldState, event: Event): HoldState => {
-        const id = String((event as { readonly id?: unknown }).id ?? "")
-        if (event.type === "HoldRequested" && !hold.requests.has(id)) {
-          return { ...hold, requests: new Set(hold.requests).add(id) }
-        }
-        if (event.type === "HoldCancelled" && !hold.cancelled.has(id)) {
-          return { ...hold, cancelled: new Set(hold.cancelled).add(id) }
-        }
-        return hold
-      }
-      const hold = actorMethod({
-        input: Schema.Struct({ text: Schema.String }),
-        output: Schema.String,
-        event: ({ invocation, input, at }) => ({ type: "HoldRequested", id: invocation.id, text: input.text, at }),
-        projection: {
-          initial: initialHoldState,
-          step: stepHoldState,
-          output: (hold: HoldState) => ({
-            currentEpoch: () => 0,
-            invocationState: (invocation) => !hold.requests.has(invocation.id) ? undefined
-              : hold.cancelled.has(invocation.id)
-                ? { status: "cancelled" as const, cause: "deadline" as const }
-                : { status: "pending" as const }
-          })
-        },
-        cancellation: {
-          event: (cancellation, at) => ({ type: "HoldCancelled", id: cancellation.invocation.id, at })
-        }
-      })
-      const holdComponent = component<HoldState, undefined>({
-        name: "hold",
-        keys: {
-          prefixes: ["hold-request:", "hold-cancel:"],
-          keyOf: (event) => {
-            if (event.type === "HoldRequested") return `hold-request:${String((event as { readonly id?: unknown }).id)}`
-            if (event.type === "HoldCancelled") return `hold-cancel:${String((event as { readonly id?: unknown }).id)}`
-            return undefined
-          }
-        },
-        initial: initialHoldState,
-        step: stepHoldState,
-        output: () => ({ view: undefined, transitions: [] })
-      })
-      const holdActor = actor({ name: "echo", methods: { hold }, components: [holdComponent] })
-      const host = await createCloudflareThreadHost({
-        storage: state.storage,
-        actorName: "echo",
-        actorInstance: "main",
-        thread: "ag.deadline-atomicity",
-        actor: holdActor,
-        keyOf: holdActor.keyOf
-      })
+      const host = await deadlineThreadHost(state, "ag.deadline-atomicity")
       const deadlineAt = Date.now() - 1
       await host.commitRoot({
         type: "HoldRequested",
@@ -391,70 +403,7 @@ describe("cloudflare actor", () => {
 
   test("a stale deadline cancellation leaves a settled invocation unchanged", async () => {
     const result = await runInDurableObject(threadStub("stale-deadline-cancellation"), async (_instance, state) => {
-      interface HoldState {
-        readonly requests: ReadonlySet<string>
-        readonly completed: ReadonlySet<string>
-        readonly cancelled: ReadonlySet<string>
-      }
-      const initialHoldState = (): HoldState => ({ requests: new Set(), completed: new Set(), cancelled: new Set() })
-      const stepHoldState = (hold: HoldState, event: Event): HoldState => {
-        const id = String((event as { readonly id?: unknown }).id ?? "")
-        if (event.type === "HoldRequested" && !hold.requests.has(id)) {
-          return { ...hold, requests: new Set(hold.requests).add(id) }
-        }
-        if (event.type === "HoldCompleted" && !hold.completed.has(id)) {
-          return { ...hold, completed: new Set(hold.completed).add(id) }
-        }
-        if (event.type === "HoldCancelled" && !hold.cancelled.has(id)) {
-          return { ...hold, cancelled: new Set(hold.cancelled).add(id) }
-        }
-        return hold
-      }
-      const hold = actorMethod({
-        input: Schema.Struct({ text: Schema.String }),
-        output: Schema.String,
-        event: ({ invocation, input, at }) => ({ type: "HoldRequested", id: invocation.id, text: input.text, at }),
-        projection: {
-          initial: initialHoldState,
-          step: stepHoldState,
-          output: (hold: HoldState) => ({
-            currentEpoch: () => 0,
-            invocationState: (invocation) => !hold.requests.has(invocation.id) ? undefined
-              : hold.cancelled.has(invocation.id)
-                ? { status: "cancelled" as const, cause: "deadline" as const }
-                : hold.completed.has(invocation.id)
-                  ? { status: "completed" as const, output: "done" }
-                  : { status: "pending" as const }
-          })
-        },
-        cancellation: {
-          event: (cancellation, at) => ({ type: "HoldCancelled", id: cancellation.invocation.id, at })
-        }
-      })
-      const holdComponent = component<HoldState, undefined>({
-        name: "hold",
-        keys: {
-          prefixes: ["hold-request:", "hold-complete:", "hold-cancel:"],
-          keyOf: (event) => {
-            if (event.type === "HoldRequested") return `hold-request:${String((event as { readonly id?: unknown }).id)}`
-            if (event.type === "HoldCompleted") return `hold-complete:${String((event as { readonly id?: unknown }).id)}`
-            if (event.type === "HoldCancelled") return `hold-cancel:${String((event as { readonly id?: unknown }).id)}`
-            return undefined
-          }
-        },
-        initial: initialHoldState,
-        step: stepHoldState,
-        output: () => ({ view: undefined, transitions: [] })
-      })
-      const holdActor = actor({ name: "echo", methods: { hold }, components: [holdComponent] })
-      const host = await createCloudflareThreadHost({
-        storage: state.storage,
-        actorName: "echo",
-        actorInstance: "main",
-        thread: "ag.stale-deadline-cancellation",
-        actor: holdActor,
-        keyOf: holdActor.keyOf
-      })
+      const host = await deadlineThreadHost(state, "ag.stale-deadline-cancellation")
       const invocation = { method: "hold", id: "hold-1", epoch: 0 }
       const deadlineAt = Date.now() - 1
       await host.commitRoot({

--- a/platform/cloudflare/test/actor.workers.ts
+++ b/platform/cloudflare/test/actor.workers.ts
@@ -48,7 +48,6 @@ const methodState = async (thread: string, call: string): Promise<unknown> => {
   return undefined
 }
 
-// Both deadline properties drive one cancellable hold actor.
 const hasHoldEvent = (events: ReadonlyArray<Event>, type: string, id: string): boolean =>
   events.some((event) => event.type === type && String((event as { readonly id?: unknown }).id) === id)
 const hold = actorMethod({

--- a/platform/cloudflare/test/actor.workers.ts
+++ b/platform/cloudflare/test/actor.workers.ts
@@ -1,5 +1,7 @@
 import { env, runInDurableObject, SELF } from "cloudflare:test"
-import { Effect, ManagedRuntime } from "effect"
+import { Effect, ManagedRuntime, Schema } from "effect"
+import { actor, actorMethod, component } from "tardie"
+import type { Event } from "@clavia/tardigrade-core/event"
 import { beforeAll, describe, expect, test } from "vitest"
 import { makeActorClient } from "@clavia/tardigrade-client"
 import type { ModelCatalog } from "@clavia/tardigrade-client/contract"
@@ -274,6 +276,117 @@ describe("cloudflare actor", () => {
       scheduledFor: deadlineAt
     }))
   })
+
+  test("an alarm commits its deadline cancellation atomically", async () => {
+    const result = await runInDurableObject(threadStub("deadline-atomicity"), async (_instance, state) => {
+      interface HoldState {
+        readonly requests: ReadonlySet<string>
+        readonly cancelled: ReadonlySet<string>
+      }
+      const initialHoldState = (): HoldState => ({ requests: new Set(), cancelled: new Set() })
+      const stepHoldState = (hold: HoldState, event: Event): HoldState => {
+        const id = String((event as { readonly id?: unknown }).id ?? "")
+        if (event.type === "HoldRequested" && !hold.requests.has(id)) {
+          return { ...hold, requests: new Set(hold.requests).add(id) }
+        }
+        if (event.type === "HoldCancelled" && !hold.cancelled.has(id)) {
+          return { ...hold, cancelled: new Set(hold.cancelled).add(id) }
+        }
+        return hold
+      }
+      const hold = actorMethod({
+        input: Schema.Struct({ text: Schema.String }),
+        output: Schema.String,
+        event: ({ invocation, input, at }) => ({ type: "HoldRequested", id: invocation.id, text: input.text, at }),
+        projection: {
+          initial: initialHoldState,
+          step: stepHoldState,
+          output: (hold: HoldState) => ({
+            currentEpoch: () => 0,
+            invocationState: (invocation) => !hold.requests.has(invocation.id) ? undefined
+              : hold.cancelled.has(invocation.id)
+                ? { status: "cancelled" as const, cause: "deadline" as const }
+                : { status: "pending" as const }
+          })
+        },
+        cancellation: {
+          event: (cancellation, at) => ({ type: "HoldCancelled", id: cancellation.invocation.id, at })
+        }
+      })
+      const holdComponent = component<HoldState, undefined>({
+        name: "hold",
+        keys: {
+          prefixes: ["hold-request:", "hold-cancel:"],
+          keyOf: (event) => {
+            if (event.type === "HoldRequested") return `hold-request:${String((event as { readonly id?: unknown }).id)}`
+            if (event.type === "HoldCancelled") return `hold-cancel:${String((event as { readonly id?: unknown }).id)}`
+            return undefined
+          }
+        },
+        initial: initialHoldState,
+        step: stepHoldState,
+        output: () => ({ view: undefined, transitions: [] })
+      })
+      const holdActor = actor({ name: "echo", methods: { hold }, components: [holdComponent] })
+      const host = await createCloudflareThreadHost({
+        storage: state.storage,
+        actorName: "echo",
+        actorInstance: "main",
+        thread: "ag.deadline-atomicity",
+        actor: holdActor,
+        keyOf: holdActor.keyOf
+      })
+      const deadlineAt = Date.now() - 1
+      await host.commitRoot({
+        type: "HoldRequested",
+        id: "hold-1",
+        text: "held",
+        call: { invocation: { method: "hold", id: "hold-1", epoch: 0 }, deadlineAt },
+        at: deadlineAt - 100
+      })
+      await host.drive()
+      const pending = await host.read()
+      const wokenAfterIngress = host.work()
+      state.storage.sql.exec(`CREATE TRIGGER reject_deadline_cancellation
+        BEFORE INSERT ON events
+        WHEN NEW.key LIKE 'cx:%'
+        BEGIN SELECT RAISE(ABORT, 'reject deadline cancellation'); END`)
+      let rejected = ""
+      try {
+        await host.recordAlarm(Date.now())
+      } catch (error) {
+        rejected = error instanceof Error ? error.message : String(error)
+      }
+      const afterRejection = await host.read()
+      const idleAfterRejection = host.work()
+      state.storage.sql.exec("DROP TRIGGER reject_deadline_cancellation")
+      await host.recordAlarm(Date.now())
+      const afterAlarm = await host.read()
+      const wokenAfterAlarm = host.work()
+      await host.drive()
+      const settled = await host.read()
+      const resting = await host.resting()
+      const idleAfterDrive = host.work()
+      await host.close()
+      return { pending, wokenAfterIngress, rejected, afterRejection, idleAfterRejection, afterAlarm, wokenAfterAlarm, settled, resting, idleAfterDrive }
+    })
+
+    expect(result.rejected).not.toBe("")
+    expect(result.pending.filter((event) => event.type === "HoldRequested")).toHaveLength(1)
+    expect(result.pending.some((event) => event.type === "AlarmFired")).toBe(false)
+    expect(result.wokenAfterIngress).toBe(0)
+    expect(result.afterRejection.filter((event) => event.type === "AlarmFired")).toEqual([])
+    expect(result.afterRejection.filter((event) => event.type === "CancellationRequested")).toEqual([])
+    expect(result.idleAfterRejection).toBe(0)
+    const alarmAt = result.afterAlarm.findIndex((event) => event.type === "AlarmFired")
+    const cancellationAt = result.afterAlarm.findIndex((event) => event.type === "CancellationRequested")
+    expect(alarmAt).toBeGreaterThanOrEqual(0)
+    expect(cancellationAt).toBeGreaterThan(alarmAt)
+    expect(result.wokenAfterAlarm).toBe(1)
+    expect(result.settled.some((event) => event.type === "HoldCancelled")).toBe(true)
+    expect(result.resting).toBe(true)
+    expect(result.idleAfterDrive).toBe(0)
+  }, WORKER_INTEGRATION_TIMEOUT_MILLIS)
 
   test("the creation cache follows the record accepted by storage", async () => {
     const target = { actor: "echo", instance: "main", thread: "ag.creation-cache" }

--- a/platform/cloudflare/test/actor.workers.ts
+++ b/platform/cloudflare/test/actor.workers.ts
@@ -7,6 +7,7 @@ import { makeActorClient } from "@clavia/tardigrade-client"
 import type { ModelCatalog } from "@clavia/tardigrade-client/contract"
 import { ModelCatalogRepository } from "@clavia/tardigrade-server/catalog-store"
 import { actorFromProjections } from "@clavia/tardigrade-core/runtime"
+import { deadlineCancellationEventsAt } from "@clavia/tardigrade-core/interaction/timeout"
 import {
   backgroundTaskOwnerOf,
   DEFAULT_BACKGROUND_TASK_OWNER,
@@ -386,6 +387,107 @@ describe("cloudflare actor", () => {
     expect(result.settled.some((event) => event.type === "HoldCancelled")).toBe(true)
     expect(result.resting).toBe(true)
     expect(result.idleAfterDrive).toBe(0)
+  }, WORKER_INTEGRATION_TIMEOUT_MILLIS)
+
+  test("a stale deadline cancellation leaves a settled invocation unchanged", async () => {
+    const result = await runInDurableObject(threadStub("stale-deadline-cancellation"), async (_instance, state) => {
+      interface HoldState {
+        readonly requests: ReadonlySet<string>
+        readonly completed: ReadonlySet<string>
+        readonly cancelled: ReadonlySet<string>
+      }
+      const initialHoldState = (): HoldState => ({ requests: new Set(), completed: new Set(), cancelled: new Set() })
+      const stepHoldState = (hold: HoldState, event: Event): HoldState => {
+        const id = String((event as { readonly id?: unknown }).id ?? "")
+        if (event.type === "HoldRequested" && !hold.requests.has(id)) {
+          return { ...hold, requests: new Set(hold.requests).add(id) }
+        }
+        if (event.type === "HoldCompleted" && !hold.completed.has(id)) {
+          return { ...hold, completed: new Set(hold.completed).add(id) }
+        }
+        if (event.type === "HoldCancelled" && !hold.cancelled.has(id)) {
+          return { ...hold, cancelled: new Set(hold.cancelled).add(id) }
+        }
+        return hold
+      }
+      const hold = actorMethod({
+        input: Schema.Struct({ text: Schema.String }),
+        output: Schema.String,
+        event: ({ invocation, input, at }) => ({ type: "HoldRequested", id: invocation.id, text: input.text, at }),
+        projection: {
+          initial: initialHoldState,
+          step: stepHoldState,
+          output: (hold: HoldState) => ({
+            currentEpoch: () => 0,
+            invocationState: (invocation) => !hold.requests.has(invocation.id) ? undefined
+              : hold.cancelled.has(invocation.id)
+                ? { status: "cancelled" as const, cause: "deadline" as const }
+                : hold.completed.has(invocation.id)
+                  ? { status: "completed" as const, output: "done" }
+                  : { status: "pending" as const }
+          })
+        },
+        cancellation: {
+          event: (cancellation, at) => ({ type: "HoldCancelled", id: cancellation.invocation.id, at })
+        }
+      })
+      const holdComponent = component<HoldState, undefined>({
+        name: "hold",
+        keys: {
+          prefixes: ["hold-request:", "hold-complete:", "hold-cancel:"],
+          keyOf: (event) => {
+            if (event.type === "HoldRequested") return `hold-request:${String((event as { readonly id?: unknown }).id)}`
+            if (event.type === "HoldCompleted") return `hold-complete:${String((event as { readonly id?: unknown }).id)}`
+            if (event.type === "HoldCancelled") return `hold-cancel:${String((event as { readonly id?: unknown }).id)}`
+            return undefined
+          }
+        },
+        initial: initialHoldState,
+        step: stepHoldState,
+        output: () => ({ view: undefined, transitions: [] })
+      })
+      const holdActor = actor({ name: "echo", methods: { hold }, components: [holdComponent] })
+      const host = await createCloudflareThreadHost({
+        storage: state.storage,
+        actorName: "echo",
+        actorInstance: "main",
+        thread: "ag.stale-deadline-cancellation",
+        actor: holdActor,
+        keyOf: holdActor.keyOf
+      })
+      const invocation = { method: "hold", id: "hold-1", epoch: 0 }
+      const deadlineAt = Date.now() - 1
+      await host.commitRoot({
+        type: "HoldRequested",
+        id: "hold-1",
+        text: "held",
+        call: { invocation, deadlineAt },
+        at: deadlineAt - 100
+      })
+      await host.drive()
+      const beforeTerminal = await host.read()
+      const stale = deadlineCancellationEventsAt(beforeTerminal, { hold }, Date.now())
+      await host.commitRoot({ type: "HoldCompleted", id: "hold-1", at: deadlineAt - 50 })
+      await host.drive()
+      const settled = await host.read()
+      for (const event of stale) await host.commitRoot(event)
+      await host.drive()
+      const afterStale = await host.read()
+      const resting = await host.resting()
+      await host.close()
+      return { stale, settled, afterStale, resting }
+    })
+
+    expect(result.stale).toHaveLength(1)
+    expect(result.stale[0]).toMatchObject({
+      type: "CancellationRequested",
+      cause: "deadline",
+      invocation: { method: "hold", id: "hold-1", epoch: 0 }
+    })
+    expect(result.settled.filter((event) => event.type === "HoldCompleted")).toHaveLength(1)
+    expect(result.afterStale.filter((event) => event.type === "HoldCompleted")).toHaveLength(1)
+    expect(result.afterStale.some((event) => event.type === "HoldCancelled")).toBe(false)
+    expect(result.resting).toBe(true)
   }, WORKER_INTEGRATION_TIMEOUT_MILLIS)
 
   test("the creation cache follows the record accepted by storage", async () => {

--- a/platform/cloudflare/test/actor.workers.ts
+++ b/platform/cloudflare/test/actor.workers.ts
@@ -6,7 +6,7 @@ import { beforeAll, describe, expect, test } from "vitest"
 import { makeActorClient } from "@clavia/tardigrade-client"
 import type { ModelCatalog } from "@clavia/tardigrade-client/contract"
 import { ModelCatalogRepository } from "@clavia/tardigrade-server/catalog-store"
-import { actorFromProjections } from "@clavia/tardigrade-core/runtime"
+import { actorFromProjections, actorRuntimeOf } from "@clavia/tardigrade-core/runtime"
 import { deadlineCancellationEventsAt } from "@clavia/tardigrade-core/interaction/timeout"
 import {
   backgroundTaskOwnerOf,
@@ -48,40 +48,22 @@ const methodState = async (thread: string, call: string): Promise<unknown> => {
   return undefined
 }
 
-// Both deadline properties drive one hold actor: a cancellable method whose invocation completes or
-// cancels on record, so the atomic and stale-snapshot tests share its fixture.
-interface HoldState {
-  readonly requests: ReadonlySet<string>
-  readonly completed: ReadonlySet<string>
-  readonly cancelled: ReadonlySet<string>
-}
-const initialHoldState = (): HoldState => ({ requests: new Set(), completed: new Set(), cancelled: new Set() })
-const stepHoldState = (hold: HoldState, event: Event): HoldState => {
-  const id = String((event as { readonly id?: unknown }).id ?? "")
-  if (event.type === "HoldRequested" && !hold.requests.has(id)) {
-    return { ...hold, requests: new Set(hold.requests).add(id) }
-  }
-  if (event.type === "HoldCompleted" && !hold.completed.has(id)) {
-    return { ...hold, completed: new Set(hold.completed).add(id) }
-  }
-  if (event.type === "HoldCancelled" && !hold.cancelled.has(id)) {
-    return { ...hold, cancelled: new Set(hold.cancelled).add(id) }
-  }
-  return hold
-}
+// Both deadline properties drive one cancellable hold actor.
+const hasHoldEvent = (events: ReadonlyArray<Event>, type: string, id: string): boolean =>
+  events.some((event) => event.type === type && String((event as { readonly id?: unknown }).id) === id)
 const hold = actorMethod({
   input: Schema.Struct({ text: Schema.String }),
   output: Schema.String,
   event: ({ invocation, input, at }) => ({ type: "HoldRequested", id: invocation.id, text: input.text, at }),
   projection: {
-    initial: initialHoldState,
-    step: stepHoldState,
-    output: (hold: HoldState) => ({
+    initial: () => [] as ReadonlyArray<Event>,
+    step: (events, event) => [...events, event],
+    output: (events) => ({
       currentEpoch: () => 0,
-      invocationState: (invocation) => !hold.requests.has(invocation.id) ? undefined
-        : hold.cancelled.has(invocation.id)
+      invocationState: (invocation) => !hasHoldEvent(events, "HoldRequested", invocation.id) ? undefined
+        : hasHoldEvent(events, "HoldCancelled", invocation.id)
           ? { status: "cancelled" as const, cause: "deadline" as const }
-          : hold.completed.has(invocation.id)
+          : hasHoldEvent(events, "HoldCompleted", invocation.id)
             ? { status: "completed" as const, output: "done" }
             : { status: "pending" as const }
     })
@@ -90,7 +72,7 @@ const hold = actorMethod({
     event: (cancellation, at) => ({ type: "HoldCancelled", id: cancellation.invocation.id, at })
   }
 })
-const holdComponent = component<HoldState, undefined>({
+const holdComponent = component<undefined, undefined>({
   name: "hold",
   keys: {
     prefixes: ["hold-request:", "hold-complete:", "hold-cancel:"],
@@ -101,11 +83,20 @@ const holdComponent = component<HoldState, undefined>({
       return undefined
     }
   },
-  initial: initialHoldState,
-  step: stepHoldState,
+  initial: () => undefined,
+  step: () => undefined,
   output: () => ({ view: undefined, transitions: [] })
 })
 const holdDeadlineActor = actor({ name: "echo", methods: { hold }, components: [holdComponent] })
+const holdDeadlineRuntime = actorRuntimeOf(holdDeadlineActor)
+const heldInvocation = (deadlineAt: number): Event => ({
+  type: "HoldRequested",
+  id: "hold-1",
+  text: "held",
+  call: { invocation: { method: "hold", id: "hold-1", epoch: 0 }, deadlineAt },
+  at: deadlineAt - 100
+})
+const eventsOf = (events: ReadonlyArray<Event>, type: string) => events.filter((event) => event.type === type)
 const deadlineThreadHost = (state: DurableObjectState, thread: string) =>
   createCloudflareThreadHost({
     storage: state.storage,
@@ -113,7 +104,7 @@ const deadlineThreadHost = (state: DurableObjectState, thread: string) =>
     actorInstance: "main",
     thread,
     actor: holdDeadlineActor,
-    keyOf: holdDeadlineActor.keyOf
+    keyOf: holdDeadlineRuntime.keyOf
   })
 
 beforeAll(async () => {
@@ -347,96 +338,57 @@ describe("cloudflare actor", () => {
   })
 
   test("an alarm commits its deadline cancellation atomically", async () => {
-    const result = await runInDurableObject(threadStub("deadline-atomicity"), async (_instance, state) => {
+    await runInDurableObject(threadStub("deadline-atomicity"), async (_instance, state) => {
       const host = await deadlineThreadHost(state, "ag.deadline-atomicity")
       const deadlineAt = Date.now() - 1
-      await host.commitRoot({
-        type: "HoldRequested",
-        id: "hold-1",
-        text: "held",
-        call: { invocation: { method: "hold", id: "hold-1", epoch: 0 }, deadlineAt },
-        at: deadlineAt - 100
-      })
+      await host.commitRoot(heldInvocation(deadlineAt))
       await host.drive()
-      const pending = await host.read()
-      const wokenAfterIngress = host.work()
+      expect(eventsOf(await host.read(), "HoldRequested")).toHaveLength(1)
+      expect(eventsOf(await host.read(), "AlarmFired")).toEqual([])
+      expect(host.work()).toBe(0)
       state.storage.sql.exec(`CREATE TRIGGER reject_deadline_cancellation
         BEFORE INSERT ON events
         WHEN NEW.key LIKE 'cx:%'
         BEGIN SELECT RAISE(ABORT, 'reject deadline cancellation'); END`)
-      let rejected = ""
-      try {
-        await host.recordAlarm(Date.now())
-      } catch (error) {
-        rejected = error instanceof Error ? error.message : String(error)
-      }
-      const afterRejection = await host.read()
-      const idleAfterRejection = host.work()
+      await expect(host.recordAlarm(Date.now())).rejects.toThrow()
+      expect(eventsOf(await host.read(), "AlarmFired")).toEqual([])
+      expect(eventsOf(await host.read(), "CancellationRequested")).toEqual([])
+      expect(host.work()).toBe(0)
       state.storage.sql.exec("DROP TRIGGER reject_deadline_cancellation")
       await host.recordAlarm(Date.now())
       const afterAlarm = await host.read()
-      const wokenAfterAlarm = host.work()
+      const alarmAt = afterAlarm.findIndex((event) => event.type === "AlarmFired")
+      expect(afterAlarm.findIndex((event) => event.type === "CancellationRequested")).toBeGreaterThan(alarmAt)
+      expect(alarmAt).toBeGreaterThanOrEqual(0)
+      expect(host.work()).toBe(1)
       await host.drive()
-      const settled = await host.read()
-      const resting = await host.resting()
-      const idleAfterDrive = host.work()
+      expect(eventsOf(await host.read(), "HoldCancelled")).toHaveLength(1)
+      expect(await host.resting()).toBe(true)
+      expect(host.work()).toBe(0)
       await host.close()
-      return { pending, wokenAfterIngress, rejected, afterRejection, idleAfterRejection, afterAlarm, wokenAfterAlarm, settled, resting, idleAfterDrive }
     })
-
-    expect(result.rejected).not.toBe("")
-    expect(result.pending.filter((event) => event.type === "HoldRequested")).toHaveLength(1)
-    expect(result.pending.some((event) => event.type === "AlarmFired")).toBe(false)
-    expect(result.wokenAfterIngress).toBe(0)
-    expect(result.afterRejection.filter((event) => event.type === "AlarmFired")).toEqual([])
-    expect(result.afterRejection.filter((event) => event.type === "CancellationRequested")).toEqual([])
-    expect(result.idleAfterRejection).toBe(0)
-    const alarmAt = result.afterAlarm.findIndex((event) => event.type === "AlarmFired")
-    const cancellationAt = result.afterAlarm.findIndex((event) => event.type === "CancellationRequested")
-    expect(alarmAt).toBeGreaterThanOrEqual(0)
-    expect(cancellationAt).toBeGreaterThan(alarmAt)
-    expect(result.wokenAfterAlarm).toBe(1)
-    expect(result.settled.some((event) => event.type === "HoldCancelled")).toBe(true)
-    expect(result.resting).toBe(true)
-    expect(result.idleAfterDrive).toBe(0)
   }, WORKER_INTEGRATION_TIMEOUT_MILLIS)
 
   test("a stale deadline cancellation leaves a settled invocation unchanged", async () => {
-    const result = await runInDurableObject(threadStub("stale-deadline-cancellation"), async (_instance, state) => {
+    await runInDurableObject(threadStub("stale-deadline-cancellation"), async (_instance, state) => {
       const host = await deadlineThreadHost(state, "ag.stale-deadline-cancellation")
       const invocation = { method: "hold", id: "hold-1", epoch: 0 }
       const deadlineAt = Date.now() - 1
-      await host.commitRoot({
-        type: "HoldRequested",
-        id: "hold-1",
-        text: "held",
-        call: { invocation, deadlineAt },
-        at: deadlineAt - 100
-      })
+      await host.commitRoot(heldInvocation(deadlineAt))
       await host.drive()
-      const beforeTerminal = await host.read()
-      const stale = deadlineCancellationEventsAt(beforeTerminal, { hold }, Date.now())
+      const stale = deadlineCancellationEventsAt(await host.read(), { hold }, Date.now())
+      expect(stale).toHaveLength(1)
+      expect(stale[0]).toMatchObject({ type: "CancellationRequested", cause: "deadline", invocation })
       await host.commitRoot({ type: "HoldCompleted", id: "hold-1", at: deadlineAt - 50 })
       await host.drive()
-      const settled = await host.read()
       for (const event of stale) await host.commitRoot(event)
       await host.drive()
       const afterStale = await host.read()
-      const resting = await host.resting()
+      expect(eventsOf(afterStale, "HoldCompleted")).toHaveLength(1)
+      expect(eventsOf(afterStale, "HoldCancelled")).toEqual([])
+      expect(await host.resting()).toBe(true)
       await host.close()
-      return { stale, settled, afterStale, resting }
     })
-
-    expect(result.stale).toHaveLength(1)
-    expect(result.stale[0]).toMatchObject({
-      type: "CancellationRequested",
-      cause: "deadline",
-      invocation: { method: "hold", id: "hold-1", epoch: 0 }
-    })
-    expect(result.settled.filter((event) => event.type === "HoldCompleted")).toHaveLength(1)
-    expect(result.afterStale.filter((event) => event.type === "HoldCompleted")).toHaveLength(1)
-    expect(result.afterStale.some((event) => event.type === "HoldCancelled")).toBe(false)
-    expect(result.resting).toBe(true)
   }, WORKER_INTEGRATION_TIMEOUT_MILLIS)
 
   test("the creation cache follows the record accepted by storage", async () => {


### PR DESCRIPTION
## What and why

When a host alarm crosses a method deadline, the host previously committed `AlarmFired` before reconciliation committed the corresponding cancellation request. A crash between those writes left the invocation pending with no remaining wake because the durable alarm fact made the deadline appear served.

This change commits the alarm fact and every cancellation owed at the observed crossing in one store append. The transaction records the complete crossing or records nothing.

## Implementation

- `deadlineCancellationEventsAt` in `packages/core/src/interaction/timeout.ts` constructs cancellation events for overdue, running, cancellable invocations. Its private selector skips future deadlines, settled invocations, existing cancellation requests, and methods without cancellation support.
- `methodDeadlineCancellationDerivation` uses the same selection logic to repair logs written before atomic alarm commits were available. Repeated alarm facts derive one cancellation per invocation, and a committed cancellation prevents another derivation.
- The Cloudflare `recordAlarm` path reads the current log and appends `AlarmFired` plus every crossed cancellation through one transactional store call.
- The Bun alarm callback applies the same batch contract through its SQLite event store.
- Both hosts mark work only after the append succeeds. Their existing cancellation reconciliation then settles the invocation.

## Verification

The branch is rebased onto `9d38ca0`, the v0.22.1 release commit. Local `bun run gate` completed all 69 tasks after the implementation and test simplification. The final rebase added only the release metadata already validated on `main`.

- Core timeout coverage passes 8 tests. The new table-driven selection test covers eligible, future, settled, already-requested, unsupported, and multiple-crossing cases. The legacy recovery test proves complete and incremental derivations agree and remain idempotent.
- The Bun host suite passes 34 tests. Its atomicity test uses a SQLite trigger to reject the cancellation insert and proves the alarm fact rolls back with it. Its recovery test proves an alarm-only legacy log gains exactly one cancellation and reaches rest.
- The Cloudflare worker suite passes 27 tests. Its atomicity test proves rollback and clean retry against real Durable Object storage. Its stale-snapshot test proves a cancellation calculated before completion cannot replace the committed completion.
- Core, Bun, and Cloudflare typechecks pass. The affected files pass oxlint and Effect diagnostics.

## Limits

An alarm-only log written before this change is repaired when its thread next wakes. A legacy thread with no traffic and no pending alarm remains idle until another event wakes it.

The durable cancellation request uses the reconciler's existing interruption behavior. An effect that cannot be interrupted may still finish, while the cancellation decision remains durable.
