### PR TITLE
feat(model): pass identity to adapter start

### DIFF
--- a/docs/how-to/server.md
+++ b/docs/how-to/server.md
@@ -108,7 +108,7 @@ Catalog responses use cursor pagination. They include `revision`, `status`, `ref
 
 ## Live inference output
 
-An embedded Bun host can pass `inferenceObserver` to `layerThreads`. The observer receives normalized text after the provider adapter and before the final action is accumulated. Each delta names the actor, thread, turn, logical attempt, physical provider request, model, text block, and sequence. The host chooses its WebSocket, SSE, Redis, or pub/sub transport.
+An embedded Bun host can pass `inferenceObserver` to `layerThreads`. The observer receives normalized text after the provider adapter and before the final action is accumulated. Each delta names the actor, instance, thread, turn, logical attempt, physical provider request, model, text block, and sequence. The host chooses its WebSocket, SSE, Redis, or pub/sub transport.
 
 ```ts
 import { Effect } from "effect"

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -43,7 +43,12 @@ const work = () => codeMode([agentsPackage({ budget: {} }), workspacePackage({ p
 // hosted binds one assembled actor to an in-process host and drives the root thread. It is the
 // test's own driver: commit a root brief, drive to quiescence, read the boundary the settle left.
 // A caller with its own host does the same three things (host.ts, Host).
-const hosted = (assembled: Actor<TestR>, mind: Mind, log: ReadonlyArray<Event> = []) => {
+const hosted = (
+  assembled: Actor<TestR>,
+  mind: Mind,
+  log: ReadonlyArray<Event> = [],
+  actorInstance: string = "main"
+) => {
   const layersFor = (_thread: string): ThreadEnv<TestR> =>
     Layer.mergeAll(
       KeyValueStore.layerMemory,
@@ -53,6 +58,7 @@ const hosted = (assembled: Actor<TestR>, mind: Mind, log: ReadonlyArray<Event> =
     )
   const host: Host = createHost<TestR>({
     actorName: "mem",
+    actorInstance,
     actorFor: (thread: string) => (thread.startsWith("ag.") ? assembled : undefined),
     layersFor
   })
@@ -84,12 +90,17 @@ const hosted = (assembled: Actor<TestR>, mind: Mind, log: ReadonlyArray<Event> =
 // rlm is the default assembly: the work surface, budget, and compaction, over an
 // in-process host. The three policy components are always mounted, so a test that swaps the
 // work surface still runs the same turn loop, budget wall, and answer contract.
-const rlm = (mind: Mind, components: ReadonlyArray<AgentComponent<AgentR>> = [work()], log: ReadonlyArray<Event> = []) =>
+const rlm = (
+  mind: Mind,
+  components: ReadonlyArray<AgentComponent<AgentR>> = [work()],
+  log: ReadonlyArray<Event> = [],
+  actorInstance: string = "main"
+) =>
   hosted(actor({
     name: "test-agent",
     methods: agentMethods,
     components: [infer([budget(components), compaction(), nativeOutput], TEST_MODEL)]
-  }), mind, log)
+  }), mind, log, actorInstance)
 
 const headText = (trajectory: ReadonlyArray<Event>): string => {
   for (let i = trajectory.length - 1; i >= 0; i--) {
@@ -247,17 +258,34 @@ describe("an assembled agent", () => {
     await mind.run("fan out and add")
     expect(seen.some(({ request }) =>
       request.identity.actor === "mem" &&
+      request.identity.instance === "main" &&
       request.identity.thread === ROOT_THREAD &&
       request.identity.turn === "run-0"
     )).toBe(true)
-    expect(new Set(seen.map(({ request }) => request.identity.thread))).toEqual(new Set([
-      ROOT_THREAD,
-      "ag.5:run-0t1.0",
-      "ag.5:run-0t1.1"
+    // Same actor name, same instance, one thread per request: the root and its children are
+    // distinguishable by identity alone.
+    expect(new Set(seen.map(({ request }) =>
+      `${request.identity.actor}:${request.identity.instance}:${request.identity.thread}`
+    ))).toEqual(new Set([
+      "mem:main:ag.root",
+      "mem:main:ag.5:run-0t1.0",
+      "mem:main:ag.5:run-0t1.1"
     ]))
     for (const { request, key } of seen) {
       expect(key?.startsWith(`${request.identity.turn}/infer/`)).toBe(true)
     }
+  })
+
+  test("two host instances of one actor name carry distinct instance identities", async () => {
+    const seen: InferRequest[] = []
+    const mind = rlm(async (request) => {
+      seen.push(request)
+      return { kind: "complete", output: "done" }
+    }, [work()], [], "other")
+    await mind.run("go")
+    expect(seen.map(({ identity }) => identity)).toEqual([
+      { actor: "mem", instance: "other", thread: ROOT_THREAD, turn: "run-0" }
+    ])
   })
 
   test("an agent initialises from a log: history carries, new runs continue past it", async () => {

--- a/packages/agent/src/inference/observer.ts
+++ b/packages/agent/src/inference/observer.ts
@@ -1,9 +1,10 @@
 import type { Effect } from "effect"
 import type { ModelRef } from "./reference"
 
-// InferenceIdentity identifies the actor turn that opened a logical model attempt (index.test.ts, "root and child inference requests carry their actor identity").
+// InferenceIdentity identifies the actor turn that opened a logical model attempt. instance names the actor instance, so two sessions of one actor name stay distinguishable at the model seam (index.test.ts, "root and child inference requests carry their actor identity").
 export interface InferenceIdentity {
   readonly actor: string
+  readonly instance: string
   readonly thread: string
   readonly turn: string
 }

--- a/packages/agent/src/inference/observer.ts
+++ b/packages/agent/src/inference/observer.ts
@@ -1,7 +1,7 @@
 import type { Effect } from "effect"
 import type { ModelRef } from "./reference"
 
-// InferenceIdentity identifies the actor turn that opened a logical model attempt. instance names the actor instance, so two sessions of one actor name stay distinguishable at the model seam (index.test.ts, "root and child inference requests carry their actor identity").
+// InferenceIdentity identifies the actor turn that opened a logical model attempt (index.test.ts, "root and child inference requests carry their actor identity"). instance names the actor instance, so two sessions of one actor name stay distinguishable at the model seam (index.test.ts, "two host instances of one actor name carry distinct instance identities").
 export interface InferenceIdentity {
   readonly actor: string
   readonly instance: string

--- a/platform/model/src/adapter.ts
+++ b/platform/model/src/adapter.ts
@@ -1,4 +1,5 @@
 import type { ModelMessage, StreamChunk, Tool } from "@tanstack/ai"
+import type { InferenceIdentity } from "tardie/inference/observer"
 import type { ModelRequest } from "tardie/inference/request"
 import type { OutputMode } from "tardie/output/contract"
 import type { ModelPricing } from "tardie/inference/usage"
@@ -50,6 +51,8 @@ export type ModelStopClass = "refused" | "truncated" | "violation" | "ok"
 export interface ModelAdapterContext {
   readonly config: ModelConfig
   readonly request: ModelRequest
+  // identity names the actor turn this attempt serves, so an adapter can attribute usage and authorize per instance (model.test.ts, "an adapter start receives the request's inference identity").
+  readonly identity: InferenceIdentity
   readonly mode: OutputMode
   readonly maxTokens: number
   readonly bounds: StreamBounds

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -11,7 +11,8 @@ import {
   repairFallback,
   VALIDATE_ONCE_FALLBACK,
   NATIVE_MODE,
-  type InferDelta
+  type InferDelta,
+  type InferenceIdentity
 } from "tardie"
 
 // reqOf wraps a trajectory in the render the actor would derive: the code surface half.
@@ -323,6 +324,56 @@ describe("infer end to end", () => {
       ) as Effect.Effect<unknown>
     )
     expect(action).toMatchObject({ kind: "complete", output: "the answer is 4" })
+  })
+
+  test("an adapter start receives the request's inference identity", async () => {
+    const seen: InferenceIdentity[] = []
+    const adapter: ModelAdapter = {
+      id: "test/identity",
+      protocols: ["bedrock-converse"],
+      start: (context) => {
+        seen.push(context.identity)
+        return {
+          stream: {
+            async *[Symbol.asyncIterator]() {
+              yield { type: "TEXT_MESSAGE_START", messageId: "s", role: "assistant", timestamp: 1 } as never
+              yield { type: "TEXT_MESSAGE_CONTENT", messageId: "s", delta: "ok", timestamp: 2 } as never
+              yield { type: "TEXT_MESSAGE_END", messageId: "s", timestamp: 3 } as never
+            }
+          }
+        }
+      }
+    }
+    const layer = infer({
+      baseUrl: "https://bedrock.test/us-east-1",
+      apiKey: "k",
+      model: "anthropic.claude-test",
+      protocol: "bedrock-converse",
+      provider: "bedrock",
+      contextWindowTokens: 128_000
+    }, modelAdapters(adapter))
+    // A root and a child of one actor name carry distinct identities, so an adapter can
+    // attribute and authorize per instance even when the actor name repeats.
+    const requestOf = (identity: InferenceIdentity) => ({
+      trajectory: [{ type: "MessageReceived", id: "m1", text: "go", at: 1 }] as ReadonlyArray<Event>,
+      identity,
+      ...surfaceRender
+    })
+    for (const identity of [
+      { actor: "mem", instance: "main", thread: "ag.root", turn: "run-0" },
+      { actor: "mem", instance: "main", thread: "ag.t1.0", turn: "run-1" }
+    ] as const) {
+      const action = await Effect.runPromise(
+        Effect.flatMap(Infer, (model) => model.react(requestOf(identity))).pipe(
+          Effect.provide(layer)
+        ) as Effect.Effect<unknown>
+      )
+      expect(action).toMatchObject({ kind: "complete", output: "ok" })
+    }
+    expect(seen).toEqual([
+      { actor: "mem", instance: "main", thread: "ag.root", turn: "run-0" },
+      { actor: "mem", instance: "main", thread: "ag.t1.0", turn: "run-1" }
+    ])
   })
 
   const ANSWER = JSON.stringify({ aspects: [{ name: "a", description: "b" }] })

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -18,7 +18,7 @@ import {
 const surfaceRender = renderOf([codeMode(), nativeOutput], [])
 const reqOf = (trajectory: ReadonlyArray<Event>) => ({
   trajectory,
-  identity: { actor: "test", thread: "root", turn: "m1" },
+  identity: { actor: "test", instance: "main", thread: "root", turn: "m1" },
   ...surfaceRender
 })
 import { Infer } from "tardie"
@@ -362,7 +362,7 @@ describe("infer end to end", () => {
     const action = (await Effect.runPromise(
       Effect.flatMap(Infer, (model) => model.react({
         trajectory: declared(),
-        identity: { actor: "test", thread: "root", turn: "m1" },
+        identity: { actor: "test", instance: "main", thread: "root", turn: "m1" },
         ...render
       })).pipe(
         Effect.provide(layer)
@@ -580,6 +580,7 @@ describe("ephemeral inference deltas", () => {
     expect(deltas).toEqual([
       {
         actor: "test",
+        instance: "main",
         thread: "root",
         turn: "m1",
         logicalAttempt: "m1/infer/0",
@@ -591,6 +592,7 @@ describe("ephemeral inference deltas", () => {
       },
       {
         actor: "test",
+        instance: "main",
         thread: "root",
         turn: "m1",
         logicalAttempt: "m1/infer/0",

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -619,6 +619,7 @@ export const infer = <const C extends ModelConfig>(
     const attempt = selectedAdapter.start({
       config,
       request: req,
+      identity,
       mode,
       maxTokens,
       bounds,


### PR DESCRIPTION
[👾 omp · openrouter/z-ai/glm-5.3 · agency: directed · intent: add the actor instance to InferenceIdentity and expose the identity at the model adapter seam]

## What and why

A custom model adapter is the seam for usage attribution and authorization, and today it cannot see who is asking. `InferenceIdentity` carries `{actor, thread, turn}`, and a `ThreadAddress` carries one more coordinate, the actor instance.

Threads separate two sessions of one actor name within a host. The instance is the coordinate a deployment uses to separate tenants of one actor name, and the adapter seam sees none of it. An adapter that meters spend per tenant or scopes a provider credential per instance has to reconstruct the instance from request text.

The change hands the identity to the adapter, instance included:

- `InferenceIdentity` gains `instance`. Both construction sites (the inference machine's model ask and the compactor's summarize pass) build the identity by spreading the `Self` thread address, so the instance arrives from the same source the actor coordinates already do, with no second derivation to keep in sync. Ephemeral delta observers inherit the field through `InferDelta`.
- `docs/how-to/server.md` lists the instance among the fields an inference delta carries, since the delta now declares the coordinate.

Non-goals:

- No routing, metering, or authorization behavior in the framework itself. The field is inert context for adapter authors.
- No durable-log change. The identity stays ephemeral, the `ModelCalled` mark keeps its existing shape, and no new field is sent to the provider.

Alternative shapes, happy to rework:

- `identity` could sit on `ModelRequest` instead of `ModelAdapterContext`. I kept them apart because `ModelRequest` is what the actor's render decides while the identity is what the platform binds, and conflating them would let a render rewrite attribution coordinates.
- The context could expose the three address fields separately. I kept the one shared `InferenceIdentity` type so the adapter seam and the delta observer read the same shape.
- If threads are considered sufficient identity (they are unique within a host), the instance field can be dropped and the rest of the change stands. The cost of keeping it is one string on a value that already exists.

Verification at 8e33508 (the head is a comment-citation follow-up to a7d7123, where the change itself was validated):

- [x] `bun run gate` passes locally (the narrow gates below all pass, and the full gate passes at this commit)
- [x] Docs updated if behavior changed (docs/how-to/server.md names the instance among the fields a delta carries; the field list on `ModelAdapterContext` appears in no docs page, generated or hand-written)
- [x] Tests cover the change
- `bun run gate --only=typecheck,lint,lint:effect`: all pass, 16 typecheck projects, 20 lint:effect projects at 0 errors and 0 warnings, oxlint and docs lint clean.
- `bun test` in packages/agent: 247 pass, 0 fail.
- `bun test` in platform/model: 60 pass, 0 fail.
- index.test.ts, "root and child inference requests carry their actor identity": now asserts the full actor:instance:thread tuple over a root and its two children, so a root and a child of one actor name are distinguishable by identity alone.
- index.test.ts, "two host instances of one actor name carry distinct instance identities": drives a second host instance of the same actor name and proves the instance coordinate follows the bound address.
- model.test.ts, "an adapter start receives the request's inference identity": a capturing adapter proves all four fields reach `start()` and that a root identity and a child identity arrive distinct.

Limits:

- The full `bun run gate` passes locally at this commit, including the app builds and the platform suites this change does not touch. Every package this change touches is covered above.
