### PR TITLE
fix(agent): name children by parent run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: canary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   gate:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   validate-title:
     name: validate pull request title
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
     steps:
       - uses: ytanikin/pr-conventional-commits@639145d78959c53c43112365837e3abd21ed67c1 # 1.5.2

--- a/e2e/actor/graph.test.ts
+++ b/e2e/actor/graph.test.ts
@@ -16,7 +16,7 @@ import {
 } from "tardie"
 import { agentsPackage } from "tardie/packages/agents"
 import { workspacePackage } from "@clavia/tardigrade-code/package/workspace"
-import { actorScenario, ROOT_THREAD, TEST_MODEL, type Mind } from "./harness"
+import { actorScenario, childThreadsOf, ROOT_THREAD, TEST_MODEL, type Mind } from "./harness"
 
 const WORKER_RESULT = output({
   name: "worker-result",
@@ -160,8 +160,9 @@ test("an actor graph covers concurrent calls, budget negotiation, structured out
     String((event as { readonly method?: unknown }).method) === "message"
   )).toHaveLength(6)
 
+  const childThreads = childThreadsOf(root)
   for (const run of runs.slice(0, 5)) {
-    const child = graph.host.read(`ag.${String(run.callId)}`)
+    const child = graph.host.read(childThreads.get(String(run.callId))!)
     expect(child.filter((event) => event.type === "BudgetExhausted")).toHaveLength(1)
     expect(child.filter((event) => event.type === "BudgetRequested")).toHaveLength(1)
     expect(child.filter((event) => event.type === "CallDispatched")).toHaveLength(1)

--- a/e2e/actor/harness.ts
+++ b/e2e/actor/harness.ts
@@ -1,5 +1,6 @@
-import { Effect, Layer } from "effect"
+import { Effect, Layer, Schema } from "effect"
 import { KeyValueStore } from "effect/unstable/persistence"
+import { ChildCreated } from "@clavia/tardigrade-core/thread"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import type { Actor } from "@clavia/tardigrade-core/actor"
 import { jsSandboxFor } from "@clavia/tardigrade-code/sandbox/defaults"
@@ -14,6 +15,18 @@ import {
 import type { Action } from "tardie/log/events"
 
 export const ROOT_THREAD = "ag.root"
+
+// childThreadsOf maps each spawn's call id to the address its ChildCreated recorded. The child's
+// address is a fact of the parent log, never a naming convention a test re-derives.
+export const childThreadsOf = (root: ReadonlyArray<Event>): ReadonlyMap<string, string> => {
+  const threads = new Map<string, string>()
+  for (const event of root) {
+    if (!Schema.is(ChildCreated)(event)) continue
+    threads.set(event.callId, event.address.thread)
+  }
+  return threads
+}
+
 export const TEST_MODEL = {
   models: {
     default: { provider: "test", model_id: "test-model" },

--- a/e2e/actor/mortyplicity.test.ts
+++ b/e2e/actor/mortyplicity.test.ts
@@ -23,7 +23,7 @@ import {
 } from "tardie"
 import { agentsPackage } from "tardie/packages/agents"
 import { workspacePackage } from "@clavia/tardigrade-code/package/workspace"
-import { actorScenario, ROOT_THREAD, TEST_MODEL, type Mind } from "./harness"
+import { actorScenario, childThreadsOf, ROOT_THREAD, TEST_MODEL, type Mind } from "./harness"
 
 type Outcome = "grant" | "deny" | "fail" | "timeout"
 
@@ -313,10 +313,11 @@ test("Rick and Morty survive generated portal, budget, permission, human, and sc
         const mission = byKey.get(match?.[1] ?? "")
         return (match?.[2] === "1" ? mission?.firstPermission : mission?.secondPermission) !== "timeout"
       })
+      const children = childThreadsOf(scenario.host.read(ROOT_THREAD))
       const timeoutCalls = scenario.host.read(ROOT_THREAD)
         .filter((event) => event.type === "PackageCalled" && field(event, "name") === "agents.run")
         .flatMap((run) => {
-          const thread = `ag.${String(field(run, "callId"))}`
+          const thread = children.get(String(field(run, "callId")))!
           const child = scenario.host.read(thread)
           const terminal = new Set(child
             .filter((event) => event.type === "ResponseReceived" || event.type === "CallTimedOut")
@@ -404,7 +405,8 @@ test("Rick and Morty survive generated portal, budget, permission, human, and sc
     const expectedPermissionResponses = missions.reduce((count, mission) =>
       count + (mission.firstPermission === "timeout" ? 0 : 1) +
       (mission.firstPermission === "grant" && mission.budget === "grant" && mission.secondPermission !== "timeout" ? 1 : 0), 0)
-    const childEvents = runs.flatMap((run) => scenario.host.read(`ag.${String(field(run, "callId"))}`))
+    const children = childThreadsOf(root)
+    const childEvents = runs.flatMap((run) => scenario.host.read(children.get(String(field(run, "callId")))!))
     const dispatchedPermissions = childEvents.filter((event) =>
       event.type === "CallDispatched" && field(event, "method") === "requestPermission"
     )
@@ -423,7 +425,7 @@ test("Rick and Morty survive generated portal, budget, permission, human, and sc
     expect(timedOut).toHaveLength(expectedTimeouts)
 
     for (const run of runs) {
-      const child = scenario.host.read(`ag.${String(field(run, "callId"))}`)
+      const child = scenario.host.read(children.get(String(field(run, "callId")))!)
       expect(child.filter((event) => event.type === "TurnCompleted")).toHaveLength(1)
       expect(child.filter((event) => event.type === "TurnFailed")).toHaveLength(0)
       expect(child.filter((event) =>
@@ -547,7 +549,7 @@ test("Rick cancels every foreground Morty across generated schedules", async () 
     const runs = root.filter((event) => event.type === "PackageCalled" && field(event, "name") === "agents.run")
     expect(runs).toHaveLength(children)
     for (const run of runs) {
-      const child = scenario.host.read(`ag.${String(field(run, "callId"))}`)
+      const child = scenario.host.read(childThreadsOf(root).get(String(field(run, "callId")))!)
       expect(child.filter((event) => event.type === "CancellationRequested")).toHaveLength(1)
       expect(child.filter((event) => event.type === "TurnCancelled")).toHaveLength(1)
       expect(child.some((event) => event.type === "TurnCompleted")).toBe(false)

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -220,11 +220,11 @@ describe("an assembled agent", () => {
       at: 1
     })
     expect(mind.host.read(ROOT_THREAD).filter((event) => event.type === "ChildCreated")).toEqual([
-      expect.objectContaining({ callId: "t1.0", address: { actor: "mem", instance: "main", thread: "ag.t1.0" }, depth: 1 }),
-      expect.objectContaining({ callId: "t1.1", address: { actor: "mem", instance: "main", thread: "ag.t1.1" }, depth: 1 })
+      expect.objectContaining({ callId: "t1.0", turn: "run-0", address: { actor: "mem", instance: "main", thread: "ag.5:run-0t1.0" }, depth: 1 }),
+      expect.objectContaining({ callId: "t1.1", turn: "run-0", address: { actor: "mem", instance: "main", thread: "ag.5:run-0t1.1" }, depth: 1 })
     ])
     // The graph existed: two child threads, each with a served turn.
-    const children = ["ag.t1.0", "ag.t1.1"].map((thread) => mind.host.read(thread))
+    const children = ["ag.5:run-0t1.0", "ag.5:run-0t1.1"].map((thread) => mind.host.read(thread))
     for (const log of children) {
       expect(threadCreatedOf(log)).toMatchObject({
         address: { actor: "mem" },
@@ -252,8 +252,8 @@ describe("an assembled agent", () => {
     )).toBe(true)
     expect(new Set(seen.map(({ request }) => request.identity.thread))).toEqual(new Set([
       ROOT_THREAD,
-      "ag.t1.0",
-      "ag.t1.1"
+      "ag.5:run-0t1.0",
+      "ag.5:run-0t1.1"
     ]))
     for (const { request, key } of seen) {
       expect(key?.startsWith(`${request.identity.turn}/infer/`)).toBe(true)
@@ -297,7 +297,7 @@ describe("an assembled agent", () => {
     expect(again.output).toBe('"4,6"')
     // The second turn ran its own execution and spawned its own children.
     expect(mind.host.read(ROOT_THREAD).filter((e) => e.type === "CodeSettled")).toHaveLength(2)
-    for (const thread of ["ag.t2.0", "ag.t2.1"]) {
+    for (const thread of ["ag.5:run-1t2.0", "ag.5:run-1t2.1"]) {
       expect(mind.host.read(thread).some((e) => e.type === "TurnCompleted")).toBe(true)
     }
   })

--- a/packages/agent/src/packages/agents.properties.test.ts
+++ b/packages/agent/src/packages/agents.properties.test.ts
@@ -32,7 +32,19 @@ const plans = fc.uniqueArray(callPlan, { selector: (plan) => plan.callId, minLen
 const childProtocol = async (calls: ReadonlyArray<CallPlan>): Promise<void> => {
   const parent = threadAddressOf("property", "main", "ag.root")
   const host = createHost({ actorName: parent.actor, actorFor: () => undefined })
-  const parentLog: Event[] = [threadCreated(parent, undefined, 0)]
+  // The parent run every spawn reads its identity from: one open turn, one recorded call per plan.
+  const parentLog: Event[] = [
+    threadCreated(parent, undefined, 0),
+    { type: "MessageReceived", id: "turn-1", text: "delegate", at: 1 },
+    ...calls.map((plan): Event => ({
+      type: "PackageCalled",
+      callId: plan.callId,
+      name: "agents.run",
+      arguments: {},
+      turn: "turn-1",
+      at: 2
+    }))
+  ]
   const actions: Array<{ readonly kind: "append" | "send"; readonly callId: string; readonly target?: ThreadAddress }> = []
   const remaining = new Map(calls.map((plan) => [plan.callId, plan.failures]))
   const plansByCall = new Map(calls.map((plan) => [plan.callId, plan]))

--- a/packages/agent/src/packages/agents.test.ts
+++ b/packages/agent/src/packages/agents.test.ts
@@ -469,6 +469,27 @@ describe("a child is named by its parent run and call", () => {
     expect(threads(sent)).toEqual(["ag.2:m1crash-1", "ag.2:m1crash-1"])
   })
 
+  test("a creation record without a turn still names its child", async () => {
+    // A record written before the turn field existed carries the address the old scheme minted;
+    // the replay reads it and never records a second child.
+    const events: Event[] = [
+      threadCreated(parseThreadAddress("mem:main:ag.root"), undefined, 0),
+      turn("m1"),
+      called("legacy-1", "m1"),
+      {
+        type: "ChildCreated",
+        callId: "legacy-1",
+        address: { actor: "mem", instance: "main", thread: "ag.legacy-1" },
+        depth: 1,
+        at: 3
+      } as Event
+    ]
+    const sent: Array<Sent> = []
+    await Effect.runPromise(background("scout", "legacy-1").pipe(Effect.provide(liveEnv(events, sent))))
+    expect(threads(sent)).toEqual(["ag.legacy-1"])
+    expect(events.filter((event) => event.type === "ChildCreated")).toHaveLength(1)
+  })
+
   test("a background child inherits the owning turn deadline without a parent link", async () => {
     const events: Event[] = [
       threadCreated(parseThreadAddress("mem:main:ag.root"), undefined, 0),

--- a/packages/agent/src/packages/agents.test.ts
+++ b/packages/agent/src/packages/agents.test.ts
@@ -490,6 +490,33 @@ describe("a child is named by its parent run and call", () => {
     expect(events.filter((event) => event.type === "ChildCreated")).toHaveLength(1)
   })
 
+  test("a derived address that names another child dies rather than delivering", async () => {
+    // A legacy call id names its child ag.<callId>, so a run can derive that address for a
+    // different call: run "m1" with call "c1" names ag.2:m1c1, the child legacy call 2:m1c1
+    // owns. The dispatch dies instead of crossing the brief.
+    const events: Event[] = [
+      threadCreated(parseThreadAddress("mem:main:ag.root"), undefined, 0),
+      turn("m1"),
+      {
+        type: "ChildCreated",
+        callId: "2:m1c1",
+        address: { actor: "mem", instance: "main", thread: "ag.2:m1c1" },
+        depth: 1,
+        at: 1
+      } as Event,
+      called("c1", "m1")
+    ]
+    const sent: Array<Sent> = []
+    const exit = await Effect.runPromiseExit(
+      background("scout", "c1").pipe(Effect.provide(liveEnv(events, sent)))
+    )
+    if (exit._tag !== "Failure") throw new Error("expected the colliding dispatch to die")
+    expect(Cause.pretty(exit.cause)).toContain(
+      "agents.run c1 derives child address mem:main:ag.2:m1c1, which child 2:m1c1 already owns"
+    )
+    expect(sent).toHaveLength(0)
+  })
+
   test("a background child inherits the owning turn deadline without a parent link", async () => {
     const events: Event[] = [
       threadCreated(parseThreadAddress("mem:main:ag.root"), undefined, 0),

--- a/packages/agent/src/packages/agents.test.ts
+++ b/packages/agent/src/packages/agents.test.ts
@@ -407,6 +407,17 @@ const liveEnv = (events: Event[], sent: Array<Sent>) => {
   )
 }
 
+// A turn head served through the actor method machinery carries its call context, deadline
+// included (packages/core/src/communication/envelope.test.ts, "methodEnvelopeOf").
+const turnWithDeadline = (id: string, deadlineAt: number): Event =>
+  ({
+    type: "MessageReceived",
+    id,
+    text: "delegate",
+    call: { invocation: { method: "message", id, epoch: 0 }, deadlineAt },
+    at: 1
+  } as Event)
+
 describe("a child is named by its parent run and call", () => {
   const run = agentsPackage().methods.run!
   const background = (text: string, callId: string) =>
@@ -456,6 +467,21 @@ describe("a child is named by its parent run and call", () => {
     events.splice(events.findIndex((event) => event.type === "ChildCreated"), 1)
     await Effect.runPromise(background("scout", "crash-1").pipe(Effect.provide(liveEnv(events, sent))))
     expect(threads(sent)).toEqual(["ag.2:m1crash-1", "ag.2:m1crash-1"])
+  })
+
+  test("a background child inherits the owning turn deadline without a parent link", async () => {
+    const events: Event[] = [
+      threadCreated(parseThreadAddress("mem:main:ag.root"), undefined, 0),
+      turnWithDeadline("m1", 86_400_002),
+      called("bg-1", "m1")
+    ]
+    const sent: Array<Sent> = []
+    await Effect.runPromise(background("scout", "bg-1").pipe(Effect.provide(liveEnv(events, sent))))
+    expect(sent[0]?.call).toEqual({
+      invocation: { method: "message", id: "bg-1", epoch: 0 },
+      deadlineAt: 86_400_002
+    })
+    expect(events.some((event) => event.type === "InvocationLinked")).toBe(false)
   })
 
   test("a run with no parent turn dies rather than naming a child", async () => {

--- a/packages/agent/src/packages/agents.test.ts
+++ b/packages/agent/src/packages/agents.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { Effect, Layer } from "effect"
+import { Cause, Effect, Layer } from "effect"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import { Router } from "@clavia/tardigrade-core/communication/router"
 import { Self } from "@clavia/tardigrade-core/runtime"
@@ -64,12 +64,19 @@ const response = (
   at: options.at ?? 1
 })
 
+// A spawn reads its parent run off the log: the turn head serving it and the package call that
+// recorded it (agents.ts, parentRunOf).
+const turn = (id: string, at = 1): Event =>
+  ({ type: "MessageReceived", id, text: "delegate", at } as Event)
+const called = (callId: string, turnId: string, at = 2): Event =>
+  ({ type: "PackageCalled", callId, name: "agents.run", arguments: {}, turn: turnId, at } as Event)
+
 describe("agentsPackage", () => {
   test("a foreground child records its invocation owner", async () => {
     const sent: Array<Sent> = []
     const appended: Array<Event> = []
     const pkg = agentsPackage()
-    const events = [{
+    const events = [turn("m1"), {
       type: "PackageCalled",
       callId: "child-1",
       name: "agents.run",
@@ -91,7 +98,7 @@ describe("agentsPackage", () => {
       type: "InvocationLinked",
       parent: { method: "message", id: "m1", epoch: 2 },
       child: expect.objectContaining({ invocation: { method: "message", id: "child-1", epoch: 0 } }),
-      target: "mem:main:ag.child-1"
+      target: "mem:main:ag.2:m1child-1"
     }))
     expect(sent[0]?.call).toMatchObject({
       parent: { method: "message", id: "m1", epoch: 2 },
@@ -187,11 +194,13 @@ describe("agentsPackage", () => {
     const sent: Array<Sent> = []
     const pkg = agentsPackage()
     await Effect.runPromise(
-      pkg.methods.run!({ text: "scout", background: true, escalatable: true }, { callId: "c1" }).pipe(Effect.provide(env(host.self("ag.root"), sent)))
+      pkg.methods.run!({ text: "scout", background: true, escalatable: true }, { callId: "c1" }).pipe(
+        Effect.provide(env(host.self("ag.root"), sent, { "ag.root": [turn("m1"), called("c1", "m1")] }))
+      )
     )
-    // Parity with the closure the in-process host used to pass: same actorName, `ag.<callId>`
-    // for the thread.
-    expect(sent[0]?.link.target).toEqual({ actor: "mem", instance: "main", thread: "ag.c1" })
+    // Parity with the closure the in-process host used to pass: same actorName, the thread
+    // named by the parent run and call (agents.ts, childThreadId).
+    expect(sent[0]?.link.target).toEqual({ actor: "mem", instance: "main", thread: "ag.2:m1c1" })
     expect(sent[0]?.event).toMatchObject({ escalatable: true })
   })
 
@@ -200,7 +209,7 @@ describe("agentsPackage", () => {
     const pkg = agentsPackage()
     await Effect.runPromise(
       pkg.methods.run!({ text: "scout", background: true, placement: "independent" }, { callId: "independent-child" })
-        .pipe(Effect.provide(env("mem:main:ag.root", sent)))
+        .pipe(Effect.provide(env("mem:main:ag.root", sent, { "ag.root": [turn("m1"), called("independent-child", "m1")] })))
     )
     expect(sent[0]?.lineage?.placement).toBe("independent")
   })
@@ -208,7 +217,7 @@ describe("agentsPackage", () => {
   test("a run refuses an unknown thread placement", async () => {
     const result = await Effect.runPromise(
       agentsPackage().methods.run!({ text: "scout", background: true, placement: "nearby" }, { callId: "bad-placement" })
-        .pipe(Effect.provide(env("mem:main:ag.root", [])))
+        .pipe(Effect.provide(env("mem:main:ag.root", [], { "ag.root": [turn("m1"), called("bad-placement", "m1")] })))
     )
     expect(result).toEqual({ error: "agents.run placement must be colocated or independent" })
   })
@@ -217,14 +226,16 @@ describe("agentsPackage", () => {
     const sent: Array<Sent> = []
     const pkg = agentsPackage()
     const answer = await Effect.runPromise(
-      pkg.methods.run!({ text: "scout", background: true }, { callId: "c3" }).pipe(Effect.provide(env("mem:main:ag.root", sent)))
+      pkg.methods.run!({ text: "scout", background: true }, { callId: "c3" }).pipe(
+        Effect.provide(env("mem:main:ag.root", sent, { "ag.root": [turn("m1"), called("c3", "m1")] }))
+      )
     )
     expect(answer).toEqual({ dispatched: true, callId: "c3" })
     const brief = sent[0]!.event as { id?: unknown }
     expect(brief.id).toBe("c3")
     expect(sent[0]!.link).toEqual({
       source: { actor: "mem", instance: "main", thread: "ag.root" },
-      target: { actor: "mem", instance: "main", thread: "ag.c3" }
+      target: { actor: "mem", instance: "main", thread: "ag.2:m1c3" }
     })
   })
 
@@ -234,16 +245,19 @@ describe("agentsPackage", () => {
     const sent: Array<Sent> = []
     const inherited = agentsPackage()
     const fixed = agentsPackage({ models: { default: selected, allow: "*" } })
+    const calls = {
+      "ag.root": [turn("m1"), called("model-1", "m1"), called("model-2", "m1"), called("model-3", "m1")]
+    }
     await Effect.runPromise(
-      inherited.methods.run!({ text: "default pass", background: true }, { callId: "model-1" }).pipe(Effect.provide(env("mem:main:ag.root", sent)))
+      inherited.methods.run!({ text: "default pass", background: true }, { callId: "model-1" }).pipe(Effect.provide(env("mem:main:ag.root", sent, calls)))
     )
     await Effect.runPromise(
-      fixed.methods.run!({ text: "fixed pass", background: true }, { callId: "model-2" }).pipe(Effect.provide(env("mem:main:ag.root", sent)))
+      fixed.methods.run!({ text: "fixed pass", background: true }, { callId: "model-2" }).pipe(Effect.provide(env("mem:main:ag.root", sent, calls)))
     )
     expect(sent[0]!.event).not.toHaveProperty("model")
     expect(sent[1]!.event).toMatchObject({ model: selected })
     await Effect.runPromise(
-      fixed.methods.run!({ text: "other", background: true, model: overridden }, { callId: "model-3" }).pipe(Effect.provide(env("mem:main:ag.root", sent)))
+      fixed.methods.run!({ text: "other", background: true, model: overridden }, { callId: "model-3" }).pipe(Effect.provide(env("mem:main:ag.root", sent, calls)))
     )
     expect(sent[2]!.event).toMatchObject({ model: overridden })
     expect(sent).toHaveLength(3)
@@ -273,7 +287,7 @@ describe("agentsPackage", () => {
     const sent: Array<Sent> = []
     await Effect.runPromise(
       pkg.methods.run!({ text: "scout", background: true }, { callId: "narrow" }).pipe(
-        Effect.provide(env("mem:main:ag.root", sent, { "ag.root": [parent] }))
+        Effect.provide(env("mem:main:ag.root", sent, { "ag.root": [parent, called("narrow", "parent")] }))
       )
     )
     expect(sent[0]!.event).toMatchObject({
@@ -297,7 +311,7 @@ describe("agentsPackage", () => {
     const sent: Array<Sent> = []
     await Effect.runPromise(
       agentsPackage().methods.run!({ text: "scout", background: true }, { callId: "inherit" }).pipe(
-        Effect.provide(env("mem:main:ag.root", sent, { "ag.root": [parent] }))
+        Effect.provide(env("mem:main:ag.root", sent, { "ag.root": [parent, called("inherit", "parent")] }))
       )
     )
     expect(sent[0]!.event).toMatchObject({
@@ -313,7 +327,7 @@ describe("agentsPackage", () => {
     const sent: Array<Sent> = []
     const pkg = agentsPackage()
     const threads = {
-      "ag.root": [response("c4", "completed", "4")]
+      "ag.root": [turn("m1"), called("c4", "m1"), response("c4", "completed", "4")]
     } as Readonly<Record<string, ReadonlyArray<Event>>>
     const answer = await Effect.runPromise(
       pkg.methods.run!({ text: "sum 2+2" }, { callId: "c4" }).pipe(Effect.provide(env("mem:main:ag.root", sent, threads)))
@@ -330,14 +344,14 @@ describe("agentsPackage", () => {
       // flip then orDie: the call must park, and a success is a defect rather than a failure
       // typed as the method's own result.
       pkg.methods.run!({ text: "sum 2+2" }, { callId: "c5" }).pipe(
-        Effect.provide(env("mem:main:ag.root", sent)),
+        Effect.provide(env("mem:main:ag.root", sent, { "ag.root": [turn("m1"), called("c5", "m1")] })),
         Effect.flip,
         Effect.orDie
       )
     )
     expect(parked).toBeInstanceOf(Park)
     expect((parked as Park).awaiting).toBe(replyId("c5"))
-    expect(formatThreadAddress(sent[0]!.link.target as ThreadAddress)).toBe("mem:main:ag.c5")
+    expect(formatThreadAddress(sent[0]!.link.target as ThreadAddress)).toBe("mem:main:ag.2:m1c5")
   })
 
   test("result reads the response from its own log", async () => {
@@ -366,13 +380,94 @@ describe("agentsPackage", () => {
       }
     })
     const answer = await Effect.runPromise(
-      pkg.methods.run!({ text: "draft", budget: 0.7 }, { callId: "c8" }).pipe(Effect.provide(env("mem:main:ag.root", sent)))
+      pkg.methods.run!({ text: "draft", budget: 0.7 }, { callId: "c8" }).pipe(
+        Effect.provide(env("mem:main:ag.root", sent, { "ag.root": [turn("m1"), called("c8", "m1")] }))
+      )
     )
     expect(answer).toEqual({ error: "agents.run takes budget as a whole number of tool calls, at least 1; got 0.7" })
     expect(draws.length).toBe(0)
     expect(sent.length).toBe(0)
   })
 
+})
+
+// A live parent log: an append lands where the next read looks, so a re-driven dispatch replays
+// against what its predecessor recorded, the way a durable store does after a crash.
+const liveEnv = (events: Event[], sent: Array<Sent>) => {
+  const self = parseThreadAddress("mem:main:ag.root")
+  return Layer.mergeAll(
+    Layer.succeed(Router, {
+      send: (envelope) => Effect.sync(() => void sent.push(envelope as Sent))
+    }),
+    Layer.succeed(Self, self),
+    Layer.succeed(EventLog, withWatermark({
+      append: (committed) => Effect.sync(() => void events.push(...committed)),
+      read: Effect.sync(() => events)
+    }))
+  )
+}
+
+describe("a child is named by its parent run and call", () => {
+  const run = agentsPackage().methods.run!
+  const background = (text: string, callId: string) =>
+    run({ text, background: true }, { callId })
+  const threads = (sent: ReadonlyArray<Sent>): ReadonlyArray<string> =>
+    sent.map(({ link }) => (link.target as ThreadAddress).thread)
+
+  test("reused call ids across turns address distinct children", async () => {
+    const events: Event[] = [
+      threadCreated(parseThreadAddress("mem:main:ag.root"), undefined, 0),
+      turn("parent-a"),
+      called("reused-call", "parent-a")
+    ]
+    const sent: Array<Sent> = []
+    await Effect.runPromise(background("first", "reused-call").pipe(Effect.provide(liveEnv(events, sent))))
+    events.push(
+      { type: "TurnCompleted", turn: "parent-a", output: "first done", at: 4 } as Event,
+      turn("parent-b"),
+      called("reused-call", "parent-b")
+    )
+    await Effect.runPromise(background("second", "reused-call").pipe(Effect.provide(liveEnv(events, sent))))
+    // The third dispatch replays the second: it reads the child the second recorded instead of
+    // deriving or claiming the first turn's child.
+    await Effect.runPromise(background("second", "reused-call").pipe(Effect.provide(liveEnv(events, sent))))
+
+    expect(threads(sent)).toEqual([
+      "ag.8:parent-areused-call",
+      "ag.8:parent-breused-call",
+      "ag.8:parent-breused-call"
+    ])
+    expect(events.filter((event) => event.type === "ChildCreated")).toMatchObject([
+      { callId: "reused-call", turn: "parent-a", address: { thread: "ag.8:parent-areused-call" } },
+      { callId: "reused-call", turn: "parent-b", address: { thread: "ag.8:parent-breused-call" } }
+    ])
+  })
+
+  test("a dispatch whose creation record never committed re-derives the same address", async () => {
+    // The crash window Child.tla opens between the record and the delivery: the re-driven
+    // dispatch has no ChildCreated to read and must land where its predecessor was headed.
+    const events: Event[] = [
+      threadCreated(parseThreadAddress("mem:main:ag.root"), undefined, 0),
+      turn("m1"),
+      called("crash-1", "m1")
+    ]
+    const sent: Array<Sent> = []
+    await Effect.runPromise(background("scout", "crash-1").pipe(Effect.provide(liveEnv(events, sent))))
+    events.splice(events.findIndex((event) => event.type === "ChildCreated"), 1)
+    await Effect.runPromise(background("scout", "crash-1").pipe(Effect.provide(liveEnv(events, sent))))
+    expect(threads(sent)).toEqual(["ag.2:m1crash-1", "ag.2:m1crash-1"])
+  })
+
+  test("a run with no parent turn dies rather than naming a child", async () => {
+    // The package call is what ties a dispatch to its run; a method reached outside one has no
+    // child to name and no duplicate to absorb.
+    const events: Event[] = [threadCreated(parseThreadAddress("mem:main:ag.root"), undefined, 0)]
+    const exit = await Effect.runPromiseExit(
+      background("scout", "orphan-1").pipe(Effect.provide(liveEnv(events, [])))
+    )
+    if (exit._tag !== "Failure") throw new Error("expected the orphaned call to die")
+    expect(Cause.pretty(exit.cause)).toContain("agents.run orphan-1 has no parent turn")
+  })
 })
 
 // The contracts a host declares for its children. A name resolves to one of these; anything else
@@ -396,7 +491,7 @@ describe("the output a spawn asks for", () => {
     const answer = await Effect.runPromise(
       pkg.methods
         .run!({ text: "scout", background: true, output: asked }, { callId: "o1" })
-        .pipe(Effect.provide(env("mem:main:ag.root", sent)))
+        .pipe(Effect.provide(env("mem:main:ag.root", sent, { "ag.root": [turn("m1"), called("o1", "m1")] })))
     )
     return { answer, brief: sent[0]?.event as { output?: unknown } | undefined }
   }

--- a/packages/agent/src/packages/agents.ts
+++ b/packages/agent/src/packages/agents.ts
@@ -535,19 +535,19 @@ export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self
           // the same way, when the fire named an explicit shared one.
           const shadow = shadowOf()
           const world = worldOf()
-          // The owning run links a foreground child: the parent invocation the child's replies
-          // ride, resolved from the recorded call's own turn and epoch.
+          // The owning run links a foreground child and bounds every child with its deadline:
+          // a background child is not linked, but it still answers the turn that fired it
+          // (agents.test.ts, "a background child inherits the owning turn deadline without a
+          // parent link").
           const owner = { method: "message", id: parentRun.turn, epoch: parentRun.epoch }
           const parent = a?.background === true ? undefined : owner
-          const parentDeadline = parent === undefined
-            ? undefined
-            : events.find((event) => {
-                const context = (event as { readonly call?: unknown }).call as Partial<ActorInvocationContext> | undefined
-                return context?.invocation !== undefined &&
-                  context.invocation.method === owner.method &&
-                  context.invocation.id === owner.id &&
-                  context.invocation.epoch === owner.epoch
-              }) as ({ readonly call?: ActorInvocationContext } & Event) | undefined
+          const parentDeadline = events.find((event) => {
+            const context = (event as { readonly call?: unknown }).call as Partial<ActorInvocationContext> | undefined
+            return context?.invocation !== undefined &&
+              context.invocation.method === owner.method &&
+              context.invocation.id === owner.id &&
+              context.invocation.epoch === owner.epoch
+          }) as ({ readonly call?: ActorInvocationContext } & Event) | undefined
           const childContext: ActorInvocationContext = {
             invocation: { method: "message", id: ctx.callId, epoch: 0 },
             ...(parent === undefined ? {} : { parent }),

--- a/packages/agent/src/packages/agents.ts
+++ b/packages/agent/src/packages/agents.ts
@@ -317,11 +317,27 @@ const childClaimOf = (
         depth: recorded.depth,
         ...(recorded.placement === undefined ? {} : { placement: recorded.placement })
       }
-  return {
-    recorded,
-    target: recorded?.address ?? sibling(parentRunId, callId, source),
-    lineage
+  const target = recorded?.address ?? sibling(parentRunId, callId, source)
+  // A legacy call id names its child ag.<callId>, so the length-prefixed scheme can derive the
+  // same address for a different dispatch (agents.test.ts, "a derived address that names another
+  // child dies rather than delivering"). No in-band marker separates the schemes, so the
+  // collision dies instead of delivering the brief to the child another dispatch owns.
+  if (recorded === undefined) {
+    const clash = events.find(
+      (event): event is ChildCreated =>
+        Schema.is(ChildCreated)(event) &&
+        event.address.actor === target.actor &&
+        event.address.instance === target.instance &&
+        event.address.thread === target.thread &&
+        (event.callId !== callId || event.turn === undefined)
+    )
+    if (clash !== undefined) {
+      throw new Error(
+        `agents.run ${callId} derives child address ${formatThreadAddress(target)}, which child ${clash.callId} already owns`
+      )
+    }
   }
+  return { recorded, target, lineage }
 }
 
 const inheritedModelsOf = (events: ReadonlyArray<Event>): ModelPolicy => {

--- a/packages/agent/src/packages/agents.ts
+++ b/packages/agent/src/packages/agents.ts
@@ -8,7 +8,7 @@ import {
 import { EventLog } from "@clavia/tardigrade-core/log"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import { definePackage, type Package } from "@clavia/tardigrade-code/package/definition"
-import { turnView } from "@clavia/tardigrade-code/execution/turns"
+import { eventEpochOf, turnOf, turnView } from "@clavia/tardigrade-code/execution/turns"
 import { budgetPolicyOf, type BudgetPolicy } from "../component/budget"
 import { Park } from "@clavia/tardigrade-code/execution/errors"
 import { boundaryId } from "@clavia/tardigrade-core/communication/message"
@@ -45,13 +45,15 @@ import {
 // quiescence and returns its terminal; `agents.run({text, background: true})` delivers the brief
 // and returns a pending handle, and `agents.result({id})` awaits that handle's reply later.
 //
-// Every call is its own agent: the child's identity is the call's id, so a Promise.all of five
-// runs is five agents by construction, and no name exists to collide on. A persistent named
-// colleague is a later explicit feature, never an accident of naming.
+// Every call is its own agent. A call id is unique only within its parent turn, so the child's
+// native thread names the pair of both identifiers, and a Promise.all of five runs is five
+// agents by construction. A persistent named colleague is a later explicit feature, never an
+// accident of naming.
 //
 // Durability costs nothing here: both modes are package calls, so the recorded pair replays a
-// committed run and re-delivers a crashed dispatch. The call id is the child's identity AND the
-// message id, so a replayed dispatch reaches the same child and is absorbed as a duplicate.
+// committed run and re-delivers a crashed dispatch. The child's address is a pure function of
+// the parent run and the call, and a replay reads the recorded ChildCreated, so a re-driven
+// dispatch reaches the same child and is absorbed as a duplicate.
 //
 // The package is a value any consumer mounts: its host privileges are services, not constructor
 // arguments. `Router` sends, `Self` names the calling thread, and `EventLog` supplies its durable
@@ -257,23 +259,54 @@ const catalogQueryOf = (args: unknown): AgentCatalogQuery => {
   }
 }
 
-// sibling is the default address: the child inherits the parent's actor instance and uses the name `ag.<callId>`. Thread placement remains a separate host decision (spawn.test.ts, "the default address is the host's own sibling"; tla/runtime/Thread.tla, CreationFirst).
-const sibling = (callId: string, self: ThreadAddress): ThreadAddress =>
-  threadAddressOf(self.actor, self.instance, `ag.${callId}`)
+// childThreadId names a child after its parent run and call id. Length-prefixing keeps the pair
+// injective even when either identifier has punctuation, so two turns reusing one call id name
+// two children (agents.test.ts, "reused call ids across turns address distinct children").
+const childThreadId = (parentRunId: string, callId: string): string =>
+  `${parentRunId.length}:${parentRunId}${callId}`
 
+// sibling is the default address: the child inherits the parent's actor instance and a thread
+// name derived from the parent run and call. Thread placement remains a separate host decision
+// (agents.test.ts, "the default address is the host's own sibling").
+const sibling = (parentRunId: string, callId: string, self: ThreadAddress): ThreadAddress =>
+  threadAddressOf(self.actor, self.instance, `ag.${childThreadId(parentRunId, callId)}`)
+
+// parentRunOf resolves the run a package call serves: its turn id and execution epoch. A call
+// outside any run has no child to name, so the dispatch dies rather than guessing.
+const parentRunOf = (call: Event): { readonly turn: string; readonly epoch: number } | undefined => {
+  const turn = turnOf(call)
+  return turn === undefined ? undefined : { turn, epoch: eventEpochOf(call) }
+}
+
+// childClaimOf resolves the child this dispatch owns. The recorded child is the ChildCreated
+// between this call's PackageCalled in the parent run and the next call reusing the id, so a
+// later turn reusing the id can never claim an earlier turn's child, and a replay reads its
+// own dispatch's record (agents.test.ts, "reused call ids across turns address distinct
+// children").
 const childClaimOf = (
   placement: unknown,
-  events: ReadonlyArray<{ readonly type: string }>,
+  events: ReadonlyArray<Event>,
   parent: ThreadCreated,
+  parentRunId: string,
   callId: string,
   source: ThreadAddress
 ) => {
   if (placement !== undefined && !Schema.is(ChildPlacement)(placement)) {
     return { error: "agents.run placement must be colocated or independent" }
   }
-  const recorded = events.find(
-    (event) => event.type === "ChildCreated" && (event as { readonly callId?: unknown }).callId === callId
-  )
+  const sent = events.findLastIndex((event) =>
+    event.type === "PackageCalled" &&
+    event.callId === callId &&
+    turnOf(event) === parentRunId)
+  const next = events.findIndex((event, index) =>
+    index > sent &&
+    event.type === "PackageCalled" &&
+    event.callId === callId)
+  const recorded = sent < 0
+    ? undefined
+    : events.slice(sent + 1, next < 0 ? undefined : next).find(
+        (event) => event.type === "ChildCreated" && event.callId === callId
+      )
   if (recorded !== undefined && !Schema.is(ChildCreated)(recorded)) {
     throw new Error(`child ${callId} has an invalid creation record`)
   }
@@ -286,7 +319,7 @@ const childClaimOf = (
       }
   return {
     recorded,
-    target: recorded?.address ?? sibling(callId, source),
+    target: recorded?.address ?? sibling(parentRunId, callId, source),
     lineage
   }
 }
@@ -449,7 +482,14 @@ export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self
             | undefined
           const text = String(a?.text ?? "")
           if (text === "") return { error: "agents.run needs { text }" }
-          const child = childClaimOf(a?.placement, events, created, ctx.callId, source)
+          const call = turnView(events).find((event) =>
+            event.type === "PackageCalled" && event.callId === ctx.callId
+          )
+          const parentRun = call === undefined ? undefined : parentRunOf(call)
+          if (parentRun === undefined) {
+            return yield* Effect.die(new Error(`agents.run ${ctx.callId} has no parent turn`))
+          }
+          const child = childClaimOf(a?.placement, events, created, parentRun.turn, ctx.callId, source)
           if ("error" in child) return child
           const { lineage, recorded: recordedChild, target } = child
           // The contract parameter is `output`, and a near-miss spelling fails silently: no
@@ -495,21 +535,18 @@ export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self
           // the same way, when the fire named an explicit shared one.
           const shadow = shadowOf()
           const world = worldOf()
-          const packageCall = events.find((event) =>
-            event.type === "PackageCalled" &&
-            String((event as { readonly callId?: unknown }).callId) === ctx.callId
-          ) as { readonly turn?: unknown; readonly epoch?: unknown } | undefined
-          const parent = a?.background === true || packageCall === undefined
-            ? undefined
-            : { method: "message", id: String(packageCall.turn ?? ""), epoch: Number(packageCall.epoch ?? 0) }
+          // The owning run links a foreground child: the parent invocation the child's replies
+          // ride, resolved from the recorded call's own turn and epoch.
+          const owner = { method: "message", id: parentRun.turn, epoch: parentRun.epoch }
+          const parent = a?.background === true ? undefined : owner
           const parentDeadline = parent === undefined
             ? undefined
             : events.find((event) => {
                 const context = (event as { readonly call?: unknown }).call as Partial<ActorInvocationContext> | undefined
                 return context?.invocation !== undefined &&
-                  context.invocation.method === parent.method &&
-                  context.invocation.id === parent.id &&
-                  context.invocation.epoch === parent.epoch
+                  context.invocation.method === owner.method &&
+                  context.invocation.id === owner.id &&
+                  context.invocation.epoch === owner.epoch
               }) as ({ readonly call?: ActorInvocationContext } & Event) | undefined
           const childContext: ActorInvocationContext = {
             invocation: { method: "message", id: ctx.callId, epoch: 0 },
@@ -522,7 +559,7 @@ export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self
               : [invocationLinked({ parent, child: childContext, target: formatThreadAddress(target), lineage, at })]
             if (recordedChild === undefined || linked.length > 0) {
               yield* log.append([
-                ...(recordedChild === undefined ? [childCreated(ctx.callId, target, lineage, at)] : []),
+                ...(recordedChild === undefined ? [childCreated(ctx.callId, target, lineage, at, parentRun.turn)] : []),
                 ...linked
               ])
             }

--- a/packages/core/src/thread/lineage.test.ts
+++ b/packages/core/src/thread/lineage.test.ts
@@ -29,6 +29,16 @@ describe("thread creation", () => {
     expect(threadKeys.keyOf(created)).toBe("thread:child:call-1")
   })
 
+  test("a child key pairs the parent run with the call", () => {
+    const root = threadCreated({ actor: "agent", instance: "main", thread: "root" }, undefined, 1)
+    const lineage = childLineageOf(root)
+    const first = childCreated("call-1", { actor: "agent", instance: "main", thread: "left" }, lineage, 2, "run-a")
+    const second = childCreated("call-1", { actor: "agent", instance: "main", thread: "right" }, lineage, 3, "run-b")
+    // Two runs reusing one call id record two children, so neither key absorbs the other.
+    expect(threadKeys.keyOf(first)).not.toBe(threadKeys.keyOf(second))
+    expect(threadKeys.keyOf(first)).toBe(`thread:child:${JSON.stringify(["run-a", "call-1"])}`)
+  })
+
   test("a child records requested placement", () => {
     const root = threadCreated({ actor: "agent", instance: "main", thread: "root" }, undefined, 1)
     const lineage = childLineageOf(root, "independent")

--- a/packages/core/src/thread/lineage.ts
+++ b/packages/core/src/thread/lineage.ts
@@ -31,10 +31,11 @@ export const ThreadCreated = Schema.Struct({
 
 export type ThreadCreated = typeof ThreadCreated.Type
 
-// ChildCreated records a child edge in its parent log before the first delivery crosses the host boundary (packages/agent/src/index.test.ts, "one complete RLM run records root and child lineage and settles with their answers").
+// ChildCreated records a child edge in its parent log before the first delivery crosses the host boundary. `turn` names the parent run that minted the call, so the edge and its dedup key are scoped to that run (packages/agent/src/index.test.ts, "one complete RLM run records root and child lineage and settles with their answers"). A record from before the field existed has no turn and keeps its call-scoped key.
 export const ChildCreated = Schema.Struct({
   type: Schema.Literal("ChildCreated"),
   callId: Schema.String,
+  turn: Schema.optional(Schema.String),
   address: ThreadAddress,
   depth: ThreadDepth,
   placement: Schema.optional(ChildPlacement),
@@ -43,9 +44,16 @@ export const ChildCreated = Schema.Struct({
 
 export type ChildCreated = typeof ChildCreated.Type
 
-export const childCreated = (callId: string, address: ThreadAddressType, lineage: ThreadLineage, at: number): ChildCreated => ({
+export const childCreated = (
+  callId: string,
+  address: ThreadAddressType,
+  lineage: ThreadLineage,
+  at: number,
+  turn?: string
+): ChildCreated => ({
   type: "ChildCreated",
   callId,
+  ...(turn === undefined ? {} : { turn }),
   address,
   depth: lineage.depth,
   ...(lineage.placement === undefined ? {} : { placement: lineage.placement }),
@@ -126,13 +134,17 @@ export const sameThreadLineage = (created: ThreadCreated, lineage: ThreadLineage
   created.parent !== undefined && sameThreadAddress(created.parent, lineage.parent) && created.depth === lineage.depth &&
   (created.placement === undefined || lineage.placement === undefined || created.placement === lineage.placement)
 
-// threadKeys gives each log one durable creation occurrence.
+// threadKeys gives each log one durable creation occurrence, scoped to the run that minted the
+// call. JSON.stringify keeps the pair injective where plain concatenation could collide.
 export const threadKeys: KeyFragment = {
   prefixes: ["thread:"],
   keyOf: (event) => {
     if (event.type === "ThreadCreated") return "thread:created"
     if (event.type !== "ChildCreated") return undefined
-    const callId = (event as { readonly callId?: unknown }).callId
-    return typeof callId === "string" ? `thread:child:${callId}` : undefined
+    const callId = typeof event.callId === "string" ? event.callId : undefined
+    if (callId === undefined) return undefined
+    return typeof event.turn === "string"
+      ? `thread:child:${JSON.stringify([event.turn, callId])}`
+      : `thread:child:${callId}`
   }
 }


### PR DESCRIPTION
[👾 omp · openrouter/z-ai/glm-5.3 · agency: directed · intent: scope child thread identity and replay to the parent run]

> Implements #361: the issue carries the reproduced defects, the ownership boundary, and the open alternative shapes, and this PR is the reference implementation for the re-keying shape. Nothing here is a request to merge as-is. If another shape wins in #361, I will rework toward it.

## What and why

A call id is unique only within its parent turn. The agents package used it as a globally unique child identity anyway. The native child thread was named `ag.<callId>`, and the recorded `ChildCreated` was looked up across the whole parent log. Two parent turns that reuse one call id therefore alias one runtime thread. The fixes below key the child's identity and replay on the pair of parent run and call id, which is injective.

The reuse is real for us. The code component mints a code execution's `execId` from the model's tool-call id (`packages/agent/src/component/code.ts`, `serveCode`), and the code reactor mints package call ids as `{execId}.{n}` (`packages/code/src/execution/ids.ts`, `callId`). A provider that reuses a tool-call id across two turns of one thread makes both turns mint identical call ids, and both turns' `agents.run` dispatches then collide.

The code package's own keying comment already states the scope: "A key names the scope its id is unique in, and no wider" (`packages/code/src/execution/events.ts`, `codeKeys`). The agents package's child naming assumed the wider scope of the whole log across every turn in it.

What the collision does today, concretely:

- The second turn's dispatch reuses the first child's address `ag.<callId>`. The delivery carries the message id `callId`, which the first child's log already holds, so the host absorbs it as a duplicate: the second brief never reaches any child, and the second parent parks until its own deadline.
- The unscoped `ChildCreated` lookup (`events.find` over the whole log) can bind a fresh dispatch to a different turn's recorded child, so a replay can deliver to a child its dispatch never created.
- Every host composes `threadKeys` as the store dedup key for `ChildCreated` (`packages/host`, `platform/bun`, `platform/cloudflare` hosts, `storeKeyOf`). The key was `thread:child:<callId>`, so the second turn's creation record is absorbed as a duplicate append and never persists, which breaks crash replay for the second child independently of the address alias.

The bug-or-hardening question, framed both ways, because the answer belongs to the maintainers:

- Real bug framing: the agents package is a value any consumer mounts. Any host that drives package methods from its own recorded machinery (as ours does) can produce the same call id in two turns, and then identity, replay, and durable dedup are all silently wrong in the ways listed above. The inference contract ("tool-call IDs fresh per turn, reused IDs absorbed") is a property of the stock turn loop, and it does not bind consumers of the package.
- Hardening framing: inside the stock runtime the collision is hard to reach. A reused tool-call id whose first execution settled is answered from the recorded settle instead of executing again (`packages/agent/src/component/code.ts`, `serveCode`), and a re-run body whose call arguments drifted dies loudly in the reactor's replay guard (`packages/code/src/execution/reactor.ts`), which also refuses to append a second `PackageCalled` for an id the log already holds. Under that framing this change is defense in depth for consumers, and the stock pipeline absorbs or refuses the reuse before the agents package ever sees it.

Either way, the durable-replay argument stands on its own. The child's address should be a pure function of the dispatch's own run, and the replay should read the child its own dispatch recorded. That is what the code now does.

- `childThreadId` names a child from the length-prefixed pair of parent run and call id, so the pair stays injective when either identifier carries punctuation, and the default sibling address becomes `ag.<len>:<parentRun><callId>` (`packages/agent/src/packages/agents.ts`). A dispatch whose derived address collides with a recorded child of a different identity (a legacy record without a `turn`, or a record from another call) dies loudly instead of delivering the brief to that child.
- The dispatch resolves its parent run from the current turn's view: the `PackageCalled` for this call within the parent run, read through `turnView`, and its execution epoch through `eventEpochOf`. A dispatch with no parent turn dies loudly instead of guessing a child. The stock reactor always records the call before the method runs, so only a consumer driving the package outside a run can reach that die.
- The replay lookup is scoped to this dispatch: the recorded child is the `ChildCreated` between this call's `PackageCalled` in the parent run and the next `PackageCalled` reusing the id, so a later turn reusing the id can never claim an earlier turn's child.
- `ChildCreated` gains an optional `turn` recording the parent run, and `threadKeys.keyOf` becomes the composite `[turn, callId]` when the field is present, so two runs reusing one call id record two children in every host store. Records from before the field existed keep the call-scoped key.
- The owning run and the linked parent are now distinct: a background child carries no parent link, and it still inherits the owning turn's deadline, so a parent cannot outlive its turn by going to the background.

Non-goals: the reply reads for awaited children are a separate concern with their own semantics decision. `awaitedBoundary` still matches the first boundary id in the whole log, so a consumer that reuses a call id across two settled turns reads the earlier turn's reply instead of its own. Scoping it needs a turn-aware shape for `agents.result({id})`, whose argument carries no turn of its own. Cancelled-response settlement sits under the same decision; #365 (https://github.com/clavia-labs/tardigrade/pull/365, commit 01f8da2, `fix(agent): settle cancelled child responses`) is the fix home for it and follows immediately if this PR merges first.

Thread placement, budget, and escalation are untouched, and so are the code reactor's own id minting and drift guard.

Alternative shapes, in case any is preferred:

- Reject on duplicate dispatch: die when a `PackageCalled` for this id already exists in another turn. Cheaper, but it turns id reuse into a hard failure for any consumer whose minting discipline allows it, and it leaves the address aliasing in place for logs written before the fix.
- Replay scoping only: keep `ag.<callId>` and scope only the `ChildCreated` lookup. That fixes cross-wired replay but not aliasing: two live threads with one name still collide at the host's address level, and the dedup key still absorbs the second creation record.
- A required `turn` field on `ChildCreated`, or an opaque hash for the thread name instead of the length-prefixed pair. The length prefix is reversible and readable in logs and support tooling, which is why I chose it; a hash is shorter but names become opaque.

## Verification

Head commit: d2ad5f3e5e06b90c4e3b28d10b206893f5fdf9ca. `bun install --frozen-lockfile` on Bun 1.4.0. The full `bun run gate` passes locally at this commit. The narrow tasks below were also run per area.

- `bun run typecheck` (tools plus every package): 0 errors.
- `bun run lint` (oxlint): clean. `bun run gate --only=lint:effect:packages:core,lint:effect:packages:agent,lint:effect:e2e`: 0 errors, 0 warnings, 3 tasks pass.
- Packages: core 118 pass, tardie (agent) 252 pass, code 94 pass, host 32 pass, channels 9 pass, client 41 pass, all via `bun test` in each package, 0 fail.
- Platforms: `bun test` in `platform/bun` 46 pass, `platform/model` 59 pass, `platform/cloudflare` 8 pass, `platform/worker-loader` 7 pass. Workerd-backed: `bun run --filter @clavia/tardigrade-cloudflare test:workers`, 19 pass.
- Apps: `apps/server` 111 pass, `apps/cli` 137 pass, in isolation. (The server catalog test is flaky when its suite runs twice in one process; unrelated to this change.)
- E2E: `bun test` in `e2e`, 3 pass including both fast-check property suites. The e2e child-thread reads now take each child's address from its recorded `ChildCreated` instead of re-deriving `ag.<callId>`, which the address change made structurally impossible.
- New coverage: `packages/agent/src/packages/agents.test.ts` has a `a child is named by its parent run and call` suite (reused call ids across turns address distinct children and a replay reads the child its own dispatch recorded, one creation record retained per run; a dispatch whose creation record never committed re-derives the same address; the background deadline inheritance; the no-parent-turn die; a creation record without a turn still names its child, the replay path for logs written before the field existed; a derived address that names another child dies rather than delivering). `packages/core/src/thread/lineage.test.ts` covers the composite dedup key.
- Limits: the TLA suite (`bun run tla`) needs `TLA2TOOLS_JAR` and a working JRE. Neither is available locally (the macOS `/usr/bin/java` stub has no runtime), so the spec checks were not run in this verification and CI's gate remains the authority. The spec files are unchanged.

- Specs: I verified by reading that `tla/runtime/Thread.tla` states no address shape (its `CreationFirst` is about the creation record's log position), so the old citation of it for the `ag.<callId>` name was wrong. The address contract now cites the test that proves it. `Child.tla` already models calls as distinct identifiers with an injective `ProposedTarget`. This change makes the implementation's child identity match that assumption rather than the spec needing work.
