### PR TITLE
fix(dev): supply application layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ examples/.data/
 
 # Reference checkouts and attachments handed to agents, never part of history
 .context/
+/artifacts/
 
 # Agent handoff letters: local working notes, never part of history
 .letters/

--- a/apps/cli/src/build.test.ts
+++ b/apps/cli/src/build.test.ts
@@ -5,7 +5,15 @@ import { join } from "node:path"
 
 import { ACTOR_ARTIFACT_VERSION } from "tardie"
 
-import { ACTOR_MANIFEST_FILE, ACTOR_MODULE_FILE, buildActor, buildSummary, lintActor, lintSummary } from "./build"
+import {
+  ACTOR_MANIFEST_FILE,
+  ACTOR_MODULE_FILE,
+  buildActor,
+  buildSummary,
+  lintActor,
+  lintSummary,
+  loadBuiltActorModule
+} from "./build"
 
 let root = ""
 
@@ -36,6 +44,18 @@ describe("buildActor", () => {
     expect(JSON.parse(await readFile(join(built.directory, ACTOR_MANIFEST_FILE), "utf8"))).toEqual(built.manifest)
     expect(built.manifest.schema).toBe(ACTOR_ARTIFACT_VERSION)
     expect(built.manifest.digest).toMatch(/^sha256:[a-f0-9]{64}$/)
+  })
+
+  test("preserves the development layer factory", async () => {
+    const path = await entry(`
+      import { actor } from "tardie"
+      export const layersFor = ({ thread }) => thread
+      export default actor({ name: "researcher", methods: {}, components: [] })
+    `)
+    const loaded = await loadBuiltActorModule(await buildActor(path, { cwd: root, out: "output" }))
+    expect(loaded.actor.name).toBe("researcher")
+    expect(typeof loaded.layersFor).toBe("function")
+    expect((loaded.layersFor as (context: { readonly thread: string }) => string)({ thread: "ag.root" })).toBe("ag.root")
   })
 
   test("refuses an unnamed module", async () => {

--- a/apps/cli/src/build.ts
+++ b/apps/cli/src/build.ts
@@ -46,9 +46,14 @@ export interface LintedActor {
   readonly calls: ReadonlyArray<LintedActorCall>
 }
 
-const definitionOf = async (modulePath: string): Promise<Actor<unknown>> => {
+const actorModuleOf = async (modulePath: string): Promise<Record<string, unknown>> => {
   const loaded: unknown = await import(`${pathToFileURL(modulePath).href}?build=${crypto.randomUUID()}`)
-  const definition = (loaded as { readonly default?: unknown }).default
+  if (typeof loaded !== "object" || loaded === null) throw new Error("actor entry must export a module")
+  return loaded as Record<string, unknown>
+}
+
+const definitionFrom = (loaded: Record<string, unknown>): Actor<unknown> => {
+  const definition = loaded.default
   if (typeof definition !== "object" || definition === null) {
     throw new Error("actor entry must default export actor({ name, methods, components })")
   }
@@ -68,6 +73,23 @@ const definitionOf = async (modulePath: string): Promise<Actor<unknown>> => {
   }
   actorMethodsOf(candidate.methods as ActorMethods)
   return candidate as Actor<unknown>
+}
+
+const definitionOf = async (modulePath: string): Promise<Actor<unknown>> =>
+  definitionFrom(await actorModuleOf(modulePath))
+
+export interface LoadedBuiltActor {
+  readonly actor: Actor<unknown>
+  readonly layersFor?: unknown
+}
+
+// loadBuiltActorModule returns the validated actor and its optional development layer factory.
+export const loadBuiltActorModule = async (built: BuiltActor): Promise<LoadedBuiltActor> => {
+  const loaded = await actorModuleOf(join(built.directory, ACTOR_MODULE_FILE))
+  return {
+    actor: definitionFrom(loaded),
+    ...(loaded.layersFor === undefined ? {} : { layersFor: loaded.layersFor })
+  }
 }
 
 // loadBuiltActor returns the validated definition from one built artifact.

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -19,9 +19,9 @@ import type { ServerR } from "@clavia/tardigrade-server/actor"
 import { modelIsConfigured } from "@clavia/tardigrade-server/host"
 import { modelCatalogConfigOf, type ModelConfig } from "@clavia/tardigrade-server/config"
 
-import { buildActor, buildSummary, DEFAULT_BUILD_DIRECTORY, lintActor, lintSummary, loadBuiltActor } from "./build"
+import { buildActor, buildSummary, DEFAULT_BUILD_DIRECTORY, lintActor, lintSummary, loadBuiltActorModule } from "./build"
 import { readFileConfig, readProjectConfig, resolveRemote, resolveServer } from "./config"
-import { availableDevPort, DEFAULT_MIN_PORT, DEV_URL_HOST, dev, openBrowser } from "./dev"
+import { availableDevPort, DEFAULT_MIN_PORT, DEV_URL_HOST, dev, devLayersForFrom, openBrowser } from "./dev"
 import { DEFAULT_ACTOR_ENTRY, DEFAULT_INIT_ACTOR_NAME, defaultInitDirectory, initActor, initSummary, terminalColorsEnabled } from "./init"
 import { withLoader } from "./loader"
 import { resolveModelLock, writeModelLock } from "./model-lock"
@@ -664,14 +664,19 @@ export const devCommand = Command.make("dev", {
       try: () => buildActor(DEFAULT_ACTOR_ENTRY, { cwd: cli.cwd }),
       catch: userErrorOf
     })
-    const definition = yield* Effect.tryPromise({
-      try: () => loadBuiltActor(built),
+    const loaded = yield* Effect.tryPromise({
+      try: () => loadBuiltActorModule(built),
+      catch: userErrorOf
+    })
+    const layersFor = yield* Effect.try({
+      try: () => devLayersForFrom<ServerR>(loaded.layersFor),
       catch: userErrorOf
     })
     const layer = yield* Effect.try({
       try: () => dev({
         config: config2,
-        actor: definition as Actor<ServerR>,
+        actor: loaded.actor as Actor<ServerR>,
+        ...(layersFor === undefined ? {} : { layersFor }),
         assets: stated(flags.ui),
         ...(flags.open ? { onListen: openBrowser } : {})
       }),

--- a/apps/cli/src/dev.test.ts
+++ b/apps/cli/src/dev.test.ts
@@ -11,10 +11,21 @@ import { ACTOR_ARTIFACT_VERSION, Infer, type Actor } from "tardie"
 import type { Action } from "tardie/log/events"
 import { PROBLEM_CONTENT_TYPE } from "@clavia/tardigrade-client/contract"
 import { layerModelCatalogUnavailable } from "@clavia/tardigrade-server/catalog"
+import type { ServerR } from "@clavia/tardigrade-server/actor"
+import type { ActorThreadLayersFor } from "@clavia/tardigrade-server/host"
 
 import { tdg } from "./commands"
 import { resolveServer } from "./config"
-import { availableDevPort, browserCommand, dev, DEV_HOST, DEV_URL_HOST, type DevOptions } from "./dev"
+import {
+  availableDevPort,
+  browserCommand,
+  dev,
+  devLayersForFrom,
+  DEV_HOST,
+  DEV_URL_HOST,
+  type DevOptions
+} from "./dev"
+import { layeredActor, layeredLayersFor } from "../test/fixtures/dev-actor"
 import { layerCli } from "./services"
 
 // Every case here boots a real server on an ephemeral port, so it competes with every other task in
@@ -59,10 +70,17 @@ const directActor: Actor<never> = {
 
 // booted starts the whole command on an ephemeral port and hands the body its base URL. ":memory:"
 // keeps the store to this process, so the case owns every event it reads.
-const booted = <A>(
+interface BootOptions<R> {
+  readonly actor?: Actor<R>
+  readonly layersFor?: ActorThreadLayersFor<R>
+  readonly onListen?: (url: string) => Promise<void>
+  readonly shutdownMillis?: number
+}
+
+const booted = <A, R = ServerR>(
   body: (baseUrl: string, hostname: string, actors: string) => Promise<A>,
   env: Record<string, string | undefined> = {},
-  options: Pick<DevOptions, "actor" | "onListen" | "shutdownMillis"> = {}
+  options: BootOptions<R> = {}
 ): Promise<A> => {
   const actors = mkdtempSync(join(tmpdir(), "tardigrade-dev-actors-"))
   const actorData = mkdtempSync(join(tmpdir(), "tardigrade-dev-data-"))
@@ -87,7 +105,7 @@ const booted = <A>(
         disableLogger: true,
         disableListenLog: true,
         ...options
-      })
+      } as DevOptions<R>)
     ),
     Effect.scoped,
     Effect.runPromise
@@ -143,6 +161,10 @@ const drive = async (baseUrl: string, args: ReadonlyArray<string>) => {
 }
 
 describe("tdg dev", () => {
+  test("a malformed development layer export is refused", () => {
+    expect(() => devLayersForFrom("layer")).toThrow("layersFor export must be a function")
+  })
+
   test("the browser launcher is selected by the operating system", () => {
     expect(browserCommand("http://localhost:4242", "darwin")).toEqual(["open", "http://localhost:4242"])
     expect(browserCommand("http://localhost:4242", "linux")).toEqual(["xdg-open", "http://localhost:4242"])
@@ -242,6 +264,31 @@ describe("tdg dev", () => {
       current: { status: 200, body: [] },
       metadata: { status: 200, body: { name: "reviewer", storage: { kind: "sqlite", location: ":memory:" } } }
     })
+  })
+
+  test("a project actor receives application services", async () => {
+    const state = await booted(async (baseUrl) => {
+      const actorInstance = await fetch(`${baseUrl}/v1/actors/main`, { method: "PUT" })
+      expect(actorInstance.status).toBe(200)
+      const accepted = await fetch(`${baseUrl}/v1/actors/main/threads/root/methods/greet/calls/layer-test`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ text: "hello" })
+      })
+      expect(accepted.status).toBe(202)
+      for (let attempt = 0; attempt < 100; attempt++) {
+        const response = await fetch(`${baseUrl}/v1/actors/main/threads/root/methods/greet/calls/layer-test`)
+        const current = await response.json() as { readonly status?: string; readonly output?: unknown }
+        if (current.status === "completed") return current
+        await Bun.sleep(10)
+      }
+      return undefined
+    }, {}, {
+      actor: layeredActor,
+      layersFor: layeredLayersFor
+    })
+
+    expect(state).toEqual({ status: "completed", output: "main:ag.root:hello" })
   })
 
   test("a local push refreshes the actor registry", async () => {

--- a/apps/cli/src/dev.ts
+++ b/apps/cli/src/dev.ts
@@ -6,7 +6,13 @@ import type { Actor } from "tardie"
 import { layerConfig, type ServerConfigValue } from "@clavia/tardigrade-server/config"
 import { layerModelCatalog, ModelCatalogStore } from "@clavia/tardigrade-server/catalog"
 import { layerFileModelCatalogRepository } from "@clavia/tardigrade-server/catalog-repository"
-import { layerActorThreads, layerThreads, type ThreadsOptions } from "@clavia/tardigrade-server/host"
+import {
+  layerActorThreads,
+  layerThreads,
+  type ActorApplicationRequirements,
+  type ActorThreadLayersFor,
+  type ThreadsOptions
+} from "@clavia/tardigrade-server/host"
 import type { ServerR } from "@clavia/tardigrade-server/actor"
 import { layerApp } from "@clavia/tardigrade-server/http"
 import { makeInferenceStream } from "@clavia/tardigrade-server/inference-stream"
@@ -115,10 +121,8 @@ export const layerVoyager = (root: string) =>
     { global: true }
   )
 
-export interface DevOptions {
+interface DevBaseOptions {
   readonly config: ServerConfigValue
-  // actor mounts one project definition directly. An omitted actor enables the self-hosted registry.
-  readonly actor?: Actor<ServerR> | undefined
   // Where the built UI lives. Absent, the two layouts a build can arrive in are tried in order
   // (assets.ts, ASSET_CANDIDATES).
   readonly assets?: string | undefined
@@ -136,10 +140,30 @@ export interface DevOptions {
   readonly onListen?: ((url: string) => Promise<void>) | undefined
 }
 
+export type DevLayersFor<Definition extends Actor<unknown>> = Definition extends Actor<infer R>
+  ? ActorThreadLayersFor<R>
+  : never
+
+type DevActorOptions<R> = [ActorApplicationRequirements<R>] extends [never]
+  ? { readonly actor: Actor<R>; readonly layersFor?: ActorThreadLayersFor<R> }
+  : { readonly actor: Actor<R>; readonly layersFor: ActorThreadLayersFor<R> }
+
+export type DevOptions<R = ServerR> = DevBaseOptions & (
+  | { readonly actor?: undefined; readonly layersFor?: never }
+  | DevActorOptions<R>
+)
+
+// devLayersForFrom validates the named layersFor export loaded from actor.ts.
+export const devLayersForFrom = <R>(value: unknown): ActorThreadLayersFor<R> | undefined => {
+  if (value === undefined) return undefined
+  if (typeof value !== "function") throw new Error("actor entry layersFor export must be a function")
+  return value as ActorThreadLayersFor<R>
+}
+
 // dev is the whole command: resolve the build, open the store, listen on loopback. It answers a
 // Layer rather than a running process, so the caller owns the scope and the process that stops
 // listening stops writing (apps/server/src/host.ts, layerThreads).
-export const dev = (options: DevOptions) => {
+export const dev = <R = ServerR>(options: DevOptions<R>) => {
   const actorRefreshMillis = options.actorRefreshMillis ?? DEFAULT_ACTOR_REFRESH_MILLIS
   if (!Number.isInteger(actorRefreshMillis) || actorRefreshMillis < 0) {
     throw new Error(`actor refresh must be a non-negative integer, got ${actorRefreshMillis}`)
@@ -162,7 +186,12 @@ export const dev = (options: DevOptions) => {
           ...threadOptions,
           actorRefresh: { debounceMillis: actorRefreshMillis }
         })
-      : layerActorThreads(options.actor, threadOptions),
+      : layerActorThreads(options.actor as Actor<ServerR>, {
+          ...threadOptions,
+          ...(options.layersFor === undefined
+            ? {}
+            : { layersFor: options.layersFor as ActorThreadLayersFor<ServerR> })
+        }),
     [config, catalog]
   )
   // provideMerge rather than provide: the listening server stays visible in the layer's own

--- a/apps/cli/test/fixtures/dev-actor.ts
+++ b/apps/cli/test/fixtures/dev-actor.ts
@@ -1,0 +1,75 @@
+import { Context, Effect, Layer, Schema } from "effect"
+import { actor, actorMethod, component } from "tardie"
+import type { Event } from "@clavia/tardigrade-core/event"
+import { effect } from "@clavia/tardigrade-core/effect"
+
+import type { DevLayersFor } from "../../src/dev"
+
+class Greeting extends Context.Service<Greeting, { readonly prefix: string; readonly thread: string }>()(
+  "tardigrade/dev-test/Greeting"
+) {}
+
+interface GreetingState {
+  readonly requests: ReadonlyMap<string, string>
+  readonly replies: ReadonlyMap<string, string>
+}
+
+const initial = (): GreetingState => ({ requests: new Map(), replies: new Map() })
+const step = (state: GreetingState, event: Event): GreetingState => {
+  const value = event as { readonly id?: unknown; readonly text?: unknown }
+  const id = String(value.id ?? "")
+  if (event.type === "GreetingRequested") return { ...state, requests: new Map(state.requests).set(id, String(value.text ?? "")) }
+  if (event.type === "GreetingCompleted") return { ...state, replies: new Map(state.replies).set(id, String(value.text ?? "")) }
+  return state
+}
+
+const greet = actorMethod({
+  input: Schema.Struct({ text: Schema.String }),
+  output: Schema.String,
+  event: ({ invocation, input, at }) => ({ type: "GreetingRequested", id: invocation.id, text: input.text, at }),
+  projection: {
+    initial,
+    step,
+    output: (state) => ({
+      currentEpoch: () => 0,
+      invocationState: (invocation) => {
+        if (!state.requests.has(invocation.id)) return undefined
+        const reply = state.replies.get(invocation.id)
+        return reply === undefined ? { status: "pending" as const } : { status: "completed" as const, output: reply }
+      }
+    })
+  }
+})
+
+export const layeredActor = actor({
+  name: "layered",
+  methods: { greet },
+  components: [component({
+    name: "greeting",
+    keys: {
+      prefixes: ["greeting-request:", "greeting-complete:"],
+      keyOf: (event) => {
+        const id = String((event as { readonly id?: unknown }).id ?? "")
+        if (event.type === "GreetingRequested") return `greeting-request:${id}`
+        if (event.type === "GreetingCompleted") return `greeting-complete:${id}`
+        return undefined
+      }
+    },
+    initial,
+    step,
+    output: (state) => ({
+      view: undefined,
+      transitions: [...state.requests].flatMap(([id, text]) => state.replies.has(id) ? [] : [effect({
+        key: `greeting:${id}`,
+        input: { id, text },
+        act: (input) => Effect.gen(function*() {
+          const greeting = yield* Greeting
+          return [{ type: "GreetingCompleted", ...input, text: `${greeting.prefix}:${greeting.thread}:${input.text}` }]
+        })
+      })])
+    })
+  })]
+})
+
+export const layeredLayersFor = (({ actorInstance, thread }) =>
+  Layer.succeed(Greeting, { prefix: actorInstance, thread })) satisfies DevLayersFor<typeof layeredActor>

--- a/apps/server/src/host.ts
+++ b/apps/server/src/host.ts
@@ -29,7 +29,7 @@ import {
   type Actor
 } from "tardie"
 import type { Action } from "tardie/log/events"
-import { createBunHost, type BunHost } from "@clavia/tardigrade-bun/host"
+import { createBunHost, type BunHost, type BunHostOptions } from "@clavia/tardigrade-bun/host"
 import { openBunActorRegistry } from "@clavia/tardigrade-bun/registry"
 import { infer } from "@clavia/tardigrade-model/model"
 import { modelAdapters, type ModelAdapter, type ModelAdapterRegistry } from "@clavia/tardigrade-model/adapter"
@@ -396,22 +396,39 @@ const definitionOf = async (modulePath: string, expected: ActorArtifactManifest)
   return candidate as Actor<ServerR>
 }
 
-const runtimeOf = async (
+export type ActorApplicationRequirements<R> = Exclude<R, ServerR>
+
+// ActorThreadLayerContext identifies the actor instance and thread receiving application services.
+export interface ActorThreadLayerContext {
+  readonly actorInstance: string
+  readonly thread: string
+}
+
+export type ActorThreadLayersFor<R> = (
+  context: ActorThreadLayerContext
+) => Layer.Layer<ActorApplicationRequirements<R>>
+
+const runtimeOf = async <R>(
   summary: ActorSummary,
   actorInstance: string,
-  definition: Actor<ServerR>,
+  definition: Actor<R>,
   database: string,
   thread: ReturnType<typeof layerThread>,
   providers: ReadonlyArray<Provider>,
-  maxConcurrentThreads: number
+  maxConcurrentThreads: number,
+  layersFor?: ActorThreadLayersFor<R>
 ): Promise<ActorRuntime> => {
   const actor = definition
-  const host: BunHost = await createBunHost<ServerR>({
+  const environmentFor = ((candidate: string) => {
+    const application = layersFor?.({ actorInstance, thread: candidate })
+    return application === undefined ? thread : Layer.mergeAll(thread, application)
+  }) as NonNullable<BunHostOptions<R>["layersFor"]>
+  const host: BunHost = await createBunHost<R>({
     database,
     actorName: summary.name,
     actorInstance,
     actorFor: (candidate) => (idOf(candidate) === undefined ? undefined : actor),
-    layersFor: () => thread,
+    layersFor: environmentFor,
     providers,
     driver: { maxConcurrentThreads },
     keyOf: (event) => actor.keyOf?.(event)
@@ -519,7 +536,15 @@ const runtimeOf = async (
   }
 }
 
-export type ActorThreadsOptions = Pick<ThreadsOptions, "infer" | "inferenceObserver" | "modelAdapters" | "providers">
+type ActorThreadsBaseOptions = Pick<ThreadsOptions, "infer" | "inferenceObserver" | "modelAdapters" | "providers">
+
+export type ActorThreadsOptions<R> = ActorThreadsBaseOptions & ([ActorApplicationRequirements<R>] extends [never]
+  ? { readonly layersFor?: ActorThreadLayersFor<R> }
+  : { readonly layersFor: ActorThreadLayersFor<R> })
+
+type ActorThreadsArguments<R> = [ActorApplicationRequirements<R>] extends [never]
+  ? [options?: ActorThreadsOptions<R>]
+  : [options: ActorThreadsOptions<R>]
 
 const actorDatabasePath = (database: string, actor: string): string =>
   database === ":memory:"
@@ -536,9 +561,9 @@ const actorIdFromDatabase = (file: string): string | undefined => {
 }
 
 // layerActorThreads mounts one deployed definition as the runtime.
-export const layerActorThreads = (
-  definition: Actor<ServerR>,
-  options: ActorThreadsOptions = {}
+export const layerActorThreads = <R>(
+  definition: Actor<R>,
+  ...[options = {} as ActorThreadsOptions<R>]: ActorThreadsArguments<R>
 ): Layer.Layer<Threads | Ingress | DriverGauge, never, ServerConfig | ModelCatalogStore> =>
   Layer.effectContext(Effect.gen(function*() {
     const config = yield* ServerConfig
@@ -561,7 +586,8 @@ export const layerActorThreads = (
         actorDatabasePath(config.db, id),
         thread,
         options.providers ?? [],
-        config.maxConcurrentThreads
+        config.maxConcurrentThreads,
+        options.layersFor
       ).then((runtime) => {
         runtimes.set(id, runtime)
         opening.delete(id)

--- a/docs/platforms/bun.mdx
+++ b/docs/platforms/bun.mdx
@@ -19,6 +19,30 @@ tdg dev
 
 The server listens on port `4242` by default. Its health endpoint is available at `/healthz`.
 
+## Provide application services
+
+An actor that requires an application Effect service can export `layersFor` beside its default actor export. `tdg dev` calls the factory for each thread and supplies the resulting Layer to the Bun host:
+
+```ts title="actor.ts"
+import { Layer } from "effect"
+import { actor } from "tardie"
+import type { DevLayersFor } from "tardie/cli/dev"
+import { AppConfig, applicationComponent } from "./application"
+
+const definition = actor({
+  name: "researcher",
+  methods: {},
+  components: [applicationComponent]
+})
+
+export const layersFor = (({ thread }) =>
+  Layer.succeed(AppConfig, { thread })) satisfies DevLayersFor<typeof definition>
+
+export default definition
+```
+
+The factory receives `actorInstance` and the internal thread address, such as `ag.root`. A Layer factory is optional when the actor has no application service requirements.
+
 ## Storage
 
 The default actor database is `.tardigrade/actor.sqlite`. Thread databases live beside it under `.tardigrade/actor.sqlite.threads/`. The host persists events before running the work they enable, so it can resume unfinished work after the process restarts.

--- a/docs/references/cli.mdx
+++ b/docs/references/cli.mdx
@@ -98,7 +98,7 @@ A command flag takes precedence over an environment variable. An environment var
 | Model catalog cache | | `TARDIGRADE_MODEL_CATALOG_CACHE` | `.tardigrade/models.json` |
 | Provider credentials | | Variables named by each provider's `env` list | Values saved by interactive setup in `.dev.vars` |
 
-`tdg dev` loads `.dev.vars`, then applies values from the process environment. It stores actor threads in `.tardigrade/actor.sqlite` under the actor directory. Keep that directory present until the server stops. A deployment reads credentials from its platform secret store.
+`tdg dev` loads `.dev.vars`, then applies values from the process environment. It stores actor threads in `.tardigrade/actor.sqlite` under the actor directory. Keep that directory present until the server stops. A deployment reads credentials from its platform secret store. An optional named `layersFor` export from `actor.ts` supplies application Effect services for each local thread.
 
 ## Validate and run locally
 


### PR DESCRIPTION
## Summary

`tdg dev` now preserves an optional named `layersFor` export from `actor.ts` and forwards it to the Bun actor host. The host builds the application Layer for each actor thread and merges it with the framework services, using the same actor instance and thread context exposed by the Cloudflare host.

The typed `dev` and `layerActorThreads` APIs require this factory when an actor declares application Effect service requirements. Actors without application requirements keep the existing `tdg dev` workflow.

The regression coverage builds the named export and completes a real method call whose component reads a supplied application service. The Bun platform and CLI references document the actor export.

## Verification

- `bun run gate`

Closes #368