### PR TITLE
feat(api): bound tree and roster reads

### DIFF
--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -1068,4 +1068,26 @@ describe("the tree", () => {
     // The node count is positive, so zero is a problem document, not an empty answer.
     expect(read.refused).toBe(400)
   })
+
+  test("a legacy stored address reads under its public name through the bounds", async () => {
+    const read = await serving(async (base) => {
+      // The events route stores a supplied root address verbatim (api.ts, append), so a caller
+      // that names its thread with the legacy prefix writes the legacy stored address, the shape
+      // every pre-contract database holds (thread-compat.ts, withLegacyThreadIds).
+      await birth(base, "ag.legacy", { id: "m1", text: "hello" })
+      const listed = async (query: string) =>
+        (await (await fetch(`${base}/v1/actors/main/threads${query}`)).json())
+      return {
+        roster: (await listed("?root=legacy&maxDepth=0")) as ReadonlyArray<ThreadSummary>,
+        tree: (await (await fetch(`${base}/v1/actors/main/threads/legacy/tree`)).json()) as ThreadNode,
+        stored: (await fetch(`${base}/v1/actors/main/threads?root=ag.legacy`)).status
+      }
+    })
+    // The listing keys logs by the public name, so the legacy address scopes and builds under it
+    // and the bounds hold on the keyed walk (thread-compat.ts, publicThreadId).
+    expect(read.roster.map((summary) => summary.id)).toEqual(["legacy"])
+    expect(read.tree.id).toBe("legacy")
+    // The stored address is not the public name, so a root that states it names no public thread.
+    expect(read.stored).toBe(404)
+  })
 })

--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -1039,4 +1039,33 @@ describe("the tree", () => {
     expect(read.listed.find((summary) => summary.id === child.id)!.parent).toBe("root")
     expect(read.ghost).toBe(404)
   })
+
+  test("bounds limit what a tree or roster read builds", async () => {
+    const read = await serving(async (base) => {
+      await birth(base, "root", { id: "m1", text: "spawn call-1" })
+      await until("the driver rests", async () => {
+        const health = (await (await fetch(`${base}/healthz`)).json()) as { status: string }
+        return health.status === "resting" ? health : undefined
+      })
+      const listed = async (query: string) =>
+        (await (await fetch(`${base}/v1/actors/main/threads${query}`)).json())
+      return {
+        depth: (await listed("?maxDepth=0")) as ReadonlyArray<ThreadSummary>,
+        rosterRoot: (await listed("?root=root")) as ReadonlyArray<ThreadSummary>,
+        childRootStatus: (await fetch(`${base}/v1/actors/main/threads?root=ghost`)).status,
+        treeNodes: (await (await fetch(`${base}/v1/actors/main/threads/root/tree?maxNodes=1`)).json()) as ThreadNode,
+        refused: (await fetch(`${base}/v1/actors/main/threads?maxNodes=0`)).status
+      }
+    })
+    // maxDepth zero keeps the roster to the roots: the child is never built.
+    expect(read.depth.map((summary) => summary.id)).toEqual(["root"])
+    // A stated root lists only its own subtree.
+    expect(read.rosterRoot.length).toBe(2)
+    // An unknown root is the unknown thread of the roster route.
+    expect(read.childRootStatus).toBe(404)
+    // maxNodes one builds the start and stops, so the tree carries no children.
+    expect(read.treeNodes.children).toEqual([])
+    // The node count is positive, so zero is a problem document, not an empty answer.
+    expect(read.refused).toBe(400)
+  })
 })

--- a/apps/server/src/projections.test.ts
+++ b/apps/server/src/projections.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, test } from "bun:test"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import { childCreated, threadCreated } from "@clavia/tardigrade-core/interaction/relations"
 
-import { summaryOf as summarize, treeOf as tree } from "./projections"
+import { summaryOf as summarize, treeOf as tree, type ThreadNode } from "./projections"
+import type { TreeBounds } from "@clavia/tardigrade-client/contract"
 const summaryOf = (id: string, events: ReadonlyArray<Event>, parent?: string) => summarize(id, events, () => "settled", parent)
-const treeOf = (logs: ReadonlyMap<string, ReadonlyArray<Event>>) => tree(logs, () => "running")
+const treeOf = (logs: ReadonlyMap<string, ReadonlyArray<Event>>, bounds?: TreeBounds) => tree(logs, () => "running", bounds)
 
 // The projections are functions of an event array, so the fixtures are event arrays: the shapes
 // below are the ones an assembled thread writes (packages/agent/src/index.test.ts and
@@ -73,7 +74,7 @@ describe("treeOf", () => {
     ])
 
   test("three levels, two roots", () => {
-    const roots = treeOf(forest())
+    const roots = treeOf(forest())!
     expect(roots.map((node) => node.id)).toEqual(["root", "other"])
     const root = roots[0]!
     expect(root.children.map((node) => node.id)).toEqual(["t1.0", "t1.1"])
@@ -83,7 +84,7 @@ describe("treeOf", () => {
   })
 
   test("every node carries its own summary, and a child names its parent", () => {
-    const root = treeOf(forest())[0]!
+    const root = treeOf(forest())![0]!
     expect(root.status).toBe("running")
     const child = root.children[0]!
     expect(child.parent).toBe("root")
@@ -97,7 +98,7 @@ describe("treeOf", () => {
     const logs = new Map<string, ReadonlyArray<Event>>([
       ["root", [created("root"), inbound("m1"), dispatched("t1"), called("t1.0", "workspace")]]
     ])
-    expect(treeOf(logs).map((node) => node.id)).toEqual(["root"])
+    expect(treeOf(logs)!.map((node) => node.id)).toEqual(["root"])
   })
 
   test("an empty registered child is absent", () => {
@@ -110,6 +111,55 @@ describe("treeOf", () => {
     const early = [created("early"), inbound("a")]
     const late = [created("late"), inbound("b")]
     const logs = new Map<string, ReadonlyArray<Event>>([["late", late], ["early", early]])
-    expect(treeOf(logs).map((node) => node.id)).toEqual(["early", "late"])
+    expect(treeOf(logs)!.map((node) => node.id)).toEqual(["early", "late"])
+  })
+})
+
+describe("treeOf bounds what it builds", () => {
+  // A wide, deep forest: root fans out to three children, one of them chains two levels further.
+  const forest = (): ReadonlyMap<string, ReadonlyArray<Event>> =>
+    new Map<string, ReadonlyArray<Event>>([
+      ["root", [created("root"), inbound("m1"), called("a1"), spawned("a1", "root", 1), called("a2"), spawned("a2", "root", 1), called("b1"), spawned("b1", "root", 1)]],
+      ["a1", [created("a1", "root", 1), inbound("a1")]],
+      ["a2", [created("a2", "root", 1), inbound("a2"), called("a2.1"), spawned("a2.1", "a2", 2), called("a2.2"), spawned("a2.2", "a2", 2)]],
+      ["a2.1", [created("a2.1", "a2", 2), inbound("a2.1")]],
+      ["a2.2", [created("a2.2", "a2", 2), inbound("a2.2"), called("a2.2.1"), spawned("a2.2.1", "a2.2", 3)]],
+      ["a2.2.1", [created("a2.2.1", "a2.2", 3), inbound("a2.2.1")]],
+      ["b1", [created("b1", "root", 1), inbound("b1")]],
+      ["other", [created("other"), inbound("m2")]]
+    ])
+  const idsOf = (nodes: ReadonlyArray<ThreadNode>): ReadonlyArray<string> =>
+    nodes.flatMap((node) => [node.id, ...idsOf(node.children)])
+
+  test("a stated root builds only that subtree", () => {
+    const tree = treeOf(forest(), { root: "a2" })!
+    expect(tree).toHaveLength(1)
+    const a2 = tree[0]!
+    expect(a2.parent).toBe("root")
+    expect(idsOf(tree)).toEqual(["a2", "a2.1", "a2.2", "a2.2.1"])
+  })
+
+  test("an unknown root reads as absent", () => {
+    expect(treeOf(forest(), { root: "ghost" })).toBeUndefined()
+  })
+
+  test("maxDepth zero keeps every start childless", () => {
+    const roots = treeOf(forest(), { maxDepth: 0 })!
+    expect(roots.map((node) => node.id)).toEqual(["root", "other"])
+    expect(roots.every((node) => node.children.length === 0)).toBe(true)
+  })
+
+  test("maxDepth cuts the descent before the deepest level", () => {
+    const roots = treeOf(forest(), { maxDepth: 2 })!
+    expect(idsOf(roots)).toEqual(["root", "a1", "a2", "a2.1", "a2.2", "b1", "other"])
+    // a2.2.1 sits at level three, one past the bound, so no node was built for it.
+    expect(idsOf(roots).includes("a2.2.1")).toBe(false)
+  })
+
+  test("maxNodes stops the walk before later roots", () => {
+    // The walk is depth-first in listing order, so four nodes spend the budget on root's subtree
+    // before `other` starts, and `other` is never built.
+    const roots = treeOf(forest(), { maxNodes: 4 })!
+    expect(idsOf(roots)).toEqual(["root", "a1", "a2", "a2.1"])
   })
 })

--- a/docs/how-to/server.md
+++ b/docs/how-to/server.md
@@ -20,7 +20,7 @@ Base path `/v1`. Runtime routes address the actor mounted at the server origin. 
 | `GET /v1/models` | Search and page public model metadata. The page reports the host model policy and default. `availability`, `provider`, `search`, `sort`, `order`, `unpriced`, `cursor`, `limit` |
 | `GET /v1/metadata` | Read the mounted actor name and storage metadata |
 | `GET /v1/methods` | List methods with standalone input and output schemas |
-| `GET /v1/threads` | List threads |
+| `GET /v1/threads` | List threads. `root`, `maxDepth`, `maxNodes` bound what the listing builds |
 | `PUT /v1/threads/{id}/methods/{method}/calls/{call}` | Call a method with its input as the body |
 | `GET /v1/threads/{id}/methods/{method}/calls/{call}` | Read a method call's derived state |
 | `POST /v1/threads/{id}/events` | Append an event, creating the thread if new |
@@ -28,7 +28,7 @@ Base path `/v1`. Runtime routes address the actor mounted at the server origin. 
 | `GET /v1/threads/{id}/events/stream` | Follow the log. Server-sent events resume from `Last-Event-ID` |
 | `GET /v1/actors/{actor}/threads/{id}/inference/stream` | Follow transient model text produced after the connection opens |
 | `GET /v1/threads/{id}/projections/{projection}` | Read a projection the mounted actor declares |
-| `GET /v1/threads/{id}/tree` | Read the spawn family |
+| `GET /v1/threads/{id}/tree` | Read the spawn family. `maxDepth`, `maxNodes` bound what the tree builds |
 | `GET /v1/actors` | List actors available to the host |
 | `PUT /v1/actors` | Push an actor artifact to the host |
 | `GET /healthz` `GET /openapi.json` `GET /docs` | Unversioned |

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -157,6 +157,22 @@ describe("the address a call goes to", () => {
     expect(url.searchParams.has("limit")).toBe(false)
   })
 
+  test("stated bounds are query params on the tree and roster reads, absent ones absent", async () => {
+    const client = makeActorClient({ baseUrl: "http://localhost:4111" , fetch: stub })
+    await client.list("main", { root: "inv-81", maxDepth: 2, maxNodes: 50 })
+    answer = () => Response.json({ id: "inv-81", depth: 0, events: 1, status: "settled", children: [] })
+    await client.tree("main", "inv-81", { maxDepth: 1 })
+    const roster = new URL(calls[0]!.url)
+    const tree = new URL(calls[1]!.url)
+    expect(roster.searchParams.get("root")).toBe("inv-81")
+    expect(roster.searchParams.get("maxDepth")).toBe("2")
+    expect(roster.searchParams.get("maxNodes")).toBe("50")
+    expect(tree.pathname).toBe("/v1/actors/main/threads/inv-81/tree")
+    expect(tree.searchParams.get("maxDepth")).toBe("1")
+    expect(tree.searchParams.has("root")).toBe(false)
+    expect(tree.searchParams.has("maxNodes")).toBe(false)
+  })
+
   test("a base with a trailing slash does not double it", async () => {
     await makeActorClient({ baseUrl: "http://127.0.0.1:4111/" , fetch: stub }).list("main")
     expect(calls[0]!.url).toBe("http://127.0.0.1:4111/v1/actors/main/threads")

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -29,6 +29,7 @@ import {
   type CancellationResult,
   type ThreadNode,
   type ThreadSummary,
+  type TreeBounds,
   type EventRow,
   type Health,
   MethodState,
@@ -188,8 +189,10 @@ export interface ActorClient<P extends Projections = {}, M extends ActorMethods 
   readonly actors: () => Promise<ReadonlyArray<ActorInstanceSummary>>
   readonly ensureActor: (actor: string) => Promise<ActorInstanceSummary>
   readonly actor: (actor: string) => Promise<ActorInstanceSummary>
-  readonly list: (actor: string) => Promise<ReadonlyArray<ThreadSummary>>
-  readonly tree: (actor: string, thread: string) => Promise<ThreadNode>
+  // list reads the actor's roster, bounded by `options` when stated (contract.ts, TreeBounds).
+  readonly list: (actor: string, options?: TreeBounds) => Promise<ReadonlyArray<ThreadSummary>>
+  // tree reads one thread's spawn family beneath it, bounded by `options` when stated (contract.ts, TreeBounds).
+  readonly tree: (actor: string, thread: string, options?: TreeBounds) => Promise<ThreadNode>
   readonly events: (actor: string, thread: string, options?: EventsOptions) => Promise<ReadonlyArray<EventRow>>
   // Appends one event to a thread's log. A brief is `{ type: "MessageReceived", id, text }`; the
   // platform requires nothing but `type` (contract.ts, Append).
@@ -327,6 +330,16 @@ const eventsQuery = (options: EventsOptions) => {
   return query
 }
 
+// The bounds query the tree and roster reads accept, built like eventsQuery so an absent bound is
+// an absent key (contract.ts, TreeBounds).
+const boundsQuery = (options: TreeBounds) => {
+  const query: { root?: string; maxDepth?: number; maxNodes?: number } = {}
+  if (options.root !== undefined) query.root = options.root
+  if (options.maxDepth !== undefined) query.maxDepth = options.maxDepth
+  if (options.maxNodes !== undefined) query.maxNodes = options.maxNodes
+  return query
+}
+
 const catalogQuery = (options: ModelPageOptions) => {
   const query: { availability?: CatalogAvailabilityFilter; cursor?: string; limit?: number; provider?: string; search?: string; sort?: ModelCatalogPriceSort; order?: ModelCatalogSortOrder; unpriced?: ModelCatalogUnpricedOrder } = {}
   if (options.availability !== undefined) query.availability = options.availability
@@ -384,8 +397,9 @@ export const makeActorClient = <const P extends Projections = {}, const M extend
     actors: () => run(api.actors.actors({})),
     ensureActor: (actor) => run(api.actors.ensureActor({ params: { id: actor } })),
     actor: (actor) => run(api.actors.actor({ params: { id: actor } })),
-    list: (actor) => run(api.threads.list({ params: { id: actor } })),
-    tree: (actor, thread) => run(api.threads.tree({ params: { id: actor, thread } })),
+    list: (actor, options) => run(api.threads.list({ params: { id: actor }, query: boundsQuery(options ?? {}) })),
+    tree: (actor, thread, options) =>
+      run(api.threads.tree({ params: { id: actor, thread }, query: boundsQuery(options ?? {}) })),
     events: (actor, thread, events = {}) =>
       run(api.threads.events({ params: { id: actor, thread }, query: eventsQuery(events) })),
     append,

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -192,7 +192,7 @@ export interface ActorClient<P extends Projections = {}, M extends ActorMethods 
   // list reads the actor's roster, bounded by `options` when stated (contract.ts, TreeBounds).
   readonly list: (actor: string, options?: TreeBounds) => Promise<ReadonlyArray<ThreadSummary>>
   // tree reads one thread's spawn family beneath it, bounded by `options` when stated (contract.ts, TreeBounds).
-  readonly tree: (actor: string, thread: string, options?: TreeBounds) => Promise<ThreadNode>
+  readonly tree: (actor: string, thread: string, options?: Omit<TreeBounds, "root">) => Promise<ThreadNode>
   readonly events: (actor: string, thread: string, options?: EventsOptions) => Promise<ReadonlyArray<EventRow>>
   // Appends one event to a thread's log. A brief is `{ type: "MessageReceived", id, text }`; the
   // platform requires nothing but `type` (contract.ts, Append).
@@ -330,8 +330,7 @@ const eventsQuery = (options: EventsOptions) => {
   return query
 }
 
-// The bounds query the tree and roster reads accept, built like eventsQuery so an absent bound is
-// an absent key (contract.ts, TreeBounds).
+// boundsQuery omits absent query parameters (client.test.ts).
 const boundsQuery = (options: TreeBounds) => {
   const query: { root?: string; maxDepth?: number; maxNodes?: number } = {}
   if (options.root !== undefined) query.root = options.root

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -159,6 +159,8 @@ export const ThreadNode = Schema.Struct({
 
 // TreeBounds names the opt-in bounds of a tree or roster read. A read with a `root` builds only
 // that subtree, `maxDepth` is the number of levels it builds beneath its start, and `maxNodes`
+// caps the nodes the read builds in total (apps-server/src/projections.test.ts, "treeOf bounds
+// what it builds").
 export interface TreeBounds {
   readonly root?: string | undefined
   readonly maxDepth?: number | undefined

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -157,10 +157,7 @@ export const ThreadNode = Schema.Struct({
   children: Schema.Array(Schema.suspend((): Schema.Codec<ThreadNode> => ThreadNode))
 }).annotate({ identifier: "ThreadNode" })
 
-// TreeBounds names the opt-in bounds of a tree or roster read. A read with a `root` builds only
-// that subtree, `maxDepth` is the number of levels it builds beneath its start, and `maxNodes`
-// caps the nodes the read builds in total (apps-server/src/projections.test.ts, "treeOf bounds
-// what it builds").
+// TreeBounds selects a subtree and caps its depth below each start and total node count (apps/server/src/projections.test.ts).
 export interface TreeBounds {
   readonly root?: string | undefined
   readonly maxDepth?: number | undefined
@@ -460,12 +457,10 @@ export const Seq = Schema.Int.pipe(
 
 const SeqQuery = Schema.optionalKey(Seq)
 
-// TreeDepth is a read's `maxDepth` bound: the levels it builds beneath its start, a non-negative
-// integer where zero keeps the start childless (apps-server/src/projections.test.ts, "treeOf bounds what it builds").
+// TreeDepth counts levels below the start; zero excludes children (apps/server/src/projections.test.ts).
 const TreeDepth = Seq
 
-// TreeNodeCount is a read's `maxNodes` bound: the nodes it builds in total, a positive integer
-// so a bounded read always builds its start (apps-server/src/projections.test.ts, "treeOf bounds what it builds").
+// TreeNodeCount includes the start node and must be positive (apps/server/src/api.test.ts).
 const TreeNodeCount = Schema.Int.pipe(
   Schema.check(Schema.makeFilter((value: number) => value > 0, { title: "above zero" }))
 )

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -157,6 +157,14 @@ export const ThreadNode = Schema.Struct({
   children: Schema.Array(Schema.suspend((): Schema.Codec<ThreadNode> => ThreadNode))
 }).annotate({ identifier: "ThreadNode" })
 
+// TreeBounds names the opt-in bounds of a tree or roster read. A read with a `root` builds only
+// that subtree, `maxDepth` is the number of levels it builds beneath its start, and `maxNodes`
+export interface TreeBounds {
+  readonly root?: string | undefined
+  readonly maxDepth?: number | undefined
+  readonly maxNodes?: number | undefined
+}
+
 export const TurnStatus = Schema.Literals(["pending", "completed", "failed", "cancelled", "parked"])
 
 export type TurnStatus = typeof TurnStatus.Type
@@ -450,6 +458,16 @@ export const Seq = Schema.Int.pipe(
 
 const SeqQuery = Schema.optionalKey(Seq)
 
+// TreeDepth is a read's `maxDepth` bound: the levels it builds beneath its start, a non-negative
+// integer where zero keeps the start childless (apps-server/src/projections.test.ts, "treeOf bounds what it builds").
+const TreeDepth = Seq
+
+// TreeNodeCount is a read's `maxNodes` bound: the nodes it builds in total, a positive integer
+// so a bounded read always builds its start (apps-server/src/projections.test.ts, "treeOf bounds what it builds").
+const TreeNodeCount = Schema.Int.pipe(
+  Schema.check(Schema.makeFilter((value: number) => value > 0, { title: "above zero" }))
+)
+
 const RuntimeActorParams = { id: ActorInstanceId }
 
 const RuntimeThreadParams = { ...RuntimeActorParams, thread: Schema.String }
@@ -478,8 +496,13 @@ export const threadsGroup = HttpApiGroup.make("threads").add(
   }),
   HttpApiEndpoint.get("list", "/v1/actors/:id/threads", {
     params: RuntimeActorParams,
+    query: {
+      root: Schema.optionalKey(Schema.String),
+      maxDepth: Schema.optionalKey(TreeDepth),
+      maxNodes: Schema.optionalKey(TreeNodeCount)
+    },
     success: Schema.Array(ThreadSummary),
-    error: [UnknownActor.schema]
+    error: [UnknownActor.schema, UnknownThread.schema]
   }),
   HttpApiEndpoint.get("events", "/v1/actors/:id/threads/:thread/events", {
     params: RuntimeThreadParams,
@@ -489,6 +512,7 @@ export const threadsGroup = HttpApiGroup.make("threads").add(
   }),
   HttpApiEndpoint.get("tree", "/v1/actors/:id/threads/:thread/tree", {
     params: RuntimeThreadParams,
+    query: { maxDepth: Schema.optionalKey(TreeDepth), maxNodes: Schema.optionalKey(TreeNodeCount) },
     success: ThreadNode,
     error: [UnknownActor.schema, UnknownThread.schema]
   })

--- a/packages/http/src/api.ts
+++ b/packages/http/src/api.ts
@@ -98,20 +98,8 @@ const logOf = (read: (id: string) => Effect.Effect<ReadonlyArray<Event>>, id: st
 const flatten = (nodes: ReadonlyArray<ThreadNode>): ReadonlyArray<ThreadSummary> =>
   nodes.flatMap(({ children, ...summary }) => [summary, ...flatten(children)])
 
-const findNode = (nodes: ReadonlyArray<ThreadNode>, id: string): ThreadNode | undefined => {
-  for (const node of nodes) {
-    if (node.id === id) return node
-    const found = findNode(node.children, id)
-    if (found !== undefined) return found
-  }
-  return undefined
-}
-
 const logsOf = (entries: ReadonlyArray<{ readonly id: string; readonly events: ReadonlyArray<Event> }>) =>
   new Map(entries.map((entry) => [entry.id, entry.events] as const))
-
-const rosterOf = (threads: ActorThreads) =>
-  Effect.map(threads.list, (entries) => flatten(treeOf(logsOf(entries), threads.statusOf)))
 
 const frameOf = (seq: number, event: unknown): string => `id: ${seq}\ndata: ${JSON.stringify(event)}\n\n`
 
@@ -409,10 +397,23 @@ export const layerThreadsGroup = (options: ApiOptions = {}) => {
           yield* threads.append(params.thread, payload)
           return { actor: params.id, thread: params.thread }
         }))
-      .handle("list", ({ params }) =>
+      .handle("list", ({ params, query }) =>
         Effect.gen(function*() {
           const threads = yield* actorOf(yield* Threads, params.id)
-          return yield* rosterOf(threads)
+          // The listing is the forest flattened, bounded by the caller's query. An unknown root is
+          // the one absent answer treeOf can read (projections.ts, treeOf).
+          const tree = treeOf(logsOf(yield* threads.list), threads.statusOf, {
+            root: query.root,
+            maxDepth: query.maxDepth,
+            maxNodes: query.maxNodes
+          })
+          if (tree === undefined) {
+            if (query.root === undefined) {
+              return yield* Effect.die(new Error("a roster read without a root cannot be absent"))
+            }
+            return yield* Effect.fail(UnknownThread.of(unknownThreadDetail(query.root)))
+          }
+          return flatten(tree)
         }))
       .handle("events", ({ params, query }) =>
         Effect.gen(function*() {
@@ -427,12 +428,18 @@ export const layerThreadsGroup = (options: ApiOptions = {}) => {
             .filter((row) => row.seq > (after ?? 0) && (types === undefined || types.includes(row.event.type)))
             .slice(0, page ?? limit)
         }))
-      .handle("tree", ({ params }) =>
+      .handle("tree", ({ params, query }) =>
         Effect.gen(function*() {
           const threads = yield* actorOf(yield* Threads, params.id)
-          // The forest is built over every log because parentage is a claim in the PARENT's log; a
-          // subtree cannot be derived from the subtree's own events (projections.ts, treeOf).
-          const node = findNode(treeOf(logsOf(yield* threads.list), threads.statusOf), params.thread)
+          // The logs are read whole because parentage is a claim in the PARENT's log, while the
+          // tree is built from the caller's thread alone: the walk starts there, so the rest of
+          // the forest is never built (projections.ts, treeOf).
+          const tree = treeOf(logsOf(yield* threads.list), threads.statusOf, {
+            root: params.thread,
+            maxDepth: query.maxDepth,
+            maxNodes: query.maxNodes
+          })
+          const node = tree === undefined ? undefined : tree[0]
           if (node === undefined) {
             return yield* Effect.fail(UnknownThread.of(unknownThreadDetail(params.thread)))
           }

--- a/packages/http/src/api.ts
+++ b/packages/http/src/api.ts
@@ -400,13 +400,7 @@ export const layerThreadsGroup = (options: ApiOptions = {}) => {
       .handle("list", ({ params, query }) =>
         Effect.gen(function*() {
           const threads = yield* actorOf(yield* Threads, params.id)
-          // The listing is the forest flattened, bounded by the caller's query. An unknown root is
-          // the one absent answer treeOf can read (projections.ts, treeOf).
-          const tree = treeOf(logsOf(yield* threads.list), threads.statusOf, {
-            root: query.root,
-            maxDepth: query.maxDepth,
-            maxNodes: query.maxNodes
-          })
+          const tree = treeOf(logsOf(yield* threads.list), threads.statusOf, query)
           if (tree === undefined) {
             if (query.root === undefined) {
               return yield* Effect.die(new Error("a roster read without a root cannot be absent"))
@@ -431,15 +425,8 @@ export const layerThreadsGroup = (options: ApiOptions = {}) => {
       .handle("tree", ({ params, query }) =>
         Effect.gen(function*() {
           const threads = yield* actorOf(yield* Threads, params.id)
-          // The logs are read whole because parentage is a claim in the PARENT's log, while the
-          // tree is built from the caller's thread alone: the walk starts there, so the rest of
-          // the forest is never built (projections.ts, treeOf).
-          const tree = treeOf(logsOf(yield* threads.list), threads.statusOf, {
-            root: params.thread,
-            maxDepth: query.maxDepth,
-            maxNodes: query.maxNodes
-          })
-          const node = tree === undefined ? undefined : tree[0]
+          const tree = treeOf(logsOf(yield* threads.list), threads.statusOf, { ...query, root: params.thread })
+          const node = tree?.[0]
           if (node === undefined) {
             return yield* Effect.fail(UnknownThread.of(unknownThreadDetail(params.thread)))
           }

--- a/packages/http/src/projections.ts
+++ b/packages/http/src/projections.ts
@@ -1,3 +1,4 @@
+import type { TreeBounds } from "@clavia/tardigrade-client/contract"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import { formatThreadAddress } from "@clavia/tardigrade-core/transport/endpoint"
 import { threadCreatedOf } from "@clavia/tardigrade-core/interaction/relations"
@@ -55,8 +56,17 @@ const firstAt = (events: ReadonlyArray<Event>): number => {
   return Number.POSITIVE_INFINITY
 }
 
-// treeOf builds the forest from ChildCreated edges in parent logs. Child ThreadCreated records confirm identity, while the parent log owns discovery.
-export const treeOf = (logs: ReadonlyMap<string, ReadonlyArray<Event>>, statusOf: ThreadStatusOf): ReadonlyArray<ThreadNode> => {
+// treeOf builds the forest from ChildCreated edges in parent logs. Child ThreadCreated records
+// confirm identity, while the parent log owns discovery. `bounds` bounds the construction, not the
+// result: the walk starts at `root`, builds at most `maxDepth` levels beneath its start, and
+// builds at most `maxNodes` nodes, so a node the bounds exclude is never built and never
+// summarized (projections.test.ts, "treeOf bounds what it builds"). An unknown `root` reads as
+// undefined, because the forest cannot see a thread no log claims.
+export const treeOf = (
+  logs: ReadonlyMap<string, ReadonlyArray<Event>>,
+  statusOf: ThreadStatusOf,
+  bounds: TreeBounds = {}
+): ReadonlyArray<ThreadNode> | undefined => {
   const createdLogs = new Map([...logs].filter(([, events]) => events.length > 0))
   const idsByAddress = new Map<string, string>()
   for (const [id, events] of createdLogs) {
@@ -86,14 +96,29 @@ export const treeOf = (logs: ReadonlyMap<string, ReadonlyArray<Event>>, statusOf
     if (siblings === undefined) childrenOf.set(parent, [child])
     else siblings.push(child)
   }
+  const root = bounds.root
+  if (root !== undefined && !createdLogs.has(root)) return undefined
   // A claim cycle is not reachable through minted call ids, but the map is an argument, so the walk
-  // carries the guard rather than trusting its caller.
+  // carries the guard rather than trusting its caller. The node budget counts down to zero and the
+  // walk stops, so a node past maxNodes or maxDepth is never built (projections.test.ts,
+  // "treeOf bounds what it builds").
   const walked = new Set<string>()
-  const node = (id: string, parent?: string): ThreadNode => {
+  let remaining = bounds.maxNodes
+  const node = (id: string, parent: string | undefined, level: number): ThreadNode | undefined => {
+    if (remaining !== undefined && remaining <= 0) return undefined
     walked.add(id)
+    if (remaining !== undefined) remaining -= 1
     const events = createdLogs.get(id) ?? []
-    const children = (childrenOf.get(id) ?? []).filter((child) => !walked.has(child)).sort(order)
-    return { ...summaryOf(id, events, statusOf, parent), children: children.map((child) => node(child, id)) }
+    const children = bounds.maxDepth !== undefined && level >= bounds.maxDepth ? [] :
+      (childrenOf.get(id) ?? []).filter((child) => !walked.has(child)).sort(order)
+        .map((child) => node(child, id, level + 1))
+        .filter((child): child is ThreadNode => child !== undefined)
+    return { ...summaryOf(id, events, statusOf, parent), children }
   }
-  return [...createdLogs.keys()].filter((id) => !parents.has(id)).sort(order).map((id) => node(id))
+  const starts = root === undefined
+    ? [...createdLogs.keys()].filter((id) => !parents.has(id)).sort(order)
+    : [root]
+  return starts
+    .map((id) => node(id, parents.get(id), 0))
+    .filter((node): node is ThreadNode => node !== undefined)
 }

--- a/packages/http/src/projections.ts
+++ b/packages/http/src/projections.ts
@@ -56,12 +56,7 @@ const firstAt = (events: ReadonlyArray<Event>): number => {
   return Number.POSITIVE_INFINITY
 }
 
-// treeOf builds the forest from ChildCreated edges in parent logs. Child ThreadCreated records
-// confirm identity, while the parent log owns discovery. `bounds` bounds the construction, not the
-// result: the walk starts at `root`, builds at most `maxDepth` levels beneath its start, and
-// builds at most `maxNodes` nodes, so a node the bounds exclude is never built and never
-// summarized (projections.test.ts, "treeOf bounds what it builds"). An unknown `root` reads as
-// undefined, because the forest cannot see a thread no log claims.
+// treeOf builds a forest within the requested bounds; an unknown root returns undefined (apps/server/src/projections.test.ts).
 export const treeOf = (
   logs: ReadonlyMap<string, ReadonlyArray<Event>>,
   statusOf: ThreadStatusOf,
@@ -98,10 +93,6 @@ export const treeOf = (
   }
   const root = bounds.root
   if (root !== undefined && !createdLogs.has(root)) return undefined
-  // A claim cycle is not reachable through minted call ids, but the map is an argument, so the walk
-  // carries the guard rather than trusting its caller. The node budget counts down to zero and the
-  // walk stops, so a node past maxNodes or maxDepth is never built (projections.test.ts,
-  // "treeOf bounds what it builds").
   const walked = new Set<string>()
   let remaining = bounds.maxNodes
   const node = (id: string, parent: string | undefined, level: number): ThreadNode | undefined => {
@@ -109,16 +100,24 @@ export const treeOf = (
     walked.add(id)
     if (remaining !== undefined) remaining -= 1
     const events = createdLogs.get(id) ?? []
-    const children = bounds.maxDepth !== undefined && level >= bounds.maxDepth ? [] :
-      (childrenOf.get(id) ?? []).filter((child) => !walked.has(child)).sort(order)
-        .map((child) => node(child, id, level + 1))
-        .filter((child): child is ThreadNode => child !== undefined)
+    const children: ThreadNode[] = []
+    if ((bounds.maxDepth === undefined || level < bounds.maxDepth) && remaining !== 0) {
+      for (const child of (childrenOf.get(id) ?? []).filter((child) => !walked.has(child)).sort(order)) {
+        const built = node(child, id, level + 1)
+        if (built === undefined) break
+        children.push(built)
+      }
+    }
     return { ...summaryOf(id, events, statusOf, parent), children }
   }
   const starts = root === undefined
     ? [...createdLogs.keys()].filter((id) => !parents.has(id)).sort(order)
     : [root]
-  return starts
-    .map((id) => node(id, parents.get(id), 0))
-    .filter((node): node is ThreadNode => node !== undefined)
+  const tree: ThreadNode[] = []
+  for (const id of starts) {
+    const built = node(id, parents.get(id), 0)
+    if (built === undefined) break
+    tree.push(built)
+  }
+  return tree
 }

--- a/packages/http/src/projections.ts
+++ b/packages/http/src/projections.ts
@@ -100,24 +100,19 @@ export const treeOf = (
     walked.add(id)
     if (remaining !== undefined) remaining -= 1
     const events = createdLogs.get(id) ?? []
-    const children: ThreadNode[] = []
-    if ((bounds.maxDepth === undefined || level < bounds.maxDepth) && remaining !== 0) {
-      for (const child of (childrenOf.get(id) ?? []).filter((child) => !walked.has(child)).sort(order)) {
-        const built = node(child, id, level + 1)
-        if (built === undefined) break
-        children.push(built)
-      }
-    }
+    const children = (bounds.maxDepth === undefined || level < bounds.maxDepth) && remaining !== 0
+      ? nodes((childrenOf.get(id) ?? []).filter((child) => !walked.has(child)).sort(order), level + 1)
+      : []
     return { ...summaryOf(id, events, statusOf, parent), children }
   }
-  const starts = root === undefined
-    ? [...createdLogs.keys()].filter((id) => !parents.has(id)).sort(order)
-    : [root]
-  const tree: ThreadNode[] = []
-  for (const id of starts) {
-    const built = node(id, parents.get(id), 0)
-    if (built === undefined) break
-    tree.push(built)
+  const nodes = (ids: ReadonlyArray<string>, level: number): ThreadNode[] => {
+    const tree: ThreadNode[] = []
+    for (const id of ids) {
+      const built = node(id, parents.get(id), level)
+      if (built === undefined) break
+      tree.push(built)
+    }
+    return tree
   }
-  return tree
+  return nodes(root === undefined ? [...createdLogs.keys()].filter((id) => !parents.has(id)).sort(order) : [root], 0)
 }

--- a/platform/cloudflare/src/actor.ts
+++ b/platform/cloudflare/src/actor.ts
@@ -1,3 +1,4 @@
+import type { TreeBounds } from "@clavia/tardigrade-client/contract"
 import { threadCreated } from "@clavia/tardigrade-core/interaction/relations"
 import { childKeyOf } from "@clavia/tardigrade-core/actor/coordinate"
 import { threadObjectNameOf } from "./transport/directory"
@@ -66,7 +67,15 @@ const actorSupervisorOf = (
   keyOf: actorEventKeyOf
 })
 
-const threadTreeOf = (rows: ReadonlyArray<ActorThreadRecord>): ReadonlyArray<ActorThreadNode> => {
+// threadTreeOf builds the tree of an actor's registered threads from its roster records, bounded
+// by `bounds` when stated: the walk starts at `root`, builds at most `maxDepth` levels beneath its
+// start, and builds at most `maxNodes` nodes, so a node the bounds exclude is never built
+// (actor.workers.ts, "a bounded tree read never builds what it does not return"). An unknown
+// `root` reads as undefined, because the roster has no such thread.
+const threadTreeOf = (
+  rows: ReadonlyArray<ActorThreadRecord>,
+  bounds: TreeBounds = {}
+): ReadonlyArray<ActorThreadNode> | undefined => {
   const entries = new Map<string, Omit<ActorThreadNode, "children">>()
   const children = new Map<string, string[]>()
   const roots: string[] = []
@@ -83,20 +92,33 @@ const threadTreeOf = (rows: ReadonlyArray<ActorThreadRecord>): ReadonlyArray<Act
     if (parent === undefined) roots.push(id)
     else children.set(parent, [...children.get(parent) ?? [], id])
   }
+  const { root, maxDepth, maxNodes } = bounds
+  if (root !== undefined && !entries.has(root)) return undefined
   const visited = new Set<string>()
-  const node = (id: string, ancestors: ReadonlySet<string>): ActorThreadNode => {
+  let built = 0
+  const node = (id: string, ancestors: ReadonlySet<string>, level: number): ActorThreadNode | undefined => {
+    if (maxNodes !== undefined && built >= maxNodes) return undefined
     if (ancestors.has(id)) throw new Error(`thread tree contains a cycle at ${JSON.stringify(id)}`)
     const entry = entries.get(id)
     if (entry === undefined) throw new Error(`thread tree is missing ${JSON.stringify(id)}`)
+    built += 1
     visited.add(id)
     const next = new Set(ancestors).add(id)
-    return {
-      ...entry,
-      children: [...children.get(id) ?? []].sort().map((child) => node(child, next))
-    }
+    const walked = maxDepth !== undefined && level >= maxDepth ? [] :
+      [...children.get(id) ?? []].sort()
+        .map((child) => node(child, next, level + 1))
+        .filter((child): child is ActorThreadNode => child !== undefined)
+    return { ...entry, children: walked }
   }
-  const tree = roots.sort().map((root) => node(root, new Set()))
-  if (visited.size !== entries.size) throw new Error("thread tree contains an orphan or cycle")
+  const tree = (root === undefined ? roots.sort() : [root])
+    .map((start) => node(start, new Set(), 0))
+    .filter((node): node is ActorThreadNode => node !== undefined)
+  // The orphan check holds only for the unbounded walk: a bounded read stops on purpose, so the
+  // entries it never reached are not orphans (actor.workers.ts, "a bounded tree read never builds
+  // what it does not return").
+  if (root === undefined && maxDepth === undefined && maxNodes === undefined && visited.size !== entries.size) {
+    throw new Error("thread tree contains an orphan or cycle")
+  }
   return tree
 }
 
@@ -300,9 +322,9 @@ export class ActorDO extends DurableObject<Env> {
     })
   }
 
-  async threadTree(): Promise<ReadonlyArray<ActorThreadNode>> {
+  async threadTree(bounds: TreeBounds = {}): Promise<ReadonlyArray<ActorThreadNode> | undefined> {
     const entries = (await this.threads()).filter((entry) => entry.state === "registered")
-    return threadTreeOf(entries)
+    return threadTreeOf(entries, bounds)
   }
 
   async alarm(): Promise<void> {

--- a/platform/cloudflare/src/actor.ts
+++ b/platform/cloudflare/src/actor.ts
@@ -100,22 +100,21 @@ const threadTreeOf = (
     built += 1
     visited.add(id)
     const next = new Set(ancestors).add(id)
-    const descendants: ActorThreadNode[] = []
-    if ((maxDepth === undefined || level < maxDepth) && (maxNodes === undefined || built < maxNodes)) {
-      for (const child of [...children.get(id) ?? []].sort()) {
-        const result = node(child, next, level + 1)
-        if (result === undefined) break
-        descendants.push(result)
-      }
-    }
+    const descendants = (maxDepth === undefined || level < maxDepth) && (maxNodes === undefined || built < maxNodes)
+      ? nodes([...children.get(id) ?? []].sort(), next, level + 1)
+      : []
     return { ...entry, children: descendants }
   }
-  const tree: ActorThreadNode[] = []
-  for (const start of root === undefined ? roots.sort() : [root]) {
-    const result = node(start, new Set(), 0)
-    if (result === undefined) break
-    tree.push(result)
+  const nodes = (ids: ReadonlyArray<string>, ancestors: ReadonlySet<string>, level: number): ActorThreadNode[] => {
+    const tree: ActorThreadNode[] = []
+    for (const id of ids) {
+      const result = node(id, ancestors, level)
+      if (result === undefined) break
+      tree.push(result)
+    }
+    return tree
   }
+  const tree = nodes(root === undefined ? roots.sort() : [root], new Set(), 0)
   // Partial reads cannot establish whether the full roster is connected (test/actor.workers.ts).
   if (root === undefined && maxDepth === undefined && maxNodes === undefined && visited.size !== entries.size) {
     throw new Error("thread tree contains an orphan or cycle")

--- a/platform/cloudflare/src/actor.ts
+++ b/platform/cloudflare/src/actor.ts
@@ -67,11 +67,7 @@ const actorSupervisorOf = (
   keyOf: actorEventKeyOf
 })
 
-// threadTreeOf builds the tree of an actor's registered threads from its roster records, bounded
-// by `bounds` when stated: the walk starts at `root`, builds at most `maxDepth` levels beneath its
-// start, and builds at most `maxNodes` nodes, so a node the bounds exclude is never built
-// (actor.workers.ts, "a bounded tree read never builds what it does not return"). An unknown
-// `root` reads as undefined, because the roster has no such thread.
+// threadTreeOf builds registered threads within the requested bounds; an unknown root returns undefined (test/actor.workers.ts).
 const threadTreeOf = (
   rows: ReadonlyArray<ActorThreadRecord>,
   bounds: TreeBounds = {}
@@ -104,18 +100,23 @@ const threadTreeOf = (
     built += 1
     visited.add(id)
     const next = new Set(ancestors).add(id)
-    const walked = maxDepth !== undefined && level >= maxDepth ? [] :
-      [...children.get(id) ?? []].sort()
-        .map((child) => node(child, next, level + 1))
-        .filter((child): child is ActorThreadNode => child !== undefined)
-    return { ...entry, children: walked }
+    const descendants: ActorThreadNode[] = []
+    if ((maxDepth === undefined || level < maxDepth) && (maxNodes === undefined || built < maxNodes)) {
+      for (const child of [...children.get(id) ?? []].sort()) {
+        const result = node(child, next, level + 1)
+        if (result === undefined) break
+        descendants.push(result)
+      }
+    }
+    return { ...entry, children: descendants }
   }
-  const tree = (root === undefined ? roots.sort() : [root])
-    .map((start) => node(start, new Set(), 0))
-    .filter((node): node is ActorThreadNode => node !== undefined)
-  // The orphan check holds only for the unbounded walk: a bounded read stops on purpose, so the
-  // entries it never reached are not orphans (actor.workers.ts, "a bounded tree read never builds
-  // what it does not return").
+  const tree: ActorThreadNode[] = []
+  for (const start of root === undefined ? roots.sort() : [root]) {
+    const result = node(start, new Set(), 0)
+    if (result === undefined) break
+    tree.push(result)
+  }
+  // Partial reads cannot establish whether the full roster is connected (test/actor.workers.ts).
   if (root === undefined && maxDepth === undefined && maxNodes === undefined && visited.size !== entries.size) {
     throw new Error("thread tree contains an orphan or cycle")
   }

--- a/platform/cloudflare/src/transport/http.ts
+++ b/platform/cloudflare/src/transport/http.ts
@@ -1,6 +1,6 @@
 import { Context, Effect, Layer, Schema } from "effect"
 import { HttpServer, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
-import { UnknownThread } from "@clavia/tardigrade-client/contract"
+import { UnknownThread, type TreeBounds } from "@clavia/tardigrade-client/contract"
 import type { ActorMethods } from "@clavia/tardigrade-core/actor/method"
 import type { ModelPolicy } from "@clavia/tardigrade-agent"
 import type { ModelCatalogState } from "@clavia/tardigrade-model/catalog"
@@ -13,6 +13,35 @@ import { CatalogApi, CatalogDiscovery, layerCatalogHandlers } from "@clavia/tard
 import { layerRequestProblems } from "@clavia/tardigrade-http/contract"
 import type { Env } from "../env"
 import type { CloudflareDirectory } from "./directory"
+
+// treeBoundsOf reads the bounds of GET /v1/actors/:id/threads from its query string: an absent
+// bound reads as undefined, and a bound that is not the integer it must be reads as its error.
+// `maxDepth` counts levels beneath the start, `maxNodes` counts nodes in total, and both must
+// hold a whole count (contract.ts, TreeBounds).
+const treeBoundsOf = (
+  request: HttpServerRequest.HttpServerRequest
+): { readonly bounds: TreeBounds } | { readonly error: string } => {
+  const query = new URL(request.url, "http://worker").searchParams
+  const boundOf = (name: string, minimum: 0 | 1): { readonly value?: number } | { readonly error: string } => {
+    const raw = query.get(name)
+    if (raw === null) return {}
+    const value = Number(raw)
+    return Number.isSafeInteger(value) && value >= minimum
+      ? { value }
+      : { error: `${name} must be ${minimum === 0 ? "a non-negative" : "a positive"} integer` }
+  }
+  const depth = boundOf("maxDepth", 0)
+  if ("error" in depth) return depth
+  const nodes = boundOf("maxNodes", 1)
+  if ("error" in nodes) return nodes
+  return {
+    bounds: {
+      root: query.get("root") ?? undefined,
+      maxDepth: depth.value,
+      maxNodes: nodes.value
+    }
+  }
+}
 
 export const DEFAULT_CLOUDFLARE_EVENT_LIMIT = 200
 
@@ -106,14 +135,18 @@ export const cloudflareHttp = ({
         return json(coordinate)
       })
     )),
-    HttpRouter.route("GET", "/v1/actors/:id/threads", workerRoute((_request, env) =>
+    HttpRouter.route("GET", "/v1/actors/:id/threads", workerRoute((request, env) =>
       Effect.gen(function* () {
         const params = yield* HttpRouter.params
         const instance = params.id ?? ""
         if (!Schema.is(ActorInstanceId)(instance)) return json({ error: "invalid actor instance id" }, 400)
         const stub = yield* Effect.promise(() => actorStub(env, actorName(), instance, false))
         if (stub === undefined) return json({ error: "unknown actor" }, 404)
-        return json(yield* Effect.promise(() => stub.threadTree()))
+        const selected = treeBoundsOf(request)
+        if ("error" in selected) return json({ error: selected.error }, 400)
+        const tree = yield* Effect.promise(() => stub.threadTree(selected.bounds))
+        if (tree === undefined) return json({ error: "unknown thread" }, 404)
+        return json(tree)
       })
     )),
     HttpRouter.route("POST", "/v1/actors/:id/threads/:thread/events", workerRoute((request, env) =>

--- a/platform/cloudflare/src/transport/http.ts
+++ b/platform/cloudflare/src/transport/http.ts
@@ -14,10 +14,7 @@ import { layerRequestProblems } from "@clavia/tardigrade-http/contract"
 import type { Env } from "../env"
 import type { CloudflareDirectory } from "./directory"
 
-// treeBoundsOf reads the bounds of GET /v1/actors/:id/threads from its query string: an absent
-// bound reads as undefined, and a bound that is not the integer it must be reads as its error.
-// `maxDepth` counts levels beneath the start, `maxNodes` counts nodes in total, and both must
-// hold a whole count (contract.ts, TreeBounds).
+// treeBoundsOf validates optional subtree, depth, and node limits (test/actor.workers.ts).
 const treeBoundsOf = (
   request: HttpServerRequest.HttpServerRequest
 ): { readonly bounds: TreeBounds } | { readonly error: string } => {

--- a/platform/cloudflare/src/transport/http.ts
+++ b/platform/cloudflare/src/transport/http.ts
@@ -19,25 +19,17 @@ const treeBoundsOf = (
   request: HttpServerRequest.HttpServerRequest
 ): { readonly bounds: TreeBounds } | { readonly error: string } => {
   const query = new URL(request.url, "http://worker").searchParams
-  const boundOf = (name: string, minimum: 0 | 1): { readonly value?: number } | { readonly error: string } => {
+  const bounds = { root: query.get("root") ?? undefined, maxDepth: undefined as number | undefined, maxNodes: undefined as number | undefined }
+  for (const [name, minimum] of [["maxDepth", 0], ["maxNodes", 1]] as const) {
     const raw = query.get(name)
-    if (raw === null) return {}
+    if (raw === null) continue
     const value = Number(raw)
-    return Number.isSafeInteger(value) && value >= minimum
-      ? { value }
-      : { error: `${name} must be ${minimum === 0 ? "a non-negative" : "a positive"} integer` }
-  }
-  const depth = boundOf("maxDepth", 0)
-  if ("error" in depth) return depth
-  const nodes = boundOf("maxNodes", 1)
-  if ("error" in nodes) return nodes
-  return {
-    bounds: {
-      root: query.get("root") ?? undefined,
-      maxDepth: depth.value,
-      maxNodes: nodes.value
+    if (!Number.isSafeInteger(value) || value < minimum) {
+      return { error: `${name} must be ${minimum === 0 ? "a non-negative" : "a positive"} integer` }
     }
+    bounds[name] = value
   }
+  return { bounds }
 }
 
 export const DEFAULT_CLOUDFLARE_EVENT_LIMIT = 200

--- a/platform/cloudflare/test/actor.workers.ts
+++ b/platform/cloudflare/test/actor.workers.ts
@@ -1114,13 +1114,10 @@ describe("cloudflare actor", () => {
     expect(idsOf(rooted)).toEqual(["wide-root", "leaf-1", "leaf-2", "leaf-3", "leaf-4"])
     // The unbounded read is a throw, not an answer: its completeness check reaches the pair.
     // The three reads above read the same roster, so each walk that answered is proof the bounds
-    // held it. The unbounded call runs inside the object, because a promise that rejects across
-    // the RPC boundary leaves the object holding an unhandled rejection the suite reports.
-    const unbounded = await runInDurableObject(directory, (instance) =>
-      instance.threadTree().then(
-        () => "answered",
-        (cause: unknown) => cause instanceof Error ? cause.message : String(cause)
-      )
+    // held it.
+    const unbounded = await directory.threadTree().then(
+      () => "answered",
+      (cause: unknown) => cause instanceof Error ? cause.message : String(cause)
     )
     expect(unbounded).toBe("thread tree contains an orphan or cycle")
   })

--- a/platform/cloudflare/test/actor.workers.ts
+++ b/platform/cloudflare/test/actor.workers.ts
@@ -18,6 +18,7 @@ import {
   modelCatalogForConfig,
   modelScopeFrom,
   retainBackgroundTask,
+  type ActorThreadNode,
   type Env
 } from "../src/worker"
 import { modelAdapters } from "@clavia/tardigrade-model/adapter"
@@ -1030,6 +1031,125 @@ describe("cloudflare actor", () => {
       "ThreadRequested",
       "ThreadRegistered"
     ])
+  })
+
+  // claimTree writes requested-and-registered thread records straight into an actor instance's
+  // own log, the shape the supervisor's registration writes, so a tree test states a roster
+  // outright. The instance is the fixture's own, because worker storage outlives a test and a
+  // roster shaped for bounds would poison another test's unbounded read.
+  const claimTree = async (
+    instance: string,
+    claims: ReadonlyArray<readonly [thread: string, parent: string | undefined, depth: number]>,
+    extra: ReadonlyArray<readonly [key: string | null, event: string]> = []
+  ): Promise<void> => {
+    const directory = (env as Env).ACTORS.getByName(JSON.stringify(["echo", instance]))
+    await directory.init("echo", instance)
+    await runInDurableObject(directory, (_instance, state) => {
+      const insert = (key: string | null, event: string) =>
+        state.storage.sql.exec(
+          `INSERT INTO events (seq, key, event) VALUES ((SELECT COALESCE(MAX(seq), 0) + 1 FROM events), ?, ?)`,
+          key,
+          event
+        )
+      for (const [thread, parent, depth] of claims) {
+        insert(
+          `thread:requested:ag.${thread}`,
+          `{"type":"ThreadRequested","thread":"ag.${thread}"${parent === undefined ? "" : `,"parentThread":"ag.${parent}"`},"depth":${depth},"at":1}`
+        )
+        insert(`thread:registered:ag.${thread}`, `{"type":"ThreadRegistered","thread":"ag.${thread}","at":2}`)
+      }
+      for (const [key, event] of extra) insert(key, event)
+    })
+  }
+
+  test("a bounded tree read never builds what it does not return", async () => {
+    // A wide root with four leaves, a deep chain four levels down, and a claim pair at its bottom
+    // whose second edge points back at itself. The pair's edges live in the claiming thread's own
+    // record, so no root path reaches it and the unbounded read fails its completeness check
+    // rather than answering (worker.ts, threadTreeOf). A bounded read that answers therefore
+    // proves the walk never built what the bounds exclude. The second claim of loop-a rides
+    // unkeyed rows, because its request and registration keys are spent on the first.
+    await claimTree("tree-bounds", [
+      ["wide-root", undefined, 0],
+      ["deep-0", undefined, 0],
+      ["leaf-1", "wide-root", 1],
+      ["leaf-2", "wide-root", 1],
+      ["leaf-3", "wide-root", 1],
+      ["leaf-4", "wide-root", 1],
+      ["deep-1", "deep-0", 1],
+      ["deep-2", "deep-1", 2],
+      ["deep-3", "deep-2", 3],
+      ["deep-4", "deep-3", 4],
+      ["loop-a", "deep-4", 5],
+      ["loop-b", "loop-a", 6]
+    ], [
+      [null, `{"type":"ThreadRequested","thread":"ag.loop-a","parentThread":"ag.loop-b","depth":7,"at":3}`],
+      [null, `{"type":"ThreadRegistered","thread":"ag.loop-a","at":4}`]
+    ])
+    const directory = (env as Env).ACTORS.getByName(JSON.stringify(["echo", "tree-bounds"]))
+    const nodeOf = (nodes: ReadonlyArray<ActorThreadNode>, id: string): ActorThreadNode | undefined => {
+      for (const node of nodes) {
+        if (node.id === id) return node
+        const found = nodeOf(node.children, id)
+        if (found !== undefined) return found
+      }
+      return undefined
+    }
+    const idsOf = (nodes: ReadonlyArray<ActorThreadNode>): ReadonlyArray<string> =>
+      nodes.flatMap((node) => [node.id, ...idsOf(node.children)])
+    const depthTwo = (await directory.threadTree({ maxDepth: 2 }))!
+    // The wide root keeps its four leaves, and the deep chain stops at its second level.
+    expect(nodeOf(depthTwo, "wide-root")?.children.map((node) => node.id))
+      .toEqual(["leaf-1", "leaf-2", "leaf-3", "leaf-4"])
+    expect(nodeOf(depthTwo, "deep-0")?.children.map((node) => node.id)).toEqual(["deep-1"])
+    expect(nodeOf(depthTwo, "deep-1")?.children.map((node) => node.id)).toEqual(["deep-2"])
+    expect(nodeOf(depthTwo, "deep-2")?.children).toEqual([])
+    expect(idsOf(depthTwo).some((id) => id === "deep-3" || id === "loop-a" || id === "loop-b")).toBe(false)
+    // The node budget runs out inside the chain, and the walk stops before wide-root entirely.
+    const budgetFour = (await directory.threadTree({ maxNodes: 4 }))!
+    expect(idsOf(budgetFour)).toEqual(["deep-0", "deep-1", "deep-2", "deep-3"])
+    expect(nodeOf(budgetFour, "deep-3")?.children).toEqual([])
+    // A stated root builds only its subtree, and the pair that walk never started on is absent.
+    const rooted = (await directory.threadTree({ root: "wide-root" }))!
+    expect(idsOf(rooted)).toEqual(["wide-root", "leaf-1", "leaf-2", "leaf-3", "leaf-4"])
+    // The unbounded read is a throw, not an answer: its completeness check reaches the pair.
+    // The three reads above read the same roster, so each walk that answered is proof the bounds
+    // held it. The unbounded call runs inside the object, because a promise that rejects across
+    // the RPC boundary leaves the object holding an unhandled rejection the suite reports.
+    const unbounded = await runInDurableObject(directory, (instance) =>
+      instance.threadTree().then(
+        () => "answered",
+        (cause: unknown) => cause instanceof Error ? cause.message : String(cause)
+      )
+    )
+    expect(unbounded).toBe("thread tree contains an orphan or cycle")
+  })
+
+  test("the threads route carries the bounds and refuses what cannot count", async () => {
+    await claimTree("tree-route", [
+      ["wide-root", undefined, 0],
+      ["leaf-1", "wide-root", 1],
+      ["leaf-2", "wide-root", 1],
+      ["deep-0", undefined, 0],
+      ["deep-1", "deep-0", 1],
+      ["deep-2", "deep-1", 2]
+    ])
+    const read = async (query: string) =>
+      await SELF.fetch(`http://test/v1/actors/tree-route/threads${query}`, { headers: authorization })
+    const routeTree = async (query: string) =>
+      (await (await read(query)).json()) as ReadonlyArray<ActorThreadNode>
+    const depthOne = await routeTree("?maxDepth=1")
+    expect(depthOne.find((node) => node.id === "deep-0")?.children.map((node) => node.id)).toEqual(["deep-1"])
+    expect(depthOne.find((node) => node.id === "deep-0")?.children[0]?.children).toEqual([])
+    expect(depthOne.find((node) => node.id === "wide-root")?.children.map((node) => node.id))
+      .toEqual(["leaf-1", "leaf-2"])
+    const rooted = await routeTree("?root=wide-root")
+    expect(rooted.map((node) => node.id)).toEqual(["wide-root"])
+    expect(rooted[0]!.children.map((node) => node.id)).toEqual(["leaf-1", "leaf-2"])
+    expect((await read("?root=ghost")).status).toBe(404)
+    expect((await read("?maxDepth=-1")).status).toBe(400)
+    expect((await read("?maxNodes=0")).status).toBe(400)
+    expect((await read("?maxNodes=many")).status).toBe(400)
   })
 
   test("a re-delivery to a registered child delivers instead of recreating", async () => {


### PR DESCRIPTION
[👾 omp · openrouter/z-ai/glm-5.3 · agency: directed · intent: bound thread tree reads during construction]

This PR requests review and merge. The bounds are opt-in on both surfaces and the unbounded default is byte-for-byte unchanged, so every shape decision below is cheap to rework in review.

## What and why

The tree and roster reads build everything and throw most of it away. We run a multi-tenant agent platform on Tardie in production. A session that spawns thousands of threads over its lifetime makes every tree read scan the full actor log and construct the full forest, so one API caller can make the host do work proportional to the actor's entire append-only history, per call, no matter how much of the tree the caller wants. The natural caller wants one subtree, or a bounded window around a root, and the reads could not express either.

On the Cloudflare worker, `GET /v1/actors/:id/threads` makes the actor Durable Object read its complete event log (`ActorDO.events()` is the full `store.read`, every event of every thread) and materialize every registered thread node, every time, for every caller. On the Bun server, `GET /v1/actors/:id/threads/:thread/tree` builds the whole forest and then extracts one node (`findNode`), and the roster flattens the whole forest to list it.

This PR adds opt-in bounds to both surfaces, applied while the tree is constructed. The walk starts at `root`, builds at most `maxDepth` levels beneath its start, and builds at most `maxNodes` nodes. A node the bounds exclude is never built, never summarized, and never serialized. Building the complete tree and truncating after would bound the response while the host still does the full work, which is the whole cost this PR removes, so there is no build-then-truncate anywhere. Absent bounds leave the reads unchanged, including the existing orphan/cycle behavior.

- `TreeBounds` is defined in the client contract (`packages/client/src/contract.ts`), the shared vocabulary of both HTTP surfaces: `root` selects the subtree to build, `maxDepth` counts levels beneath the start (zero keeps the start childless), `maxNodes` caps the node count in total and must be positive so a bounded read always builds its start. `GET /v1/actors/:id/threads` gains `root`/`maxDepth`/`maxNodes` and `GET /v1/actors/:id/threads/:thread/tree` gains `maxDepth`/`maxNodes` (its path already names the root). The roster route now fails with the existing `unknown-thread` problem document when a stated root names a thread no log holds.
- `treeOf` in `apps/server/src/projections.ts` applies the bounds during its walk. The node budget counts down and the walk stops, and the depth cut closes a node's children before any deeper node is built. The tree endpoint now constructs from the caller's thread alone instead of building the forest and searching it, so `findNode` is gone. The roster handler inlines the flatten, and a stated root lists only its own subtree.
- The client (`tardie/client`) passes bounds through `list` and `tree` as an optional `TreeBounds` argument, so a consumer bounds a read without hand-building a URL.
- The Cloudflare worker applies the same bounds inside `threadTreeOf` (`platform/cloudflare/src/worker.ts`). The entries and children maps are one pass over the roster records (unavoidable, the roster is the discovery), but the recursive walk counts nodes and levels and never reaches what the bounds exclude. The orphan/cycle completeness check holds only for the unbounded walk, because a bounded read stops on purpose and the entries it never reached are not orphans. `ActorDO.threadTree` takes the bounds over RPC, and the route parses `root`/`maxDepth`/`maxNodes` with the same non-negative/positive integer refusals the events route uses. The route answers 400 on a bound that cannot count and 404 on an unknown root.

## Rebase onto main

Rebased onto `main` at `924a5c0`, after #381 (`fix(agent): scope child thread identities`) and #384 (`fix(server): preserve supplied root identifiers`). #384 stores new HTTP root threads under the supplied id without the `ag.` prefix and adds the legacy lookup compatibility layer (`apps/server/src/thread-compat.ts`); both behaviors are kept whole. The bounds ride on the public names the listing already reports: on the server, `withLegacyThreadIds` keys the listing by the public name, so a stated root resolves for a new-style unprefixed id and for a legacy `ag.`-prefixed stored address alike, and on the worker, `threadTreeOf` keys its entries by `publicThreadId` the same way. New coverage pins the interaction: an `ag.`-prefixed stored address scopes and builds under its public name through the bounds on both the roster and the tree route (`api.test.ts`, "a legacy stored address reads under its public name through the bounds"), and the worker tests seed their rosters as legacy-prefixed records while asserting the unprefixed public ids in every answer.

## Non-goals

- The unbounded default is untouched. An unbounded read produces the same nodes and the same orphan/cycle throw as before, on both surfaces.
- The log read itself is not bounded. The server reads every thread log because parentage is a claim in the PARENT's log, and the Cloudflare actor DO reads its full event log because roster records are derived from it. The bounds remove the node construction, the response size, and the caller's download, not the scan. Making the scan itself selective needs a durable index and is deliberately out of scope here. That scan is the subject of the separate index issue.
- No event-lookup index. A receipt refresh needs an indexed exact-fact lookup over the log rather than a bounded history walk. We drafted the index as a separate issue (root/maxDepth/maxNodes do not address it) and will file it separately for discussion. This PR stays read-side bounding only.

## Alternative shapes

- A server-side default cap on the reads. Rejected: a default the consumer did not choose changes what existing callers receive, and a visible constant nobody can set is the exact "silent hardcoding" AGENTS.md rules out. Opt-in bounds keep the contract additive.
- Absolute `depth` semantics (bound by the record's own depth field) instead of levels beneath the start. The records carry a depth, so it reads naturally, but a subtree read under a deep root could then not express "two levels of my subtree" without arithmetic, and the tree route's path-named root made relative levels the simpler contract. Easy to switch if the absolute reading is preferred.

## Verification

Head commit: cd8c8573fc00e8f5783e924fd519867629e2051a, on `main` at `924a5c0`. Bun 1.4.0, `bun install --frozen-lockfile`. Per touched area:

- `bun run typecheck` in `packages/client`, `apps/server`, `platform/cloudflare`: 0 errors each. `apps/cli`, `apps/voyager`, and `apps/web` also typecheck clean, since they consume the client contract.
- `bun test` in `packages/client`: 44 pass, 0 fail. Includes a test that stated bounds become query params on the tree and roster reads and absent ones stay absent.
- `bun test` in `apps/server`: 127 pass, 0 fail. `projections.test.ts` gains a `treeOf bounds what it builds` suite over a wide/deep fixture (a stated root builds only its subtree; an unknown root reads as absent; `maxDepth` zero keeps every start childless; `maxDepth` two cuts the descent before the deepest level; `maxNodes` four stops the walk before later roots are built). `api.test.ts` gains two route-level tests: the roster at `?maxDepth=0` omits the spawned child, `?root=` scopes and 404s, and `?maxNodes=0` is a 400 problem document rather than an empty answer; and the rebase coverage above, which writes a legacy `ag.`-prefixed stored address through the events route and reads it under its public name through `?root=legacy&maxDepth=0` and the tree route, with the stored-address form itself a 404.
- `bun test` in `platform/cloudflare`: 8 pass, 0 fail. `bun run test:workers`: 23 pass, 0 fail. The new tests seed a roster of raw requested-and-registered records on the fixture's own actor instance, with a claim pair at the bottom of a deep chain whose second edge points back at itself. The unbounded read of that roster is a throw (its completeness check reaches the pair), while `maxDepth`, `maxNodes`, and `root` reads of the same roster all answer, which is the proof the bounded walks never built what the bounds exclude (on this builder, a node that is not in the response was never constructed). The route test covers `maxDepth=1`, a scoped `root`, the 404 for an unknown root, and the 400s for `maxDepth=-1`, `maxNodes=0`, and `maxNodes=many`.
- `bun run gate --only=lint:docs`, `--only=knip`: pass. Docs updated: `docs/how-to/server.md` states the bounds on the threads listing and tree rows.

## Limits

- The server-side "never built" proof is structural. `treeOf` is a pure projection whose output is its entire effect, so asserting the deep nodes are absent from the response is the strongest claim available there. The construction-time proof (the read answers where the unbounded read cannot) lives in the Cloudflare worker tests.
- The workers tests under `test/actor.workers.ts` are excluded from the project's `tsc` typecheck on main (only `src` and `test/fixture.worker.ts` are in its tsconfigs), so the new workers tests carry no compile-time check beyond vitest's transform, same as the existing suite.
