### PR TITLE
fix(agent): scope child thread identities

### DIFF
--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -987,8 +987,17 @@ describe("the tree", () => {
         const health = (await (await fetch(`${base}/healthz`)).json()) as { status: string }
         return health.status === "resting" ? health : undefined
       })
+      const tree = (await (await fetch(`${base}/v1/actors/main/threads/root/tree`)).json()) as ThreadNode
+      const childId = tree.children[0]!.id
+      const childEvents = (await (await fetch(`${base}/v1/actors/main/threads/${childId}/events`)).json()) as ReadonlyArray<EventRow>
+      expect(childId).toMatch(/^[0-9a-f]{64}$/)
+      expect(childEvents.some(({ event }) => event.type === "TurnCompleted")).toBe(true)
+      expect(childEvents[0]!.event).toMatchObject({
+        address: { thread: childId }, parent: { thread: "ag.root" }
+      })
+      await birth(base, childId, { id: "follow-up", text: "hello again" })
       return {
-        tree: (await (await fetch(`${base}/v1/actors/main/threads/root/tree`)).json()) as ThreadNode,
+        tree,
         listed: (await (await fetch(`${base}/v1/actors/main/threads`)).json()) as ReadonlyArray<ThreadSummary>,
         ghost: (await fetch(`${base}/v1/actors/main/threads/ghost/tree`)).status
       }

--- a/apps/server/src/api.ts
+++ b/apps/server/src/api.ts
@@ -39,7 +39,8 @@ import { ModelCatalogStore } from "./catalog"
 import { providerAvailabilitiesOf } from "./catalog-availability"
 import { modelsPageOf, providersPageOf } from "./catalog-page"
 import { ServerConfig } from "./config"
-import { idOf, Threads, type ActorThreads } from "./host"
+import { Threads, type ActorThreads } from "./host"
+import { publicThreadId, resolveThreadId } from "./thread-compat"
 import type { InferenceStream } from "./inference-stream"
 import { problemResponse } from "./problem"
 import { treeOf, type ThreadSummary } from "./projections"
@@ -135,10 +136,10 @@ const frameOf = (seq: number, event: unknown): string => `id: ${seq}\ndata: ${JS
 const HEARTBEAT = ": tardigrade\n\n"
 
 const actorThreadOf = (record: ActorThreadRecord): ActorThread => ({
-  id: idOf(record.thread) ?? record.thread,
+  id: publicThreadId(record.thread),
   ...(record.parentThread === undefined
     ? {}
-    : { parent: idOf(record.parentThread) ?? record.parentThread }),
+    : { parent: publicThreadId(record.parentThread) }),
   depth: record.depth
 })
 
@@ -352,7 +353,7 @@ const inferenceStreamResponse = (
   const body = new ReadableStream<Uint8Array>({
     start(controller) {
       unsubscribe = inference.subscribe((delta) => {
-        if (delta.instance !== actor || idOf(delta.thread) !== thread) return
+        if (delta.instance !== actor || delta.thread !== thread) return
         if ((controller.desiredSize ?? 1) <= 0) return
         controller.enqueue(encoder.encode(`data: ${JSON.stringify(delta)}\n\n`))
       })
@@ -403,10 +404,12 @@ export const layerStream = (options: ApiOptions = {}) => {
       "/v1/actors/:id/threads/:thread/inference/stream",
       Effect.gen(function*() {
         const params = yield* HttpRouter.params
+        const threads = yield* (yield* Threads).ensure(paramOf(params, "id"))
+        const thread = yield* resolveThreadId(paramOf(params, "thread"), (thread) => Effect.map(threads.actorThread(thread), (record) => record !== undefined))
         return yield* inferenceStreamResponse(
           options.inference!,
           paramOf(params, "id"),
-          paramOf(params, "thread"),
+          thread,
           heartbeat,
           bufferCapacity
         )

--- a/apps/server/src/host.ts
+++ b/apps/server/src/host.ts
@@ -46,6 +46,7 @@ import { ModelCatalogStore, type ModelCatalogState } from "./catalog"
 import { providerAvailabilitiesOf } from "./catalog-availability"
 import { modelsPageOf, providersPageOf } from "./catalog-page"
 import { DriverGauge } from "./driver-gauge"
+import { resolveThreadId, withLegacyThreadIds } from "./thread-compat"
 
 const serverModelAdaptersFor = async (config: ServerConfigValue): Promise<ModelAdapterRegistry> => {
   const protocols = new Set(Object.values(config.model.providers).map((provider) => provider.protocol))
@@ -71,23 +72,6 @@ const serverModelAdaptersFor = async (config: ServerConfigValue): Promise<ModelA
   for (const protocol of protocols) adapters.resolve(protocol)
   return adapters
 }
-
-// The durable host, the assembly it runs, and the loop that drives it, behind one service. The
-// routes speak thread ids; the thread a host knows lives here and nowhere else, so a route can never
-// name a thread and the store can never see an id.
-
-// THREAD_PREFIX is the id-to-thread map (apps-server-spec.md, "Resources"). A thread outside it belongs
-// to something other than a thread and never appears in a listing. The prefix stays `ag.` while the
-// API's noun is the thread, because the thread is where the agent assembly runs, and that assembly
-// mints its own child threads under the same prefix (packages/agent/src/packages/agents.ts, `sibling`). Renaming
-// it would rename addresses a spawn already wrote into a durable log.
-export const THREAD_PREFIX = "ag."
-
-export const threadOf = (id: string): string => `${THREAD_PREFIX}${id}`
-
-// idOf is threadOf's inverse, undefined for a thread this server does not own.
-export const idOf = (thread: string): string | undefined =>
-  thread.startsWith(THREAD_PREFIX) ? thread.slice(THREAD_PREFIX.length) : undefined
 
 // ActorPushRefused is why a pushed actor was not accepted, in the sentence the route prints. The
 // artifact checks and the swap both raise it, so a caller reads one failure rather than telling a
@@ -427,7 +411,7 @@ const runtimeOf = async <R>(
     database,
     actorName: summary.name,
     actorInstance,
-    actorFor: (candidate) => (idOf(candidate) === undefined ? undefined : actor),
+    actorFor: () => actor,
     layersFor: environmentFor,
     providers,
     driver: { maxConcurrentThreads },
@@ -468,17 +452,17 @@ const runtimeOf = async <R>(
     )
   )
   await host.recover()
-  const read = (id: string) => Effect.promise(() => host.read(threadOf(id)))
+  const read = (id: string) => Effect.promise(() => host.read(id))
   const readPage = (id: string, mark: number, limit: number) =>
-    Effect.promise(() => host.readPage(threadOf(id), mark, limit))
+    Effect.promise(() => host.readPage(id, mark, limit))
   const awaitHead = (id: string, mark: number) =>
-    Effect.promise((signal) => host.awaitHead(threadOf(id), mark, signal))
+    Effect.promise((signal) => host.awaitHead(id, mark, signal))
   const awaitActorHead = (mark: number) => Effect.promise((signal) => host.awaitActorHead(mark, signal))
   const commitRoot = (id: string, event: Event) =>
     Effect.gen(function*() {
       const at = yield* Clock.currentTimeMillis
       const stamped = event.at === undefined ? { ...event, at } : event
-      yield* Effect.promise(() => host.commitRoot(host.self(threadOf(id)), stamped))
+      yield* Effect.promise(() => host.commitRoot(host.self(id), stamped))
     })
   const commit = (delivery: Envelope) =>
     Effect.gen(function*() {
@@ -489,7 +473,7 @@ const runtimeOf = async <R>(
         ...delivery,
         link: {
           source: delivery.link.source,
-          target: { actor: summary.name, instance: actorInstance, thread: threadOf(delivery.link.target.thread) }
+          target: { actor: summary.name, instance: actorInstance, thread: delivery.link.target.thread }
         },
         event: stamped
       }
@@ -512,18 +496,17 @@ const runtimeOf = async <R>(
     awaitActorHead,
     list: Effect.gen(function*() {
       const threads = yield* Effect.promise(() => host.threads())
-      const ids = threads.flatMap((candidate) => {
-        const id = idOf(candidate)
-        return id === undefined ? [] : [id]
-      })
-      return yield* Effect.forEach(ids, (id) => Effect.map(read(id), (events) => ({ id, events })))
+      return yield* Effect.forEach(threads, (id) => Effect.map(read(id), (events) => ({ id, events })))
     }),
     settled
   }
   return {
     summary,
-    threads,
-    commit,
+    threads: withLegacyThreadIds(threads),
+    commit: (delivery) => Effect.flatMap(
+      resolveThreadId(delivery.link.target.thread, (thread) => Effect.map(threads.actorThread(thread), (record) => record !== undefined)),
+      (thread) => commit({ ...delivery, link: { ...delivery.link, target: { ...delivery.link.target, thread } } })
+    ),
     schedule: Effect.sync(() => {
       request()
     }),

--- a/apps/server/src/thread-compat.test.ts
+++ b/apps/server/src/thread-compat.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test"
+import { Effect } from "effect"
+import type { ActorThreadRecord } from "@clavia/tardigrade-core/actor"
+import type { ActorThreads } from "./host"
+import { publicThreadId, resolveThreadId, withLegacyThreadIds } from "./thread-compat"
+
+const lookup = (...ids: string[]): ActorThreads["actorThread"] => (thread) => Effect.succeed(
+  ids.includes(thread) ? { thread, depth: 0, state: "registered" } : undefined
+)
+const exists = (...ids: string[]) => (thread: string) => Effect.succeed(ids.includes(thread))
+
+test("legacy public names retain their stored addresses", async () => {
+  expect(publicThreadId("ag.root")).toBe("root")
+  expect(publicThreadId("ag.ag.root")).toBe("ag.root")
+  expect(await Effect.runPromise(resolveThreadId("root", exists("ag.root")))).toBe("ag.root")
+  expect(await Effect.runPromise(resolveThreadId("root", exists()))).toBe("ag.root")
+  expect(await Effect.runPromise(resolveThreadId("ag.root", exists("ag.ag.root")))).toBe("ag.ag.root")
+})
+
+test("registered opaque thread ids round-trip without a required prefix", async () => {
+  for (const id of ["thread_abc", "worker", "one:two", "三"]) {
+    expect(publicThreadId(id)).toBe(id)
+    expect(await Effect.runPromise(resolveThreadId(id, exists(id)))).toBe(id)
+  }
+})
+
+test("ambiguous public ids fail instead of selecting another log", async () => {
+  await expect(Effect.runPromise(resolveThreadId("root", exists("root", "ag.root")))).rejects.toThrow("ambiguous")
+})
+
+test("the adapter translates public operations while preserving raw directory records", async () => {
+  const records: ActorThreadRecord[] = [
+    { thread: "ag.root", depth: 0, state: "registered" },
+    { thread: "thread_child", parentThread: "ag.root", depth: 1, state: "registered" }
+  ]
+  const received: string[] = []
+  const capture = (thread: string) => Effect.sync(() => { received.push(thread) })
+  const raw: ActorThreads = {
+    methods: {}, sqlite: ":memory:",
+    append: (thread) => capture(thread),
+    events: (thread) => capture(thread).pipe(Effect.as([])),
+    eventsPage: (thread) => capture(thread).pipe(Effect.as([])),
+    awaitHead: (thread) => capture(thread).pipe(Effect.as(0)),
+    actorEventsPage: () => Effect.succeed([]),
+    actorThreads: Effect.succeed({ cursor: 2, threads: records }),
+    actorThread: lookup(...records.map((record) => record.thread)),
+    awaitActorHead: () => Effect.succeed(2),
+    list: Effect.succeed(records.map((record) => ({ id: record.thread, events: [] }))),
+    settled: Effect.void
+  }
+  const api = withLegacyThreadIds(raw)
+  await Effect.runPromise(api.append("root", { type: "MessageReceived" }))
+  await Effect.runPromise(api.events("thread_child"))
+  await Effect.runPromise(api.eventsPage("root", 0, 10))
+  await Effect.runPromise(api.awaitHead("thread_child", 0))
+  expect(received).toEqual(["ag.root", "thread_child", "ag.root", "thread_child"])
+  expect((await Effect.runPromise(api.list)).map((entry) => entry.id)).toEqual(["root", "thread_child"])
+  expect(await Effect.runPromise(api.actorThreads)).toEqual({ cursor: 2, threads: records })
+  await expect(Effect.runPromise(withLegacyThreadIds({
+    ...raw, list: Effect.succeed([{ id: "ag.root", events: [] }, { id: "root", events: [] }])
+  }).list)).rejects.toThrow("ambiguous")
+})

--- a/apps/server/src/thread-compat.ts
+++ b/apps/server/src/thread-compat.ts
@@ -1,0 +1,41 @@
+import { Effect } from "effect"
+import type { ActorThreads } from "./host"
+
+const LEGACY_PREFIX = "ag."
+
+// publicThreadId preserves legacy public names and exposes other thread identifiers unchanged (thread-compat.test.ts).
+export const publicThreadId = (thread: string): string =>
+  thread.startsWith(LEGACY_PREFIX) ? thread.slice(LEGACY_PREFIX.length) : thread
+
+// resolveThreadId resolves registered public names and retains legacy placement for new HTTP threads (thread-compat.test.ts).
+export const resolveThreadId = (id: string, exists: (thread: string) => Effect.Effect<boolean>): Effect.Effect<string> =>
+  Effect.gen(function*() {
+    const legacy = `${LEGACY_PREFIX}${id}`
+    const registeredLegacy = yield* exists(legacy)
+    const registeredExact = yield* exists(id)
+    if (registeredLegacy && registeredExact) {
+      return yield* Effect.die(new Error(`ambiguous public thread id ${JSON.stringify(id)}: both stored addresses exist`))
+    }
+    return registeredLegacy || !registeredExact ? legacy : id
+  })
+
+// withLegacyThreadIds adapts public operations without changing stored addresses or actor selection (thread-compat.test.ts).
+export const withLegacyThreadIds = (threads: ActorThreads): ActorThreads => {
+  const resolve = (id: string) => resolveThreadId(id, (thread) => Effect.map(threads.actorThread(thread), (record) => record !== undefined))
+  return {
+    ...threads,
+    append: (id, event) => Effect.flatMap(resolve(id), (thread) => threads.append(thread, event)),
+    events: (id) => Effect.flatMap(resolve(id), threads.events),
+    eventsPage: (id, mark, limit) => Effect.flatMap(resolve(id), (thread) => threads.eventsPage(thread, mark, limit)),
+    awaitHead: (id, mark) => Effect.flatMap(resolve(id), (thread) => threads.awaitHead(thread, mark)),
+    list: Effect.map(threads.list, (entries) => {
+      const names = new Set<string>()
+      return entries.map(({ id: thread, events }) => {
+        const id = publicThreadId(thread)
+        if (names.has(id)) throw new Error(`ambiguous public thread id ${JSON.stringify(id)}: multiple stored addresses exist`)
+        names.add(id)
+        return { id, events }
+      })
+    })
+  }
+}

--- a/e2e/actor/harness.ts
+++ b/e2e/actor/harness.ts
@@ -68,7 +68,7 @@ export const actorScenario = (
     )
   const host: Host = createHost<TestR>({
     actorName: "mem",
-    actorFor: (thread: string) => thread.startsWith("ag.") ? assembled : undefined,
+    actorFor: () => assembled,
     layersFor,
     keyOf: assembled.keyOf,
     ...(options.pick === undefined ? {} : { pick: options.pick }),

--- a/e2e/actor/mortyplicity.test.ts
+++ b/e2e/actor/mortyplicity.test.ts
@@ -439,12 +439,11 @@ test("Rick and Morty survive generated portal, budget, permission, human, and sc
   }), { numRuns: 40 })
 }, 60_000)
 
-test("Rick cancels every foreground Morty across generated schedules", async () => {
-  await fc.assert(fc.asyncProperty(fc.record({
-    children: fc.integer({ min: 1, max: 6 }),
-    headroom: fc.integer({ min: 1, max: 3 }),
-    schedule: fc.array(fc.nat(), { minLength: 8, maxLength: 32 })
-  }), async ({ children, headroom, schedule }) => {
+const cancelForegroundMortys = async ({ children, headroom, schedule }: {
+  readonly children: number
+  readonly headroom: number
+  readonly schedule: ReadonlyArray<number>
+}) => {
     const concurrency = children + headroom
     let startedChild!: () => void
     const childStarted = new Promise<void>((resolve) => {
@@ -548,15 +547,31 @@ test("Rick cancels every foreground Morty across generated schedules", async () 
 
     const runs = root.filter((event) => event.type === "PackageCalled" && field(event, "name") === "agents.run")
     expect(runs).toHaveLength(children)
-    for (const run of runs) {
-      const child = scenario.host.read(childThreadsOf(root).get(String(field(run, "callId")))!)
+    const createdChildren = childThreadsOf(root)
+    expect(createdChildren.size).toBeGreaterThan(0)
+    expect(createdChildren.size).toBeLessThanOrEqual(children)
+    const attemptedCalls = new Set(runs.map((run) => String(field(run, "callId"))))
+    for (const [callId, thread] of createdChildren) {
+      expect(attemptedCalls.has(callId)).toBe(true)
+      const child = scenario.host.read(thread)
       expect(child.filter((event) => event.type === "CancellationRequested")).toHaveLength(1)
       expect(child.filter((event) => event.type === "TurnCancelled")).toHaveLength(1)
       expect(child.some((event) => event.type === "TurnCompleted")).toBe(false)
       expect(child.some((event) => event.type === "TextReturned")).toBe(false)
     }
     expect(scenario.host.resting()).toBe(true)
-  }), { numRuns: 20 })
+}
+
+test("Rick cancels every foreground Morty across generated schedules", async () => {
+  await fc.assert(fc.asyncProperty(fc.record({
+    children: fc.integer({ min: 1, max: 6 }),
+    headroom: fc.integer({ min: 1, max: 3 }),
+    schedule: fc.array(fc.nat(), { minLength: 8, maxLength: 32 })
+  }), (input) => cancelForegroundMortys(input)), { numRuns: 20 })
+}, 30_000)
+
+test("Rick cancels created Mortys while concurrent spawns are pending", async () => {
+  await cancelForegroundMortys({ children: 2, headroom: 1, schedule: Array(8).fill(0) })
 }, 30_000)
 
 test("Rick settles when a foreground Morty is cancelled", async () => {

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -15,7 +15,7 @@ import { Infer, NativeOutputSupport, type InferRequest } from "./inference/contr
 import { boundaryOf } from "./output/boundary"
 import { resumeTurn } from "./runtime/resume"
 import { agentsPackage } from "./packages/agents"
-import { threadCreated, threadCreatedOf } from "@clavia/tardigrade-core/thread"
+import { threadCreated, threadCreatedOf, type ChildCreated } from "@clavia/tardigrade-core/thread"
 import { linkOf } from "@clavia/tardigrade-core/communication/link"
 import { methodEnvelopeOf } from "@clavia/tardigrade-core/communication/envelope"
 import { threadAddressOf } from "@clavia/tardigrade-core/communication/endpoint"
@@ -59,7 +59,7 @@ const hosted = (
   const host: Host = createHost<TestR>({
     actorName: "mem",
     actorInstance,
-    actorFor: (thread: string) => (thread.startsWith("ag.") ? assembled : undefined),
+    actorFor: () => assembled,
     layersFor
   })
   if (log.length > 0) host.seed(ROOT_THREAD, log)
@@ -230,12 +230,14 @@ describe("an assembled agent", () => {
       depth: 0,
       at: 1
     })
-    expect(mind.host.read(ROOT_THREAD).filter((event) => event.type === "ChildCreated")).toEqual([
-      expect.objectContaining({ callId: "t1.0", turn: "run-0", address: { actor: "mem", instance: "main", thread: "ag.5:run-0t1.0" }, depth: 1 }),
-      expect.objectContaining({ callId: "t1.1", turn: "run-0", address: { actor: "mem", instance: "main", thread: "ag.5:run-0t1.1" }, depth: 1 })
+    const records = mind.host.read(ROOT_THREAD).filter((event): event is ChildCreated => event.type === "ChildCreated")
+    expect(records).toMatchObject([
+      { callId: "t1.0", turn: "run-0", address: { actor: "mem", instance: "main" }, depth: 1 },
+      { callId: "t1.1", turn: "run-0", address: { actor: "mem", instance: "main" }, depth: 1 }
     ])
     // The graph existed: two child threads, each with a served turn.
-    const children = ["ag.5:run-0t1.0", "ag.5:run-0t1.1"].map((thread) => mind.host.read(thread))
+    expect(new Set(records.map((record) => record.address.thread)).size).toBe(2)
+    const children = records.map((record) => mind.host.read(record.address.thread))
     for (const log of children) {
       expect(threadCreatedOf(log)).toMatchObject({
         address: { actor: "mem" },
@@ -268,8 +270,9 @@ describe("an assembled agent", () => {
       `${request.identity.actor}:${request.identity.instance}:${request.identity.thread}`
     ))).toEqual(new Set([
       "mem:main:ag.root",
-      "mem:main:ag.5:run-0t1.0",
-      "mem:main:ag.5:run-0t1.1"
+      ...mind.host.read(ROOT_THREAD)
+        .filter((event): event is ChildCreated => event.type === "ChildCreated")
+        .map(({ address }) => `${address.actor}:${address.instance}:${address.thread}`)
     ]))
     for (const { request, key } of seen) {
       expect(key?.startsWith(`${request.identity.turn}/infer/`)).toBe(true)
@@ -325,8 +328,11 @@ describe("an assembled agent", () => {
     expect(again.output).toBe('"4,6"')
     // The second turn ran its own execution and spawned its own children.
     expect(mind.host.read(ROOT_THREAD).filter((e) => e.type === "CodeSettled")).toHaveLength(2)
-    for (const thread of ["ag.5:run-1t2.0", "ag.5:run-1t2.1"]) {
-      expect(mind.host.read(thread).some((e) => e.type === "TurnCompleted")).toBe(true)
+    const children = mind.host.read(ROOT_THREAD)
+      .filter((event): event is ChildCreated => event.type === "ChildCreated" && event.turn === "run-1")
+    expect(children).toHaveLength(2)
+    for (const child of children) {
+      expect(mind.host.read(child.address.thread).some((e) => e.type === "TurnCompleted")).toBe(true)
     }
   })
 

--- a/packages/agent/src/packages/agents.properties.test.ts
+++ b/packages/agent/src/packages/agents.properties.test.ts
@@ -14,21 +14,21 @@ import { agentsPackage } from "./agents"
 interface CallPlan {
   readonly callId: string
   readonly failures: number
-  readonly failurePoint: "before" | "after"
+  readonly failurePoint: "record" | "before" | "after"
   readonly placement: "colocated" | "independent" | undefined
 }
 
 const callPlan = fc.record({
   callId: fc.stringMatching(/^[a-z][a-z0-9_]{0,12}$/),
   failures: fc.integer({ min: 0, max: 4 }),
-  failurePoint: fc.constantFrom<CallPlan["failurePoint"]>("before", "after"),
+  failurePoint: fc.constantFrom<CallPlan["failurePoint"]>("record", "before", "after"),
   placement: fc.option(fc.constantFrom<"colocated" | "independent">("colocated", "independent"), { nil: undefined })
 })
 
 const plans = fc.uniqueArray(callPlan, { selector: (plan) => plan.callId, minLength: 1, maxLength: 7 })
 
 // childProtocol runs the implementation against the transitions in Child.tla. The parent log is
-// durable across attempts, while the router may fail on either side of the child commit.
+// durable across attempts, with finite failures before creation or on either side of delivery.
 const childProtocol = async (calls: ReadonlyArray<CallPlan>): Promise<void> => {
   const parent = threadAddressOf("property", "main", "ag.root")
   const host = createHost({ actorName: parent.actor, actorFor: () => undefined })
@@ -50,6 +50,14 @@ const childProtocol = async (calls: ReadonlyArray<CallPlan>): Promise<void> => {
   const plansByCall = new Map(calls.map((plan) => [plan.callId, plan]))
   const append = (events: ReadonlyArray<Event>): Effect.Effect<void> => Effect.sync(() => {
     for (const event of events) {
+      if (event.type === "ChildCreated") {
+        const callId = String(event.callId)
+        const left = remaining.get(callId) ?? 0
+        if (left > 0 && plansByCall.get(callId)?.failurePoint === "record") {
+          remaining.set(callId, left - 1)
+          throw new Error("injected creation record failure")
+        }
+      }
       const key = threadKeys.keyOf(event)
       if (key !== undefined && parentLog.some((candidate) => threadKeys.keyOf(candidate) === key)) continue
       parentLog.push(event)
@@ -82,12 +90,14 @@ const childProtocol = async (calls: ReadonlyArray<CallPlan>): Promise<void> => {
 
   for (const plan of calls) {
     for (let attempt = 0; attempt <= plan.failures; attempt++) {
-      await Effect.runPromise(
+      const result = await Effect.runPromise(
         run(
           { text: plan.callId, background: true, ...(plan.placement === undefined ? {} : { placement: plan.placement }) },
           { callId: plan.callId }
         ).pipe(Effect.provide(environment), Effect.exit)
       )
+      expect(result._tag).toBe(attempt < plan.failures ? "Failure" : "Success")
+      if (result._tag === "Success") expect(result.value).toEqual({ dispatched: true, callId: plan.callId })
     }
   }
 
@@ -100,7 +110,9 @@ const childProtocol = async (calls: ReadonlyArray<CallPlan>): Promise<void> => {
     const callActions = actions.filter((action) => action.callId === plan.callId)
     expect(callActions[0]?.kind).toBe("append")
     expect(callActions.filter((action) => action.kind === "append")).toHaveLength(1)
-    expect(callActions.filter((action) => action.kind === "send")).toHaveLength(plan.failures + 1)
+    expect(callActions.filter((action) => action.kind === "send")).toHaveLength(
+      plan.failurePoint === "record" ? 1 : plan.failures + 1
+    )
     for (const sent of callActions.filter((action) => action.kind === "send")) expect(sent.target).toEqual(record.address)
 
     const childLog = host.read(record.address.thread)
@@ -118,7 +130,79 @@ const childProtocol = async (calls: ReadonlyArray<CallPlan>): Promise<void> => {
 }
 
 describe("child creation protocol", () => {
-  test("matches Child.tla across retries and crash windows", async () => {
+  test("liveness: creation completes after finite failures when dispatch is retried", async () => {
     await fc.assert(fc.asyncProperty(plans, childProtocol), { numRuns: 200 })
+  })
+
+  test("safety: parent threads, turns, and depths isolate children while replay retains ownership", async () => {
+    await fc.assert(fc.asyncProperty(
+      fc.stringMatching(/^[a-z][a-z0-9_]{0,12}$/),
+      fc.string({ minLength: 1, maxLength: 30 }),
+      fc.string({ minLength: 1, maxLength: 30 }),
+      fc.integer({ min: 2, max: 5 }),
+      async (rootId, turnToken, callToken, depth) => {
+        const turn = `turn:${turnToken}`
+        const callId = `call:${callToken}`
+        const host = createHost({ actorName: "property", actorFor: () => undefined })
+        const targets = new Set<string>()
+        const run = agentsPackage().methods.run!
+        const dispatch = async (parent: ThreadAddress, level: number): Promise<ThreadAddress> => {
+          const events: Event[] = [...host.read(parent.thread)]
+          for (const event of events.filter((event) => event.type === "MessageReceived")) {
+            events.push({ type: "TurnCompleted", turn: event.id, output: "accepted", at: 1 })
+          }
+          let target: ThreadAddress | undefined
+          const environment = Layer.mergeAll(
+            Layer.succeed(Self, parent),
+            Layer.succeed(EventLog, withWatermark({
+              read: Effect.succeed(events),
+              append: (tail) => Effect.sync(() => {
+                for (const event of tail) {
+                  const key = threadKeys.keyOf(event)
+                  if (key !== undefined && events.some((prior) => threadKeys.keyOf(prior) === key)) continue
+                  events.push(event)
+                }
+              })
+            })),
+            Layer.succeed(Router, {
+              send: (envelope) => Effect.sync(() => {
+                target = envelope.link.target as ThreadAddress
+                host.commit(envelope as never)
+              })
+            })
+          )
+          for (const currentTurn of [turn, `${turn}x`]) {
+            events.push(
+              { type: "MessageReceived", id: currentTurn, text: "delegate", at: 1 },
+              { type: "PackageCalled", callId, name: "agents.run", turn: currentTurn, at: 2 }
+            )
+            const invoke = () => Effect.runPromise(run({ text: "child", background: true }, { callId })
+              .pipe(Effect.provide(environment)))
+            expect(await invoke()).toEqual({ dispatched: true, callId })
+            const first = target!
+            expect(first.thread).toMatch(/^[0-9a-f]{64}$/)
+            expect(first.thread).not.toBe(parent.thread)
+            expect(targets.has(first.thread)).toBe(false)
+            targets.add(first.thread)
+            expect(await invoke()).toEqual({ dispatched: true, callId })
+            expect(target).toEqual(first)
+            const records = events.filter((event) => event.type === "ChildCreated" && event.turn === currentTurn)
+            expect(records).toHaveLength(1)
+            expect(records[0]).toMatchObject({ address: first, callId, depth: level + 1 })
+            const childLog = host.read(first.thread)
+            expect(threadCreatedOf(childLog)).toMatchObject({ address: first, parent, depth: level + 1 })
+            expect(childLog.filter((event) => event.type === "MessageReceived")).toHaveLength(1)
+            events.push({ type: "TurnCompleted", turn: currentTurn, output: "done", at: 3 })
+          }
+          return target!
+        }
+        for (const thread of [rootId, `${rootId}x`]) {
+          let parent = threadAddressOf("property", "main", thread)
+          host.seed(thread, [threadCreated(parent, undefined, 0)])
+          for (let level = 0; level < depth; level++) parent = await dispatch(parent, level)
+        }
+        expect(targets.size).toBe(4 * depth)
+      }
+    ), { numRuns: 100 })
   })
 })

--- a/packages/agent/src/packages/agents.test.ts
+++ b/packages/agent/src/packages/agents.test.ts
@@ -17,7 +17,7 @@ import {
 import type { Link } from "@clavia/tardigrade-core/communication/link"
 import type { Envelope } from "@clavia/tardigrade-core/communication/envelope"
 import { EventLog, withWatermark } from "@clavia/tardigrade-core/log"
-import { threadCreated } from "@clavia/tardigrade-core/thread"
+import { childKeyOf, childThreadId, threadCreated, threadCreatedOf } from "@clavia/tardigrade-core/thread"
 import { codeSystemFor } from "../component/code"
 
 // The package is a value: its three privileges arrive as services, so a test binds them the way
@@ -82,6 +82,11 @@ const turn = (id: string, at = 1): Event =>
 const called = (callId: string, turnId: string, at = 2): Event =>
   ({ type: "PackageCalled", callId, name: "agents.run", arguments: {}, turn: turnId, at } as Event)
 
+const expectedThread = (turn: string, call: string) => childThreadId({
+  parent: parseThreadAddress("mem:main:ag.root"),
+  child: childKeyOf(JSON.stringify([turn, call]))
+})
+
 describe("agentsPackage", () => {
   test("a foreground child records its invocation owner", async () => {
     const sent: Array<Sent> = []
@@ -109,7 +114,7 @@ describe("agentsPackage", () => {
       type: "InvocationLinked",
       parent: { method: "message", id: "m1", epoch: 2 },
       child: expect.objectContaining({ invocation: { method: "message", id: "child-1", epoch: 0 } }),
-      target: "mem:main:ag.2:m1child-1"
+      target: `mem:main:${await expectedThread("m1", "child-1")}`
     }))
     expect(sent[0]?.call).toMatchObject({
       parent: { method: "message", id: "m1", epoch: 2 },
@@ -209,9 +214,7 @@ describe("agentsPackage", () => {
         Effect.provide(env(host.self("ag.root"), sent, { "ag.root": [turn("m1"), called("c1", "m1")] }))
       )
     )
-    // Parity with the closure the in-process host used to pass: same actorName, the thread
-    // named by the parent run and call (agents.ts, childThreadId).
-    expect(sent[0]?.link.target).toEqual({ actor: "mem", instance: "main", thread: "ag.2:m1c1" })
+    expect(sent[0]?.link.target).toEqual({ actor: "mem", instance: "main", thread: await expectedThread("m1", "c1") })
     expect(sent[0]?.event).toMatchObject({ escalatable: true })
   })
 
@@ -233,7 +236,7 @@ describe("agentsPackage", () => {
     expect(result).toEqual({ error: "agents.run placement must be colocated or independent" })
   })
 
-  test("the callId is the child's identity and the link returns to the parent", async () => {
+  test("the callId identifies the child invocation and the link returns to the parent", async () => {
     const sent: Array<Sent> = []
     const pkg = agentsPackage()
     const answer = await Effect.runPromise(
@@ -246,7 +249,7 @@ describe("agentsPackage", () => {
     expect(brief.id).toBe("c3")
     expect(sent[0]!.link).toEqual({
       source: { actor: "mem", instance: "main", thread: "ag.root" },
-      target: { actor: "mem", instance: "main", thread: "ag.2:m1c3" }
+      target: { actor: "mem", instance: "main", thread: await expectedThread("m1", "c3") }
     })
   })
 
@@ -362,7 +365,7 @@ describe("agentsPackage", () => {
     )
     expect(parked).toBeInstanceOf(Park)
     expect((parked as Park).awaiting).toBe(replyId("c5"))
-    expect(formatThreadAddress(sent[0]!.link.target as ThreadAddress)).toBe("mem:main:ag.2:m1c5")
+    expect(formatThreadAddress(sent[0]!.link.target as ThreadAddress)).toBe(`mem:main:${await expectedThread("m1", "c5")}`)
   })
 
   test("a cancelled reply settles the run as a failed answer", async () => {
@@ -435,7 +438,7 @@ describe("agentsPackage", () => {
 // A live parent log: an append lands where the next read looks, so a re-driven dispatch replays
 // against what its predecessor recorded, the way a durable store does after a crash.
 const liveEnv = (events: Event[], sent: Array<Sent>) => {
-  const self = parseThreadAddress("mem:main:ag.root")
+  const self = threadCreatedOf(events)!.address
   return Layer.mergeAll(
     Layer.succeed(Router, {
       send: (envelope) => Effect.sync(() => void sent.push(envelope as Sent))
@@ -459,7 +462,7 @@ const turnWithDeadline = (id: string, deadlineAt: number): Event =>
     at: 1
   } as Event)
 
-describe("a child is named by its parent run and call", () => {
+describe("a child is named by its parent address, run, and call", () => {
   const run = agentsPackage().methods.run!
   const background = (text: string, callId: string) =>
     run({ text, background: true }, { callId })
@@ -485,14 +488,42 @@ describe("a child is named by its parent run and call", () => {
     await Effect.runPromise(background("second", "reused-call").pipe(Effect.provide(liveEnv(events, sent))))
 
     expect(threads(sent)).toEqual([
-      "ag.8:parent-areused-call",
-      "ag.8:parent-breused-call",
-      "ag.8:parent-breused-call"
+      await expectedThread("parent-a", "reused-call"),
+      await expectedThread("parent-b", "reused-call"),
+      await expectedThread("parent-b", "reused-call")
     ])
     expect(events.filter((event) => event.type === "ChildCreated")).toMatchObject([
-      { callId: "reused-call", turn: "parent-a", address: { thread: "ag.8:parent-areused-call" } },
-      { callId: "reused-call", turn: "parent-b", address: { thread: "ag.8:parent-breused-call" } }
+      { callId: "reused-call", turn: "parent-a", address: { thread: await expectedThread("parent-a", "reused-call") } },
+      { callId: "reused-call", turn: "parent-b", address: { thread: await expectedThread("parent-b", "reused-call") } }
     ])
+  })
+
+  test("a child spawning with its parent's turn and call ids cannot address itself", async () => {
+    const root = parseThreadAddress("mem:main:ag.root")
+    const events: Event[] = [threadCreated(root, undefined, 0), turn("m1"), called("c1", "m1")]
+    const sent: Array<Sent> = []
+    await Effect.runPromise(background("child", "c1").pipe(Effect.provide(liveEnv(events, sent))))
+    const child = sent[0]!.link.target as ThreadAddress
+    const childEvents: Event[] = [
+      threadCreated(child, { parent: root, depth: 1 }, 0),
+      turn("m1"), called("c1", "m1")
+    ]
+    await Effect.runPromise(background("grandchild", "c1").pipe(Effect.provide(liveEnv(childEvents, sent))))
+    expect(new Set([root.thread, ...threads(sent)]).size).toBe(3)
+    expect(sent[1]?.lineage).toMatchObject({ parent: child, depth: 2 })
+  })
+
+  test("a turn-scoped legacy creation record retains its address on replay", async () => {
+    const events: Event[] = [
+      threadCreated(parseThreadAddress("mem:main:ag.root"), undefined, 0),
+      turn("m1"), called("c1", "m1"),
+      { type: "ChildCreated", callId: "c1", turn: "m1",
+        address: { actor: "mem", instance: "main", thread: "ag.2:m1c1" }, depth: 1, at: 3 }
+    ]
+    const sent: Array<Sent> = []
+    await Effect.runPromise(background("child", "c1").pipe(Effect.provide(liveEnv(events, sent))))
+    expect(threads(sent)).toEqual(["ag.2:m1c1"])
+    expect(events.filter((event) => event.type === "ChildCreated")).toHaveLength(1)
   })
 
   test("a dispatch whose creation record never committed re-derives the same address", async () => {
@@ -507,7 +538,7 @@ describe("a child is named by its parent run and call", () => {
     await Effect.runPromise(background("scout", "crash-1").pipe(Effect.provide(liveEnv(events, sent))))
     events.splice(events.findIndex((event) => event.type === "ChildCreated"), 1)
     await Effect.runPromise(background("scout", "crash-1").pipe(Effect.provide(liveEnv(events, sent))))
-    expect(threads(sent)).toEqual(["ag.2:m1crash-1", "ag.2:m1crash-1"])
+    expect(threads(sent)).toEqual([await expectedThread("m1", "crash-1"), await expectedThread("m1", "crash-1")])
   })
 
   test("a creation record without a turn still names its child", async () => {
@@ -532,16 +563,13 @@ describe("a child is named by its parent run and call", () => {
   })
 
   test("a derived address that names another child dies rather than delivering", async () => {
-    // A legacy call id names its child ag.<callId>, so a run can derive that address for a
-    // different call: run "m1" with call "c1" names ag.2:m1c1, the child legacy call 2:m1c1
-    // owns. The dispatch dies instead of crossing the brief.
     const events: Event[] = [
       threadCreated(parseThreadAddress("mem:main:ag.root"), undefined, 0),
       turn("m1"),
       {
         type: "ChildCreated",
         callId: "2:m1c1",
-        address: { actor: "mem", instance: "main", thread: "ag.2:m1c1" },
+        address: { actor: "mem", instance: "main", thread: await expectedThread("m1", "c1") },
         depth: 1,
         at: 1
       } as Event,
@@ -553,7 +581,7 @@ describe("a child is named by its parent run and call", () => {
     )
     if (exit._tag !== "Failure") throw new Error("expected the colliding dispatch to die")
     expect(Cause.pretty(exit.cause)).toContain(
-      "agents.run c1 derives child address mem:main:ag.2:m1c1, which child 2:m1c1 already owns"
+      `agents.run c1 derives child address mem:main:${await expectedThread("m1", "c1")}, which child 2:m1c1 already owns`
     )
     expect(sent).toHaveLength(0)
   })

--- a/packages/agent/src/packages/agents.ts
+++ b/packages/agent/src/packages/agents.ts
@@ -18,8 +18,10 @@ import { methodEnvelopeOf } from "@clavia/tardigrade-core/communication/envelope
 import {
   ChildCreated,
   childCreated,
+  childKeyOf,
   childLineageOf,
   ChildPlacement,
+  childThreadId,
   threadCreatedOf,
   type ThreadCreated,
   type ThreadLineage
@@ -41,55 +43,19 @@ import {
   type ModelPolicyOverride
 } from "../inference/access"
 
-// agentsPackage provides model catalog discovery and ad-hoc agents. `agents.providers` and
-// `agents.models` search the available providers and models. `agents.run({text})` runs a fresh agent to
-// quiescence and returns its terminal; `agents.run({text, background: true})` delivers the brief
-// and returns a pending handle, and `agents.result({id})` awaits that handle's reply later.
-//
-// Every call is its own agent. A call id is unique only within its parent turn, so the child's
-// native thread names the pair of both identifiers, and a Promise.all of five runs is five
-// agents by construction. A persistent named colleague is a later explicit feature, never an
-// accident of naming.
-//
-// Durability costs nothing here: both modes are package calls, so the recorded pair replays a
-// committed run and re-delivers a crashed dispatch. The child's address is a pure function of
-// the parent run and the call, and a replay reads the recorded ChildCreated, so a re-driven
-// dispatch reaches the same child and is absorbed as a duplicate.
-//
-// The package is a value any consumer mounts: its host privileges are services, not constructor
-// arguments. `Router` sends, `Self` names the calling thread, and `EventLog` supplies its durable
-// calls, responses, and creation record.
-//
-// A plain foreground run parks, the same mechanism `tasks.fire` (`src/packages/tasks.ts`) uses:
-// deliver the brief through a link from this thread, then await the reply row on this thread, host-side
-// `Park` when it has not landed yet (`src/code/execute.ts`'s proxy is what turns that into a promise
-// that never settles for the code body). It never holds a call open.
-//
-// An escalatable run keeps the same call pending while the child negotiates through the parent's
-// requestBudget method. The original call receives only the child's terminal response.
-
-// SpawnOptions is the placement's environment: who the family works as, how a child's budget is
-// drawn from the run, and the isolation labels a brief carries down. Every field has a default,
-// and `budget` is one of them rather than a constant this module reads: a spawn with no stated
-// budget takes the same ceiling the child's own reactor would, and a consumer that moved that
-// ceiling moves both (budget.ts, BudgetPolicy).
+// SpawnOptions configures child budgets, model access, output contracts, and inherited metadata.
 export interface SpawnOptions {
-  // The output contracts a spawning body may ask a child for, by name. Model-authored code has
-  // no TypeScript checking (packages/code/src/execution/reactor.ts runs it through AsyncFunction), so a
-  // name resolved here is the only path where the schema was proved at compile time by the host
-  // that declared it. A raw schema stays reachable and is preflighted instead (spawn.test.ts,
-  // "the output a spawn asks for").
+  // outputs supplies named output contracts available to child runs.
   readonly outputs?: Readonly<Record<string, OutputContract>>
   // catalog supplies provider and model discovery to the package.
   readonly catalog?: AgentCatalog
   // models narrows inherited authority and may select a default for children started by this package.
   readonly models?: ModelPolicyOverride
   readonly actorNameOf?: () => string | undefined
+  // reserve grants a child budget; implementations must reuse grants for replayed call IDs.
   readonly reserve?: (callId: string, want: number) => Promise<number>
   readonly shadowOf?: () => boolean
-  // The parent's explicit world label, when its own fire named a shared world instead of taking
-  // the anonymous one (docs/worlds.md). Forwarded onto every spawn's brief the same way `shadow`
-  // is, so a whole family stays on one shared world's facets.
+  // worldOf supplies the world label forwarded to child briefs.
   readonly worldOf?: () => string | undefined
   readonly budget?: Partial<BudgetPolicy>
 }
@@ -260,31 +226,21 @@ const catalogQueryOf = (args: unknown): AgentCatalogQuery => {
   }
 }
 
-// childThreadId names a child after its parent run and call id. Length-prefixing keeps the pair
-// injective even when either identifier has punctuation, so two turns reusing one call id name
-// two children (agents.test.ts, "reused call ids across turns address distinct children").
-const childThreadId = (parentRunId: string, callId: string): string =>
-  `${parentRunId.length}:${parentRunId}${callId}`
+// sibling derives a child address within the parent's actor instance (agents.test.ts, "the default address is the host's own sibling").
+const sibling = async (parentRunId: string, callId: string, self: ThreadAddress): Promise<ThreadAddress> =>
+  threadAddressOf(self.actor, self.instance, await childThreadId({
+    parent: self,
+    child: childKeyOf(JSON.stringify([parentRunId, callId]))
+  }))
 
-// sibling is the default address: the child inherits the parent's actor instance and a thread
-// name derived from the parent run and call. Thread placement remains a separate host decision
-// (agents.test.ts, "the default address is the host's own sibling").
-const sibling = (parentRunId: string, callId: string, self: ThreadAddress): ThreadAddress =>
-  threadAddressOf(self.actor, self.instance, `ag.${childThreadId(parentRunId, callId)}`)
-
-// parentRunOf resolves the run a package call serves: its turn id and execution epoch. A call
-// outside any run has no child to name, so the dispatch dies rather than guessing.
+// parentRunOf returns the package call's owning turn and execution epoch, if present.
 const parentRunOf = (call: Event): { readonly turn: string; readonly epoch: number } | undefined => {
   const turn = turnOf(call)
   return turn === undefined ? undefined : { turn, epoch: eventEpochOf(call) }
 }
 
-// childClaimOf resolves the child this dispatch owns. The recorded child is the ChildCreated
-// between this call's PackageCalled in the parent run and the next call reusing the id, so a
-// later turn reusing the id can never claim an earlier turn's child, and a replay reads its
-// own dispatch's record (agents.test.ts, "reused call ids across turns address distinct
-// children").
-const childClaimOf = (
+// childClaimOf scopes a child to its parent turn and call, preserving recorded addresses on replay (agents.test.ts).
+const childClaimOf = async (
   placement: unknown,
   events: ReadonlyArray<Event>,
   parent: ThreadCreated,
@@ -318,11 +274,8 @@ const childClaimOf = (
         depth: recorded.depth,
         ...(recorded.placement === undefined ? {} : { placement: recorded.placement })
       }
-  const target = recorded?.address ?? sibling(parentRunId, callId, source)
-  // A legacy call id names its child ag.<callId>, so the length-prefixed scheme can derive the
-  // same address for a different dispatch (agents.test.ts, "a derived address that names another
-  // child dies rather than delivering"). No in-band marker separates the schemes, so the
-  // collision dies instead of delivering the brief to the child another dispatch owns.
+  const target = recorded?.address ?? await sibling(parentRunId, callId, source)
+  // clash rejects a derived address already claimed by another recorded child (agents.test.ts, "a derived address that names another child dies rather than delivering").
   if (recorded === undefined) {
     const clash = events.find(
       (event): event is ChildCreated =>
@@ -346,6 +299,7 @@ const inheritedModelsOf = (events: ReadonlyArray<Event>): ModelPolicy => {
   return head?.models === undefined ? DEFAULT_MODEL_POLICY : modelPolicyOf(head.models)
 }
 
+// agentsPackage exposes model discovery, child dispatch, and result retrieval.
 export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self | EventLog> => {
   const actorNameOf = options.actorNameOf ?? (() => undefined)
   const reserve = options.reserve ?? (async (_callId: string, want: number) => want)
@@ -483,8 +437,6 @@ export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self
       }),
       run: (args, ctx) =>
         Effect.gen(function* () {
-          // The three cross-thread privileges, read where the work happens: send, identity,
-          // observe. A host that binds them serves this method; nothing here closes over one.
           const router = yield* Router
           const source = yield* Self
           const log = yield* EventLog
@@ -506,12 +458,11 @@ export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self
           if (parentRun === undefined) {
             return yield* Effect.die(new Error(`agents.run ${ctx.callId} has no parent turn`))
           }
-          const child = childClaimOf(a?.placement, events, created, parentRun.turn, ctx.callId, source)
+          const child = yield* Effect.promise(() =>
+            childClaimOf(a?.placement, events, created, parentRun.turn, ctx.callId, source)
+          )
           if ("error" in child) return child
           const { lineage, recorded: recordedChild, target } = child
-          // The contract parameter is `output`, and a near-miss spelling fails silently: no
-          // contract means a prose answer, so the caller's field reads come back undefined and
-          // the run returns something plausible and wrong. Say so instead.
           if (a?.output === undefined && a?.outputSchema !== undefined) {
             return { error: "agents.run takes the contract as `output`, not `outputSchema`" }
           }
@@ -527,9 +478,6 @@ export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self
           if ("error" in declaredOutput) return declaredOutput
           const output = declaredOutput.contract
           const outputDeclaration = output === undefined ? undefined : { name: output.name, schema: output.schema }
-          // asked is the tool-call budget carried on the brief. It accepts a whole positive count
-          // because rounding could turn a requested child into an exhausted run (spawn.test.ts,
-          // "a fractional budget"). An absent budget takes the per-agent default.
           const asked = a?.budget
           let want = defaultBudget
           if (asked !== undefined) {
@@ -538,24 +486,12 @@ export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self
             }
             want = asked
           }
-          // Draw from the run's single budget before the child spawns, so the whole tree is bounded by
-          // it whatever the fan-out. A partial budget grants what is left; a spent budget grants 0, and
-          // then no agent spawns, which is how the tree stops. The draw is keyed on this call's id, so
-          // a re-driven code body reuses its grant and never draws twice.
           const budget = yield* Effect.promise(() => reserve(ctx.callId, want))
           if (budget <= 0) return { error: "the run's budget is exhausted; no budget to spawn this agent" }
-          // The child works as the same member the parent does: the actor rides every brief in the
-          // family, so a run's whole tree resolves providers identically.
           const actor = actorNameOf()
-          // The parent's own shadow reading, never the tool args: an agent cannot set or unset it, so
-          // a whole run family is shadow by construction from the fire alone. `world` rides along
-          // the same way, when the fire named an explicit shared one.
           const shadow = shadowOf()
           const world = worldOf()
-          // The owning run links a foreground child and bounds every child with its deadline:
-          // a background child is not linked, but it still answers the turn that fired it
-          // (agents.test.ts, "a background child inherits the owning turn deadline without a
-          // parent link").
+          // owner supplies the deadline for both dispatch modes (agents.test.ts, "a background child inherits the owning turn deadline without a parent link").
           const owner = { method: "message", id: parentRun.turn, epoch: parentRun.epoch }
           const parent = a?.background === true ? undefined : owner
           const parentDeadline = events.find((event) => {
@@ -597,28 +533,17 @@ export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self
             }, lineage))
           })
           if (a?.background === true) {
-            // A background run uses the same actor protocol. Its budget request can be served while
-            // no code body awaits it, and its terminal is collected later by agents.result.
             const at = yield* Clock.currentTimeMillis
             yield* dispatch(at)
             return { dispatched: true, callId: ctx.callId }
           }
-          // Foreground runs park on their terminal response. A replay reads that response
-          // before redelivering the same brief.
           const already = yield* awaitedBoundary(ctx.callId)
           if (already !== undefined) return shape(answerOf(already), ctx.callId, output)
           const at = yield* Clock.currentTimeMillis
           yield* dispatch(at)
           return yield* new Park({ callId: ctx.callId, awaiting: boundaryId(ctx.callId, 0) })
         }),
-      // Await a run already fired in the background: no delivery, the same reply-or-park read the
-      // plain foreground branch of `run` takes. `id` is the `callId` an earlier `background: true`
-      // run answered.
-      //
-      // The method response carries the contract accepted with the original call. A later argument
-      // cannot reinterpret prose that happens to be JSON as a shape nobody asked the child for
-      // (spawn.test.ts, "a later call cannot invent a contract the run never declared").
-      //
+      // result validates a background response against its recorded output contract (agents.test.ts, "a later call cannot invent a contract the run never declared").
       result: (args, ctx) =>
         Effect.gen(function* () {
           const a = args as { id?: unknown } | undefined
@@ -633,11 +558,7 @@ export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self
   })
 }
 
-// outputAsked resolves what a code body asked the child to answer in. A name is a contract the
-// host declared, whose schema a TypeScript signature already checked. A schema object is the
-// dynamic escape hatch: model-authored code carries no compile-time proof, so the schema is
-// preflighted against the supported profile here, before the child is briefed and before any
-// model is called (output.ts, outputProfileErrors). Anything else is an error the caller reads.
+// outputAsked resolves a named contract or validates an inline schema (agents.test.ts, "the output a spawn asks for").
 const outputAsked = (
   asked: unknown,
   outputs: Readonly<Record<string, OutputContract>>,
@@ -668,9 +589,7 @@ const outputAsked = (
   return { contract: built.contract }
 }
 
-// INLINE_OUTPUT_NAME is the schema identity an inline schema carries on the wire. Every declared
-// contract names itself; an inline one has no name to carry, so the log and the provider both
-// read this one and an operator can tell the two apart.
+// INLINE_OUTPUT_NAME labels inline output schemas on the wire.
 export const INLINE_OUTPUT_NAME = "inline"
 
 interface SpawnBoundaryContext {
@@ -706,7 +625,7 @@ const contractOf = (
     : { contract: built.contract }
 }
 
-// awaitedBoundaryOf projects one child response from the caller's private log. A cancelled response remains structured and settles the wait (agents.test.ts, "a cancelled reply settles the run as a failed answer", "a cancelled reply with no reason settles as a bare cancelled error"). A delivered method response is a ResponseReceived carrying the round-zero boundary id (response.test.ts, "returns a terminal through the accepted call link").
+// awaitedBoundaryOf reads a round-zero child response and its recorded output contract (agents.test.ts).
 const awaitedBoundaryOf = (events: ReadonlyArray<Event>, turn: string): SpawnBoundary | undefined => {
   const response = events.find(
     (event) => event.type === "ResponseReceived" && event.id === boundaryId(turn, 0)
@@ -731,8 +650,8 @@ const awaitedBoundary = (turn: string): Effect.Effect<SpawnBoundary | undefined,
     return awaitedBoundaryOf(yield* log.read, turn)
   })
 
-// answerOf maps a child terminal to the package's public result. Cancellation metadata remains on SpawnBoundary while callers keep the existing error result (agents.test.ts, "a cancelled reply settles the run as a failed answer").
 const ERROR_PREFIX = "error: "
+// answerOf maps a child terminal to output or error, including cancellation (agents.test.ts, "a cancelled reply settles the run as a failed answer").
 const answerOf = (reply: SpawnBoundary): {
   readonly output?: string
   readonly error?: string
@@ -746,11 +665,7 @@ const answerOf = (reply: SpawnBoundary): {
     : { error: reply.text.startsWith(ERROR_PREFIX) ? reply.text.slice(ERROR_PREFIX.length) : reply.text }
 }
 
-// shape renders a terminal as the code's return value.
-// A terminal under a contract comes back decoded and validated. A terminal that misses the
-// contract comes back as an error rather than as a value: the child's own reactor already refused
-// such an answer, so one arriving here means the reply did not come from that path, and reading it
-// as the contract's shape would be the reinterpretation this whole surface exists to prevent.
+// shape decodes successful output against its contract and reports validation failures (agents.test.ts, "a reply invalid under A but valid under B still fails as A").
 const shape = (
   answer: { output?: string; error?: string },
   turn: string,

--- a/packages/core/src/thread/identity.test.ts
+++ b/packages/core/src/thread/identity.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test"
+import fc from "fast-check"
+import { childKeyOf, childThreadId, threadIdOf, type ChildKey, type ThreadId } from "./index"
+
+const parent = { actor: "researcher", instance: "main", thread: "root" }
+const opaqueString = fc.array(fc.integer({ min: 0, max: 0xffff }), { minLength: 1, maxLength: 80 })
+  .map((units) => String.fromCharCode(...units))
+const coordinates = fc.record({
+  parent: fc.record({
+    actor: opaqueString,
+    instance: opaqueString.map((value) => value.replaceAll(":", "_")),
+    thread: opaqueString
+  }),
+  child: opaqueString.map((value) => childKeyOf(value))
+})
+
+// Safety properties await derivation; the test runner's timeout also checks completion on sampled inputs.
+describe("child identity safety", () => {
+  test("replay stability: identical coordinates retain their identity", async () => {
+    await fc.assert(fc.asyncProperty(coordinates, async ({ parent, child }) => {
+      const id = await childThreadId({ parent, child })
+      expect(await childThreadId({ parent: { ...parent }, child })).toBe(id)
+    }))
+  })
+
+  test("replay stability: the persisted encoding matches a fixed digest", async () => {
+    const id = await childThreadId({ parent, child: childKeyOf("step") })
+    expect(String(id)).toBe("ddc9895cb08a2f469846924b97c3b997dfb82ed5f6d1ff9c04174d89af7dcb27")
+  })
+
+  test("scope separation: every coordinate and tuple boundary contributes", async () => {
+    await fc.assert(fc.asyncProperty(coordinates, async ({ parent, child }) => {
+      const ids = await Promise.all([
+        childThreadId({ parent, child }),
+        childThreadId({ parent: { ...parent, actor: parent.actor + "x" }, child }),
+        childThreadId({ parent: { ...parent, instance: parent.instance + "x" }, child }),
+        childThreadId({ parent: { ...parent, thread: parent.thread + "x" }, child }),
+        childThreadId({ parent, child: childKeyOf(child + "x") })
+      ])
+      expect(new Set(ids).size).toBe(ids.length)
+    }))
+    const pairs = [["a", "b:c"], ["a:b", "c"], ["a", "\ud800"], ["a", "\ufffd"]] as const
+    const ids = await Promise.all(pairs.map(([thread, child]) => childThreadId({
+      parent: { ...parent, thread }, child: childKeyOf(child)
+    })))
+    expect(new Set(ids).size).toBe(pairs.length)
+  })
+
+  test("root separation: distinct roots have disjoint descendants at every equal depth", async () => {
+    await fc.assert(fc.asyncProperty(
+      coordinates,
+      fc.constantFrom("actor", "instance", "thread"),
+      fc.array(fc.uniqueArray(opaqueString, { minLength: 1, maxLength: 3 }), { minLength: 2, maxLength: 4 }),
+      async ({ parent }, coordinate, levels) => {
+        const otherRoot = { ...parent, [coordinate]: parent[coordinate] + "x" }
+        let left = [parent]
+        let right = [otherRoot]
+        for (const keys of levels) {
+          const descend = (parents: typeof left) => Promise.all(parents.flatMap((address) =>
+            keys.map(async (key) => ({
+              ...address,
+              thread: await childThreadId({ parent: address, child: childKeyOf(key) })
+            }))
+          ))
+          const next = await Promise.all([descend(left), descend(right)])
+          left = next[0]
+          right = next[1]
+          const leftIds = new Set(left.map((address) => address.thread))
+          const rightIds = new Set(right.map((address) => address.thread))
+          expect(leftIds.size).toBe(left.length)
+          expect(rightIds.size).toBe(right.length)
+          for (const id of rightIds) expect(leftIds.has(id)).toBe(false)
+        }
+      }
+    ))
+  })
+
+  test("valid bounded output: derivations resolve and invalid coordinates reject", async () => {
+    await fc.assert(fc.asyncProperty(coordinates, async (input) => {
+      expect(await childThreadId(input)).toMatch(/^[0-9a-f]{64}$/)
+    }))
+    let thread = "root".repeat(10_000)
+    for (let depth = 0; depth < 20; depth++) {
+      thread = await childThreadId({ parent: { ...parent, thread }, child: childKeyOf("step".repeat(10_000)) })
+      expect(thread).toMatch(/^[0-9a-f]{64}$/)
+    }
+    for (const invalid of ["", null, 1]) {
+      expect(() => childKeyOf(invalid)).toThrow()
+      expect(() => threadIdOf(invalid)).toThrow()
+    }
+    const child = childKeyOf("step")
+    for (const invalidParent of [
+      { ...parent, actor: "" },
+      { ...parent, instance: "" },
+      { ...parent, instance: "a:b" },
+      { ...parent, thread: "" }
+    ]) {
+      await expect(childThreadId({ parent: invalidParent, child })).rejects.toThrow()
+    }
+    await expect(childThreadId({ parent, child: "" as ChildKey })).rejects.toThrow()
+  })
+})
+
+test("type safety: thread identifiers cannot substitute for child keys", () => {
+  const thread: ThreadId = threadIdOf("root")
+  // @ts-expect-error ThreadId cannot identify a parent-scoped child.
+  const child: ChildKey = thread
+  expect(String(child)).toBe("root")
+})

--- a/packages/core/src/thread/identity.ts
+++ b/packages/core/src/thread/identity.ts
@@ -1,0 +1,31 @@
+import { Schema } from "effect"
+import { ThreadAddress } from "../communication/endpoint"
+
+// ChildKey identifies a child within its parent's thread namespace.
+export const ChildKey = Schema.NonEmptyString.pipe(Schema.brand("ChildKey"))
+export type ChildKey = typeof ChildKey.Type
+
+// ThreadId identifies a thread within an actor instance.
+export const ThreadId = Schema.NonEmptyString.pipe(Schema.brand("ThreadId"))
+export type ThreadId = typeof ThreadId.Type
+
+// childKeyOf validates a creator-supplied child key.
+export const childKeyOf = Schema.decodeUnknownSync(ChildKey)
+
+// threadIdOf validates a caller-supplied thread identifier.
+export const threadIdOf = Schema.decodeUnknownSync(ThreadId)
+
+// childThreadId derives a fixed-width identifier from the complete parent address and child key (identity.test.ts).
+export const childThreadId = async (coordinates: {
+  readonly parent: ThreadAddress
+  readonly child: ChildKey
+}): Promise<ThreadId> => {
+  const parent = Schema.decodeSync(ThreadAddress)(coordinates.parent)
+  const actor = Schema.decodeSync(Schema.NonEmptyString)(parent.actor)
+  const thread = threadIdOf(parent.thread)
+  const child = childKeyOf(coordinates.child)
+  const encoded = JSON.stringify(["child-thread", actor, parent.instance, thread, child])
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(encoded))
+  const hex = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("")
+  return threadIdOf(hex)
+}

--- a/packages/core/src/thread/index.ts
+++ b/packages/core/src/thread/index.ts
@@ -1,1 +1,2 @@
 export * from "./lineage"
+export * from "./identity"

--- a/platform/cloudflare/src/worker.ts
+++ b/platform/cloudflare/src/worker.ts
@@ -26,6 +26,7 @@ import {
 } from "@clavia/tardigrade-server/catalog"
 import { providerAvailabilitiesOf } from "@clavia/tardigrade-server/catalog-availability"
 import { modelsPageOf, providersPageOf } from "@clavia/tardigrade-server/catalog-page"
+import { publicThreadId, resolveThreadId } from "@clavia/tardigrade-server/thread-compat"
 import { canonicalModelConfig, modelConfigOf, type ModelConfig, type ModelProviderConfig } from "@clavia/tardigrade-server/config"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import { EventLog, eventLogFrom } from "@clavia/tardigrade-core/log"
@@ -98,11 +99,6 @@ export interface Env {
   readonly TARDIGRADE_SANDBOX_TRANSPORT?: string
 }
 
-const THREAD_PREFIX = "ag."
-const actorThreadOf = (thread: string): string => thread.startsWith(THREAD_PREFIX) ? thread : `${THREAD_PREFIX}${thread}`
-const threadIdOf = (thread: string): string | undefined =>
-  thread.startsWith(THREAD_PREFIX) ? thread.slice(THREAD_PREFIX.length) : undefined
-
 export interface ActorThreadNode {
   readonly id: string
   readonly parent?: string
@@ -150,9 +146,9 @@ const threadTreeOf = (rows: ReadonlyArray<ActorThreadRecord>): ReadonlyArray<Act
   const children = new Map<string, string[]>()
   const roots: string[] = []
   for (const row of rows) {
-    const id = threadIdOf(row.thread)
-    if (id === undefined) continue
-    const parent = row.parentThread === undefined ? undefined : threadIdOf(row.parentThread)
+    const id = publicThreadId(row.thread)
+    if (entries.has(id)) throw new Error(`ambiguous public thread id ${JSON.stringify(id)}: multiple stored addresses exist`)
+    const parent = row.parentThread === undefined ? undefined : publicThreadId(row.parentThread)
     entries.set(id, {
       id,
       ...(parent === undefined ? {} : { parent }),
@@ -987,9 +983,8 @@ export class ThreadDO extends DurableObject<Env> {
 
   async append(thread: string, event: Event): Promise<boolean> {
     if (!this.initialized()) return false
-    const actorThread = actorThreadOf(thread)
     const ownedThread = this.thread()
-    if (ownedThread !== actorThread) {
+    if (ownedThread !== thread) {
       throw new Error("request thread does not match the Thread DO identity")
     }
     const stamped = event.at === undefined ? { ...event, at: Date.now() } : event
@@ -1035,9 +1030,8 @@ export class ThreadDO extends DurableObject<Env> {
   }
 
   async events(thread: string): Promise<ReadonlyArray<Event>> {
-    const actorThread = actorThreadOf(thread)
     const ownedThread = this.thread()
-    if (ownedThread !== actorThread) {
+    if (ownedThread !== thread) {
       throw new Error("request thread does not match the Thread DO identity")
     }
     return (await this.host()).read()
@@ -1047,9 +1041,8 @@ export class ThreadDO extends DurableObject<Env> {
     thread: string,
     query: { readonly after: number; readonly limit: number; readonly types?: ReadonlyArray<string> }
   ): Promise<ReadonlyArray<{ readonly seq: number; readonly event: Event }>> {
-    const actorThread = actorThreadOf(thread)
     const ownedThread = this.thread()
-    if (ownedThread !== actorThread) {
+    if (ownedThread !== thread) {
       throw new Error("request thread does not match the Thread DO identity")
     }
     if (!Number.isSafeInteger(query.after) || query.after < 0) throw new Error("event query after must be a non-negative integer")
@@ -1101,21 +1094,23 @@ const actorStub = async (
   return stub
 }
 
+const resolvePublicThread = (env: Env, name: string, instance: string, id: string): Promise<string> =>
+  Effect.runPromise(resolveThreadId(id, (thread) => Effect.promise(() =>
+    env.THREADS.getByName(threadObjectNameOf(name, instance, thread)).exists(name, instance, thread)
+  )))
+
 const threadStub = async (
   env: Env,
   name: string,
   instance: string,
   thread: string
-): Promise<DurableObjectStub<ThreadDO> | undefined> => {
+): Promise<{ readonly stub: DurableObjectStub<ThreadDO>; readonly thread: string } | undefined> => {
   if (!deployed(name)) return undefined
-  const targetThread = actorThreadOf(thread)
+  const targetThread = await resolvePublicThread(env, name, instance, thread)
   const stub = env.THREADS.getByName(threadObjectNameOf(name, instance, targetThread))
   if (!(await stub.exists(name, instance, targetThread))) return undefined
-  return stub
+  return { stub, thread: targetThread }
 }
-
-const addressedThreadStub = (env: Env, name: string, instance: string, thread: string): DurableObjectStub<ThreadDO> =>
-  env.THREADS.getByName(threadObjectNameOf(name, instance, actorThreadOf(thread)))
 
 class WorkerEnv extends Context.Service<WorkerEnv, Env>()("tardigrade/cloudflare/WorkerEnv") {}
 
@@ -1284,7 +1279,8 @@ const routes = [
       if (!Schema.is(ActorInstanceId)(instance)) return json({ error: "invalid actor instance id" }, 400)
       const directory = yield* Effect.promise(() => actorStub(env, deployedActor, instance, false))
       if (directory === undefined) return json({ error: "unknown actor" }, 404)
-      yield* Effect.promise(() => directory.createThread(actorThreadOf(thread)))
+      const address = yield* Effect.promise(() => resolvePublicThread(env, deployedActor, instance, thread))
+      yield* Effect.promise(() => directory.createThread(address))
       return json({ actor: instance, thread })
     })
   )),
@@ -1301,7 +1297,7 @@ const routes = [
       if (method === undefined) return json({ error: "unknown method" }, 404)
       const stub = yield* Effect.promise(() => threadStub(env, actor, instance, thread))
       if (stub === undefined) return json({ error: "unknown thread" }, 404)
-      const events = yield* Effect.promise(() => stub.events(thread)).pipe(
+      const events = yield* Effect.promise(() => stub.stub.events(stub.thread)).pipe(
         Effect.map((value) => value as ReadonlyArray<Event>)
       )
       const existing = events.map(actorInvocationContextFrom).find((context) =>
@@ -1327,7 +1323,7 @@ const routes = [
       }
       const decoded = methodEventOf(method, { ...context, input, at })
       if ("error" in decoded) return json({ error: decoded.error }, 400)
-      const appended = yield* Effect.promise(() => stub.append(thread, invokedEventOf(context, decoded.event)))
+      const appended = yield* Effect.promise(() => stub.stub.append(stub.thread, invokedEventOf(context, decoded.event)))
       if (!appended) return json({ error: "unknown thread" }, 404)
       return json({ actor: instance, thread, method: methodName, call, deadlineAt }, 202)
     })
@@ -1345,7 +1341,7 @@ const routes = [
       if (method === undefined) return json({ error: "unknown method" }, 404)
       const stub = yield* Effect.promise(() => threadStub(env, actor, instance, thread))
       if (stub === undefined) return json({ error: "unknown thread" }, 404)
-      const events = yield* Effect.promise(() => stub.events(thread)).pipe(
+      const events = yield* Effect.promise(() => stub.stub.events(stub.thread)).pipe(
         Effect.map((value) => value as ReadonlyArray<Event>)
       )
       const epoch = method.currentEpoch(events, call)
@@ -1367,7 +1363,7 @@ const routes = [
       if (method.cancellation === undefined) return json({ error: "method does not declare cancellation" }, 400)
       const stub = yield* Effect.promise(() => threadStub(env, actor, instance, thread))
       if (stub === undefined) return json({ error: "unknown thread" }, 404)
-      const events = yield* Effect.promise(() => stub.events(thread)).pipe(
+      const events = yield* Effect.promise(() => stub.stub.events(stub.thread)).pipe(
         Effect.map((value) => value as ReadonlyArray<Event>)
       )
       const epoch = method.currentEpoch(events, call)
@@ -1385,7 +1381,7 @@ const routes = [
       const payload = (yield* request.json.pipe(Effect.orElseSucceed(() => ({})))) as { readonly reason?: unknown }
       if (payload.reason !== undefined && typeof payload.reason !== "string") return json({ error: "reason must be a string" }, 400)
       const at = yield* Clock.currentTimeMillis
-      const appended = yield* Effect.promise(() => stub.append(thread, cancellationRequested({
+      const appended = yield* Effect.promise(() => stub.stub.append(stub.thread, cancellationRequested({
         request: cancellationRequestIdOf(invocation),
         invocation,
         cause: "requested",
@@ -1413,12 +1409,13 @@ const routes = [
       const instance = params.id ?? ""
       const thread = params.thread ?? ""
       if (!Schema.is(ActorInstanceId)(instance)) return json({ error: "invalid actor instance id" }, 400)
-      const stub = addressedThreadStub(env, actor, instance, thread)
+      const stub = yield* Effect.promise(() => threadStub(env, actor, instance, thread))
+      if (stub === undefined) return json({ error: "unknown thread" }, 404)
       const event = (yield* request.json.pipe(Effect.orElseSucceed(() => undefined))) as Event | undefined
       if (typeof event !== "object" || event === null || typeof event.type !== "string" || event.type === "") {
         return json({ error: "event type is required" }, 400)
       }
-      const appended = yield* Effect.promise(() => stub.append(thread, event))
+      const appended = yield* Effect.promise(() => stub.stub.append(stub.thread, event))
       if (!appended) return json({ error: "unknown thread" }, 404)
       return json({ actor: instance, thread }, 202)
     })
@@ -1439,7 +1436,7 @@ const routes = [
       if (!Number.isSafeInteger(limit) || limit < 0) return json({ error: "limit must be a non-negative integer" }, 400)
       const types = url.searchParams.get("types")?.split(",").map((type) => type.trim()).filter((type) => type.length > 0)
       return yield* Effect.tryPromise({
-        try: () => stub.queryEvents(thread, { after, limit, ...(types === undefined ? {} : { types }) }),
+        try: () => stub.stub.queryEvents(stub.thread, { after, limit, ...(types === undefined ? {} : { types }) }),
         catch: (cause) => cause instanceof Error ? cause.message : String(cause)
       }).pipe(Effect.match({
         onFailure: (error) => json({ error }, 500),

--- a/platform/cloudflare/test/actor.workers.ts
+++ b/platform/cloudflare/test/actor.workers.ts
@@ -606,6 +606,37 @@ describe("cloudflare actor", () => {
       .toEqual(["first-secret", "second-secret"])
   })
 
+  test("opaque child addresses execute and round-trip through the public API", async () => {
+    const directory = controlStub()
+    await directory.init("echo", "main")
+    await directory.createThread("ag.opaque-parent")
+    const parent = { actor: "echo", instance: "main", thread: "ag.opaque-parent" }
+    const target = { ...parent, thread: "thread_opaque-child" }
+    await directory.deliverChild({
+      link: { source: parent, target },
+      event: { type: "MessageReceived", id: "opaque-brief", text: "hello", at: 1 },
+      lineage: { parent, depth: 1 }
+    })
+    const tree = await directory.threadTree()
+    expect(tree.find((node) => node.id === "opaque-parent")?.children).toEqual([
+      expect.objectContaining({ id: target.thread, parent: "opaque-parent", depth: 1 })
+    ])
+    const accepted = await SELF.fetch(`http://test/v1/actors/main/threads/${target.thread}/methods/echo/calls/opaque-call`, {
+      method: "PUT", headers: { ...authorization, "content-type": "application/json" },
+      body: JSON.stringify({ text: "hello opaque" })
+    })
+    expect(accepted.status).toBe(202)
+    expect(await methodState(target.thread, "opaque-call")).toEqual({
+      status: "completed", output: `workers:${target.thread}:1:hello opaque`
+    })
+    const read = await SELF.fetch(`http://test/v1/actors/main/threads/${target.thread}/events`, { headers: authorization })
+    expect(read.status).toBe(200)
+    const rows = await read.json() as Array<{ readonly event: { readonly type: string; readonly address?: unknown } }>
+    expect(rows[0]?.event.address).toEqual(target)
+    const native = (env as Env).THREADS.getByName(JSON.stringify(["echo", "main", target.thread]))
+    expect((await native.events(target.thread))[0]).toMatchObject({ address: target })
+  })
+
   test("actor supervisor creates a child after durable acceptance", async () => {
     const directory = controlStub()
     await directory.init("echo", "main")
@@ -668,7 +699,7 @@ describe("cloudflare actor", () => {
         children: []
       }]
     })
-    const childEvents = await threadStub("directory-child").events("directory-child")
+    const childEvents = await threadStub("directory-child").events("ag.directory-child")
     expect(childEvents.map((event) => event.type)).toEqual(["ThreadCreated", "MessageReceived"])
     const actorEvents = await runInDurableObject(directory, (_instance, state) =>
       state.storage.sql.exec<{ event: string }>("SELECT event FROM events ORDER BY seq").toArray()
@@ -713,7 +744,7 @@ describe("cloudflare actor", () => {
       event: { type: "MessageReceived", id: "re-delivery-second", text: "again", at: 3 },
       lineage
     })
-    const childEvents = await threadStub("re-delivery-child").events("re-delivery-child")
+    const childEvents = await threadStub("re-delivery-child").events("ag.re-delivery-child")
     expect(childEvents.map((event) => event.type)).toEqual(["ThreadCreated", "MessageReceived", "MessageReceived"])
     let childStatus = await threadStub("re-delivery-child").status()
     for (let attempt = 0; attempt < 100; attempt++) {
@@ -767,7 +798,7 @@ describe("cloudflare actor", () => {
     const deadlineAt = Date.now() - 1
     const stub = threadStub("timeout")
     await createThread("timeout")
-    await stub.append("timeout", {
+    await stub.append("ag.timeout", {
       type: "CallDispatched",
       id: "overdue-1",
       method: "inspect",
@@ -778,10 +809,10 @@ describe("cloudflare actor", () => {
       at: deadlineAt - 10
     })
 
-    let events = await stub.events("timeout")
+    let events = await stub.events("ag.timeout")
     for (let attempt = 0; attempt < 100 && !events.some((event) => event.type === "CallTimedOut"); attempt++) {
       await new Promise((resolve) => setTimeout(resolve, 10))
-      events = await stub.events("timeout")
+      events = await stub.events("ag.timeout")
     }
 
     expect(events).toContainEqual(expect.objectContaining({


### PR DESCRIPTION
Scope child IDs to the full parent address so reused turn/call IDs stay separate across roots and depths.

Every edge below uses turn `turn-0` and call `call-0` in actor `agent`, instance `main`. After IDs are actual SHA-256 outputs, abbreviated for readability.

Before: reused turn/call IDs collide across roots and depths.

```text
ID = "ag." + turn.length + ":" + turn + call

agent / main
├── ag.root-a
│   └── ag.6:turn-0call-0
│       └── ag.6:turn-0call-0  (same address as parent)
└── ag.root-b
    └── ag.6:turn-0call-0      (same address as root-a's child)

```

After: the full parent address scopes each derived ID. Here, `parent.threadId` means the parent’s thread ID (`ThreadAddress.thread` in code). New roots retain their supplied IDs.

```text
ID = SHA256(["child-thread", actor, instance, parent.threadId, childKey])
childKey = JSON.stringify([turn, call])

agent / main
├── root-a
│   └── 2d19c4a16040…
│       └── dacb8ee33f96…
└── root-b
    └── 408b56ff1b53…
        └── acd03dc33e19…
```

- Core exports typed ChildKey/ThreadId helpers; derived IDs are 64 hex characters. Replay preserves recorded addresses.
- Hosts route by address without prefix checks. A separate compatibility layer resolves existing legacy names; new roots are stored without an added prefix.
- Properties and regressions cover separation, replay, dispatch retries, opaque routing, and cancellation of created children.

Verified: `bun run gate`, all 69 tasks passed.

Addresses the child-thread collision in #375. Reply correlation and background result identity remain follow-up work.