### PR TITLE
fix: expose accounting coverage

### DIFF
--- a/apps/server/src/host.ts
+++ b/apps/server/src/host.ts
@@ -299,8 +299,7 @@ const layerInferFrom = (
         provider: selected.provider,
         ...(selected.region === undefined ? {} : { region: selected.region }),
         contextWindowTokens: selected.contextWindowTokens,
-        ...(selected.maxOutputTokens === undefined ? {} : { maxOutputTokens: selected.maxOutputTokens }),
-        ...(selected.pricing === undefined ? {} : { pricing: selected.pricing })
+        ...(selected.maxOutputTokens === undefined ? {} : { maxOutputTokens: selected.maxOutputTokens })
       }, adapters, observer === undefined ? {} : { observer })
       return Effect.flatMap(Infer, (model) => model.react(request, key, signal)).pipe(Effect.provide(binding))
     })

--- a/docs/how-to/migrate.md
+++ b/docs/how-to/migrate.md
@@ -169,32 +169,45 @@ Run the same representative task once with Tardigrade. Use the same model, setti
 
 Each recorded attempt keeps captured provider usage under `usage.providerReports[].providerSpecific`. One report contains the provider object directly. Multiple observations from one request appear as an array in arrival order. Retries retain their reports as separate entries. The default model binding records these reports with unknown normalized token counts and costs.
 
-A model binding can supply `ModelConfig.usageAdapter` to interpret a report under an explicit provider contract. The callback receives a `ProviderUsageReport` and returns optional `Usage` metrics. It can return `undefined` when it cannot interpret the report. Tardigrade preserves the raw report alongside those metrics. An adapter exception or invalid numeric metric fails the inference with the raw report attached. An adapter failure does not trigger a provider retry.
-
-For analysis after a run, pass a saved report and a callback to `usageFrom(report, adapter)`, or reduce the raw reports directly. The callback owns field selection, cache inclusion, reasoning inclusion, and the combination of multiple observations. Tardigrade does not infer those rules from provider names or field aliases.
+A model binding selects an interpretation through `ModelConfig.usageAdapter`. `OPENAI_CHAT_COMPLETIONS_USAGE_V1` is a versioned adapter for the [OpenAI Chat Completions usage contract](https://github.com/openai/openai-python/blob/2a98f6a1dee448c6410531c89c2de0af4383c6a7/src/openai/types/completion_usage.py). It validates token counts and subset relationships. Missing or null optional breakdowns remain unknown. Cached input and reasoning output are parts of the reported input and output counts; they are not added to those counts. Selecting this adapter asserts that the route uses that contract. A gateway that serves a different usage schema needs a matching adapter, even when its request API accepts Chat Completions.
 
 ```ts
-import { usageFrom, type UsageAdapter } from "tardie"
+import { OPENAI_CHAT_COMPLETIONS_USAGE_V1, usageFrom } from "tardie"
 
-const report = {
-  provider: "example",
-  model: "model-a",
-  providerSpecific: { input_count: 10, output_count: 4 }
-}
-
-const exampleUsage: UsageAdapter = ({ providerSpecific }) => {
-  if (providerSpecific === null || typeof providerSpecific !== "object") return undefined
-  if (!("input_count" in providerSpecific) || !("output_count" in providerSpecific)) return undefined
-  const input = providerSpecific.input_count
-  const output = providerSpecific.output_count
-  if (typeof input !== "number" || typeof output !== "number") return undefined
-  return { promptTokens: input, completionTokens: output }
-}
-
-const usage = usageFrom(report, exampleUsage)
+const usage = usageFrom({
+  provider: "openai",
+  model: "example-model",
+  providerSpecific: {
+    prompt_tokens: 10,
+    completion_tokens: 4,
+    total_tokens: 14,
+    prompt_tokens_details: { cached_tokens: 2 },
+    completion_tokens_details: { reasoning_tokens: 1 }
+  }
+}, OPENAI_CHAT_COMPLETIONS_USAGE_V1)
 ```
 
-`usageIn(events, turn)` sums explicitly interpreted metrics from the event log. If any recorded attempt omits a metric, its numeric total stays unknown. A measured zero remains zero. Token counts must be non-negative safe integers, and costs must be non-negative finite numbers. Numeric strings require explicit conversion in the adapter. Transport interruptions can leave partial reports or no report, so benchmark acceptance must check accounting completeness.
+The adapter identity and version accompany the interpreted usage. A custom contract can supply a descriptor with `id`, `version`, and `adapt`, or a callback for local interpretation. Tardigrade preserves raw reports alongside interpreted metrics. An omitted adapter leaves metrics unknown. The model binding retains raw evidence and records an accounting error when interpretation fails; a valid model output remains available. Repairing interpretation does not repeat generation. Saved reports can be interpreted again with `usageFrom(report, adapter)`.
+
+Execution completion and accounting coverage are separate. `coverageIn(events, turn)` checks the framework's recorded inference invocations and their consequences. Its default requires prompt and completion token counts. A caller can choose other required metrics, including a cost metric, without making token-only collection depend on pricing. The result identifies missing metrics and unresolved evidence. Its `observed` field is a subtotal of known contributions, and only a result with `status: "complete"` has `total`.
+
+```ts
+import { coverageIn } from "tardie"
+
+const coverage = coverageIn(events, turn, {
+  required: ["promptTokens", "completionTokens"]
+})
+
+if (coverage.status === "complete") {
+  console.log(coverage.total.promptTokens, coverage.total.completionTokens)
+} else {
+  console.log(coverage.observed, coverage.missing, coverage.unresolved)
+}
+```
+
+Coverage is scoped to framework-recorded inference invocations. A recorded call with no consequence remains unresolved, including an earlier occurrence whose later retry returned a result. Internal transport retries can contribute several provider reports to one invocation. This projection does not establish that every physical HTTP request was durably recorded before submission, or recover a receipt that the provider never exposed. Custom transports must expose their own request evidence. The application decides whether incomplete coverage pauses collection, blocks publication, or requires intervention.
+
+`usageIn(events, turn)` returns interpreted usage with missing native-attempt evidence kept unknown. Use `coverageIn` when a report requires evidence of completeness and the identities of unresolved invocations. A measured zero remains zero. Token counts must be non-negative safe integers, and costs must be non-negative finite numbers. Numeric strings require explicit conversion in a custom adapter.
 
 `priced(usage, table)` estimates cost from explicit prompt, completion, cache-read, and cache-write counts. An unused cache bucket needs an explicit zero. A positive cache bucket needs its matching rate. The helper keeps `reportedCostUsd` and `estimatedCostUsd` as distinct metrics. Its `costUsd` projection prefers an existing cost, then the reported cost, then the estimate. A complete table recomputes the estimate. An incomplete table preserves a recorded estimate or leaves it unknown. The binding rejects `ModelConfig.pricing`. Price tables belong in explicit usage adapters or analysis code.
 

--- a/docs/how-to/migrate.md
+++ b/docs/how-to/migrate.md
@@ -167,9 +167,38 @@ Validate the import before cutover:
 
 Run the same representative task once with Tardigrade. Use the same model, settings, input, data, and timer boundary as the baseline. Check semantic output parity before comparing efficiency.
 
-Use `usageIn(events, turn)` or the recorded attempt usage to total Tardigrade input and output tokens. Each usage stamp keeps normalized cache-read, cache-write, and reasoning counts when the provider supplies them. Each `providerReports` entry keeps one physical request's unconventional fields unchanged under `providerSpecific`, including reports from retried requests. The field contains the provider object directly when the request produced one report and an array when it produced several. `reportedCostUsd` keeps the provider figure, and `estimatedCostUsd` keeps an independent projection from the configured price table. `costUsd` remains the provider figure when available and otherwise uses the table estimate. Measure latency from request delivery through the terminal event.
+Each recorded attempt keeps captured provider usage under `usage.providerReports[].providerSpecific`. One report contains the provider object directly. Multiple observations from one request appear as an array in arrival order. Retries retain their reports as separate entries. The default model binding records these reports with unknown normalized token counts and costs.
 
-A price table needs `cachedPromptUsdPerToken` or `cacheWritePromptUsdPerToken` when the matching usage bucket is greater than zero. Tardigrade leaves the estimate unknown when a reported cache bucket has no declared rate. Calling `priced` with a complete new table recomputes `estimatedCostUsd`; a table that cannot price the usage preserves a recorded estimate.
+A model binding can supply `ModelConfig.usageAdapter` to interpret a report under an explicit provider contract. The callback receives a `ProviderUsageReport` and returns optional `Usage` metrics. It can return `undefined` when it cannot interpret the report. Tardigrade preserves the raw report alongside those metrics. An adapter exception or invalid numeric metric fails the inference with the raw report attached. An adapter failure does not trigger a provider retry.
+
+For analysis after a run, pass a saved report and a callback to `usageFrom(report, adapter)`, or reduce the raw reports directly. The callback owns field selection, cache inclusion, reasoning inclusion, and the combination of multiple observations. Tardigrade does not infer those rules from provider names or field aliases.
+
+```ts
+import { usageFrom, type UsageAdapter } from "tardie"
+
+const report = {
+  provider: "example",
+  model: "model-a",
+  providerSpecific: { input_count: 10, output_count: 4 }
+}
+
+const exampleUsage: UsageAdapter = ({ providerSpecific }) => {
+  if (providerSpecific === null || typeof providerSpecific !== "object") return undefined
+  if (!("input_count" in providerSpecific) || !("output_count" in providerSpecific)) return undefined
+  const input = providerSpecific.input_count
+  const output = providerSpecific.output_count
+  if (typeof input !== "number" || typeof output !== "number") return undefined
+  return { promptTokens: input, completionTokens: output }
+}
+
+const usage = usageFrom(report, exampleUsage)
+```
+
+`usageIn(events, turn)` sums explicitly interpreted metrics from the event log. If any recorded attempt omits a metric, its numeric total stays unknown. A measured zero remains zero. Token counts must be non-negative safe integers, and costs must be non-negative finite numbers. Numeric strings require explicit conversion in the adapter. Transport interruptions can leave partial reports or no report, so benchmark acceptance must check accounting completeness.
+
+`priced(usage, table)` estimates cost from explicit prompt, completion, cache-read, and cache-write counts. An unused cache bucket needs an explicit zero. A positive cache bucket needs its matching rate. The helper keeps `reportedCostUsd` and `estimatedCostUsd` as distinct metrics. Its `costUsd` projection prefers an existing cost, then the reported cost, then the estimate. A complete table recomputes the estimate. An incomplete table preserves a recorded estimate or leaves it unknown. The binding rejects `ModelConfig.pricing`. Price tables belong in explicit usage adapters or analysis code.
+
+Measure latency from request delivery through the terminal event.
 
 For each numeric measure, report `change = Tardigrade - existing` and `percent = change / existing * 100`. A negative token, cost, latency, line, or dependency change is a reduction. Leave the percentage unavailable when the existing value is zero or either value is missing.
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -153,6 +153,7 @@ export {
   sumUsage,
   ZERO_USAGE,
   type Usage,
+  type UsageAdapter,
   type ProviderUsageReport,
   type CostSource,
   type ModelPricing

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -146,17 +146,34 @@ export { agentKeys, outputRepaired, outputRetryRequested, TURN_FAILURE_CAUSES, t
 export { resumeTurn, type ResumeTurnOptions, type TurnDriver } from "./runtime/resume"
 export {
   usageIn,
+  coverageIn,
+  OPENAI_CHAT_COMPLETIONS_USAGE_V1,
   usageOf,
   usageFrom,
+  usageWithAccountingError,
+  validateUsageAdapterSelection,
   priced,
   costOf,
   sumUsage,
   ZERO_USAGE,
+  DEFAULT_USAGE_COVERAGE_METRICS,
+  USAGE_COVERAGE_SCOPE,
   type Usage,
   type UsageAdapter,
+  type UsageAdapterDescriptor,
+  type UsageAdapterIdentity,
+  type UsageAdapterSelection,
+  type UsageAccountingError,
   type ProviderUsageReport,
   type CostSource,
-  type ModelPricing
+  type ModelPricing,
+  type UsageCoverage,
+  type UsageCoverageMetric,
+  type UsageCoverageOptions,
+  type UsageCoverageGap,
+  type UsageCoverageUnresolved,
+  type CompleteUsageCoverage,
+  type IncompleteUsageCoverage
 } from "./inference/usage"
 
 // Where a settle left a turn. A caller driving its own host reads the answer here, because a

--- a/packages/agent/src/inference/machine.ts
+++ b/packages/agent/src/inference/machine.ts
@@ -193,6 +193,7 @@ const consequenceOf = (action: Action, ctx: Consequence): Event => {
         callId: action.callId,
         name: action.name,
         arguments: action.arguments,
+        attemptKey: ctx.attempt,
         usage,
         ...(action.mode === undefined ? {} : { mode: action.mode }),
         ...stampOf(action),

--- a/packages/agent/src/inference/usage.test.ts
+++ b/packages/agent/src/inference/usage.test.ts
@@ -1,11 +1,83 @@
 import { describe, expect, test } from "bun:test"
 import type { Event } from "@clavia/tardigrade-core/log/event"
-import { priced, sumUsage, usageFrom, usageIn, usageOf, ZERO_USAGE } from "./usage"
+import {
+  coverageIn,
+  DEFAULT_USAGE_COVERAGE_METRICS,
+  OPENAI_CHAT_COMPLETIONS_USAGE_V1,
+  priced,
+  sumUsage,
+  usageFrom,
+  usageWithAccountingError,
+  usageIn,
+  usageOf,
+  ZERO_USAGE
+} from "./usage"
 
 const table = { promptUsdPerToken: 0.001, completionUsdPerToken: 0.002 }
 const counts = { promptTokens: 10, completionTokens: 4, cachedPromptTokens: 0, cacheWritePromptTokens: 0 }
 
 describe("usageFrom", () => {
+  test("the named OpenAI Chat Completions adapter preserves identity and subsets", () => {
+    const report = {
+      provider: "openai",
+      model: "gpt-test",
+      providerSpecific: {
+        prompt_tokens: 10,
+        completion_tokens: 8,
+        total_tokens: 18,
+        prompt_tokens_details: { cached_tokens: 4, cache_write_tokens: 2 },
+        completion_tokens_details: { reasoning_tokens: 3 }
+      }
+    }
+    expect(usageFrom(report, OPENAI_CHAT_COMPLETIONS_USAGE_V1)).toEqual({
+      provider: "openai",
+      model: "gpt-test",
+      promptTokens: 10,
+      completionTokens: 8,
+      totalTokens: 18,
+      cachedPromptTokens: 4,
+      cacheWritePromptTokens: 2,
+      reasoningTokens: 3,
+      usageAdapter: { id: "openai/chat-completions-usage", version: "1" },
+      providerReports: [report]
+    })
+  })
+
+  test("the OpenAI adapter rejects cumulative snapshots, contradictions, and invalid counts", () => {
+    const report = (providerSpecific: unknown) => ({ providerSpecific })
+    for (const raw of [
+      [{ prompt_tokens: 1 }, { prompt_tokens: 2 }],
+      { prompt_tokens: 3, prompt_tokens_details: { cached_tokens: 4 } },
+      { completion_tokens: 3, completion_tokens_details: { reasoning_tokens: 4 } },
+      { prompt_tokens: 3, completion_tokens: 2, total_tokens: 4 },
+      { prompt_tokens: 4, total_tokens: 3 },
+      { prompt_tokens: -1 },
+      { prompt_tokens: 1.5 },
+      { prompt_tokens: 1, prompt_tokens_details: [] }
+    ]) expect(() => usageFrom(report(raw), OPENAI_CHAT_COMPLETIONS_USAGE_V1)).toThrow()
+  })
+
+  test("nullable OpenAI detail objects and counts remain unknown", () => {
+    expect(usageFrom({ providerSpecific: {
+      prompt_tokens: 10,
+      completion_tokens: 4,
+      total_tokens: 14,
+      prompt_tokens_details: null,
+      completion_tokens_details: { reasoning_tokens: null }
+    } }, OPENAI_CHAT_COMPLETIONS_USAGE_V1)).toMatchObject({
+      promptTokens: 10,
+      completionTokens: 4,
+      totalTokens: 14
+    })
+    expect(usageFrom({ providerSpecific: {
+      prompt_tokens: 10,
+      prompt_tokens_details: { cache_write_tokens: 3 }
+    } }, OPENAI_CHAT_COMPLETIONS_USAGE_V1)).toMatchObject({
+      promptTokens: 10,
+      cacheWritePromptTokens: 3
+    })
+  })
+
   test("raw reports stay uninterpreted by default", () => {
     for (const raw of [
       { prompt_tokens: 137973, completion_tokens: 188, cache_creation_input_tokens: 137970, cost: 0 },
@@ -146,6 +218,42 @@ describe("sumUsage", () => {
     expect(usageOf(JSON.parse(JSON.stringify(summed)))).toEqual(summed)
   })
 
+  test("mixed named adapters do not claim one interpretation", () => {
+    const first = { id: "test/one", version: "1", adapt: () => ({ promptTokens: 1 }) }
+    const second = { id: "test/two", version: "1", adapt: () => ({ promptTokens: 2 }) }
+    expect(sumUsage([
+      usageFrom({ providerSpecific: {} }, first),
+      usageFrom({ providerSpecific: {} }, second)
+    ])).not.toHaveProperty("usageAdapter")
+  })
+
+  test("adapter errors retain the selected descriptor identity and raw report", () => {
+    const descriptor = {
+      id: "test/strict-usage",
+      version: "7",
+      adapt: () => { throw new Error("bad usage shape") }
+    }
+    expect(usageWithAccountingError({ providerSpecific: { raw: true } }, descriptor, "bad usage shape")).toEqual({
+      providerReports: [{ providerSpecific: { raw: true } }],
+      usageAdapter: { id: descriptor.id, version: descriptor.version },
+      accountingErrors: [{ kind: "adapter", message: "bad usage shape" }]
+    })
+  })
+
+  test("numeric aggregation never returns unsafe token or infinite cost totals", () => {
+    const summed = sumUsage([
+      { promptTokens: Number.MAX_SAFE_INTEGER },
+      { promptTokens: 1 }
+    ])
+    expect(summed.promptTokens).toBeUndefined()
+    expect(summed.accountingErrors).toMatchObject([
+      { kind: "aggregation", message: expect.stringContaining("aggregation") }
+    ])
+    const cost = sumUsage([{ costUsd: Number.MAX_VALUE }, { costUsd: Number.MAX_VALUE }])
+    expect(cost.costUsd).toBeUndefined()
+    expect(cost.accountingErrors).toMatchObject([{ kind: "aggregation" }])
+  })
+
 })
 
 describe("usageIn", () => {
@@ -172,14 +280,7 @@ describe("usageIn", () => {
       { type: "ModelCalled", callId: "m1/infer/1", ordinal: 1, turn: "m1", at: 3 },
       { type: "TurnCompleted", output: "ok", turn: "m1", at: 4 }
     ]
-    expect(usageIn(log, "m1")).toEqual({
-      promptTokens: 10,
-      completionTokens: 4,
-      costUsd: 0.01,
-      costSource: "provider",
-      provider: "openai",
-      model: "m"
-    })
+    expect(usageIn(log, "m1")).toEqual({})
     expect(usageIn(log, "m2")).toEqual(ZERO_USAGE)
   })
 
@@ -207,6 +308,17 @@ describe("usageIn", () => {
     ).toEqual(billed)
   })
 
+  test("an unmatched native consequence keeps usageIn unknown", () => {
+    const billed = { promptTokens: 10, completionTokens: 4 }
+    const log: Event[] = [
+      { type: "ModelCalled", callId: "m1/infer/0", ordinal: 0, turn: "m1", at: 1 },
+      { type: "TurnCompleted", attemptKey: "m1/infer/unrelated", output: "other", turn: "m1", usage: billed, at: 2 },
+      { type: "TurnCompleted", attemptKey: "m1/infer/0", output: "ok", turn: "m1", usage: billed, at: 3 }
+    ]
+    expect(coverageIn(log, "m1")).toMatchObject({ status: "incomplete", unresolved: [{ reason: "unmatched-consequence" }] })
+    expect(usageIn(log, "m1")).toEqual({})
+  })
+
   test("usageOf keeps a labeled figure and drops a source with no cost", () => {
     expect(usageOf({ promptTokens: 3, completionTokens: 1, costUsd: 0, costSource: "provider" })).toEqual({
       promptTokens: 3,
@@ -219,5 +331,123 @@ describe("usageIn", () => {
       sumUsage([usageOf({ promptTokens: 3, completionTokens: 1, costUsd: 0.4, costSource: "table" })])
         .estimatedCostUsd
     ).toBeUndefined()
+  })
+})
+
+describe("coverageIn", () => {
+  const billed = (attemptKey: string, usage: unknown): Event => ({
+    type: "TurnCompleted",
+    output: "ok",
+    attemptKey,
+    turn: "m1",
+    usage,
+    at: 3
+  } as Event)
+
+  test("reports observed subtotal and exact required token total independently of cost", () => {
+    const coverage = coverageIn([
+      { type: "ModelCalled", callId: "m1/infer/0", ordinal: 0, turn: "m1", at: 1 },
+      billed("m1/infer/0", { promptTokens: 10, completionTokens: 4 })
+    ], "m1")
+    expect(coverage.status).toBe("complete")
+    if (coverage.status === "complete") {
+      expect(coverage.observed).toMatchObject({ promptTokens: 10, completionTokens: 4 })
+      expect(coverage.total).toEqual({ promptTokens: 10, completionTokens: 4 })
+    }
+    expect(DEFAULT_USAGE_COVERAGE_METRICS).toEqual(["promptTokens", "completionTokens"])
+  })
+
+  test("leaves an earlier repeated occurrence unresolved and never sums a duplicate terminal", () => {
+    const log: Event[] = [
+      { type: "ModelCalled", callId: "m1/infer/0", ordinal: 0, turn: "m1", at: 1 },
+      { type: "ModelCalled", callId: "m1/infer/0", ordinal: 1, turn: "m1", at: 2 },
+      billed("m1/infer/0", { promptTokens: 10, completionTokens: 4 }),
+      billed("m1/infer/0", { promptTokens: 10, completionTokens: 4 })
+    ]
+    const coverage = coverageIn(log, "m1")
+    expect(coverage.status).toBe("incomplete")
+    expect(coverage.observed).toMatchObject({ promptTokens: 10, completionTokens: 4 })
+    expect(coverage.missing).toMatchObject([{ ordinal: 0, reason: "missing-consequence" }])
+    expect(coverage.unresolved).toEqual([])
+  })
+
+  test("an identical duplicate consequence is inert while a conflicting duplicate is unresolved", () => {
+    const call: Event = { type: "ModelCalled", callId: "m1/infer/0", ordinal: 0, turn: "m1", at: 1 }
+    const first = billed("m1/infer/0", { promptTokens: 10, completionTokens: 4 })
+    const duplicate = billed("m1/infer/0", { promptTokens: 10, completionTokens: 4 })
+    const conflict = billed("m1/infer/0", { promptTokens: 11, completionTokens: 4 })
+    expect(coverageIn([call, first, duplicate], "m1").status).toBe("complete")
+    expect(coverageIn([call, first, conflict], "m1")).toMatchObject({
+      status: "incomplete",
+      unresolved: [{ reason: "duplicate-consequence", message: "conflicting duplicate consequence" }]
+    })
+  })
+
+  test("unrelated same-turn events and separate epochs do not satisfy a native mark", () => {
+    const coverage = coverageIn([
+      { type: "ModelCalled", callId: "m1/infer/0", ordinal: 0, turn: "m1", at: 0 },
+      { ...billed("m1/infer/0", { promptTokens: 10, completionTokens: 4 }), epoch: 0 },
+      { type: "ModelCalled", callId: "m1/infer/0", ordinal: 0, turn: "m1", epoch: 1, at: 1 },
+      { type: "ToolReturned", callId: "unrelated", result: {}, turn: "m1", epoch: 1, at: 2 },
+      { ...billed("m1/infer/0", { promptTokens: 10, completionTokens: 4 }), epoch: 0 }
+    ], "m1")
+    expect(coverage.status).toBe("incomplete")
+    expect(coverage.missing).toMatchObject([{ reason: "missing-consequence", epoch: 1 }])
+  })
+
+  test("a cost-only coverage total is typed and complete", () => {
+    const coverage = coverageIn([
+      { type: "ModelCalled", callId: "m1/infer/0", ordinal: 0, turn: "m1", at: 1 },
+      billed("m1/infer/0", { costUsd: 0.2 })
+    ], "m1", { required: ["costUsd"] })
+    if (coverage.status === "complete") {
+      const total: number = coverage.total.costUsd
+      expect(total).toBe(0.2)
+      // @ts-expect-error total exposes only caller-required metrics
+      const unrequested = coverage.total.promptTokens
+      void unrequested
+    }
+    // @ts-expect-error a non-default generic selection requires an explicit required option
+    coverageIn<readonly ["costUsd"]>([], "m1")
+    const dynamicRequired: ReadonlyArray<"costUsd"> = ["costUsd"]
+    const dynamicCoverage = coverageIn([], "m1", { required: dynamicRequired })
+    if (dynamicCoverage.status === "complete") {
+      const maybePrompt: number | undefined = dynamicCoverage.total.promptTokens
+      expect(maybePrompt).toBeUndefined()
+      // @ts-expect-error dynamic metric arrays cannot promise every metric is present
+      const assumedPrompt: number = dynamicCoverage.total.promptTokens
+      void assumedPrompt
+    }
+  })
+
+  test("marks missing receipts, raw-only reports, adapter errors, and requested cost independently", () => {
+    const coverage = coverageIn([
+      { type: "ModelCalled", callId: "m1/infer/0", ordinal: 0, turn: "m1", at: 1 },
+      billed("m1/infer/0", { providerReports: [{ providerSpecific: { future: 1 } }] }),
+      { type: "ModelCalled", callId: "m1/infer/1", ordinal: 1, turn: "m1", at: 4 }
+    ], "m1", { required: ["promptTokens", "completionTokens", "costUsd"] })
+    expect(coverage.status).toBe("incomplete")
+    expect(coverage.missing).toHaveLength(2)
+    expect(coverage.observed).toEqual({ providerReports: [{ providerSpecific: { future: 1 } }] })
+  })
+
+  test("adapter interpretation errors remain visible and make coverage incomplete", () => {
+    const coverage = coverageIn([
+      { type: "ModelCalled", callId: "m1/infer/0", ordinal: 0, turn: "m1", at: 1 },
+      billed("m1/infer/0", {
+        promptTokens: 10,
+        completionTokens: 4,
+        accountingErrors: [{ kind: "adapter", message: "invalid usage" }]
+      })
+    ], "m1")
+    expect(coverage.status).toBe("incomplete")
+    expect(coverage.unresolved).toMatchObject([{ reason: "accounting-error", message: "invalid usage" }])
+  })
+
+  test("empty scope is complete with zero required metrics", () => {
+    expect(coverageIn([], "m1", { required: ["promptTokens", "costUsd"] })).toMatchObject({
+      status: "complete",
+      total: { promptTokens: 0, costUsd: 0 }
+    })
   })
 })

--- a/packages/agent/src/inference/usage.test.ts
+++ b/packages/agent/src/inference/usage.test.ts
@@ -119,6 +119,88 @@ describe("priced and usageFrom", () => {
     ).toMatchObject({ estimatedCostUsd: 4 * 0.001 + 4 * 0.0002 + 2 * 0.00125 + 4 * 0.002 })
   })
 
+  test("gateway prompt totals already include cache creation", () => {
+    const raw = {
+      prompt_tokens: 137973,
+      completion_tokens: 188,
+      total_tokens: 138161,
+      cache_creation_input_tokens: 137970,
+      prompt_tokens_details: { cached_tokens: 0 },
+      completion_tokens_details: { reasoning_tokens: 118 },
+      cost: 0,
+      market_cost: 0.8670275
+    }
+    const pricing = {
+      promptUsdPerToken: 10 / 1_000_000,
+      completionUsdPerToken: 50 / 1_000_000,
+      cachedPromptUsdPerToken: 1 / 1_000_000,
+      cacheWritePromptUsdPerToken: 12.5 / 1_000_000
+    }
+    const expected = {
+      promptTokens: 137973,
+      completionTokens: 188,
+      totalTokens: 138161,
+      cachedPromptTokens: 0,
+      cacheWritePromptTokens: 137970,
+      reasoningTokens: 118,
+      reportedCostUsd: 0,
+      costUsd: 0,
+      costSource: "provider" as const,
+      estimatedCostUsd: 3 * pricing.promptUsdPerToken + 137970 * pricing.cacheWritePromptUsdPerToken + 188 * pricing.completionUsdPerToken,
+      providerReports: [{ providerSpecific: raw }]
+    }
+    expect(usageFrom(raw, pricing)).toEqual(expected)
+    expect(
+      usageFrom([raw, { promptTokens: 137973, completionTokens: 188, totalTokens: 138161 }], pricing)
+    ).toEqual(expected)
+    const stamp = { provider: "vercel-ai-gateway", model: "openai/gpt-6-astra" }
+    const providerMetrics = { usage: raw, provider_metadata: undefined }
+    expect(usageFrom([raw, undefined], pricing, stamp, providerMetrics)).toEqual({
+      ...expected,
+      ...stamp,
+      providerReports: [{ ...stamp, providerSpecific: providerMetrics }]
+    })
+  })
+
+  test("prompt totals include cache reads and writes across field aliases", () => {
+    for (const prompt of [{ promptTokens: 10 }, { prompt_tokens: 10 }]) {
+      for (const cache of [
+        { cacheReadInputTokens: 4, cacheWriteInputTokens: 2 },
+        { cache_read_input_tokens: 4, cache_write_input_tokens: 2 },
+        { cacheReadInputTokens: 4, cacheCreationInputTokens: 2 },
+        { cache_read_input_tokens: 4, cache_creation_input_tokens: 2 }
+      ]) {
+        expect(usageFrom({ ...prompt, ...cache, completionTokens: 3, totalTokens: 13 })).toMatchObject({
+          promptTokens: 10,
+          completionTokens: 3,
+          totalTokens: 13,
+          cachedPromptTokens: 4,
+          cacheWritePromptTokens: 2
+        })
+      }
+    }
+  })
+
+  test("Anthropic and Converse input counts exclude cache reads and writes", () => {
+    for (const raw of [
+      { input_tokens: 4, output_tokens: 3, cache_read_input_tokens: 4, cache_creation_input_tokens: 2 },
+      { inputTokens: 4, outputTokens: 3, totalTokens: 7, cacheReadInputTokens: 4, cacheWriteInputTokens: 2 }
+    ]) {
+      const pricing = { ...table, cachedPromptUsdPerToken: 0.0002, cacheWritePromptUsdPerToken: 0.00125 }
+      const expected = {
+        promptTokens: 10,
+        completionTokens: 3,
+        cachedPromptTokens: 4,
+        cacheWritePromptTokens: 2,
+        estimatedCostUsd: 4 * 0.001 + 4 * 0.0002 + 2 * 0.00125 + 3 * 0.002
+      }
+      expect(usageFrom(raw, pricing)).toMatchObject(expected)
+      expect(
+        usageFrom([raw, { promptTokens: 4, completionTokens: 3, totalTokens: 7 }], pricing)
+      ).toMatchObject(expected)
+    }
+  })
+
   test("a normalized adapter view fills details the raw report omits", () => {
     const raw = { prompt_tokens: 10, completion_tokens: 4, cost: 0 }
     expect(

--- a/packages/agent/src/inference/usage.test.ts
+++ b/packages/agent/src/inference/usage.test.ts
@@ -1,254 +1,102 @@
 import { describe, expect, test } from "bun:test"
 import type { Event } from "@clavia/tardigrade-core/log/event"
-import { costNumber, priced, sumUsage, usageFrom, usageIn, usageOf, ZERO_USAGE } from "./usage"
+import { priced, sumUsage, usageFrom, usageIn, usageOf, ZERO_USAGE } from "./usage"
 
 const table = { promptUsdPerToken: 0.001, completionUsdPerToken: 0.002 }
+const counts = { promptTokens: 10, completionTokens: 4, cachedPromptTokens: 0, cacheWritePromptTokens: 0 }
 
-describe("priced and usageFrom", () => {
-  test("a provider bill and a table estimate coexist", () => {
-    const raw = {
-      prompt_tokens: 10,
-      completion_tokens: 4,
-      total_tokens: 14,
-      prompt_tokens_details: { cached_tokens: 4 },
-      completion_tokens_details: { reasoning_tokens: 2 },
-      cost: 0
+describe("usageFrom", () => {
+  test("raw reports stay uninterpreted by default", () => {
+    for (const raw of [
+      { prompt_tokens: 137973, completion_tokens: 188, cache_creation_input_tokens: 137970, cost: 0 },
+      { input_tokens: 3, cache_creation_input_tokens: 137970, output_tokens: 188 },
+      { inputTokens: 3, cacheWriteInputTokens: 137970, outputTokens: 188 },
+      { promptTokens: 10, completionTokens: 4, costUsd: 1 },
+      { future_billable_units: 3 },
+      {},
+      null
+    ]) {
+      const report = { provider: "p", model: "m", providerSpecific: raw }
+      expect(usageFrom(report)).toEqual({ provider: "p", model: "m", providerReports: [report] })
     }
-    const billed = usageFrom(
-      raw,
-      { ...table, cachedPromptUsdPerToken: 0.0001 },
-      {
-        provider: "vercel-ai-gateway",
-        model: "anthropic/claude-sonnet-4.6"
-      }
-    )
-    expect(billed).toEqual({
-      promptTokens: 10,
-      completionTokens: 4,
-      totalTokens: 14,
-      cachedPromptTokens: 4,
-      reasoningTokens: 2,
-      costUsd: 0,
-      costSource: "provider",
-      reportedCostUsd: 0,
-      estimatedCostUsd: 6 * 0.001 + 4 * 0.0001 + 4 * 0.002,
-      provider: "vercel-ai-gateway",
-      model: "anthropic/claude-sonnet-4.6",
-      providerReports: [
-        { provider: "vercel-ai-gateway", model: "anthropic/claude-sonnet-4.6", providerSpecific: raw }
-      ]
-    })
-
-    const filledRaw = { prompt_tokens: 10, completion_tokens: 4 }
-    const filled = usageFrom(filledRaw, table, { provider: "openai", model: "test" })
-    expect(filled).toEqual({
-      promptTokens: 10,
-      completionTokens: 4,
-      costUsd: 10 * 0.001 + 4 * 0.002,
-      costSource: "table",
-      estimatedCostUsd: 10 * 0.001 + 4 * 0.002,
-      provider: "openai",
-      model: "test",
-      providerReports: [{ provider: "openai", model: "test", providerSpecific: filledRaw }]
-    })
-    const unknownRaw = { promptTokens: 10, completionTokens: 4 }
-    const unknown = usageFrom(unknownRaw)
-    expect(unknown).toEqual({
-      promptTokens: 10,
-      completionTokens: 4,
-      providerReports: [{ providerSpecific: unknownRaw }]
-    })
-    const futureRaw = { future_billable_units: 3 }
-    expect(usageFrom(futureRaw, table, { provider: "future", model: "m" })).toEqual({
-      promptTokens: 0,
-      completionTokens: 0,
-      provider: "future",
-      model: "m",
-      providerReports: [{ provider: "future", model: "m", providerSpecific: futureRaw }]
-    })
-    expect(usageFrom(undefined)).toBeUndefined()
   })
 
-  test("priced retains a provider figure and recomputes the table projection", () => {
-    const reported = { promptTokens: 1, completionTokens: 1, costUsd: 9, costSource: "provider" as const }
-    expect(priced(reported, table)).toEqual({
-      ...reported,
-      reportedCostUsd: 9,
-      estimatedCostUsd: 0.003
+  test("the caller selects the usage interpretation", () => {
+    const raw = { input: 10, output: 4, cache: 6, paid: 0 }
+    const report = { provider: "p", model: "m", providerSpecific: raw }
+    const inclusive = usageFrom(report, (received) => {
+      expect(received).toBe(report)
+      return { promptTokens: raw.input, completionTokens: raw.output, cachedPromptTokens: raw.cache, reportedCostUsd: raw.paid }
     })
-    expect(priced({ promptTokens: 10, completionTokens: 4 }, table)).toMatchObject({
-      costUsd: 10 * 0.001 + 4 * 0.002,
-      costSource: "table",
-      estimatedCostUsd: 10 * 0.001 + 4 * 0.002
+    const exclusive = usageFrom(report, () => ({ promptTokens: raw.input + raw.cache }))
+    expect(inclusive).toEqual({
+      provider: "p", model: "m", promptTokens: 10, completionTokens: 4,
+      cachedPromptTokens: 6, reportedCostUsd: 0, providerReports: [report]
     })
-    expect(priced({ promptTokens: 1, completionTokens: 1, costUsd: 9 }, table)).toEqual({
-      promptTokens: 1,
-      completionTokens: 1,
-      costUsd: 9,
-      estimatedCostUsd: 0.003
-    })
-    expect(
-      priced({ promptTokens: 1, completionTokens: 1, costUsd: 9, estimatedCostUsd: 8 }, table)
-    ).toEqual({
-      promptTokens: 1,
-      completionTokens: 1,
-      costUsd: 9,
-      estimatedCostUsd: 0.003
-    })
-    const recordedTable = {
-      promptTokens: 10,
-      completionTokens: 4,
-      cachedPromptTokens: 5,
-      costUsd: 0.7,
-      costSource: "table" as const
+    expect(exclusive.promptTokens).toBe(16)
+    expect(usageFrom(report, () => undefined)).toEqual(usageFrom(report))
+    expect(raw).toEqual({ input: 10, output: 4, cache: 6, paid: 0 })
+  })
+
+  test("multiple observations reach the caller without merging or summing", () => {
+    const observations = [{ input_tokens: 10 }, { output_tokens: 4 }, { output_tokens: 8 }]
+    const report = { providerSpecific: observations }
+    expect(usageFrom(report, (received) => {
+      expect(received.providerSpecific).toBe(observations)
+      return { promptTokens: 10, completionTokens: 8 }
+    })).toEqual({ promptTokens: 10, completionTokens: 8, providerReports: [report] })
+  })
+
+  test("normalized metrics reject coercion and invalid numbers", () => {
+    for (const value of ["10", null, -1, NaN, Infinity, 0.5, Number.MAX_SAFE_INTEGER + 1]) {
+      expect(() => usageOf({ promptTokens: value })).toThrow("usage.promptTokens")
     }
-    expect(priced(recordedTable, table)).toEqual(recordedTable)
+    expect(() => usageFrom({ providerSpecific: {} }, () => ({ completionTokens: NaN }))).toThrow("usage.completionTokens")
+    expect(() => usageOf({ costUsd: "0.2" })).toThrow("usage.costUsd")
+    expect(() => usageOf("invalid")).toThrow("usage must be an object")
+    expect(() => usageOf({ costUsd: 1, costSource: "guessed" })).toThrow("usage.costSource")
+    expect(usageOf({})).toEqual({})
+    expect(usageOf({ promptTokens: 0 })).toEqual({ promptTokens: 0 })
+    expect(() => usageFrom({} as never)).toThrow("ProviderUsageReport")
+  })
+})
+
+describe("priced", () => {
+  test("a provider bill and a table estimate coexist", () => {
+    expect(priced({ ...counts, costUsd: 0, costSource: "provider" }, table)).toEqual({
+      ...counts, costUsd: 0, costSource: "provider", reportedCostUsd: 0, estimatedCostUsd: (10 * 0.001 + 4 * 0.002)
+    })
+    expect(priced(counts, table)).toEqual({ ...counts, costUsd: (10 * 0.001 + 4 * 0.002), costSource: "table", estimatedCostUsd: (10 * 0.001 + 4 * 0.002) })
+    expect(priced({ ...counts, reportedCostUsd: 2 }, table)).toMatchObject({ costUsd: 2, costSource: "provider", estimatedCostUsd: (10 * 0.001 + 4 * 0.002) })
+  })
+
+  test("pricing requires explicit cache counts", () => {
+    for (const usage of [
+      {},
+      { promptTokens: 10, completionTokens: 4 },
+      { promptTokens: 10, completionTokens: 4, cachedPromptTokens: 0 },
+      { promptTokens: 10, completionTokens: 4, cacheWritePromptTokens: 0 }
+    ]) expect(priced(usage, table)).toEqual(usage)
+    const raw = usageFrom({ providerSpecific: { prompt_tokens: 10, completion_tokens: 4, cost: 0 } })
+    expect(priced(raw, table)).toEqual(raw)
   })
 
   test("cache buckets require declared rates", () => {
-    const usage = { promptTokens: 10, completionTokens: 4, cachedPromptTokens: 5 }
+    const usage = { ...counts, cachedPromptTokens: 4, cacheWritePromptTokens: 2 }
     expect(priced(usage, table)).toEqual(usage)
-    expect(
-      priced(usage, { ...table, cachedPromptUsdPerToken: 0.0002 })
-    ).toMatchObject({ estimatedCostUsd: 5 * 0.001 + 5 * 0.0002 + 4 * 0.002 })
-    expect(
-      priced(
-        { promptTokens: 10, completionTokens: 4, cachedPromptTokens: 4, cacheWritePromptTokens: 2 },
-        { ...table, cachedPromptUsdPerToken: 0.0002, cacheWritePromptUsdPerToken: 0.00125 }
-      )
-    ).toMatchObject({ estimatedCostUsd: 4 * 0.001 + 4 * 0.0002 + 2 * 0.00125 + 4 * 0.002 })
+    expect(priced(usage, { ...table, cachedPromptUsdPerToken: 0.0002 })).toEqual(usage)
+    expect(priced(usage, { ...table, cachedPromptUsdPerToken: 0.0002, cacheWritePromptUsdPerToken: 0.00125 }))
+      .toMatchObject({ estimatedCostUsd: 4 * 0.001 + 4 * 0.0002 + 2 * 0.00125 + 4 * 0.002 })
+    const inconsistent = { ...counts, cachedPromptTokens: 11 }
+    expect(priced(inconsistent, { ...table, cachedPromptUsdPerToken: 0.0002 })).toEqual(inconsistent)
+    expect(priced(counts, { ...table, promptUsdPerToken: NaN })).toEqual(counts)
   })
 
-  test("gateway prompt totals already include cache creation", () => {
-    const raw = {
-      prompt_tokens: 137973,
-      completion_tokens: 188,
-      total_tokens: 138161,
-      cache_creation_input_tokens: 137970,
-      prompt_tokens_details: { cached_tokens: 0 },
-      completion_tokens_details: { reasoning_tokens: 118 },
-      cost: 0,
-      market_cost: 0.8670275
-    }
-    const pricing = {
-      promptUsdPerToken: 10 / 1_000_000,
-      completionUsdPerToken: 50 / 1_000_000,
-      cachedPromptUsdPerToken: 1 / 1_000_000,
-      cacheWritePromptUsdPerToken: 12.5 / 1_000_000
-    }
-    const expected = {
-      promptTokens: 137973,
-      completionTokens: 188,
-      totalTokens: 138161,
-      cachedPromptTokens: 0,
-      cacheWritePromptTokens: 137970,
-      reasoningTokens: 118,
-      reportedCostUsd: 0,
-      costUsd: 0,
-      costSource: "provider" as const,
-      estimatedCostUsd: 3 * pricing.promptUsdPerToken + 137970 * pricing.cacheWritePromptUsdPerToken + 188 * pricing.completionUsdPerToken,
-      providerReports: [{ providerSpecific: raw }]
-    }
-    expect(usageFrom(raw, pricing)).toEqual(expected)
-    expect(
-      usageFrom([raw, { promptTokens: 137973, completionTokens: 188, totalTokens: 138161 }], pricing)
-    ).toEqual(expected)
-    const stamp = { provider: "vercel-ai-gateway", model: "openai/gpt-6-astra" }
-    const providerMetrics = { usage: raw, provider_metadata: undefined }
-    expect(usageFrom([raw, undefined], pricing, stamp, providerMetrics)).toEqual({
-      ...expected,
-      ...stamp,
-      providerReports: [{ ...stamp, providerSpecific: providerMetrics }]
-    })
-  })
-
-  test("prompt totals include cache reads and writes across field aliases", () => {
-    for (const prompt of [{ promptTokens: 10 }, { prompt_tokens: 10 }]) {
-      for (const cache of [
-        { cacheReadInputTokens: 4, cacheWriteInputTokens: 2 },
-        { cache_read_input_tokens: 4, cache_write_input_tokens: 2 },
-        { cacheReadInputTokens: 4, cacheCreationInputTokens: 2 },
-        { cache_read_input_tokens: 4, cache_creation_input_tokens: 2 }
-      ]) {
-        expect(usageFrom({ ...prompt, ...cache, completionTokens: 3, totalTokens: 13 })).toMatchObject({
-          promptTokens: 10,
-          completionTokens: 3,
-          totalTokens: 13,
-          cachedPromptTokens: 4,
-          cacheWritePromptTokens: 2
-        })
-      }
-    }
-  })
-
-  test("Anthropic and Converse input counts exclude cache reads and writes", () => {
-    for (const raw of [
-      { input_tokens: 4, output_tokens: 3, cache_read_input_tokens: 4, cache_creation_input_tokens: 2 },
-      { inputTokens: 4, outputTokens: 3, totalTokens: 7, cacheReadInputTokens: 4, cacheWriteInputTokens: 2 }
-    ]) {
-      const pricing = { ...table, cachedPromptUsdPerToken: 0.0002, cacheWritePromptUsdPerToken: 0.00125 }
-      const expected = {
-        promptTokens: 10,
-        completionTokens: 3,
-        cachedPromptTokens: 4,
-        cacheWritePromptTokens: 2,
-        estimatedCostUsd: 4 * 0.001 + 4 * 0.0002 + 2 * 0.00125 + 3 * 0.002
-      }
-      expect(usageFrom(raw, pricing)).toMatchObject(expected)
-      expect(
-        usageFrom([raw, { promptTokens: 4, completionTokens: 3, totalTokens: 7 }], pricing)
-      ).toMatchObject(expected)
-    }
-  })
-
-  test("a normalized adapter view fills details the raw report omits", () => {
-    const raw = { prompt_tokens: 10, completion_tokens: 4, cost: 0 }
-    expect(
-      usageFrom(
-        [
-          raw,
-          {
-            promptTokens: 10,
-            completionTokens: 4,
-            totalTokens: 15,
-            promptTokensDetails: { cachedTokens: 4, cacheWriteTokens: 2 },
-            completionTokensDetails: { reasoningTokens: 2 }
-          }
-        ],
-        { ...table, cachedPromptUsdPerToken: 0.0002, cacheWritePromptUsdPerToken: 0.00125 }
-      )
-    ).toMatchObject({
-      totalTokens: 15,
-      cachedPromptTokens: 4,
-      cacheWritePromptTokens: 2,
-      reasoningTokens: 2,
-      reportedCostUsd: 0,
-      providerReports: [{ providerSpecific: raw }]
-    })
-
-    const converse = { inputTokens: 10, outputTokens: 2, totalTokens: 12, cacheReadInputTokens: 4 }
-    expect(
-      usageFrom(
-        [converse, { promptTokens: 10, completionTokens: 2, totalTokens: 12 }],
-        { ...table, cachedPromptUsdPerToken: 0.0002 },
-        { provider: "bedrock", model: "m" },
-        converse
-      )
-    ).toMatchObject({
-      promptTokens: 14,
-      completionTokens: 2,
-      totalTokens: 16,
-      cachedPromptTokens: 4,
-      estimatedCostUsd: 10 * 0.001 + 4 * 0.0002 + 2 * 0.002
-    })
-    expect(usageFrom({ promptTokens: 3, completionTokens: 2, totalTokens: 0 })).not.toHaveProperty("totalTokens")
-  })
-
-  test("costNumber reads the seats a gateway actually writes", () => {
-    expect(costNumber({ cost: 0.01 })).toBe(0.01)
-    expect(costNumber({ costUsd: "0.2" })).toBe(0.2)
-    expect(costNumber({ gateway: { cost: 0 } })).toBe(0)
-    expect(costNumber({ prompt_tokens: 3 })).toBeUndefined()
+  test("a recorded estimate survives an incomplete table and a complete table recomputes it", () => {
+    const usage = { ...counts, cachedPromptTokens: 4, estimatedCostUsd: 9 }
+    expect(priced(usage, table)).toMatchObject({ estimatedCostUsd: 9 })
+    expect(priced(usage, { ...table, cachedPromptUsdPerToken: 0.0002 }))
+      .toMatchObject({ estimatedCostUsd: 6 * 0.001 + 4 * 0.0002 + 4 * 0.002 })
   })
 })
 
@@ -288,33 +136,16 @@ describe("sumUsage", () => {
     expect(sumUsage([])).toEqual(ZERO_USAGE)
   })
 
-  test("raw provider metrics survive normalization and aggregation", () => {
-    const first = usageFrom(
-      { inputTokens: 10, outputTokens: 2, totalTokens: 12, cacheReadInputTokens: 4 },
-      undefined,
-      { provider: "bedrock", model: "m" }
-    )!
-    const second = usageFrom(
-      { inputTokens: 12, outputTokens: 3, totalTokens: 15, cacheReadInputTokens: 5 },
-      undefined,
-      { provider: "bedrock", model: "m" }
-    )!
-    expect(
-      priced(first, { ...table, cachedPromptUsdPerToken: 0.0002 })
-    ).toMatchObject({ estimatedCostUsd: 10 * 0.001 + 4 * 0.0002 + 2 * 0.002 })
-    const summed = sumUsage([first, second])
-    expect(summed).toMatchObject({
-      promptTokens: 31,
-      completionTokens: 5,
-      totalTokens: 36,
-      cachedPromptTokens: 9,
-      providerReports: [
-        { provider: "bedrock", model: "m", providerSpecific: first.providerReports![0]!.providerSpecific },
-        { provider: "bedrock", model: "m", providerSpecific: second.providerReports![0]!.providerSpecific }
-      ]
-    })
+  test("raw reports survive aggregation and unknown metrics stay unknown", () => {
+    const raw = usageFrom({ provider: "p", model: "m", providerSpecific: { future_units: 3 } })
+    const measured = { promptTokens: 10, completionTokens: 2, costUsd: 1 }
+    expect(sumUsage([measured, raw])).toEqual({ providerReports: raw.providerReports! })
+    expect(sumUsage([measured, { completionTokens: 3 }])).toEqual({ completionTokens: 5 })
+    const summed = sumUsage([raw, raw])
+    expect(summed.providerReports).toHaveLength(2)
     expect(usageOf(JSON.parse(JSON.stringify(summed)))).toEqual(summed)
   })
+
 })
 
 describe("usageIn", () => {
@@ -367,7 +198,7 @@ describe("usageIn", () => {
       { type: "TurnCompleted", output: "ok", usage: billed, turn: "m1", at: 2 },
       { type: "TurnFailed", error: "gave up", turn: "m1", at: 3 }
     ]
-    expect(usageIn(log, "m1")).toEqual({ promptTokens: 10, completionTokens: 4 })
+    expect(usageIn(log, "m1")).toEqual({})
     expect(
       usageIn(
         [{ type: "ToolCalled", callId: "m1/infer/0", name: "execute", arguments: {}, usage: billed, at: 1 }],

--- a/packages/agent/src/inference/usage.ts
+++ b/packages/agent/src/inference/usage.ts
@@ -10,6 +10,17 @@ export interface ProviderUsageReport {
   readonly providerSpecific: unknown
 }
 
+// UsageAdapterIdentity identifies the contract that interpreted a provider report.
+export interface UsageAdapterIdentity {
+  readonly id: string
+  readonly version: string
+}
+
+export interface UsageAccountingError {
+  readonly kind: "adapter" | "aggregation"
+  readonly message: string
+}
+
 // Usage carries raw reports and optional interpreted metrics; an omitted metric is unknown (usage.test.ts, "raw reports stay uninterpreted by default").
 export interface Usage {
   readonly promptTokens?: number
@@ -28,6 +39,8 @@ export interface Usage {
   readonly provider?: string
   readonly model?: string
   readonly providerReports?: ReadonlyArray<ProviderUsageReport>
+  readonly usageAdapter?: UsageAdapterIdentity
+  readonly accountingErrors?: ReadonlyArray<UsageAccountingError>
 }
 
 // ModelPricing states the rates used for an independent cost projection.
@@ -48,7 +61,18 @@ const asRecord = (value: unknown): Record<string, unknown> | undefined =>
   value !== null && typeof value === "object" ? (value as Record<string, unknown>) : undefined
 
 // UsageAdapter interprets one physical request under a caller-defined provider contract.
-export type UsageAdapter = (report: ProviderUsageReport) => Omit<Usage, "provider" | "model" | "providerReports"> | undefined
+export type UsageAdapter = ((report: ProviderUsageReport) => Omit<Usage, "provider" | "model" | "providerReports"> | undefined) & {
+  readonly usageAdapter?: UsageAdapterIdentity
+}
+
+// UsageAdapterDescriptor keeps a named interpretation beside its callable implementation.
+export interface UsageAdapterDescriptor {
+  readonly id: string
+  readonly version: string
+  readonly adapt: UsageAdapter
+}
+
+export type UsageAdapterSelection = UsageAdapter | UsageAdapterDescriptor
 
 const numberOf = (value: unknown, field: string): number | undefined => {
   if (value === undefined) return undefined
@@ -56,6 +80,67 @@ const numberOf = (value: unknown, field: string): number | undefined => {
     throw new TypeError(`usage.${field} must be a non-negative ${field.endsWith("Tokens") ? "safe integer" : "finite number"}`)
   }
   return value
+}
+
+const openAiCount = (value: unknown, field: string): number | undefined => {
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError(`openai.chat-completions.${field} must be a non-negative safe integer`)
+  }
+  return value
+}
+
+const openAiObject = (value: unknown, field: string): Record<string, unknown> | undefined => {
+  if (value === undefined) return undefined
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`openai.chat-completions.${field} must be an object`)
+  }
+  return value as Record<string, unknown>
+}
+
+const openAiDetails = (value: unknown, field: string): Record<string, unknown> | undefined =>
+  value === null ? undefined : openAiObject(value, field)
+
+const openAiSubset = (parent: number | undefined, child: number | undefined, field: string): void => {
+  if (parent !== undefined && child !== undefined && child > parent) {
+    throw new TypeError(`openai.chat-completions.${field} must be a subset of its total`)
+  }
+}
+
+// OPENAI_CHAT_COMPLETIONS_USAGE_V1 interprets the documented Chat Completions usage object.
+// Cached input tokens are included in prompt_tokens, and reasoning tokens are included in
+// completion_tokens (usage.test.ts, "OpenAI Chat Completions usage preserves subsets").
+export const OPENAI_CHAT_COMPLETIONS_USAGE_V1: UsageAdapterDescriptor = {
+  id: "openai/chat-completions-usage",
+  version: "1",
+  adapt: (report) => {
+    const raw = openAiObject(report.providerSpecific, "usage")
+    if (raw === undefined) throw new TypeError("openai.chat-completions.usage must be an object")
+    const promptTokens = openAiCount(raw.prompt_tokens, "prompt_tokens")
+    const completionTokens = openAiCount(raw.completion_tokens, "completion_tokens")
+    const totalTokens = openAiCount(raw.total_tokens, "total_tokens")
+    const promptDetails = openAiDetails(raw.prompt_tokens_details, "prompt_tokens_details")
+    const completionDetails = openAiDetails(raw.completion_tokens_details, "completion_tokens_details")
+    const cachedPromptTokens = openAiCount(promptDetails?.cached_tokens, "prompt_tokens_details.cached_tokens")
+    const cacheWritePromptTokens = openAiCount(promptDetails?.cache_write_tokens, "prompt_tokens_details.cache_write_tokens")
+    const reasoningTokens = openAiCount(completionDetails?.reasoning_tokens, "completion_tokens_details.reasoning_tokens")
+    openAiSubset(promptTokens, cachedPromptTokens, "prompt_tokens_details.cached_tokens")
+    openAiSubset(promptTokens, cacheWritePromptTokens, "prompt_tokens_details.cache_write_tokens")
+    openAiSubset(completionTokens, reasoningTokens, "completion_tokens_details.reasoning_tokens")
+    openAiSubset(totalTokens, promptTokens, "prompt_tokens")
+    openAiSubset(totalTokens, completionTokens, "completion_tokens")
+    if (totalTokens !== undefined && promptTokens !== undefined && completionTokens !== undefined && totalTokens !== promptTokens + completionTokens) {
+      throw new TypeError("openai.chat-completions.total_tokens must equal prompt_tokens plus completion_tokens")
+    }
+    return {
+      ...(promptTokens === undefined ? {} : { promptTokens }),
+      ...(completionTokens === undefined ? {} : { completionTokens }),
+      ...(totalTokens === undefined ? {} : { totalTokens }),
+      ...(cachedPromptTokens === undefined ? {} : { cachedPromptTokens }),
+      ...(cacheWritePromptTokens === undefined ? {} : { cacheWritePromptTokens }),
+      ...(reasoningTokens === undefined ? {} : { reasoningTokens })
+    }
+  }
 }
 
 // costOf prices explicit token buckets and returns undefined when a count or required rate is unknown (usage.test.ts, "pricing requires explicit cache counts").
@@ -126,17 +211,71 @@ export const priced = (usage: Usage, pricing?: ModelPricing): Usage => {
   }
 }
 
+const adapterOf = (selection: UsageAdapterSelection | undefined): UsageAdapter | undefined => {
+  if (selection === undefined) return undefined
+  if (typeof selection === "function") {
+    const identity = selection.usageAdapter
+    if (identity !== undefined && !isAdapterIdentity(identity)) throw new TypeError("usage adapter identity must contain non-empty string id and version")
+    return selection
+  }
+  if (!isAdapterDescriptor(selection)) {
+    throw new TypeError("usage adapter descriptor must contain non-empty string id, version, and adapt")
+  }
+  return selection.adapt
+}
+
+const isAdapterIdentity = (value: unknown): value is UsageAdapterIdentity => {
+  const record = asRecord(value)
+  return record !== undefined && !Array.isArray(value) && typeof record.id === "string" && record.id !== "" && typeof record.version === "string" && record.version !== ""
+}
+
+const isAdapterDescriptor = (value: unknown): value is UsageAdapterDescriptor =>
+  isAdapterIdentity(value) && typeof (value as { readonly adapt?: unknown }).adapt === "function"
+
+// validateUsageAdapterSelection rejects malformed runtime configuration before a model request
+// can dispatch (usage.test.ts, "invalid adapter descriptors fail before fetch").
+export const validateUsageAdapterSelection = (selection: unknown): void => {
+  if (selection !== undefined) adapterOf(selection as UsageAdapterSelection)
+}
+
+const adapterIdentityOf = (selection: UsageAdapterSelection | undefined): UsageAdapterIdentity | undefined => {
+  if (selection === undefined) return undefined
+  adapterOf(selection)
+  return typeof selection === "function" ? selection.usageAdapter : { id: selection.id, version: selection.version }
+}
+
+const safeAdapterIdentityOf = (selection: unknown): UsageAdapterIdentity | undefined => {
+  if (typeof selection === "function") {
+    const identity = (selection as { readonly usageAdapter?: unknown }).usageAdapter
+    return isAdapterIdentity(identity) ? identity : undefined
+  }
+  return isAdapterIdentity(selection) ? { id: selection.id, version: selection.version } : undefined
+}
+
 // usageFrom preserves a raw report and applies an adapter only when the caller supplies one (usage.test.ts, "raw reports stay uninterpreted by default").
-export const usageFrom = (report: ProviderUsageReport, adapter?: UsageAdapter): Usage => {
+export const usageFrom = (report: ProviderUsageReport, adapter?: UsageAdapterSelection): Usage => {
   if (asRecord(report) === undefined || !("providerSpecific" in report)) {
     throw new TypeError("usageFrom requires a ProviderUsageReport with providerSpecific")
   }
-  const { provider: _provider, model: _model, providerReports: _reports, ...metrics } = usageOf(adapter?.(report))
+  const { provider: _provider, model: _model, providerReports: _reports, ...metrics } = usageOf(adapterOf(adapter)?.(report))
+  const identity = adapterIdentityOf(adapter)
   return {
     ...metrics,
     ...(report.provider === undefined ? {} : { provider: report.provider }),
     ...(report.model === undefined ? {} : { model: report.model }),
+    ...(identity === undefined ? {} : { usageAdapter: identity }),
     providerReports: [report]
+  }
+}
+
+// usageWithAccountingError preserves the selected descriptor while withholding its invalid
+// interpretation from numeric metrics (usage.test.ts, "adapter errors retain provenance").
+export const usageWithAccountingError = (report: ProviderUsageReport, adapter: UsageAdapterSelection | undefined, message: string): Usage => {
+  const identity = safeAdapterIdentityOf(adapter)
+  return {
+    ...usageFrom(report),
+    ...(identity === undefined ? {} : { usageAdapter: identity }),
+    accountingErrors: [{ kind: "adapter", message }]
   }
 }
 
@@ -171,6 +310,22 @@ export const usageOf = (value: unknown): Usage => {
   }
   const provider = carried?.provider
   const model = carried?.model
+  const usageAdapterValue = carried?.usageAdapter
+  const usageAdapterRecord = usageAdapterValue === undefined ? undefined : asRecord(usageAdapterValue)
+  if (usageAdapterValue !== undefined && (usageAdapterRecord === undefined || typeof usageAdapterRecord.id !== "string" || typeof usageAdapterRecord.version !== "string")) {
+    throw new TypeError("usage.usageAdapter must contain string id and version")
+  }
+  const accountingErrorsValue = carried?.accountingErrors
+  if (accountingErrorsValue !== undefined && !Array.isArray(accountingErrorsValue)) {
+    throw new TypeError("usage.accountingErrors must be an array")
+  }
+  const accountingErrors = accountingErrorsValue?.map((error) => {
+    const record = asRecord(error)
+    if (record === undefined || (record.kind !== "adapter" && record.kind !== "aggregation") || typeof record.message !== "string") {
+      throw new TypeError("usage.accountingErrors must contain typed accounting errors")
+    }
+    return { kind: record.kind as "adapter" | "aggregation", message: record.message }
+  })
   const reportedCostUsd = numberOf(carried?.reportedCostUsd, "reportedCostUsd")
   const estimatedCostUsd = numberOf(carried?.estimatedCostUsd, "estimatedCostUsd")
   const promptTokens = numberOf(carried?.promptTokens, "promptTokens")
@@ -193,6 +348,8 @@ export const usageOf = (value: unknown): Usage => {
     ...(estimatedCostUsd === undefined ? {} : { estimatedCostUsd }),
     ...(typeof provider === "string" && provider !== "" ? { provider } : {}),
     ...(typeof model === "string" && model !== "" ? { model } : {}),
+    ...(usageAdapterRecord === undefined ? {} : { usageAdapter: { id: usageAdapterRecord.id as string, version: usageAdapterRecord.version as string } }),
+    ...(accountingErrors === undefined ? {} : { accountingErrors }),
     ...(providerReports === undefined ? {} : { providerReports })
   }
 }
@@ -207,17 +364,26 @@ const same = (a: string | undefined, b: string | undefined): string | undefined 
 
 export const sumUsage = (parts: ReadonlyArray<Usage>): Usage => {
   if (parts.length === 0) return ZERO_USAGE
-  let costUsd = 0
-  let known = true
   let source: CostSource | undefined
   let provider: string | undefined
   let model: string | undefined
   const providerReports: ProviderUsageReport[] = []
+  const accountingErrors: UsageAccountingError[] = []
+  let usageAdapter: UsageAdapterIdentity | undefined
+  let mixedAdapters = false
+  let missingAdapter = false
   let first = true
   for (const part of parts) {
     providerReports.push(...(part.providerReports ?? []))
-    if (part.costUsd === undefined) known = false
-    else costUsd += part.costUsd
+    accountingErrors.push(...(part.accountingErrors ?? []))
+    if (part.usageAdapter !== undefined) {
+      if (missingAdapter) mixedAdapters = true
+      if (usageAdapter === undefined) usageAdapter = part.usageAdapter
+      else if (usageAdapter.id !== part.usageAdapter.id || usageAdapter.version !== part.usageAdapter.version) mixedAdapters = true
+    } else {
+      if (usageAdapter !== undefined) mixedAdapters = true
+      missingAdapter = true
+    }
     if (first) {
       source = part.costSource
       provider = part.provider
@@ -229,23 +395,30 @@ export const sumUsage = (parts: ReadonlyArray<Usage>): Usage => {
       model = same(model, part.model)
     }
   }
-  const sumKnown = (read: (part: Usage) => number | undefined): number | undefined => {
+  const sumMetric = (read: (part: Usage) => number | undefined, name: string): number | undefined => {
     let total = 0
     for (const part of parts) {
       const value = read(part)
       if (value === undefined) return undefined
-      total += value
+      const next = total + value
+      if (!Number.isFinite(next) || (name.endsWith("Tokens") && !Number.isSafeInteger(next))) {
+        accountingErrors.push({ kind: "aggregation", message: `${name} aggregation exceeded its numeric range` })
+        return undefined
+      }
+      total = next
     }
     return total
   }
-  const promptTokens = sumKnown((part) => part.promptTokens)
-  const completionTokens = sumKnown((part) => part.completionTokens)
-  const totalTokens = sumKnown((part) => part.totalTokens)
-  const cachedPromptTokens = sumKnown((part) => part.cachedPromptTokens)
-  const cacheWritePromptTokens = sumKnown((part) => part.cacheWritePromptTokens)
-  const reasoningTokens = sumKnown((part) => part.reasoningTokens)
-  const reportedCostUsd = sumKnown((part) => part.reportedCostUsd)
-  const estimatedCostUsd = sumKnown((part) => part.estimatedCostUsd)
+  const costUsd = sumMetric((part) => part.costUsd, "costUsd")
+  const known = costUsd !== undefined
+  const promptTokens = sumMetric((part) => part.promptTokens, "promptTokens")
+  const completionTokens = sumMetric((part) => part.completionTokens, "completionTokens")
+  const totalTokens = sumMetric((part) => part.totalTokens, "totalTokens")
+  const cachedPromptTokens = sumMetric((part) => part.cachedPromptTokens, "cachedPromptTokens")
+  const cacheWritePromptTokens = sumMetric((part) => part.cacheWritePromptTokens, "cacheWritePromptTokens")
+  const reasoningTokens = sumMetric((part) => part.reasoningTokens, "reasoningTokens")
+  const reportedCostUsd = sumMetric((part) => part.reportedCostUsd, "reportedCostUsd")
+  const estimatedCostUsd = sumMetric((part) => part.estimatedCostUsd, "estimatedCostUsd")
   return {
     ...(promptTokens === undefined ? {} : { promptTokens }),
     ...(completionTokens === undefined ? {} : { completionTokens }),
@@ -258,6 +431,8 @@ export const sumUsage = (parts: ReadonlyArray<Usage>): Usage => {
     ...(estimatedCostUsd === undefined ? {} : { estimatedCostUsd }),
     ...(provider === undefined ? {} : { provider }),
     ...(model === undefined ? {} : { model }),
+    ...(mixedAdapters || usageAdapter === undefined ? {} : { usageAdapter }),
+    ...(accountingErrors.length === 0 ? {} : { accountingErrors }),
     ...(providerReports.length === 0 ? {} : { providerReports })
   }
 }
@@ -270,16 +445,282 @@ const ofTurn = (event: Event, turn: string): boolean => {
   return callId === turn || callId.startsWith(`${turn}/`)
 }
 
-// usageIn sums what one turn spent on the model. A live attempt's consequence carries the
-// spend as its `usage` field, so the sum reads fields, never event types. An empty usage is an
-// attempt with unreported spend, and it keeps the total unknown (usage.test.ts, "unknown is
-// sticky"). An event with no usage field is no attempt: a died ModelCalled and the give-up
-// TurnFailed invent nothing.
-export const usageIn = (log: ReadonlyArray<Event>, turn: string): Usage =>
-  sumUsage(
-    log.flatMap((event) => {
+export const DEFAULT_USAGE_COVERAGE_METRICS = ["promptTokens", "completionTokens"] as const
+export type UsageCoverageMetric =
+  | "promptTokens"
+  | "completionTokens"
+  | "totalTokens"
+  | "cachedPromptTokens"
+  | "cacheWritePromptTokens"
+  | "reasoningTokens"
+  | "costUsd"
+  | "reportedCostUsd"
+  | "estimatedCostUsd"
+export const USAGE_COVERAGE_SCOPE = "framework-recorded-inference-invocations" as const
+
+export interface UsageCoverageOptions {
+  readonly required?: ReadonlyArray<UsageCoverageMetric>
+}
+
+export interface UsageCoverageGap {
+  readonly reason: "missing-consequence" | "missing-usage" | "missing-metrics"
+  readonly turn: string
+  readonly epoch: number
+  readonly callId: string
+  readonly ordinal?: number
+  readonly metrics: ReadonlyArray<UsageCoverageMetric>
+}
+
+export interface UsageCoverageUnresolved {
+  readonly reason: "accounting-error" | "duplicate-consequence" | "unmatched-consequence"
+  readonly turn: string
+  readonly epoch: number
+  readonly callId?: string
+  readonly ordinal?: number
+  readonly message?: string
+}
+
+type CoverageTotal<M extends ReadonlyArray<UsageCoverageMetric>> =
+  number extends M["length"]
+    ? Partial<Record<UsageCoverageMetric, number>>
+    : { readonly [K in M[number]]: number }
+
+export interface CompleteUsageCoverage {
+  readonly status: "complete"
+  readonly scope: typeof USAGE_COVERAGE_SCOPE
+  readonly observed: Usage
+  readonly total: CoverageTotal<typeof DEFAULT_USAGE_COVERAGE_METRICS>
+  readonly missing: ReadonlyArray<never>
+  readonly unresolved: ReadonlyArray<never>
+}
+
+export interface IncompleteUsageCoverage {
+  readonly status: "incomplete"
+  readonly scope: typeof USAGE_COVERAGE_SCOPE
+  readonly observed: Usage
+  readonly missing: ReadonlyArray<UsageCoverageGap>
+  readonly unresolved: ReadonlyArray<UsageCoverageUnresolved>
+  readonly total?: never
+}
+
+export type UsageCoverage<M extends ReadonlyArray<UsageCoverageMetric> = typeof DEFAULT_USAGE_COVERAGE_METRICS> =
+  | (Omit<CompleteUsageCoverage, "total"> & { readonly total: CoverageTotal<M> })
+  | IncompleteUsageCoverage
+
+interface NativeCall {
+  readonly eventIndex: number
+  readonly turn: string
+  readonly epoch: number
+  readonly callId: string
+  readonly ordinal: number | undefined
+  readonly usage?: Usage
+  matched: boolean
+}
+
+interface MatchedUsage {
+  readonly call: NativeCall
+  readonly eventIndex: number
+  readonly usage: Usage | undefined
+}
+
+const epochOf = (event: Event): number => {
+  const epoch = asRecord(event)?.epoch
+  return typeof epoch === "number" && Number.isFinite(epoch) ? epoch : 0
+}
+
+const attemptKeyOf = (event: Event): string | undefined => {
+  const value = asRecord(event)?.attemptKey ?? asRecord(event)?.attempt
+  return typeof value === "string" ? value : undefined
+}
+
+const isConsequence = (event: Event): boolean =>
+  event.type === "ToolCalled" || event.type === "TurnCompleted" || event.type === "TurnFailed" || event.type === "OutputRejected"
+
+const metricOf = (usage: Usage | undefined, metric: UsageCoverageMetric): number | undefined =>
+  usage?.[metric]
+
+const subtotalOf = (parts: ReadonlyArray<Usage>): Usage => {
+  if (parts.length === 0) return {}
+  const errors = parts.flatMap((part) => part.accountingErrors ?? [])
+  const sumKnown = (metric: UsageCoverageMetric): number | undefined => {
+    let total = 0
+    let found = false
+    for (const part of parts) {
+      const value = metricOf(part, metric)
+      if (value !== undefined) {
+        const next = total + value
+        if (!Number.isFinite(next) || (metric.endsWith("Tokens") && !Number.isSafeInteger(next))) {
+          errors.push({ kind: "aggregation", message: `${metric} aggregation exceeded its numeric range` })
+          return undefined
+        }
+        total = next
+        found = true
+      }
+    }
+    return found ? total : undefined
+  }
+  const firstProvider = parts[0]?.provider
+  const firstModel = parts[0]?.model
+  const provider = parts.every((part) => part.provider === firstProvider) ? firstProvider : undefined
+  const model = parts.every((part) => part.model === firstModel) ? firstModel : undefined
+  const reports = parts.flatMap((part) => part.providerReports ?? [])
+  const adapters = parts.map((part) => part.usageAdapter).filter((adapter): adapter is UsageAdapterIdentity => adapter !== undefined)
+  const adapter = adapters.length > 0 && adapters.every((candidate) => candidate.id === adapters[0]!.id && candidate.version === adapters[0]!.version) && parts.every((part) => part.usageAdapter !== undefined)
+    ? adapters[0]
+    : undefined
+  const promptTokens = sumKnown("promptTokens")
+  const completionTokens = sumKnown("completionTokens")
+  const sumOptional = (metric: UsageCoverageMetric): number | undefined => sumKnown(metric)
+  const costUsd = sumKnown("costUsd")
+  return {
+    ...(promptTokens === undefined ? {} : { promptTokens }),
+    ...(completionTokens === undefined ? {} : { completionTokens }),
+    ...(["totalTokens", "cachedPromptTokens", "cacheWritePromptTokens", "reasoningTokens", "reportedCostUsd", "estimatedCostUsd"] as const).reduce<Record<string, number>>((result, metric) => {
+      const value = sumOptional(metric)
+      if (value !== undefined) result[metric] = value
+      return result
+    }, {}),
+    ...(costUsd === undefined ? {} : { costUsd }),
+    ...(provider === undefined ? {} : { provider }),
+    ...(model === undefined ? {} : { model }),
+    ...(adapter === undefined ? {} : { usageAdapter: adapter }),
+    ...(errors.length === 0 ? {} : { accountingErrors: errors }),
+    ...(reports.length === 0 ? {} : { providerReports: reports })
+  }
+}
+
+const validCoverageMetrics = (required: ReadonlyArray<UsageCoverageMetric> | undefined): ReadonlyArray<UsageCoverageMetric> => {
+  const metrics = required ?? DEFAULT_USAGE_COVERAGE_METRICS
+  if (metrics.length === 0 || new Set(metrics).size !== metrics.length || metrics.some((metric) => !["promptTokens", "completionTokens", "totalTokens", "cachedPromptTokens", "cacheWritePromptTokens", "reasoningTokens", "costUsd", "reportedCostUsd", "estimatedCostUsd"].includes(metric))) {
+    throw new TypeError("usage coverage required metrics must be a non-empty list of declared numeric usage metrics")
+  }
+  return metrics
+}
+
+const totalOf = <M extends ReadonlyArray<UsageCoverageMetric>>(observed: Usage, required: M, empty: boolean): CoverageTotal<M> => {
+  const total: Record<string, number> = {}
+  for (const metric of required) {
+    const value = observed[metric]
+    if (value === undefined && !empty) throw new Error(`coverage total is missing required metric ${metric}`)
+    total[metric] = value ?? 0
+  }
+  return total as CoverageTotal<M>
+}
+
+interface NativeEvidenceProjection {
+  readonly calls: ReadonlyArray<NativeCall>
+  readonly matched: ReadonlyArray<MatchedUsage>
+  readonly unresolved: ReadonlyArray<UsageCoverageUnresolved>
+}
+
+const nativeProjectionIn = (log: ReadonlyArray<Event>, turn: string): NativeEvidenceProjection => {
+  const calls: NativeCall[] = []
+  for (const [eventIndex, event] of log.entries()) {
+    if (event.type !== "ModelCalled" || !ofTurn(event, turn)) continue
+    const value = asRecord(event)!
+    calls.push({
+      eventIndex,
+      turn,
+      epoch: epochOf(event),
+      callId: String(value.callId ?? ""),
+      ordinal: typeof value.ordinal === "number" ? value.ordinal : undefined,
+      matched: false
+    })
+  }
+  const matched: MatchedUsage[] = []
+  const unresolved: UsageCoverageUnresolved[] = []
+  const matchedUsage = new Map<NativeCall, Usage | undefined>()
+  for (const [eventIndex, event] of log.entries()) {
+    if (!isConsequence(event) || !ofTurn(event, turn)) continue
+    const value = asRecord(event)!
+    const key = attemptKeyOf(event)
+    if (key === undefined && event.type !== "ToolCalled") continue
+    const epoch = epochOf(event)
+    const candidates = calls.filter((call) => call.eventIndex < eventIndex && call.epoch === epoch && (key === undefined || call.callId === key))
+    const call = candidates.at(-1)
+    if (call === undefined) {
+      if (key !== undefined) {
+        unresolved.push({ reason: "unmatched-consequence", turn, epoch, callId: key })
+      }
+      continue
+    }
+    const rawUsage = value.usage
+    const usage = rawUsage === undefined ? undefined : usageOf(rawUsage)
+    const previous = matchedUsage.get(call)
+    if (matchedUsage.has(call)) {
+      if (JSON.stringify(previous) !== JSON.stringify(usage)) {
+        unresolved.push({ reason: "duplicate-consequence", turn, epoch, callId: call.callId, ...(call.ordinal === undefined ? {} : { ordinal: call.ordinal }), message: "conflicting duplicate consequence" })
+      }
+      continue
+    }
+    call.matched = true
+    matchedUsage.set(call, usage)
+    matched.push({ call, eventIndex, usage })
+  }
+  return { calls, matched, unresolved }
+}
+
+// coverageIn projects only durable ModelCalled marks and their native consequences. A repeated
+// mark is a distinct occurrence, so a later terminal cannot settle an earlier crash (usage.test.ts,
+// "repeated native marks leave the earlier occurrence unresolved").
+export function coverageIn(log: ReadonlyArray<Event>, turn: string, options?: UsageCoverageOptions & { readonly required?: typeof DEFAULT_USAGE_COVERAGE_METRICS }): UsageCoverage
+export function coverageIn<const M extends ReadonlyArray<UsageCoverageMetric>>(log: ReadonlyArray<Event>, turn: string, options: UsageCoverageOptions & { readonly required: M }): UsageCoverage<M>
+export function coverageIn<M extends ReadonlyArray<UsageCoverageMetric>>(log: ReadonlyArray<Event>, turn: string, options: UsageCoverageOptions = {}): UsageCoverage<M> {
+  const required = validCoverageMetrics(options.required) as M
+  const projection = nativeProjectionIn(log, turn)
+  const { calls, matched } = projection
+  const unresolved: UsageCoverageUnresolved[] = [...projection.unresolved]
+  const missing: UsageCoverageGap[] = []
+  const evidence: Usage[] = []
+  for (const call of calls) {
+    const answer = matched.find((candidate) => candidate.call === call)
+    if (answer === undefined) {
+      missing.push({ reason: "missing-consequence", turn, epoch: call.epoch, callId: call.callId, ...(call.ordinal === undefined ? {} : { ordinal: call.ordinal }), metrics: required })
+      continue
+    }
+    if (answer.usage === undefined) {
+      missing.push({ reason: "missing-usage", turn, epoch: call.epoch, callId: call.callId, ...(call.ordinal === undefined ? {} : { ordinal: call.ordinal }), metrics: required })
+      continue
+    }
+    evidence.push(answer.usage)
+    const absent = required.filter((metric) => metricOf(answer.usage, metric) === undefined)
+    if (absent.length > 0) {
+      missing.push({ reason: "missing-metrics", turn, epoch: call.epoch, callId: call.callId, ...(call.ordinal === undefined ? {} : { ordinal: call.ordinal }), metrics: absent })
+    }
+    for (const error of answer.usage.accountingErrors ?? []) {
+      unresolved.push({ reason: "accounting-error", turn, epoch: call.epoch, callId: call.callId, ...(call.ordinal === undefined ? {} : { ordinal: call.ordinal }), message: error.message })
+    }
+  }
+  const observed = subtotalOf(evidence)
+  for (const error of observed.accountingErrors ?? []) {
+    if (error.kind === "aggregation") unresolved.push({ reason: "accounting-error", turn, epoch: 0, message: error.message })
+  }
+  const complete = missing.length === 0 && unresolved.length === 0 && required.every((metric) => calls.length === 0 || observed[metric] !== undefined)
+  if (complete) return { status: "complete", scope: USAGE_COVERAGE_SCOPE, observed, total: totalOf(observed, required, calls.length === 0), missing: [], unresolved: [] }
+  return { status: "incomplete", scope: USAGE_COVERAGE_SCOPE, observed, missing, unresolved }
+}
+
+const nativeUsagePartsIn = (log: ReadonlyArray<Event>, turn: string): ReadonlyArray<Usage> => {
+  const projection = nativeProjectionIn(log, turn)
+  const parts: Usage[] = projection.matched.flatMap((match) => {
+    if (match.usage === undefined) return [{}]
+    return match.usage.accountingErrors === undefined ? [match.usage] : [match.usage, {}]
+  })
+  for (const call of projection.calls) if (!call.matched) parts.push({})
+  for (const _unresolved of projection.unresolved) parts.push({})
+  return parts
+}
+
+// usageIn retains its compatibility shape while refusing an exact metric when native coverage
+// is incomplete. coverageIn exposes the observed subtotal and the reason for that uncertainty.
+export const usageIn = (log: ReadonlyArray<Event>, turn: string): Usage => {
+  const native = log.some((event) => event.type === "ModelCalled" && ofTurn(event, turn))
+  if (!native) {
+    return sumUsage(log.flatMap((event) => {
       if (!ofTurn(event, turn)) return []
       const carried = asRecord(event)?.usage
       return carried === undefined ? [] : [usageOf(carried)]
-    })
-  )
+    }))
+  }
+  return sumUsage(nativeUsagePartsIn(log, turn))
+}

--- a/packages/agent/src/inference/usage.ts
+++ b/packages/agent/src/inference/usage.ts
@@ -102,27 +102,28 @@ interface TokenMetrics {
 const tokensOf = (value: unknown): TokenMetrics | undefined => {
   const rec = asRecord(value)
   if (rec === undefined) return undefined
-  const prompt = firstNumber(rec, ["promptTokens", "prompt_tokens", "inputTokens", "input_tokens"])
+  const inclusivePrompt = firstNumber(rec, ["promptTokens", "prompt_tokens"])
+  const prompt = inclusivePrompt ?? firstNumber(rec, ["inputTokens", "input_tokens"])
   const completion = firstNumber(rec, ["completionTokens", "completion_tokens", "outputTokens", "output_tokens"])
   if (prompt === undefined && completion === undefined) return undefined
   const total = firstNumber(rec, ["totalTokens", "total_tokens"])
-  const exclusiveCached = firstNumber(rec, ["cacheReadInputTokens", "cache_read_input_tokens"])
+  const inputCached = firstNumber(rec, ["cacheReadInputTokens", "cache_read_input_tokens"])
   const cached =
-    exclusiveCached ??
+    inputCached ??
     firstNumber(rec, ["cachedPromptTokens", "cached_prompt_tokens", "cachedTokens", "cached_tokens"]) ??
     nestedNumber(rec, [
       ["promptTokensDetails", ["cachedTokens", "cached_tokens"]],
       ["prompt_tokens_details", ["cachedTokens", "cached_tokens"]],
       ["input_tokens_details", ["cachedTokens", "cached_tokens"]]
     ])
-  const exclusiveCacheWrite = firstNumber(rec, [
+  const inputCacheWrite = firstNumber(rec, [
     "cacheWriteInputTokens",
     "cache_write_input_tokens",
     "cacheCreationInputTokens",
     "cache_creation_input_tokens"
   ])
   const cacheWrite =
-    exclusiveCacheWrite ??
+    inputCacheWrite ??
     firstNumber(rec, ["cacheWritePromptTokens", "cache_write_prompt_tokens"]) ??
     nestedNumber(rec, [
       ["promptTokensDetails", ["cacheWriteTokens", "cache_write_tokens"]],
@@ -136,8 +137,10 @@ const tokensOf = (value: unknown): TokenMetrics | undefined => {
       ["completion_tokens_details", ["reasoningTokens", "reasoning_tokens"]],
       ["output_tokens_details", ["reasoningTokens", "reasoning_tokens"]]
     ])
-  const cacheBucketsWereExclusive = exclusiveCached !== undefined || exclusiveCacheWrite !== undefined
-  const exclusivePromptTokens = (exclusiveCached ?? 0) + (exclusiveCacheWrite ?? 0)
+  // inclusivePrompt includes cache buckets even when a gateway uses input-token cache field names (usage.test.ts, "gateway prompt totals already include cache creation").
+  const cacheBucketsWereExclusive =
+    inclusivePrompt === undefined && (inputCached !== undefined || inputCacheWrite !== undefined)
+  const exclusivePromptTokens = cacheBucketsWereExclusive ? (inputCached ?? 0) + (inputCacheWrite ?? 0) : 0
   const normalizedTotal =
     total === undefined || (total === 0 && (prompt ?? 0) + (completion ?? 0) > 0)
       ? undefined

--- a/packages/agent/src/inference/usage.ts
+++ b/packages/agent/src/inference/usage.ts
@@ -1,10 +1,6 @@
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import { turnOf } from "@clavia/tardigrade-code/execution/turns"
 
-// Usage is what one model attempt spent. The normalized fields support projections, while
-// providerReports preserve the metrics each provider returned for later normalization and
-// repricing (usage.test.ts, "raw provider metrics survive normalization and aggregation").
-
 export type CostSource = "provider" | "table"
 
 // ProviderUsageReport keeps one physical request's provider metrics and serving coordinates.
@@ -14,9 +10,10 @@ export interface ProviderUsageReport {
   readonly providerSpecific: unknown
 }
 
+// Usage carries raw reports and optional interpreted metrics; an omitted metric is unknown (usage.test.ts, "raw reports stay uninterpreted by default").
 export interface Usage {
-  readonly promptTokens: number
-  readonly completionTokens: number
+  readonly promptTokens?: number
+  readonly completionTokens?: number
   readonly totalTokens?: number
   readonly cachedPromptTokens?: number
   readonly cacheWritePromptTokens?: number
@@ -44,136 +41,49 @@ export interface ModelPricing {
   readonly cacheWritePromptUsdPerToken?: number
 }
 
+// ZERO_USAGE represents an empty set of attempts (usage.test.ts, "unknown is sticky, and mixed sources take the weaker label").
 export const ZERO_USAGE: Usage = { promptTokens: 0, completionTokens: 0 }
 
 const asRecord = (value: unknown): Record<string, unknown> | undefined =>
   value !== null && typeof value === "object" ? (value as Record<string, unknown>) : undefined
 
-const numberOf = (value: unknown): number | undefined => {
-  if (typeof value === "number" && Number.isFinite(value)) return value
-  if (typeof value === "string" && value !== "") {
-    const n = Number(value)
-    return Number.isFinite(n) ? n : undefined
+// UsageAdapter interprets one physical request under a caller-defined provider contract.
+export type UsageAdapter = (report: ProviderUsageReport) => Omit<Usage, "provider" | "model" | "providerReports"> | undefined
+
+const numberOf = (value: unknown, field: string): number | undefined => {
+  if (value === undefined) return undefined
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || (field.endsWith("Tokens") && !Number.isSafeInteger(value))) {
+    throw new TypeError(`usage.${field} must be a non-negative ${field.endsWith("Tokens") ? "safe integer" : "finite number"}`)
   }
-  return undefined
+  return value
 }
 
-const firstNumber = (rec: Record<string, unknown>, keys: ReadonlyArray<string>): number | undefined => {
-  for (const key of keys) {
-    const n = numberOf(rec[key])
-    if (n !== undefined) return n
-  }
-  return undefined
-}
-
-const nestedNumber = (
-  rec: Record<string, unknown>,
-  seats: ReadonlyArray<readonly [container: string, keys: ReadonlyArray<string>]>
-): number | undefined => {
-  for (const [container, keys] of seats) {
-    const nested = asRecord(rec[container])
-    if (nested === undefined) continue
-    const found = firstNumber(nested, keys)
-    if (found !== undefined) return found
-  }
-  return undefined
-}
-
-// costNumber reads a provider-billed dollar amount from a usage object. Gateways disagree on
-// the field name, so every common seat is checked; a table fill never writes these keys.
-export const costNumber = (value: unknown): number | undefined => {
-  const rec = asRecord(value)
-  if (rec === undefined) return undefined
-  const direct = firstNumber(rec, ["cost", "costUsd", "total_cost", "cost_usd"])
-  if (direct !== undefined) return direct
-  return costNumber(rec.gateway)
-}
-
-interface TokenMetrics {
-  readonly promptTokens: number
-  readonly completionTokens: number
-  readonly totalTokens?: number
-  readonly cachedPromptTokens?: number
-  readonly cacheWritePromptTokens?: number
-  readonly reasoningTokens?: number
-  readonly cacheBucketsWereExclusive?: true
-}
-
-const tokensOf = (value: unknown): TokenMetrics | undefined => {
-  const rec = asRecord(value)
-  if (rec === undefined) return undefined
-  const inclusivePrompt = firstNumber(rec, ["promptTokens", "prompt_tokens"])
-  const prompt = inclusivePrompt ?? firstNumber(rec, ["inputTokens", "input_tokens"])
-  const completion = firstNumber(rec, ["completionTokens", "completion_tokens", "outputTokens", "output_tokens"])
-  if (prompt === undefined && completion === undefined) return undefined
-  const total = firstNumber(rec, ["totalTokens", "total_tokens"])
-  const inputCached = firstNumber(rec, ["cacheReadInputTokens", "cache_read_input_tokens"])
-  const cached =
-    inputCached ??
-    firstNumber(rec, ["cachedPromptTokens", "cached_prompt_tokens", "cachedTokens", "cached_tokens"]) ??
-    nestedNumber(rec, [
-      ["promptTokensDetails", ["cachedTokens", "cached_tokens"]],
-      ["prompt_tokens_details", ["cachedTokens", "cached_tokens"]],
-      ["input_tokens_details", ["cachedTokens", "cached_tokens"]]
-    ])
-  const inputCacheWrite = firstNumber(rec, [
-    "cacheWriteInputTokens",
-    "cache_write_input_tokens",
-    "cacheCreationInputTokens",
-    "cache_creation_input_tokens"
-  ])
-  const cacheWrite =
-    inputCacheWrite ??
-    firstNumber(rec, ["cacheWritePromptTokens", "cache_write_prompt_tokens"]) ??
-    nestedNumber(rec, [
-      ["promptTokensDetails", ["cacheWriteTokens", "cache_write_tokens"]],
-      ["prompt_tokens_details", ["cacheWriteTokens", "cache_write_tokens"]],
-      ["input_tokens_details", ["cacheWriteTokens", "cache_write_tokens"]]
-    ])
-  const reasoning =
-    firstNumber(rec, ["reasoningTokens", "reasoning_tokens"]) ??
-    nestedNumber(rec, [
-      ["completionTokensDetails", ["reasoningTokens", "reasoning_tokens"]],
-      ["completion_tokens_details", ["reasoningTokens", "reasoning_tokens"]],
-      ["output_tokens_details", ["reasoningTokens", "reasoning_tokens"]]
-    ])
-  // inclusivePrompt includes cache buckets even when a gateway uses input-token cache field names (usage.test.ts, "gateway prompt totals already include cache creation").
-  const cacheBucketsWereExclusive =
-    inclusivePrompt === undefined && (inputCached !== undefined || inputCacheWrite !== undefined)
-  const exclusivePromptTokens = cacheBucketsWereExclusive ? (inputCached ?? 0) + (inputCacheWrite ?? 0) : 0
-  const normalizedTotal =
-    total === undefined || (total === 0 && (prompt ?? 0) + (completion ?? 0) > 0)
-      ? undefined
-      : total + exclusivePromptTokens
-  return {
-    promptTokens: (prompt ?? 0) + exclusivePromptTokens,
-    completionTokens: completion ?? 0,
-    ...(normalizedTotal === undefined ? {} : { totalTokens: normalizedTotal }),
-    ...(cached === undefined ? {} : { cachedPromptTokens: cached }),
-    ...(cacheWrite === undefined ? {} : { cacheWritePromptTokens: cacheWrite }),
-    ...(reasoning === undefined ? {} : { reasoningTokens: reasoning }),
-    ...(cacheBucketsWereExclusive ? { cacheBucketsWereExclusive: true as const } : {})
-  }
-}
-
+// costOf prices explicit token buckets and returns undefined when a count or required rate is unknown (usage.test.ts, "pricing requires explicit cache counts").
 export const costOf = (
   pricing: ModelPricing | undefined,
-  promptTokens: number,
-  completionTokens: number,
-  cachedPromptTokens: number = 0,
-  cacheWritePromptTokens: number = 0
+  promptTokens: number | undefined,
+  completionTokens: number | undefined,
+  cachedPromptTokens: number | undefined,
+  cacheWritePromptTokens: number | undefined
 ): number | undefined => {
-  if (pricing === undefined) return undefined
+  if (pricing === undefined || promptTokens === undefined || completionTokens === undefined || cachedPromptTokens === undefined || cacheWritePromptTokens === undefined) return undefined
+  for (const count of [promptTokens, completionTokens, cachedPromptTokens, cacheWritePromptTokens]) {
+    if (!Number.isSafeInteger(count) || count < 0) return undefined
+  }
+  for (const rate of [pricing.promptUsdPerToken, pricing.completionUsdPerToken, pricing.cachedPromptUsdPerToken ?? 0, pricing.cacheWritePromptUsdPerToken ?? 0]) {
+    if (!Number.isFinite(rate) || rate < 0) return undefined
+  }
   if (cachedPromptTokens > 0 && pricing.cachedPromptUsdPerToken === undefined) return undefined
   if (cacheWritePromptTokens > 0 && pricing.cacheWritePromptUsdPerToken === undefined) return undefined
   const uncachedPromptTokens = promptTokens - cachedPromptTokens - cacheWritePromptTokens
   if (uncachedPromptTokens < 0) return undefined
-  return (
+  const estimate = (
     uncachedPromptTokens * pricing.promptUsdPerToken +
     cachedPromptTokens * (pricing.cachedPromptUsdPerToken ?? 0) +
     cacheWritePromptTokens * (pricing.cacheWritePromptUsdPerToken ?? 0) +
     completionTokens * pricing.completionUsdPerToken
   )
+  return Number.isFinite(estimate) ? estimate : undefined
 }
 
 // priced projects a table independently from the reported bill. costUsd keeps its compatibility
@@ -216,73 +126,18 @@ export const priced = (usage: Usage, pricing?: ModelPricing): Usage => {
   }
 }
 
-// usageFrom builds spend from one provider reply. The first reported part is retained verbatim;
-// later normalized parts refine fields without replacing details that only the wire exposed.
-export const usageFrom = (
-  reported: unknown,
-  pricing?: ModelPricing,
-  stamp?: { readonly provider?: string; readonly model?: string },
-  providerMetrics?: unknown
-): Usage | undefined => {
-  const parts = Array.isArray(reported) ? reported : [reported]
-  let tokens: TokenMetrics | undefined
-  let billed: number | undefined
-  let raw: unknown = providerMetrics
-  for (const part of parts) {
-    if (raw === undefined && part !== undefined && part !== null) raw = part
-    const next = tokensOf(part)
-    if (next !== undefined) {
-      const keepExclusiveFold =
-        tokens?.cacheBucketsWereExclusive === true &&
-        next.cacheBucketsWereExclusive !== true &&
-        next.cachedPromptTokens === undefined &&
-        next.cacheWritePromptTokens === undefined
-      const totalTokens = keepExclusiveFold ? tokens?.totalTokens : (next.totalTokens ?? tokens?.totalTokens)
-      const cachedPromptTokens = next.cachedPromptTokens ?? tokens?.cachedPromptTokens
-      const cacheWritePromptTokens = next.cacheWritePromptTokens ?? tokens?.cacheWritePromptTokens
-      const reasoningTokens = next.reasoningTokens ?? tokens?.reasoningTokens
-      tokens =
-        tokens === undefined
-          ? next
-          : {
-              promptTokens: keepExclusiveFold ? tokens.promptTokens : next.promptTokens,
-              completionTokens: next.completionTokens,
-              ...(totalTokens === undefined ? {} : { totalTokens }),
-              ...(cachedPromptTokens === undefined ? {} : { cachedPromptTokens }),
-              ...(cacheWritePromptTokens === undefined ? {} : { cacheWritePromptTokens }),
-              ...(reasoningTokens === undefined ? {} : { reasoningTokens }),
-              ...(tokens.cacheBucketsWereExclusive === true || next.cacheBucketsWereExclusive === true
-                ? { cacheBucketsWereExclusive: true as const }
-                : {})
-            }
-    }
-    const cost = costNumber(part)
-    if (cost !== undefined) billed = cost
+// usageFrom preserves a raw report and applies an adapter only when the caller supplies one (usage.test.ts, "raw reports stay uninterpreted by default").
+export const usageFrom = (report: ProviderUsageReport, adapter?: UsageAdapter): Usage => {
+  if (asRecord(report) === undefined || !("providerSpecific" in report)) {
+    throw new TypeError("usageFrom requires a ProviderUsageReport with providerSpecific")
   }
-  if (tokens === undefined && billed === undefined && raw === undefined) return undefined
-  const usage: Usage = {
-    promptTokens: tokens?.promptTokens ?? 0,
-    completionTokens: tokens?.completionTokens ?? 0,
-    ...(tokens?.totalTokens === undefined ? {} : { totalTokens: tokens.totalTokens }),
-    ...(tokens?.cachedPromptTokens === undefined ? {} : { cachedPromptTokens: tokens.cachedPromptTokens }),
-    ...(tokens?.cacheWritePromptTokens === undefined ? {} : { cacheWritePromptTokens: tokens.cacheWritePromptTokens }),
-    ...(tokens?.reasoningTokens === undefined ? {} : { reasoningTokens: tokens.reasoningTokens }),
-    ...(stamp?.provider === undefined ? {} : { provider: stamp.provider }),
-    ...(stamp?.model === undefined ? {} : { model: stamp.model }),
-    ...(billed === undefined ? {} : { costUsd: billed, costSource: "provider" as const, reportedCostUsd: billed }),
-    ...(raw === undefined
-      ? {}
-      : {
-          providerReports: [
-            {
-              ...(stamp?.provider === undefined ? {} : { provider: stamp.provider }),
-              ...(stamp?.model === undefined ? {} : { model: stamp.model }),
-              providerSpecific: raw
-            }
-          ]
-        })
+  const { provider: _provider, model: _model, providerReports: _reports, ...metrics } = usageOf(adapter?.(report))
+  return {
+    ...metrics,
+    ...(report.provider === undefined ? {} : { provider: report.provider }),
+    ...(report.model === undefined ? {} : { model: report.model }),
+    providerReports: [report]
   }
-  return tokens === undefined ? usage : priced(usage, pricing)
 }
 
 const reportsOf = (value: unknown): ReadonlyArray<ProviderUsageReport> | undefined => {
@@ -303,22 +158,31 @@ const reportsOf = (value: unknown): ReadonlyArray<ProviderUsageReport> | undefin
   return reports.length === 0 ? undefined : reports
 }
 
+// usageOf reads the declared Usage schema without aliases or numeric coercion (usage.test.ts, "normalized metrics reject coercion and invalid numbers").
 export const usageOf = (value: unknown): Usage => {
   const carried = asRecord(value)
-  const costUsd = numberOf(carried?.costUsd)
+  if (value !== undefined && (carried === undefined || Array.isArray(value))) {
+    throw new TypeError("usage must be an object")
+  }
+  const costUsd = numberOf(carried?.costUsd, "costUsd")
   const source = carried?.costSource
+  if (source !== undefined && source !== "provider" && source !== "table") {
+    throw new TypeError("usage.costSource must be provider or table")
+  }
   const provider = carried?.provider
   const model = carried?.model
-  const reportedCostUsd = numberOf(carried?.reportedCostUsd)
-  const estimatedCostUsd = numberOf(carried?.estimatedCostUsd)
-  const totalTokens = numberOf(carried?.totalTokens)
-  const cachedPromptTokens = numberOf(carried?.cachedPromptTokens)
-  const cacheWritePromptTokens = numberOf(carried?.cacheWritePromptTokens)
-  const reasoningTokens = numberOf(carried?.reasoningTokens)
+  const reportedCostUsd = numberOf(carried?.reportedCostUsd, "reportedCostUsd")
+  const estimatedCostUsd = numberOf(carried?.estimatedCostUsd, "estimatedCostUsd")
+  const promptTokens = numberOf(carried?.promptTokens, "promptTokens")
+  const completionTokens = numberOf(carried?.completionTokens, "completionTokens")
+  const totalTokens = numberOf(carried?.totalTokens, "totalTokens")
+  const cachedPromptTokens = numberOf(carried?.cachedPromptTokens, "cachedPromptTokens")
+  const cacheWritePromptTokens = numberOf(carried?.cacheWritePromptTokens, "cacheWritePromptTokens")
+  const reasoningTokens = numberOf(carried?.reasoningTokens, "reasoningTokens")
   const providerReports = reportsOf(carried?.providerReports)
   return {
-    promptTokens: numberOf(carried?.promptTokens) ?? 0,
-    completionTokens: numberOf(carried?.completionTokens) ?? 0,
+    ...(promptTokens === undefined ? {} : { promptTokens }),
+    ...(completionTokens === undefined ? {} : { completionTokens }),
     ...(totalTokens === undefined ? {} : { totalTokens }),
     ...(cachedPromptTokens === undefined ? {} : { cachedPromptTokens }),
     ...(cacheWritePromptTokens === undefined ? {} : { cacheWritePromptTokens }),
@@ -343,8 +207,6 @@ const same = (a: string | undefined, b: string | undefined): string | undefined 
 
 export const sumUsage = (parts: ReadonlyArray<Usage>): Usage => {
   if (parts.length === 0) return ZERO_USAGE
-  let promptTokens = 0
-  let completionTokens = 0
   let costUsd = 0
   let known = true
   let source: CostSource | undefined
@@ -353,8 +215,6 @@ export const sumUsage = (parts: ReadonlyArray<Usage>): Usage => {
   const providerReports: ProviderUsageReport[] = []
   let first = true
   for (const part of parts) {
-    promptTokens += part.promptTokens
-    completionTokens += part.completionTokens
     providerReports.push(...(part.providerReports ?? []))
     if (part.costUsd === undefined) known = false
     else costUsd += part.costUsd
@@ -378,6 +238,8 @@ export const sumUsage = (parts: ReadonlyArray<Usage>): Usage => {
     }
     return total
   }
+  const promptTokens = sumKnown((part) => part.promptTokens)
+  const completionTokens = sumKnown((part) => part.completionTokens)
   const totalTokens = sumKnown((part) => part.totalTokens)
   const cachedPromptTokens = sumKnown((part) => part.cachedPromptTokens)
   const cacheWritePromptTokens = sumKnown((part) => part.cacheWritePromptTokens)
@@ -385,8 +247,8 @@ export const sumUsage = (parts: ReadonlyArray<Usage>): Usage => {
   const reportedCostUsd = sumKnown((part) => part.reportedCostUsd)
   const estimatedCostUsd = sumKnown((part) => part.estimatedCostUsd)
   return {
-    promptTokens,
-    completionTokens,
+    ...(promptTokens === undefined ? {} : { promptTokens }),
+    ...(completionTokens === undefined ? {} : { completionTokens }),
     ...(totalTokens === undefined ? {} : { totalTokens }),
     ...(cachedPromptTokens === undefined ? {} : { cachedPromptTokens }),
     ...(cacheWritePromptTokens === undefined ? {} : { cacheWritePromptTokens }),

--- a/packages/agent/src/log/events.ts
+++ b/packages/agent/src/log/events.ts
@@ -42,15 +42,18 @@ export const OutputPolicy = Schema.Struct({
   fallback: Schema.optional(Schema.Unknown)
 })
 
-// ToolCalled is the ask: the turn calls a tool. `callId` correlates the return to this call.
+// ToolCalled is the consequence of one native inference invocation. `attemptKey` correlates the
+// consequence to its ModelCalled mark when the binding recorded it (usage.test.ts, "native
+// consequences match by attempt key").
 export const ToolCalled = Schema.Struct({
   type: Schema.Literal("ToolCalled"),
   callId: Schema.String,
   name: Schema.String,
   arguments: Schema.Unknown,
-  // The spend of the attempt this call answered (packages/agent/src/inference/usage.ts). An empty object
-  // is an attempt with unreported spend; an absent field is an event no attempt produced.
+  // The spend of the attempt this call answered (packages/agent/src/inference/usage.ts). An empty
+  // object is an attempt with unreported spend, and an absent field is an unresolved receipt.
   usage: Schema.optional(Schema.Unknown),
+  attemptKey: Schema.optional(Schema.String),
   endpoint: Schema.optional(Endpoint),
   // A tool call may be one response in a turn that declares final output. Its effective mode is
   // recorded here so replay does not decide how this attempt ran from a current capability
@@ -455,6 +458,7 @@ export const toolCalled = (
     readonly callId: string
     readonly name: string
     readonly arguments?: unknown
+    readonly attemptKey?: string
     readonly mode?: unknown
   } & EpochStamp
 ): Event => ({ type: "ToolCalled", ...fields }) as Event

--- a/packages/agent/src/runtime/composition.test.ts
+++ b/packages/agent/src/runtime/composition.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { Context, Effect, Layer, Ref } from "effect"
+import { Context, Deferred, Effect, Fiber, Layer, Ref } from "effect"
 import { KeyValueStore } from "effect/unstable/persistence"
 import { FetchHttpClient } from "effect/unstable/http"
 import type { Event } from "@clavia/tardigrade-core/log/event"
@@ -28,6 +28,7 @@ import { requestPermissionMethod } from "../actor/permission"
 import { receive } from "./turn"
 import { Infer, NativeOutputSupport, type InferRequest } from "../inference/contract"
 import { selectedModelOf } from "../inference/machine"
+import { coverageIn } from "../inference/usage"
 
 const TEST_MODEL = { models: { default: { provider: "test", model_id: "test-model" }, allow: "*" } } as const
 
@@ -197,6 +198,28 @@ describe("infer component", () => {
     expect(events.filter((event) => event.type === "ModelCalled").map((event) =>
       (event as { readonly model?: unknown }).model
     )).toEqual([recorded, recorded])
+  })
+
+  test("a native ModelCalled left by a crashed machine is incomplete coverage", async () => {
+    const entered = await Effect.runPromise(Deferred.make<void>())
+    const mind = Layer.succeed(Infer, {
+      react: () => Deferred.succeed(entered, undefined).pipe(Effect.andThen(Effect.never))
+    })
+    const agent = assembled(infer([nativeOutput], TEST_MODEL))
+    const events = await run(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.forkChild(settleActor(agent))
+        yield* Deferred.await(entered)
+        yield* Fiber.interrupt(fiber)
+        return yield* readLog
+      }),
+      Layer.mergeAll(memoryLog([{ type: "MessageReceived", id: "m1", text: "crash", at: 1 }]), mind, noRouter, KeyValueStore.layerMemory)
+    )
+    expect(events.some((event) => event.type === "ModelCalled")).toBe(true)
+    expect(coverageIn(events, "m1")).toMatchObject({
+      status: "incomplete",
+      missing: [{ reason: "missing-consequence" }]
+    })
   })
 
   test("a historical model string durably fails its turn", async () => {

--- a/platform/cloudflare/src/worker.ts
+++ b/platform/cloudflare/src/worker.ts
@@ -405,8 +405,7 @@ const modelLayer = (
         provider: request.model.provider,
         ...(selectedModel.provider.region === undefined ? {} : { region: selectedModel.provider.region }),
         contextWindowTokens: selectedModel.contextWindowTokens,
-        ...(selectedModel.metadata.maxOutputTokens === undefined ? {} : { maxOutputTokens: selectedModel.metadata.maxOutputTokens }),
-        ...(selectedModel.metadata.pricing === undefined ? {} : { pricing: selectedModel.metadata.pricing })
+        ...(selectedModel.metadata.maxOutputTokens === undefined ? {} : { maxOutputTokens: selectedModel.metadata.maxOutputTokens })
       }, adapters, observer === undefined ? {} : { observer })
       return Effect.flatMap(Infer, (model) => model.react(request, key, signal)).pipe(Effect.provide(selected))
     }

--- a/platform/model/src/adapter.ts
+++ b/platform/model/src/adapter.ts
@@ -2,7 +2,7 @@ import type { ModelMessage, StreamChunk, Tool } from "@tanstack/ai"
 import type { InferenceIdentity } from "tardie/inference/observer"
 import type { ModelRequest } from "tardie/inference/request"
 import type { OutputMode } from "tardie/output/contract"
-import type { ModelPricing } from "tardie/inference/usage"
+import type { UsageAdapter } from "tardie/inference/usage"
 import type { ModelProtocol } from "./directory"
 import type { OutputCapability } from "./output"
 
@@ -34,8 +34,10 @@ export interface ModelConfig {
   readonly stream?: Partial<StreamBounds>
   // output states the endpoint guarantee; an omitted value promises no native contract support.
   readonly output?: OutputCapability
-  // pricing supplies the estimate used when the provider reports tokens without a billed cost.
-  readonly pricing?: ModelPricing
+  // usageAdapter interprets raw reports for this binding; omission preserves raw data with unknown metrics (model.test.ts, "raw usage stays uninterpreted without an adapter").
+  readonly usageAdapter?: UsageAdapter
+  // pricing is rejected at construction; explicit adapters can call priced (model.test.ts, "implicit pricing is rejected before dispatch").
+  readonly pricing?: never
   // throttleRetryDelaysMs sets the backoff bases and its length sets the retry count.
   readonly throttleRetryDelaysMs?: ReadonlyArray<number>
   // retryAfterJitterMs adds a random wait to a provider Retry-After value.

--- a/platform/model/src/adapter.ts
+++ b/platform/model/src/adapter.ts
@@ -2,7 +2,7 @@ import type { ModelMessage, StreamChunk, Tool } from "@tanstack/ai"
 import type { InferenceIdentity } from "tardie/inference/observer"
 import type { ModelRequest } from "tardie/inference/request"
 import type { OutputMode } from "tardie/output/contract"
-import type { UsageAdapter } from "tardie/inference/usage"
+import type { UsageAdapterSelection } from "tardie/inference/usage"
 import type { ModelProtocol } from "./directory"
 import type { OutputCapability } from "./output"
 
@@ -35,7 +35,7 @@ export interface ModelConfig {
   // output states the endpoint guarantee; an omitted value promises no native contract support.
   readonly output?: OutputCapability
   // usageAdapter interprets raw reports for this binding; omission preserves raw data with unknown metrics (model.test.ts, "raw usage stays uninterpreted without an adapter").
-  readonly usageAdapter?: UsageAdapter
+  readonly usageAdapter?: UsageAdapterSelection
   // pricing is rejected at construction; explicit adapters can call priced (model.test.ts, "implicit pricing is rejected before dispatch").
   readonly pricing?: never
   // throttleRetryDelaysMs sets the backoff bases and its length sets the retry count.

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -12,6 +12,8 @@ import {
   VALIDATE_ONCE_FALLBACK,
   NATIVE_MODE,
   type InferDelta,
+  priced,
+  type UsageAdapter,
   type InferenceIdentity
 } from "tardie"
 
@@ -521,7 +523,7 @@ describe("infer end to end", () => {
     // The whole refusal is reported, assembled from its deltas.
     expect((action as { error?: string }).error).toContain("I cannot help with that.")
     // A refusal still spent the prompt, so the turn records what it cost, and who served it.
-    expect(action.usage).toMatchObject({ promptTokens: 11 })
+    expect(action.usage?.providerReports?.[0]?.providerSpecific).toEqual({ prompt_tokens: 11, completion_tokens: 0 })
     expect(action.endpoint).toMatchObject({ provider: "openai", model: "m" })
     expect(action.mode).toEqual({ kind: "native", name: "native" })
   })
@@ -737,176 +739,161 @@ describe("ephemeral inference deltas", () => {
 
 const usageChunk = (usage: Record<string, unknown>) => ({ id: "u", choices: [], usage })
 
-describe("infer: cost provenance", () => {
+describe("infer: explicit usage", () => {
+  test("implicit pricing is rejected before dispatch", () => {
+    expect(() => testInfer({
+      baseUrl: "https://model.test", apiKey: "k", model: "m",
+      // @ts-expect-error automatic pricing requires an explicit usage adapter
+      pricing: { promptUsdPerToken: 0.001, completionUsdPerToken: 0.002 }
+    })).toThrow("call priced inside usageAdapter")
+  })
+
   const okText = [
     { id: "r", choices: [{ index: 0, delta: { role: "assistant", content: "ok" } }] },
     { id: "r", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }
   ]
-  const table = { promptUsdPerToken: 0.001, completionUsdPerToken: 0.002 }
+  const run = (config: Partial<import("./model").ModelConfig>) => Effect.runPromise(
+    Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
+      Effect.provide(testInfer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "m", ...config }))
+    ) as Effect.Effect<Action>
+  )
 
-  test("a billed cost is provider, an omitted cost is table or unknown", async () => {
-    const rawUsage = {
-      prompt_tokens: 10,
-      completion_tokens: 4,
-      total_tokens: 14,
-      prompt_tokens_details: { cached_tokens: 4 },
-      completion_tokens_details: { reasoning_tokens: 2 },
-      cost: 0
+  test("raw usage stays uninterpreted without an adapter", async () => {
+    const raw = {
+      prompt_tokens: 137973, completion_tokens: 188, total_tokens: 138161,
+      cache_creation_input_tokens: 137970, prompt_tokens_details: { cached_tokens: 0 }, cost: 0
     }
-    const billed = await Effect.runPromise(
-      Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
-        Effect.provide(
-          testInfer({
-            baseUrl: "https://model.test/v1",
-            apiKey: "k",
-            model: "test-model",
-            provider: "openai",
-            pricing: { ...table, cachedPromptUsdPerToken: 0.0001 },
-            fetch: (async () =>
-              sse([{ ...okText[0], usage: null }, okText[1], usageChunk(rawUsage)])) as unknown as typeof globalThis.fetch
-          })
-        )
-      ) as Effect.Effect<Action>
-    )
-    expect(billed).toMatchObject({
-      kind: "complete",
-      output: "ok",
-      usage: {
-        promptTokens: 10,
-        completionTokens: 4,
-        totalTokens: 14,
-        cachedPromptTokens: 4,
-        reasoningTokens: 2,
-        costUsd: 0,
-        costSource: "provider",
-        reportedCostUsd: 0,
-        estimatedCostUsd: 6 * 0.001 + 4 * 0.0001 + 4 * 0.002,
-        provider: "openai",
-        model: "test-model",
-        providerReports: [{ provider: "openai", model: "test-model", providerSpecific: rawUsage }]
-      }
-    })
-
-    const filled = await Effect.runPromise(
-      Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
-        Effect.provide(
-          testInfer({
-            baseUrl: "https://model.test/v1",
-            apiKey: "k",
-            model: "test-model",
-            provider: "openai",
-            pricing: table,
-            fetch: (async () => sse([...okText, usageChunk({ prompt_tokens: 10, completion_tokens: 4 })])) as unknown as typeof globalThis.fetch
-          })
-        )
-      ) as Effect.Effect<Action>
-    )
-    expect(filled.usage).toEqual({
-      promptTokens: 10,
-      completionTokens: 4,
-      costUsd: 10 * 0.001 + 4 * 0.002,
-      costSource: "table",
-      estimatedCostUsd: 10 * 0.001 + 4 * 0.002,
-      provider: "openai",
-      model: "test-model",
-      providerReports: [
-        {
-          provider: "openai",
-          model: "test-model",
-          providerSpecific: { prompt_tokens: 10, completion_tokens: 4 }
-        }
-      ]
-    })
-
-    const unknown = await Effect.runPromise(
-      Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
-        Effect.provide(
-          testInfer({
-            baseUrl: "https://model.test/v1",
-            apiKey: "k",
-            model: "test-model",
-            fetch: (async () => sse(okText)) as unknown as typeof globalThis.fetch
-          })
-        )
-      ) as Effect.Effect<Action>
-    )
-    expect(unknown).toMatchObject({ kind: "complete", output: "ok" })
+    const action = await run({ fetch: (async () => sse([...okText, usageChunk(raw)])) })
+    expect(action).toMatchObject({ kind: "complete", output: "ok" })
+    expect(action.usage).toEqual({ provider: "test", model: "m", providerReports: [{ provider: "test", model: "m", providerSpecific: raw }] })
   })
 
-  test("gateway cache creation is counted once through the streamed adapter", async () => {
-    const rawUsage = {
-      prompt_tokens: 137973,
-      completion_tokens: 188,
-      total_tokens: 138161,
-      cache_creation_input_tokens: 137970,
-      prompt_tokens_details: { cached_tokens: 0 },
-      cost: 0
-    }
-    const action = await Effect.runPromise(
-      Effect.flatMap(Infer, (model) =>
-        model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))
-      ).pipe(
-        Effect.provide(
-          testInfer({
-            baseUrl: "https://model.test/v1",
-            apiKey: "k",
-            model: "test-model",
-            pricing: { ...table, cacheWritePromptUsdPerToken: 0.00125 },
-            fetch: (async () => sse([...okText, usageChunk(rawUsage)])) as unknown as typeof globalThis.fetch
-          })
-        )
-      ) as Effect.Effect<Action>
-    )
-    expect(action).toMatchObject({
-      kind: "complete",
-      usage: {
-        promptTokens: 137973,
-        completionTokens: 188,
-        totalTokens: 138161,
-        cachedPromptTokens: 0,
-        cacheWritePromptTokens: 137970,
-        costUsd: 0,
-        costSource: "provider",
-        reportedCostUsd: 0,
-        estimatedCostUsd: 3 * 0.001 + 137970 * 0.00125 + 188 * 0.002,
-        providerReports: [{ providerSpecific: rawUsage }]
+  test("an explicit adapter owns token and cost interpretation", async () => {
+    const raw = { input: 10, output: 4, cached: 6, paid: 0 }
+    const action = await run({
+      fetch: (async () => sse([...okText, usageChunk(raw)])),
+      usageAdapter: (report) => {
+        expect(report).toEqual({ provider: "test", model: "m", providerSpecific: raw })
+        return priced({
+          promptTokens: raw.input, completionTokens: raw.output, cachedPromptTokens: raw.cached,
+          cacheWritePromptTokens: 0, reportedCostUsd: raw.paid
+        }, { promptUsdPerToken: 0.001, completionUsdPerToken: 0.002, cachedPromptUsdPerToken: 0.0001 })
       }
     })
-  })
-
-  test("multiple wire usage objects remain one lossless physical report", async () => {
-    const detailed = {
-      prompt_tokens: 10,
-      completion_tokens: 4,
-      total_tokens: 14,
-      prompt_tokens_details: { cached_tokens: 4 },
-      completion_tokens_details: { reasoning_tokens: 2 }
-    }
-    const billed = { prompt_tokens: 10, completion_tokens: 4, total_tokens: 14, cost: 0 }
-    const action = await Effect.runPromise(
-      Effect.flatMap(Infer, (model) =>
-        model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))
-      ).pipe(
-        Effect.provide(
-          testInfer({
-            baseUrl: "https://model.test/v1",
-            apiKey: "k",
-            model: "test-model",
-            provider: "openai",
-            pricing: { ...table, cachedPromptUsdPerToken: 0.0001 },
-            fetch: (async () =>
-              sse([...okText, usageChunk(detailed), usageChunk(billed)])) as unknown as typeof globalThis.fetch
-          })
-        )
-      ) as Effect.Effect<Action>
-    )
     expect(action.usage).toMatchObject({
-      cachedPromptTokens: 4,
-      reasoningTokens: 2,
-      reportedCostUsd: 0,
-      estimatedCostUsd: 6 * 0.001 + 4 * 0.0001 + 4 * 0.002,
-      providerReports: [{ provider: "openai", model: "test-model", providerSpecific: [detailed, billed] }]
+      promptTokens: 10, completionTokens: 4, cachedPromptTokens: 6, costUsd: 0,
+      costSource: "provider", reportedCostUsd: 0, estimatedCostUsd: 4 * 0.001 + 6 * 0.0001 + 4 * 0.002
     })
+    expect(action.usage?.providerReports?.[0]?.providerSpecific).toEqual(raw)
+  })
+
+  test("multiple wire observations stay intact for a caller reducer", async () => {
+    const first = { prompt_tokens: 10, completion_tokens: 2 }
+    const last = { prompt_tokens: 10, completion_tokens: 4, cost: 0 }
+    const action = await run({
+      fetch: (async () => sse([...okText, usageChunk(first), usageChunk(last)])),
+      usageAdapter: (report) => {
+        expect(report.providerSpecific).toEqual([first, last])
+        return { promptTokens: 10, completionTokens: 4 }
+      }
+    })
+    expect(action.usage?.promptTokens).toBe(10)
+    expect(action.usage?.completionTokens).toBe(4)
+    expect(action.usage?.providerReports?.[0]?.providerSpecific).toEqual([first, last])
+  })
+
+  test("an adapter error preserves raw data and never retries the request", async () => {
+    for (const usageAdapter of [
+      () => { throw new Error("timeout in custom usage parser") },
+      () => ({ promptTokens: NaN })
+    ] satisfies UsageAdapter[]) {
+      let calls = 0
+      let translations = 0
+      const raw = { future_units: 3 }
+      const action = await run({
+        fetch: (async () => { calls++; return sse([...okText, usageChunk(raw)]) }),
+        usageAdapter: () => { translations++; return usageAdapter() },
+        sleep: async () => {}
+      })
+      expect(calls).toBe(1)
+      expect(translations).toBe(1)
+      expect(action.kind).toBe("fail")
+      expect("error" in action && action.error).toContain("usage adapter failed")
+      expect(action.usage).toEqual({ provider: "test", model: "m", providerReports: [{ provider: "test", model: "m", providerSpecific: raw }] })
+    }
+  })
+
+  test("a missing retry report keeps token and cost totals unknown", async () => {
+    let calls = 0
+    const raw = { prompt_tokens: 10, completion_tokens: 4 }
+    const action = await run({
+      fetch: (async () => calls++ === 0
+        ? new Response("busy", { status: 429 })
+        : sse([...okText, usageChunk(raw)])),
+      usageAdapter: () => ({ promptTokens: 10, completionTokens: 4, costUsd: 1 }),
+      throttleRetryDelaysMs: [0], sleep: async () => {}
+    })
+    expect(calls).toBe(2)
+    expect(action.kind).toBe("complete")
+    expect(action.usage).toEqual({ providerReports: [{ provider: "test", model: "m", providerSpecific: raw }] })
+  })
+
+  test("partial usage survives a stream failure", async () => {
+    const raw = { prompt_tokens: 10 }
+    const encoder = new TextEncoder()
+    let reads = 0
+    const action = await run({
+      fetch: (async () => new Response(new ReadableStream({
+        async pull(controller) {
+          if (reads++ === 0) controller.enqueue(encoder.encode(`data: ${JSON.stringify(usageChunk(raw))}\n\n`))
+          else {
+            await new Promise((resolve) => setTimeout(resolve, 0))
+            controller.error(new Error("stream ended unexpectedly"))
+          }
+        }
+      }), { headers: { "content-type": "text/event-stream" } })),
+      throttleRetryDelaysMs: []
+    })
+    expect(action.kind).toBe("fail")
+    expect(action.usage?.providerReports?.[0]?.providerSpecific).toEqual(raw)
+    expect(action.usage?.completionTokens).toBeUndefined()
+  })
+
+  test("protocol envelopes preserve raw usage without SDK fallback", async () => {
+    const input = { input_tokens: 3, cache_creation_input_tokens: 10 }
+    const output = { output_tokens: 4 }
+    const converse = { inputTokens: 3, outputTokens: 4, cacheReadInputTokens: 10 }
+    for (const [protocol, response, reported, expected] of [
+      ["anthropic-messages", sse([{ type: "message_start", message: { usage: input } }, { type: "message_delta", usage: output }]), undefined, [input, output]],
+      ["openai-responses", sse([{ type: "response.completed", response: { usage: { ...input, ...output } } }]), undefined, { ...input, ...output }],
+      ["bedrock-converse", new Response("{}"), converse, converse],
+      ["openai-chat-completions", new Response("{}"), undefined, undefined]
+    ] as const) {
+      const adapter: ModelAdapter = {
+        id: "fixture", protocols: [protocol],
+        start: (context) => ({
+          reportedUsage: () => reported,
+          stream: {
+            async *[Symbol.asyncIterator]() {
+              await (await context.fetch("https://model.test")).text()
+              yield { type: "TEXT_MESSAGE_START", messageId: "s", role: "assistant", timestamp: 1 } as never
+              yield { type: "TEXT_MESSAGE_CONTENT", messageId: "s", delta: "ok", timestamp: 2 } as never
+              yield { type: "TEXT_MESSAGE_END", messageId: "s", timestamp: 3 } as never
+              yield { type: "RUN_FINISHED", timestamp: 4, usage: { promptTokens: 999, completionTokens: 999 } } as never
+            }
+          }
+        })
+      }
+      const action = await Effect.runPromise(
+        Effect.flatMap(Infer, (model) => model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
+          Effect.provide(infer({ baseUrl: "https://model.test", apiKey: "k", provider: "p", model: "m", protocol, contextWindowTokens: 128_000, fetch: (async () => response) }, modelAdapters(adapter)))
+        ) as Effect.Effect<Action>
+      )
+      expect(action.kind).toBe("complete")
+      expect(action.usage?.providerReports?.[0]?.providerSpecific).toEqual(expected)
+      expect(action.usage?.promptTokens).toBeUndefined()
+      expect(action.usage?.completionTokens).toBeUndefined()
+    }
   })
 })
 
@@ -1215,7 +1202,11 @@ describe("truncation", () => {
       model: "m",
       baseUrl: "https://x",
       apiKey: "k",
-      fetch: fetchImpl as never
+      fetch: fetchImpl as never,
+      usageAdapter: (report) => {
+        const raw = report.providerSpecific as { prompt_tokens: number; completion_tokens: number; cost: number }
+        return { promptTokens: raw.prompt_tokens, completionTokens: raw.completion_tokens, costUsd: raw.cost, reportedCostUsd: raw.cost, costSource: "provider" }
+      }
     })
     const action = await Effect.runPromise(
       Effect.flatMap(Infer, (i) => i.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))).pipe(
@@ -1283,8 +1274,6 @@ describe("truncation", () => {
       ) as Effect.Effect<Action>
     )
     expect(routed.usage).toMatchObject({
-      costUsd: 0.002,
-      costSource: "provider",
       provider: "DeepInfra",
       model: "meta-llama/llama-3.1-70b-instruct"
     })

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -833,6 +833,47 @@ describe("infer: cost provenance", () => {
     expect(unknown).toMatchObject({ kind: "complete", output: "ok" })
   })
 
+  test("gateway cache creation is counted once through the streamed adapter", async () => {
+    const rawUsage = {
+      prompt_tokens: 137973,
+      completion_tokens: 188,
+      total_tokens: 138161,
+      cache_creation_input_tokens: 137970,
+      prompt_tokens_details: { cached_tokens: 0 },
+      cost: 0
+    }
+    const action = await Effect.runPromise(
+      Effect.flatMap(Infer, (model) =>
+        model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "go", at: 1 }]))
+      ).pipe(
+        Effect.provide(
+          testInfer({
+            baseUrl: "https://model.test/v1",
+            apiKey: "k",
+            model: "test-model",
+            pricing: { ...table, cacheWritePromptUsdPerToken: 0.00125 },
+            fetch: (async () => sse([...okText, usageChunk(rawUsage)])) as unknown as typeof globalThis.fetch
+          })
+        )
+      ) as Effect.Effect<Action>
+    )
+    expect(action).toMatchObject({
+      kind: "complete",
+      usage: {
+        promptTokens: 137973,
+        completionTokens: 188,
+        totalTokens: 138161,
+        cachedPromptTokens: 0,
+        cacheWritePromptTokens: 137970,
+        costUsd: 0,
+        costSource: "provider",
+        reportedCostUsd: 0,
+        estimatedCostUsd: 3 * 0.001 + 137970 * 0.00125 + 188 * 0.002,
+        providerReports: [{ providerSpecific: rawUsage }]
+      }
+    })
+  })
+
   test("multiple wire usage objects remain one lossless physical report", async () => {
     const detailed = {
       prompt_tokens: 10,

--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -11,6 +11,7 @@ import {
   repairFallback,
   VALIDATE_ONCE_FALLBACK,
   NATIVE_MODE,
+  OPENAI_CHAT_COMPLETIONS_USAGE_V1,
   type InferDelta,
   priced,
   type UsageAdapter,
@@ -758,6 +759,18 @@ describe("infer: explicit usage", () => {
     ) as Effect.Effect<Action>
   )
 
+  test("an invalid adapter descriptor fails construction before fetch", () => {
+    let calls = 0
+    expect(() => testInfer({
+      baseUrl: "https://model.test/v1",
+      apiKey: "k",
+      model: "m",
+      fetch: (async () => { calls++; return sse([]) }),
+      usageAdapter: { id: 1, version: "1", adapt: () => ({}) } as never
+    })).toThrow("non-empty string id")
+    expect(calls).toBe(0)
+  })
+
   test("raw usage stays uninterpreted without an adapter", async () => {
     const raw = {
       prompt_tokens: 137973, completion_tokens: 188, total_tokens: 138161,
@@ -766,6 +779,30 @@ describe("infer: explicit usage", () => {
     const action = await run({ fetch: (async () => sse([...okText, usageChunk(raw)])) })
     expect(action).toMatchObject({ kind: "complete", output: "ok" })
     expect(action.usage).toEqual({ provider: "test", model: "m", providerReports: [{ provider: "test", model: "m", providerSpecific: raw }] })
+  })
+
+  test("the named OpenAI Chat Completions adapter works through the model binding", async () => {
+    const raw = {
+      prompt_tokens: 10,
+      completion_tokens: 4,
+      total_tokens: 14,
+      prompt_tokens_details: { cached_tokens: 2, cache_write_tokens: 1 },
+      completion_tokens_details: { reasoning_tokens: 1 }
+    }
+    const action = await run({
+      fetch: (async () => sse([...okText, usageChunk(raw)])),
+      usageAdapter: OPENAI_CHAT_COMPLETIONS_USAGE_V1
+    })
+    expect(action).toMatchObject({ kind: "complete", output: "ok" })
+    expect(action.usage).toMatchObject({
+      promptTokens: 10,
+      completionTokens: 4,
+      totalTokens: 14,
+      cachedPromptTokens: 2,
+      cacheWritePromptTokens: 1,
+      reasoningTokens: 1,
+      usageAdapter: { id: "openai/chat-completions-usage", version: "1" }
+    })
   })
 
   test("an explicit adapter owns token and cost interpretation", async () => {
@@ -817,10 +854,33 @@ describe("infer: explicit usage", () => {
       })
       expect(calls).toBe(1)
       expect(translations).toBe(1)
-      expect(action.kind).toBe("fail")
-      expect("error" in action && action.error).toContain("usage adapter failed")
-      expect(action.usage).toEqual({ provider: "test", model: "m", providerReports: [{ provider: "test", model: "m", providerSpecific: raw }] })
+      expect(action).toMatchObject({ kind: "complete", output: "ok" })
+      expect(action.usage).toEqual({
+        provider: "test",
+        model: "m",
+        providerReports: [{ provider: "test", model: "m", providerSpecific: raw }],
+        accountingErrors: [{ kind: "adapter", message: expect.any(String) }]
+      })
     }
+  })
+
+  test("a named adapter error preserves descriptor provenance on valid output", async () => {
+    const descriptor = {
+      id: "test/usage-contract",
+      version: "3",
+      adapt: () => { throw new Error("contract mismatch") }
+    }
+    const raw = { future_units: 3 }
+    const action = await run({
+      fetch: (async () => sse([...okText, usageChunk(raw)])),
+      usageAdapter: descriptor
+    })
+    expect(action).toMatchObject({ kind: "complete", output: "ok" })
+    expect(action.usage).toMatchObject({
+      usageAdapter: { id: descriptor.id, version: descriptor.version },
+      accountingErrors: [{ kind: "adapter", message: "contract mismatch" }],
+      providerReports: [{ providerSpecific: raw }]
+    })
   })
 
   test("a missing retry report keeps token and cost totals unknown", async () => {

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -26,7 +26,7 @@ import {
   fallbackSystemFor
 } from "./output"
 import type { OutputMode } from "tardie/output/contract"
-import { sumUsage, usageFrom, type Usage } from "tardie/inference/usage"
+import { sumUsage, usageFrom, usageWithAccountingError, validateUsageAdapterSelection, type Usage } from "tardie/inference/usage"
 import type {
   ModelAdapterRegistry,
   ModelConfig,
@@ -188,7 +188,6 @@ export const DEFAULT_RETRY_AFTER_JITTER_MS = 1_000
 // isRetryableFailure recognizes status-bearing provider failures and flattened transport errors.
 // The latter have no HTTP response metadata (model.test.ts, "infer: transient retry").
 const isRetryableFailure = (e: unknown): boolean => {
-  if (e instanceof UsageAdapterError) return false
   const err = e as { status?: unknown; statusCode?: unknown; message?: unknown }
   const status = typeof err.status === "number" ? err.status : typeof err.statusCode === "number" ? err.statusCode : undefined
   if (status === 429 || (status !== undefined && status >= 500)) return true
@@ -533,8 +532,6 @@ const failed = <E extends Error>(error: E, usage: Usage | undefined, endpoint: A
 const spentOf = (parts: ReadonlyArray<Usage>, missed: boolean): Usage | undefined =>
   parts.length === 0 ? undefined : sumUsage(missed ? [...parts, {}] : parts)
 
-class UsageAdapterError extends Error {}
-
 // infer provides NativeOutputSupport in its layer type only for a statically known native capability that accepts tools.
 export const infer = <const C extends ModelConfig>(
   config: C,
@@ -545,6 +542,7 @@ export const infer = <const C extends ModelConfig>(
   if ("pricing" in config) {
     throw new TypeError("ModelConfig.pricing is unsupported; call priced inside usageAdapter")
   }
+  validateUsageAdapterSelection(config.usageAdapter)
   if (!Number.isSafeInteger(config.contextWindowTokens) || config.contextWindowTokens <= 0) {
     throw new Error(`contextWindowTokens must be a positive integer, got ${config.contextWindowTokens}`)
   }
@@ -628,11 +626,18 @@ export const infer = <const C extends ModelConfig>(
       try {
         return { usage: usageFrom(report, config.usageAdapter), endpoint, wire }
       } catch (error) {
-        throw failed(
-          new UsageAdapterError(`usage adapter failed: ${error instanceof Error ? error.message : String(error)}`),
-          usageFrom(report),
-          endpoint
-        )
+        // Interpretation is accounting, so a malformed report cannot erase an otherwise valid
+        // model answer. The raw report and typed error stay on the consequence for a later
+        // coverage projection to mark incomplete (model.test.ts, "an adapter error preserves the
+        // model output and raw evidence").
+        const message = error instanceof Error ? error.message : String(error)
+        return {
+          usage: {
+            ...usageWithAccountingError(report, config.usageAdapter, message)
+          },
+          endpoint,
+          wire
+        }
       }
     }
     try {

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -4,7 +4,6 @@ import {
   type ModelMessage,
   type ProcessorResult,
   type StreamChunk,
-  type TokenUsage,
   type Tool,
   type ToolCall
 } from "@tanstack/ai"
@@ -189,6 +188,7 @@ export const DEFAULT_RETRY_AFTER_JITTER_MS = 1_000
 // isRetryableFailure recognizes status-bearing provider failures and flattened transport errors.
 // The latter have no HTTP response metadata (model.test.ts, "infer: transient retry").
 const isRetryableFailure = (e: unknown): boolean => {
+  if (e instanceof UsageAdapterError) return false
   const err = e as { status?: unknown; statusCode?: unknown; message?: unknown }
   const status = typeof err.status === "number" ? err.status : typeof err.statusCode === "number" ? err.statusCode : undefined
   if (status === 429 || (status !== undefined && status >= 500)) return true
@@ -329,10 +329,8 @@ interface Wire {
   readonly refusal?: string
 }
 
-// captureWire reads the last `usage` object (and provenance) off an SSE (or JSON) body. The
-// OpenAI-compat adapter normalizes tokens and drops extra keys; a gateway's billed dollar
-// lives on those keys (packages/agent/src/inference/usage.ts, costNumber).
-const captureWire = async (reader: BodyReader): Promise<Wire | undefined> => {
+// captureWire preserves usage reports in response order, including partial streams (model.test.ts, "partial usage survives a stream failure").
+const captureWire = async (reader: BodyReader, protocol: ModelConfig["protocol"]): Promise<Wire | undefined> => {
   const chunks: Uint8Array[] = []
   try {
     for (;;) {
@@ -352,9 +350,15 @@ const captureWire = async (reader: BodyReader): Promise<Wire | undefined> => {
     return undefined
   }
   const wireOf = (parsed: { usage?: unknown; provider?: unknown; model?: unknown }): Wire => {
+    const envelope = parsed as { type?: string; response?: { usage?: unknown }; message?: { usage?: unknown } }
+    const usage = protocol === "openai-responses"
+      ? envelope.response?.usage ?? parsed.usage
+      : protocol === "anthropic-messages" && envelope.type === "message_start"
+        ? envelope.message?.usage
+        : parsed.usage
     const refusal = refusalOf(parsed as never)
     return {
-      ...(parsed.usage === undefined || parsed.usage === null ? {} : { usage: parsed.usage }),
+      ...(usage === undefined || usage === null ? {} : { usage }),
       ...(typeof parsed.provider === "string" ? { provider: parsed.provider } : {}),
       ...(typeof parsed.model === "string" ? { model: parsed.model } : {}),
       ...(refusal === undefined ? {} : { refusal })
@@ -393,6 +397,7 @@ const withCapture = (
   base: FetchImpl | undefined,
   key: string | undefined,
   sink: { promise: Promise<Wire | undefined>; reader?: BodyReader },
+  protocol: ModelConfig["protocol"],
   signal?: AbortSignal
 ): FetchImpl => {
   const inner = withKey(base, key) ?? ((input, init) => globalThis.fetch(input, init))
@@ -409,23 +414,10 @@ const withCapture = (
     const [live, copy] = res.body.tee()
     const reader = copy.getReader()
     sink.reader = reader
-    sink.promise = captureWire(reader).catch(() => undefined)
+    sink.promise = captureWire(reader, protocol).catch(() => undefined)
     return new Response(live, { status: res.status, statusText: res.statusText, headers: res.headers })
   }
 }
-
-const tapTokens = (
-  stream: AsyncIterable<StreamChunk>,
-  into: { tokens?: TokenUsage }
-): AsyncIterable<StreamChunk> => ({
-  async *[Symbol.asyncIterator]() {
-    for await (const chunk of stream) {
-      const tokens = (chunk as { usage?: TokenUsage }).usage
-      if (tokens !== undefined) into.tokens = tokens
-      yield chunk
-    }
-  }
-})
 
 interface DeltaDelivery {
   readonly offer: (delta: InferDelta) => Effect.Effect<boolean>
@@ -538,24 +530,10 @@ const carriesEndpoint = (e: unknown): boolean => endpointOn(e) !== undefined
 const failed = <E extends Error>(error: E, usage: Usage | undefined, endpoint: AttemptEndpoint): E =>
   Object.assign(error, { usage, endpoint })
 
-const spentOf = (parts: ReadonlyArray<Usage>, missed: boolean): Usage | undefined => {
-  if (parts.length === 0) return undefined
-  const summed = sumUsage(parts)
-  if (!missed) return summed
-  return {
-    promptTokens: summed.promptTokens,
-    completionTokens: summed.completionTokens,
-    ...(summed.totalTokens === undefined ? {} : { totalTokens: summed.totalTokens }),
-    ...(summed.cachedPromptTokens === undefined ? {} : { cachedPromptTokens: summed.cachedPromptTokens }),
-    ...(summed.cacheWritePromptTokens === undefined
-      ? {}
-      : { cacheWritePromptTokens: summed.cacheWritePromptTokens }),
-    ...(summed.reasoningTokens === undefined ? {} : { reasoningTokens: summed.reasoningTokens }),
-    ...(summed.provider === undefined ? {} : { provider: summed.provider }),
-    ...(summed.model === undefined ? {} : { model: summed.model }),
-    ...(summed.providerReports === undefined ? {} : { providerReports: summed.providerReports })
-  }
-}
+const spentOf = (parts: ReadonlyArray<Usage>, missed: boolean): Usage | undefined =>
+  parts.length === 0 ? undefined : sumUsage(missed ? [...parts, {}] : parts)
+
+class UsageAdapterError extends Error {}
 
 // infer provides NativeOutputSupport in its layer type only for a statically known native capability that accepts tools.
 export const infer = <const C extends ModelConfig>(
@@ -564,6 +542,9 @@ export const infer = <const C extends ModelConfig>(
   options: ModelInferOptions = {}
 ): Layer.Layer<Infer | NativeOutputProvided<C>> => {
   assertSupportedBun()
+  if ("pricing" in config) {
+    throw new TypeError("ModelConfig.pricing is unsupported; call priced inside usageAdapter")
+  }
   if (!Number.isSafeInteger(config.contextWindowTokens) || config.contextWindowTokens <= 0) {
     throw new Error(`contextWindowTokens must be a positive integer, got ${config.contextWindowTokens}`)
   }
@@ -609,12 +590,11 @@ export const infer = <const C extends ModelConfig>(
     const sink: { promise: Promise<Wire | undefined>; reader?: BodyReader } = {
       promise: Promise.resolve(undefined)
     }
-    const held: { tokens?: TokenUsage } = {}
     const attemptController = new AbortController()
     const attemptSignal = signal === undefined
       ? attemptController.signal
       : AbortSignal.any([signal, attemptController.signal])
-    const fetcher = withCapture(config.fetch, keyForRung, sink, attemptSignal)
+    const fetcher = withCapture(config.fetch, keyForRung, sink, config.protocol, attemptSignal)
     const fallbackSystem = fallbackSystemFor(req.output, mode)
     const attempt = selectedAdapter.start({
       config,
@@ -637,25 +617,27 @@ export const infer = <const C extends ModelConfig>(
       // the true split; the configured stamp covers a wire that stays silent.
       const reportedUsage = attempt.reportedUsage?.()
       const providerMetrics = wire?.usageReports ?? (reportedUsage === undefined ? [] : [reportedUsage])
-      const usage = usageFrom(
-        [...providerMetrics, held.tokens],
-        config.pricing,
-        {
-          ...stampOf(config),
-          ...(wire?.provider === undefined ? {} : { provider: wire.provider }),
-          ...(wire?.model === undefined ? {} : { model: wire.model })
-        },
-        providerMetrics.length === 0
-          ? undefined
-          : providerMetrics.length === 1
-            ? providerMetrics[0]
-            : providerMetrics
-      )
-      return { usage, endpoint: endpointOf(config, wire), wire }
+      const endpoint = endpointOf(config, wire)
+      if (providerMetrics.length === 0) return { usage: undefined, endpoint, wire }
+      const report = {
+        ...stampOf(config),
+        ...(wire?.provider === undefined ? {} : { provider: wire.provider }),
+        ...(wire?.model === undefined ? {} : { model: wire.model }),
+        providerSpecific: providerMetrics.length === 1 ? providerMetrics[0] : providerMetrics
+      }
+      try {
+        return { usage: usageFrom(report, config.usageAdapter), endpoint, wire }
+      } catch (error) {
+        throw failed(
+          new UsageAdapterError(`usage adapter failed: ${error instanceof Error ? error.message : String(error)}`),
+          usageFrom(report),
+          endpoint
+        )
+      }
     }
     try {
       const normalized = observed(
-        tapTokens(bounded(attempt.stream, bounds), held),
+        bounded(attempt.stream, bounds),
         delivery,
         identity,
         key,
@@ -780,7 +762,7 @@ export const infer = <const C extends ModelConfig>(
               const billed = served(withSpend(action, spentOf(parts, missed)), endpoint)
               return req.output === undefined ? billed : { ...billed, mode }
             }
-            remember(usage, isTruncated(e) || usage !== undefined)
+            remember(usage, true)
             if (isTruncated(e)) {
               if (rung + 1 < ladder.length) {
                 rung += 1
@@ -856,8 +838,12 @@ export const infer = <const C extends ModelConfig>(
         if (action.usage.provider !== undefined) {
           yield* Effect.annotateCurrentSpan("gen_ai.provider.name", action.usage.provider)
         }
-        yield* Effect.annotateCurrentSpan("gen_ai.usage.input_tokens", action.usage.promptTokens)
-        yield* Effect.annotateCurrentSpan("gen_ai.usage.output_tokens", action.usage.completionTokens)
+        if (action.usage.promptTokens !== undefined) {
+          yield* Effect.annotateCurrentSpan("gen_ai.usage.input_tokens", action.usage.promptTokens)
+        }
+        if (action.usage.completionTokens !== undefined) {
+          yield* Effect.annotateCurrentSpan("gen_ai.usage.output_tokens", action.usage.completionTokens)
+        }
         if (action.usage.cachedPromptTokens !== undefined) {
           yield* Effect.annotateCurrentSpan("gen_ai.usage.cache_read.input_tokens", action.usage.cachedPromptTokens)
         }


### PR DESCRIPTION
Provider usage schemas disagree about cache counts, reasoning counts, and prices. Automatic interpretation can double-count tokens, while summing only received usage can hide an inference invocation whose receipt never arrived. This change preserves raw evidence by default and supplies explicit interpretation and coverage tools so applications can assess accounting independently of task completion.

- Add an explicitly selected, versioned OpenAI Chat Completions usage adapter and retain custom adapter support. Validate counts and subset relationships without guessing gateway pricing or adding cache and reasoning tokens twice.
- Preserve raw reports and record accounting errors when interpretation fails, while retaining otherwise valid model output.
- Add typed coverage over recorded inference invocations, with required metrics, observed subtotals, identified evidence gaps, and exact totals available only for complete coverage.
- Keep missing evidence unknown in usage aggregation, including interrupted invocations and retries, and distinguish reported charges from explicit estimates.
- Document the supported adapter, accounting coverage, and the boundary between recorded invocation evidence and physical HTTP execution.

The default preserves raw usage without interpreting it. Model bindings reject automatic pricing. Applications explicitly select the usage contract and required metrics, then choose whether incomplete accounting pauses collection or prevents publication. The coverage helper does not certify that every physical HTTP request was durably recorded before submission, and cannot retrieve a provider receipt that is unavailable.

Validation: all 69 repository gate tasks pass. The focused adapter, aggregation, coverage, inference-composition and model-binding run passes 118 tests with 349 assertions; compile-time checks cover literal and dynamically selected metrics. Tests cover missing receipts, interrupted invocations, duplicate evidence, retries, invalid counts, and interpretation errors without repeated generation.
