### PR TITLE
fix(server): preserve supplied root identifiers

### DIFF
--- a/apps/cli/src/dev.test.ts
+++ b/apps/cli/src/dev.test.ts
@@ -288,7 +288,7 @@ describe("tdg dev", () => {
       layersFor: layeredLayersFor
     })
 
-    expect(state).toEqual({ status: "completed", output: "main:ag.root:hello" })
+    expect(state).toEqual({ status: "completed", output: "main:root:hello" })
   })
 
   test("a local push refreshes the actor registry", async () => {

--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -798,7 +798,7 @@ describe("the event stream", () => {
       const delta: InferDelta = {
         actor: "agent",
         instance: "main",
-        thread: "ag.alpha",
+        thread: "alpha",
         turn: "turn-1",
         logicalAttempt: "turn-1/infer/0",
         physicalAttempt: "physical-1",
@@ -993,7 +993,7 @@ describe("the tree", () => {
       expect(childId).toMatch(/^[0-9a-f]{64}$/)
       expect(childEvents.some(({ event }) => event.type === "TurnCompleted")).toBe(true)
       expect(childEvents[0]!.event).toMatchObject({
-        address: { thread: childId }, parent: { thread: "ag.root" }
+        address: { thread: childId }, parent: { thread: "root" }
       })
       await birth(base, childId, { id: "follow-up", text: "hello again" })
       return {

--- a/apps/server/src/host.test.ts
+++ b/apps/server/src/host.test.ts
@@ -361,8 +361,8 @@ describe("the threads service", () => {
     )
 
     expect(deltas.map(({ thread, model, blockIndex, sequence, text }) => ({ thread, model, blockIndex, sequence, text }))).toEqual([
-      { thread: "ag.stream", model: streamedModel, blockIndex: 0, sequence: 0, text: "hel" },
-      { thread: "ag.stream", model: streamedModel, blockIndex: 0, sequence: 1, text: "lo" }
+      { thread: "stream", model: streamedModel, blockIndex: 0, sequence: 0, text: "hel" },
+      { thread: "stream", model: streamedModel, blockIndex: 0, sequence: 1, text: "lo" }
     ])
   })
 

--- a/apps/server/src/thread-compat.test.ts
+++ b/apps/server/src/thread-compat.test.ts
@@ -13,8 +13,13 @@ test("legacy public names retain their stored addresses", async () => {
   expect(publicThreadId("ag.root")).toBe("root")
   expect(publicThreadId("ag.ag.root")).toBe("ag.root")
   expect(await Effect.runPromise(resolveThreadId("root", exists("ag.root")))).toBe("ag.root")
-  expect(await Effect.runPromise(resolveThreadId("root", exists()))).toBe("ag.root")
   expect(await Effect.runPromise(resolveThreadId("ag.root", exists("ag.ag.root")))).toBe("ag.ag.root")
+})
+
+test("new thread ids are stored as supplied", async () => {
+  for (const id of ["root", "ag.root", "thread_abc", "one:two", "三"]) {
+    expect(await Effect.runPromise(resolveThreadId(id, exists()))).toBe(id)
+  }
 })
 
 test("registered opaque thread ids round-trip without a required prefix", async () => {

--- a/apps/server/src/thread-compat.ts
+++ b/apps/server/src/thread-compat.ts
@@ -7,7 +7,7 @@ const LEGACY_PREFIX = "ag."
 export const publicThreadId = (thread: string): string =>
   thread.startsWith(LEGACY_PREFIX) ? thread.slice(LEGACY_PREFIX.length) : thread
 
-// resolveThreadId resolves registered public names and retains legacy placement for new HTTP threads (thread-compat.test.ts).
+// resolveThreadId resolves existing legacy names and preserves supplied IDs for new threads (thread-compat.test.ts).
 export const resolveThreadId = (id: string, exists: (thread: string) => Effect.Effect<boolean>): Effect.Effect<string> =>
   Effect.gen(function*() {
     const legacy = `${LEGACY_PREFIX}${id}`
@@ -16,7 +16,7 @@ export const resolveThreadId = (id: string, exists: (thread: string) => Effect.E
     if (registeredLegacy && registeredExact) {
       return yield* Effect.die(new Error(`ambiguous public thread id ${JSON.stringify(id)}: both stored addresses exist`))
     }
-    return registeredLegacy || !registeredExact ? legacy : id
+    return registeredLegacy ? legacy : id
   })
 
 // withLegacyThreadIds adapts public operations without changing stored addresses or actor selection (thread-compat.test.ts).

--- a/packages/agent/src/packages/agents.test.ts
+++ b/packages/agent/src/packages/agents.test.ts
@@ -498,21 +498,6 @@ describe("a child is named by its parent address, run, and call", () => {
     ])
   })
 
-  test("a child spawning with its parent's turn and call ids cannot address itself", async () => {
-    const root = parseThreadAddress("mem:main:ag.root")
-    const events: Event[] = [threadCreated(root, undefined, 0), turn("m1"), called("c1", "m1")]
-    const sent: Array<Sent> = []
-    await Effect.runPromise(background("child", "c1").pipe(Effect.provide(liveEnv(events, sent))))
-    const child = sent[0]!.link.target as ThreadAddress
-    const childEvents: Event[] = [
-      threadCreated(child, { parent: root, depth: 1 }, 0),
-      turn("m1"), called("c1", "m1")
-    ]
-    await Effect.runPromise(background("grandchild", "c1").pipe(Effect.provide(liveEnv(childEvents, sent))))
-    expect(new Set([root.thread, ...threads(sent)]).size).toBe(3)
-    expect(sent[1]?.lineage).toMatchObject({ parent: child, depth: 2 })
-  })
-
   test("a turn-scoped legacy creation record retains its address on replay", async () => {
     const events: Event[] = [
       threadCreated(parseThreadAddress("mem:main:ag.root"), undefined, 0),

--- a/packages/core/src/thread/identity.test.ts
+++ b/packages/core/src/thread/identity.test.ts
@@ -16,13 +16,6 @@ const coordinates = fc.record({
 
 // Safety properties await derivation; the test runner's timeout also checks completion on sampled inputs.
 describe("child identity safety", () => {
-  test("replay stability: identical coordinates retain their identity", async () => {
-    await fc.assert(fc.asyncProperty(coordinates, async ({ parent, child }) => {
-      const id = await childThreadId({ parent, child })
-      expect(await childThreadId({ parent: { ...parent }, child })).toBe(id)
-    }))
-  })
-
   test("replay stability: the persisted encoding matches a fixed digest", async () => {
     const id = await childThreadId({ parent, child: childKeyOf("step") })
     expect(String(id)).toBe("ddc9895cb08a2f469846924b97c3b997dfb82ed5f6d1ff9c04174d89af7dcb27")
@@ -46,30 +39,37 @@ describe("child identity safety", () => {
     expect(new Set(ids).size).toBe(pairs.length)
   })
 
-  test("root separation: distinct roots have disjoint descendants at every equal depth", async () => {
+  test("tree separation: distinct nodes have distinct addresses across roots and depths", async () => {
     await fc.assert(fc.asyncProperty(
       coordinates,
       fc.constantFrom("actor", "instance", "thread"),
-      fc.array(fc.uniqueArray(opaqueString, { minLength: 1, maxLength: 3 }), { minLength: 2, maxLength: 4 }),
-      async ({ parent }, coordinate, levels) => {
-        const otherRoot = { ...parent, [coordinate]: parent[coordinate] + "x" }
-        let left = [parent]
-        let right = [otherRoot]
-        for (const keys of levels) {
-          const descend = (parents: typeof left) => Promise.all(parents.flatMap((address) =>
-            keys.map(async (key) => ({
-              ...address,
-              thread: await childThreadId({ parent: address, child: childKeyOf(key) })
-            }))
-          ))
-          const next = await Promise.all([descend(left), descend(right)])
-          left = next[0]
-          right = next[1]
-          const leftIds = new Set(left.map((address) => address.thread))
-          const rightIds = new Set(right.map((address) => address.thread))
-          expect(leftIds.size).toBe(left.length)
-          expect(rightIds.size).toBe(right.length)
-          for (const id of rightIds) expect(leftIds.has(id)).toBe(false)
+      fc.uniqueArray(opaqueString, { minLength: 1, maxLength: 3 }),
+      fc.tuple(fc.integer({ min: 2, max: 4 }), fc.integer({ min: 2, max: 4 })),
+      async ({ parent }, coordinate, keys, depths) => {
+        // root uses a non-hex name to exclude aliases with generated descendants.
+        const root = { ...parent, thread: `root:${parent.thread}` }
+        const roots = [root, { ...root, [coordinate]: root[coordinate] + "x" }]
+        const addressKey = (address: typeof root) => JSON.stringify([address.actor, address.instance, address.thread])
+        const seen = new Set(roots.map(addressKey))
+        expect(seen.size).toBe(2)
+        for (const [index, origin] of roots.entries()) {
+          let frontier = [origin]
+          for (let depth = 0; depth < depths[index]!; depth++) {
+            const descendants = await Promise.all(frontier.flatMap((address) =>
+              keys.map(async (key) => {
+                const coordinates = { parent: address, child: childKeyOf(key) }
+                const thread = await childThreadId(coordinates)
+                expect(await childThreadId({ ...coordinates, parent: { ...address } })).toBe(thread)
+                return { ...address, thread }
+              })
+            ))
+            for (const descendant of descendants) {
+              const identity = addressKey(descendant)
+              expect(seen.has(identity)).toBe(false)
+              seen.add(identity)
+            }
+            frontier = descendants
+          }
         }
       }
     ))

--- a/packages/host/src/host.properties.test.ts
+++ b/packages/host/src/host.properties.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test"
+import fc from "fast-check"
+import { formatThreadAddress, threadAddressOf } from "@clavia/tardigrade-core/communication/endpoint"
+import type { Event } from "@clavia/tardigrade-core/log/event"
+import { threadCreatedOf } from "@clavia/tardigrade-core/thread"
+import { createHost } from "./host"
+
+const ownerId = fc.stringMatching(/^[a-z][a-z0-9_-]{0,12}$/)
+const threadId = fc.string({ minLength: 1, maxLength: 40 })
+
+test("root addresses isolate logs across actors, instances, and threads while repeated addresses reuse a log", () => {
+  fc.assert(fc.property(ownerId, ownerId, threadId, (actor, instance, thread) => {
+    const roots = [thread, `${thread}x`]
+    const owners = [actor, `${actor}x`].flatMap((actorName) =>
+      [instance, `${instance}x`].map((actorInstance) => ({
+        actorName,
+        actorInstance,
+        host: createHost({ actorName, actorInstance, actorFor: () => undefined })
+      }))
+    )
+    const records = owners.flatMap(({ actorName, actorInstance, host }) => roots.map((thread) => {
+      const address = threadAddressOf(actorName, actorInstance, thread)
+      const wire = formatThreadAddress(address)
+      const first: Event = { type: "MessageReceived", id: "same-call", text: wire, at: 1 }
+      expect(host.self(thread)).toBe(wire)
+      host.commitRoot(wire, first)
+      return { host, address, wire, first }
+    }))
+    expect(new Set(records.map(({ wire }) => wire)).size).toBe(records.length)
+
+    for (const { host, address, first } of records) {
+      const events = host.read(address.thread)
+      expect(threadCreatedOf(events)).toMatchObject({ address, depth: 0 })
+      expect(events.filter((event) => event.type === "MessageReceived")).toEqual([first])
+    }
+    for (const [index, { host, address, wire, first }] of records.entries()) {
+      host.commitRoot(formatThreadAddress({ ...address }), { ...first })
+      host.commitRoot(wire, { type: "MessageReceived", id: "next-call", text: wire, at: 2 })
+      for (const [otherIndex, record] of records.entries()) {
+        const events = record.host.read(record.address.thread)
+        expect(events.filter((event) => event.type === "ThreadCreated")).toHaveLength(1)
+        expect(events.filter((event) => event.type === "MessageReceived")).toEqual([
+          record.first,
+          ...(otherIndex <= index
+            ? [{ type: "MessageReceived", id: "next-call", text: record.wire, at: 2 }]
+            : [])
+        ])
+      }
+    }
+  }))
+})

--- a/platform/cloudflare/test/actor.workers.ts
+++ b/platform/cloudflare/test/actor.workers.ts
@@ -19,7 +19,7 @@ import { plaintextEventCodec } from "../src/storage"
 
 const authorization = { authorization: "Bearer workers-test-token" }
 const WORKER_INTEGRATION_TIMEOUT_MILLIS = 15_000
-const threadObjectNameOf = (thread: string): string => JSON.stringify(["echo", "main", `ag.${thread}`])
+const threadObjectNameOf = (thread: string): string => JSON.stringify(["echo", "main", thread])
 const controlStub = () => (env as Env).ACTORS.getByName(JSON.stringify(["echo", "main"]))
 const threadStub = (thread: string) => (env as Env).THREADS.getByName(threadObjectNameOf(thread))
 const alarm = (thread: string) =>
@@ -102,7 +102,7 @@ describe("cloudflare actor", () => {
   })
 
   test("commit observers see only published durable heads", async () => {
-    const commits = await runInDurableObject(threadStub("commit-observer"), async (_instance, state) => {
+    const commits = await runInDurableObject(threadStub("ag.commit-observer"), async (_instance, state) => {
       const seen: Array<number> = []
       let observed = () => {}
       const firstObserved = new Promise<void>((resolve) => { observed = resolve })
@@ -135,7 +135,7 @@ describe("cloudflare actor", () => {
   })
 
   test("incremental commits decode only the creation record and new tail", async () => {
-    const decoded = await runInDurableObject(threadStub("incremental-ingress"), async (_instance, state) => {
+    const decoded = await runInDurableObject(threadStub("ag.incremental-ingress"), async (_instance, state) => {
       const batches: Array<number> = []
       const host = await createCloudflareThreadHost({
         storage: state.storage,
@@ -171,7 +171,7 @@ describe("cloudflare actor", () => {
   })
 
   test("a cold empty thread reports rest before settlement", async () => {
-    const resting = await runInDurableObject(threadStub("cold-resting"), async (_instance, state) => {
+    const resting = await runInDurableObject(threadStub("ag.cold-resting"), async (_instance, state) => {
       const host = await createCloudflareThreadHost({
         storage: state.storage,
         actorName: "echo",
@@ -189,7 +189,7 @@ describe("cloudflare actor", () => {
 
   test("method-less actors retain outgoing call deadlines", async () => {
     const deadlineAt = Date.now() - 1
-    const result = await runInDurableObject(threadStub("method-less-deadline"), async (_instance, state) => {
+    const result = await runInDurableObject(threadStub("ag.method-less-deadline"), async (_instance, state) => {
       const host = await createCloudflareThreadHost({
         storage: state.storage,
         actorName: "echo",
@@ -225,7 +225,7 @@ describe("cloudflare actor", () => {
     const target = { actor: "echo", instance: "main", thread: "ag.creation-cache" }
     const source = { actor: "echo", instance: "main", thread: "ag.requested-parent" }
     const storedParent = { actor: "echo", instance: "main", thread: "ag.stored-parent" }
-    const result = await runInDurableObject(threadStub("creation-cache"), async (_instance, state) => {
+    const result = await runInDurableObject(threadStub("ag.creation-cache"), async (_instance, state) => {
       let injected = false
       const host = await createCloudflareThreadHost({
         storage: state.storage,
@@ -459,7 +459,7 @@ describe("cloudflare actor", () => {
       call: "workers-smoke",
       deadlineAt: expect.any(Number)
     })
-    expect(await methodState("root", "workers-smoke")).toEqual({ status: "completed", output: "workers:ag.root:1:Run in workerd." })
+    expect(await methodState("root", "workers-smoke")).toEqual({ status: "completed", output: "workers:root:1:Run in workerd." })
     expect(await alarm("root")).toBeNull()
     const client = makeActorClient({
       baseUrl: "http://test",
@@ -475,7 +475,7 @@ describe("cloudflare actor", () => {
         deadlineAt: expect.any(Number)
       })
     expect(await client.methodState("main", "root", "echo", "workers-smoke"))
-      .toEqual({ status: "completed", output: "workers:ag.root:1:Run in workerd." })
+      .toEqual({ status: "completed", output: "workers:root:1:Run in workerd." })
     const events = await SELF.fetch("http://test/v1/actors/main/threads/root/events", { headers: authorization })
     expect((await events.json() as ReadonlyArray<{ readonly event: { readonly type: string } }>).map((row) => row.event.type)).toEqual([
       "ThreadCreated",
@@ -507,8 +507,8 @@ describe("cloudflare actor", () => {
     ])
     const first = await methodState("application-a", "application-a")
     const second = await methodState("application-b", "application-b")
-    expect(first).toEqual({ status: "completed", output: "workers:ag.application-a:1:first" })
-    expect(second).toEqual({ status: "completed", output: "workers:ag.application-b:1:second" })
+    expect(first).toEqual({ status: "completed", output: "workers:application-a:1:first" })
+    expect(second).toEqual({ status: "completed", output: "workers:application-b:1:second" })
     expect(threadStub("application-a").id.equals(threadStub("application-b").id)).toBe(false)
     const firstEvents = await runInDurableObject(threadStub("application-a"), (_instance, state) =>
       state.storage.sql.exec<{ count: number }>("SELECT COUNT(*) AS count FROM events").toArray()
@@ -546,7 +546,7 @@ describe("cloudflare actor", () => {
     expect(accepted.status).toBe(202)
     expect(await methodState("sealed", "sealed-call")).toEqual({
       status: "completed",
-      output: "workers:ag.sealed:1:classified prompt"
+      output: "workers:sealed:1:classified prompt"
     })
     const repeated = await SELF.fetch("http://test/v1/actors/main/threads/sealed/methods/echo/calls/sealed-call", {
       method: "PUT",
@@ -556,7 +556,7 @@ describe("cloudflare actor", () => {
     expect(repeated.status).toBe(202)
     expect(await methodState("sealed", "sealed-call")).toEqual({
       status: "completed",
-      output: "workers:ag.sealed:1:classified prompt"
+      output: "workers:sealed:1:classified prompt"
     })
 
     const response = await SELF.fetch("http://test/v1/actors/main/threads/sealed/events", { headers: authorization })
@@ -699,7 +699,7 @@ describe("cloudflare actor", () => {
         children: []
       }]
     })
-    const childEvents = await threadStub("directory-child").events("ag.directory-child")
+    const childEvents = await threadStub("ag.directory-child").events("ag.directory-child")
     expect(childEvents.map((event) => event.type)).toEqual(["ThreadCreated", "MessageReceived"])
     const actorEvents = await runInDurableObject(directory, (_instance, state) =>
       state.storage.sql.exec<{ event: string }>("SELECT event FROM events ORDER BY seq").toArray()
@@ -744,13 +744,13 @@ describe("cloudflare actor", () => {
       event: { type: "MessageReceived", id: "re-delivery-second", text: "again", at: 3 },
       lineage
     })
-    const childEvents = await threadStub("re-delivery-child").events("ag.re-delivery-child")
+    const childEvents = await threadStub("ag.re-delivery-child").events("ag.re-delivery-child")
     expect(childEvents.map((event) => event.type)).toEqual(["ThreadCreated", "MessageReceived", "MessageReceived"])
-    let childStatus = await threadStub("re-delivery-child").status()
+    let childStatus = await threadStub("ag.re-delivery-child").status()
     for (let attempt = 0; attempt < 100; attempt++) {
       if (childStatus.dirty === 0 && childStatus.status === "resting") break
       await delay()
-      childStatus = await threadStub("re-delivery-child").status()
+      childStatus = await threadStub("ag.re-delivery-child").status()
     }
     expect(childStatus).toMatchObject({ dirty: 0, status: "resting" })
   }, WORKER_INTEGRATION_TIMEOUT_MILLIS)
@@ -762,7 +762,7 @@ describe("cloudflare actor", () => {
     const parent = { actor: "echo", instance: "main", thread: "ag.recovery-parent" }
     const target = { actor: "echo", instance: "main", thread: "ag.recovery-child" }
     const lineage = { parent, depth: 1, placement: "independent" as const }
-    const child = threadStub("recovery-child")
+    const child = threadStub("ag.recovery-child")
     await child.init("echo", "main", "ag.recovery-child")
     await child.stageCreation({
       link: { source: parent, target },
@@ -798,7 +798,7 @@ describe("cloudflare actor", () => {
     const deadlineAt = Date.now() - 1
     const stub = threadStub("timeout")
     await createThread("timeout")
-    await stub.append("ag.timeout", {
+    await stub.append("timeout", {
       type: "CallDispatched",
       id: "overdue-1",
       method: "inspect",
@@ -809,10 +809,10 @@ describe("cloudflare actor", () => {
       at: deadlineAt - 10
     })
 
-    let events = await stub.events("ag.timeout")
+    let events = await stub.events("timeout")
     for (let attempt = 0; attempt < 100 && !events.some((event) => event.type === "CallTimedOut"); attempt++) {
       await new Promise((resolve) => setTimeout(resolve, 10))
-      events = await stub.events("ag.timeout")
+      events = await stub.events("timeout")
     }
 
     expect(events).toContainEqual(expect.objectContaining({

--- a/platform/cloudflare/test/fixture.worker.ts
+++ b/platform/cloudflare/test/fixture.worker.ts
@@ -202,7 +202,7 @@ const worker = cloudflareWorker(actor({
   }),
   layersFor: ({ env, thread }: CloudflareWorkerLayerContext<FixtureEnv>) =>
     Layer.succeed(ThreadApplication, { prefix: env.APPLICATION_PREFIX, thread, calls: 0 }),
-  storeFor: ({ thread }) => thread === "ag.sealed"
+  storeFor: ({ thread }) => thread === "sealed"
     ? {
         codec: encryptedEventCodec(thread, keyFor()),
         indexKey: hmacSha256EventKeyIndex(indexKeyFor(), thread)


### PR DESCRIPTION
Store new HTTP root threads under the supplied ID. Legacy lookup remains available for existing prefixed roots.

```text
                         Before          After
New public root-a        ag.root-a       root-a
Existing legacy root-b   ag.root-b       ag.root-b
```

- Strengthen the tree property to check uniqueness across roots and depths, plus replay stability.
- Add a host property for isolated root logs and repeated-address reuse across actors, instances, and threads.
- Remove redundant tests and update Bun, CLI, and Cloudflare fixtures for unprefixed new roots.

Verified: `bun run gate`, all 69 tasks passed.

Follow-up to #381. Reply correlation and background result identity in #375 remain outside this change.