### PR TITLE
fix(agent): journal partial output on cancellation

### DIFF
--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -210,18 +210,38 @@ describe("an assembled agent", () => {
     }
   }
 
-  test("a cancelled inference journals the answer it had already streamed", async () => {
+  const textOutcomes = (log: ReadonlyArray<Event>, turn: string) => {
+    const events = log.filter((event) => event.turn === turn)
+    return events.flatMap((event, index) => {
+      if (event.type !== "TextReturned") return []
+      const owner = events.slice(0, index).findLast((prior) => prior.type === "ModelCalled")
+      const next = events[index + 1]
+      return [{ text: event.text, owner: owner?.ordinal, interrupted: next?.type === "TurnCancelled" }]
+    })
+  }
+
+  test.each(["inference", "tool"])("text outcomes derive from the log when cancelling during %s", async (stage) => {
     let markStarted!: () => void
     const started = new Promise<void>((resolve) => {
       markStarted = resolve
     })
+    let inferred = 0
+    const components = [tool({
+      spec: { name: "read", description: "read", inputSchema: {} },
+      run: () => {
+        if (stage === "inference") return Effect.succeed("ok")
+        markStarted()
+        return Effect.never
+      }
+    })]
     const mind = rlm(async (request, key, _signal, onDelta) => {
+      if (inferred++ === 0) return { kind: "call", callId: "read-1", name: "read", arguments: {}, text: "Let me check." }
       streamOf(request, key, "p1", ["hello ", "world"], onDelta)
       markStarted()
       await new Promise<void>(() => {})
       return { kind: "complete", output: "late" }
-    })
-    mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
+    }, components)
+    await mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
       type: "MessageReceived",
       id: "m1",
       text: "wait",
@@ -229,7 +249,7 @@ describe("an assembled agent", () => {
     } as Event)
     const driving = mind.host.drive()
     await started
-    mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
+    await mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
       type: "CancellationRequested",
       request: "x1",
       invocation: { method: "message", id: "m1", epoch: 0 },
@@ -240,15 +260,13 @@ describe("an assembled agent", () => {
     await driving
 
     const log = mind.host.read(ROOT_THREAD)
-    const partialsOf = (events: ReadonlyArray<Event>) =>
-      events.filter((event) => event.type === "TextReturned" && (event as { readonly partial?: unknown }).partial === true)
-    expect(partialsOf(log)).toEqual([
-      expect.objectContaining({ text: "hello world", partial: true, turn: "m1" })
-    ])
-    // The prose precedes the terminal that explains it, the order a tool answer keeps.
-    expect(log.findIndex((event) => partialsOf([event]).length > 0)).toBeLessThan(
-      log.findIndex((event) => event.type === "TurnCancelled")
-    )
+    const expected = [
+      { text: "Let me check.", owner: 0, interrupted: false },
+      ...(stage === "inference" ? [{ text: "hello world", owner: 1, interrupted: true }] : [])
+    ]
+    expect(textOutcomes(log, "m1")).toEqual(expected)
+    expect(log.filter((event) => event.type === "TextReturned").every((event) => !("partial" in event))).toBe(true)
+    expect(textOutcomes(JSON.parse(JSON.stringify(log)), "m1")).toEqual(expected)
     expect(log.some((event) => event.type === "TurnCompleted")).toBe(false)
 
     // The reload reads the same stopped answer back: replay of a cancelled turn neither
@@ -258,6 +276,7 @@ describe("an assembled agent", () => {
       calls += 1
       return { kind: "complete", output: "must not run" }
     }, [work()], log)
+    await reloaded.host.drive()
     expect(calls).toBe(0)
     expect(reloaded.host.read(ROOT_THREAD)).toEqual(log)
   })
@@ -274,7 +293,7 @@ describe("an assembled agent", () => {
       await new Promise<void>(() => {})
       return { kind: "complete", output: "late" }
     })
-    mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
+    await mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
       type: "MessageReceived",
       id: "m1",
       text: "wait",
@@ -282,7 +301,7 @@ describe("an assembled agent", () => {
     } as Event)
     const driving = mind.host.drive()
     await started
-    mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
+    await mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
       type: "CancellationRequested",
       request: "x1",
       invocation: { method: "message", id: "m1", epoch: 0 },
@@ -292,8 +311,9 @@ describe("an assembled agent", () => {
     await driving
 
     const log = mind.host.read(ROOT_THREAD)
-    expect(log.filter((event) => event.type === "TextReturned" && (event as { readonly partial?: unknown }).partial === true))
-      .toEqual([expect.objectContaining({ text: "second try", partial: true, turn: "m1" })])
+    expect(log.filter((event) => event.type === "TextReturned"))
+      .toEqual([expect.objectContaining({ text: "second try", turn: "m1" })])
+    expect(textOutcomes(log, "m1")).toEqual([{ text: "second try", owner: 0, interrupted: true }])
   })
 
   test("a normally completing inference journals no partial", async () => {
@@ -304,7 +324,7 @@ describe("an assembled agent", () => {
     const answer = await mind.run("go")
     expect(answer.output).toBe("an answer")
     expect(mind.host.read(ROOT_THREAD).some(
-      (event) => event.type === "TextReturned" && (event as { readonly partial?: unknown }).partial === true
+      (event) => event.type === "TextReturned"
     )).toBe(false)
   })
 
@@ -326,7 +346,7 @@ describe("an assembled agent", () => {
         failure: { cause: "inference_error", attempts: 1 }
       }
     })
-    mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
+    await mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
       type: "MessageReceived",
       id: "m1",
       text: "wait",
@@ -334,7 +354,7 @@ describe("an assembled agent", () => {
     } as Event)
     const driving = mind.host.drive()
     await started
-    mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
+    await mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
       type: "CancellationRequested",
       request: "x1",
       invocation: { method: "message", id: "m1", epoch: 0 },
@@ -345,9 +365,10 @@ describe("an assembled agent", () => {
 
     const log = mind.host.read(ROOT_THREAD)
     const partials = log.filter(
-      (event) => event.type === "TextReturned" && (event as { readonly partial?: unknown }).partial === true
+      (event) => event.type === "TextReturned"
     )
-    expect(partials).toEqual([expect.objectContaining({ text: "half an answer", partial: true, turn: "m1" })])
+    expect(partials).toEqual([expect.objectContaining({ text: "half an answer", turn: "m1" })])
+    expect(textOutcomes(log, "m1")).toEqual([{ text: "half an answer", owner: 0, interrupted: true }])
     // Whichever side of the abort race wins, the turn ends in exactly one terminal.
     const terminals = log.filter(
       (event) => event.type === "TurnCancelled" || event.type === "TurnFailed" || event.type === "TurnCompleted"

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -10,6 +10,7 @@ import { workspacePackage } from "@clavia/tardigrade-code/package/workspace"
 import { createHost, type Host, type ThreadEnv } from "@clavia/tardigrade-host/host"
 import type { Action } from "./log/events"
 import { Infer, NativeOutputSupport, type InferRequest } from "./inference/contract"
+import type { InferDelta } from "./inference/observer"
 import { boundaryOf } from "./output/boundary"
 import { resumeTurn } from "./runtime/resume"
 import { agentsPackage } from "./packages/agents"
@@ -28,7 +29,12 @@ const TEST_MODEL = { models: { default: { provider: "test", model_id: "test-mode
 // routes briefs and replies, parks and wakes the root, and ask returns
 // when the root settles. No app imports anywhere.
 
-type Mind = (request: InferRequest, key?: string) => Promise<Action>
+type Mind = (
+  request: InferRequest,
+  key?: string,
+  signal?: AbortSignal,
+  onDelta?: (delta: InferDelta) => void
+) => Promise<Action>
 
 type Settled = { readonly turn: string; readonly output?: string; readonly error?: string }
 
@@ -51,7 +57,10 @@ const hosted = (
     Layer.mergeAll(
       KeyValueStore.layerMemory,
       jsSandboxFor({}),
-      Layer.succeed(Infer, { react: (request: InferRequest, key?: string) => Effect.promise(() => mind(request, key)) }),
+      Layer.succeed(Infer, {
+        react: (request: InferRequest, key?: string, signal?: AbortSignal, onDelta?: (delta: InferDelta) => void) =>
+          Effect.promise(() => mind(request, key, signal, onDelta))
+      }),
       Layer.succeed(NativeOutputSupport, { withTools: true })
     )
   const host: Host = createHost<TestR>({
@@ -176,6 +185,175 @@ describe("an assembled agent", () => {
       expect.objectContaining({ request: "x1", turn: "m1", reason: "operator stopped it" })
     ])
     expect(log.some((event) => event.type === "TurnCompleted")).toBe(false)
+  })
+
+  // streamOf builds the delta sequence a binding emits while the provider streams: the same
+  // identity the request carried, one logical attempt, and the physical attempt the fragments
+  // belong to.
+  const streamOf = (
+    request: InferRequest,
+    key: string | undefined,
+    physical: string,
+    chunks: ReadonlyArray<string>,
+    onDelta: ((delta: InferDelta) => void) | undefined
+  ) => {
+    for (const [sequence, text] of chunks.entries()) {
+      onDelta?.({
+        ...request.identity,
+        logicalAttempt: key ?? request.identity.turn,
+        physicalAttempt: physical,
+        model: request.model ?? { provider: "test", model_id: "test-model" },
+        blockIndex: 0,
+        sequence,
+        text
+      })
+    }
+  }
+
+  test("a cancelled inference journals the answer it had already streamed", async () => {
+    let markStarted!: () => void
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve
+    })
+    const mind = rlm(async (request, key, _signal, onDelta) => {
+      streamOf(request, key, "p1", ["hello ", "world"], onDelta)
+      markStarted()
+      await new Promise<void>(() => {})
+      return { kind: "complete", output: "late" }
+    })
+    mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
+      type: "MessageReceived",
+      id: "m1",
+      text: "wait",
+      at: 1
+    } as Event)
+    const driving = mind.host.drive()
+    await started
+    mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
+      type: "CancellationRequested",
+      request: "x1",
+      invocation: { method: "message", id: "m1", epoch: 0 },
+      cause: "requested",
+      reason: "operator stopped it",
+      at: 2
+    } as Event)
+    await driving
+
+    const log = mind.host.read(ROOT_THREAD)
+    const partialsOf = (events: ReadonlyArray<Event>) =>
+      events.filter((event) => event.type === "TextReturned" && (event as { readonly partial?: unknown }).partial === true)
+    expect(partialsOf(log)).toEqual([
+      expect.objectContaining({ text: "hello world", partial: true, turn: "m1" })
+    ])
+    // The prose precedes the terminal that explains it, the order a tool answer keeps.
+    expect(log.findIndex((event) => partialsOf([event]).length > 0)).toBeLessThan(
+      log.findIndex((event) => event.type === "TurnCancelled")
+    )
+    expect(log.some((event) => event.type === "TurnCompleted")).toBe(false)
+
+    // The reload reads the same stopped answer back: replay of a cancelled turn neither
+    // re-infers nor appends a second partial.
+    let calls = 0
+    const reloaded = rlm(async () => {
+      calls += 1
+      return { kind: "complete", output: "must not run" }
+    }, [work()], log)
+    expect(calls).toBe(0)
+    expect(reloaded.host.read(ROOT_THREAD)).toEqual(log)
+  })
+
+  test("a retried physical attempt journals only the text it streamed", async () => {
+    let markStarted!: () => void
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve
+    })
+    const mind = rlm(async (request, key, _signal, onDelta) => {
+      streamOf(request, key, "p1", ["the first attempt died"], onDelta)
+      streamOf(request, key, "p2", ["second ", "try"], onDelta)
+      markStarted()
+      await new Promise<void>(() => {})
+      return { kind: "complete", output: "late" }
+    })
+    mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
+      type: "MessageReceived",
+      id: "m1",
+      text: "wait",
+      at: 1
+    } as Event)
+    const driving = mind.host.drive()
+    await started
+    mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
+      type: "CancellationRequested",
+      request: "x1",
+      invocation: { method: "message", id: "m1", epoch: 0 },
+      cause: "requested",
+      at: 2
+    } as Event)
+    await driving
+
+    const log = mind.host.read(ROOT_THREAD)
+    expect(log.filter((event) => event.type === "TextReturned" && (event as { readonly partial?: unknown }).partial === true))
+      .toEqual([expect.objectContaining({ text: "second try", partial: true, turn: "m1" })])
+  })
+
+  test("a normally completing inference journals no partial", async () => {
+    const mind = rlm(async (request, key, _signal, onDelta) => {
+      streamOf(request, key, "p1", ["an ", "answer"], onDelta)
+      return { kind: "complete", output: "an answer" }
+    })
+    const answer = await mind.run("go")
+    expect(answer.output).toBe("an answer")
+    expect(mind.host.read(ROOT_THREAD).some(
+      (event) => event.type === "TextReturned" && (event as { readonly partial?: unknown }).partial === true
+    )).toBe(false)
+  })
+
+  test("a provider that settles on the abort signal journals its partial exactly once", async () => {
+    let markStarted!: () => void
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve
+    })
+    const mind = rlm(async (request, key, signal, onDelta) => {
+      streamOf(request, key, "p1", ["half ", "an answer"], onDelta)
+      markStarted()
+      await new Promise<void>((resolve) => {
+        if (signal?.aborted === true) resolve()
+        else signal?.addEventListener("abort", () => resolve(), { once: true })
+      })
+      return {
+        kind: "fail",
+        error: "the connection was aborted",
+        failure: { cause: "inference_error", attempts: 1 }
+      }
+    })
+    mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
+      type: "MessageReceived",
+      id: "m1",
+      text: "wait",
+      at: 1
+    } as Event)
+    const driving = mind.host.drive()
+    await started
+    mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
+      type: "CancellationRequested",
+      request: "x1",
+      invocation: { method: "message", id: "m1", epoch: 0 },
+      cause: "requested",
+      at: 2
+    } as Event)
+    await driving
+
+    const log = mind.host.read(ROOT_THREAD)
+    const partials = log.filter(
+      (event) => event.type === "TextReturned" && (event as { readonly partial?: unknown }).partial === true
+    )
+    expect(partials).toEqual([expect.objectContaining({ text: "half an answer", partial: true, turn: "m1" })])
+    // Whichever side of the abort race wins, the turn ends in exactly one terminal.
+    const terminals = log.filter(
+      (event) => event.type === "TurnCancelled" || event.type === "TurnFailed" || event.type === "TurnCompleted"
+    )
+    expect(terminals).toHaveLength(1)
+    expect(log.indexOf(partials[0]!)).toBeLessThan(log.indexOf(terminals[0]!))
   })
 
   test("distinct cancel calls absorb into one terminal and both receive a response", async () => {

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -187,9 +187,7 @@ describe("an assembled agent", () => {
     expect(log.some((event) => event.type === "TurnCompleted")).toBe(false)
   })
 
-  // streamOf builds the delta sequence a binding emits while the provider streams: the same
-  // identity the request carried, one logical attempt, and the physical attempt the fragments
-  // belong to.
+  // streamOf emits normalized text deltas for a physical attempt.
   const streamOf = (
     request: InferRequest,
     key: string | undefined,
@@ -220,11 +218,20 @@ describe("an assembled agent", () => {
     })
   }
 
+  const cancelAfter = async (mind: ReturnType<typeof rlm>, started: Promise<void>) => {
+    await mind.host.commitRoot(mind.host.self(ROOT_THREAD), { type: "MessageReceived", id: "m1", text: "wait", at: 1 } as Event)
+    const driving = mind.host.drive()
+    await started
+    await mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
+      type: "CancellationRequested", request: "x1", invocation: { method: "message", id: "m1", epoch: 0 },
+      cause: "requested", reason: "operator stopped it", at: 2
+    } as Event)
+    await driving
+    return mind.host.read(ROOT_THREAD)
+  }
+
   test.each(["inference", "tool"])("text outcomes derive from the log when cancelling during %s", async (stage) => {
-    let markStarted!: () => void
-    const started = new Promise<void>((resolve) => {
-      markStarted = resolve
-    })
+    const { promise: started, resolve: markStarted } = Promise.withResolvers<void>()
     let inferred = 0
     const components = [tool({
       spec: { name: "read", description: "read", inputSchema: {} },
@@ -241,25 +248,7 @@ describe("an assembled agent", () => {
       await new Promise<void>(() => {})
       return { kind: "complete", output: "late" }
     }, components)
-    await mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
-      type: "MessageReceived",
-      id: "m1",
-      text: "wait",
-      at: 1
-    } as Event)
-    const driving = mind.host.drive()
-    await started
-    await mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
-      type: "CancellationRequested",
-      request: "x1",
-      invocation: { method: "message", id: "m1", epoch: 0 },
-      cause: "requested",
-      reason: "operator stopped it",
-      at: 2
-    } as Event)
-    await driving
-
-    const log = mind.host.read(ROOT_THREAD)
+    const log = await cancelAfter(mind, started)
     const expected = [
       { text: "Let me check.", owner: 0, interrupted: false },
       ...(stage === "inference" ? [{ text: "hello world", owner: 1, interrupted: true }] : [])
@@ -282,10 +271,7 @@ describe("an assembled agent", () => {
   })
 
   test("a retried physical attempt journals only the text it streamed", async () => {
-    let markStarted!: () => void
-    const started = new Promise<void>((resolve) => {
-      markStarted = resolve
-    })
+    const { promise: started, resolve: markStarted } = Promise.withResolvers<void>()
     const mind = rlm(async (request, key, _signal, onDelta) => {
       streamOf(request, key, "p1", ["the first attempt died"], onDelta)
       streamOf(request, key, "p2", ["second ", "try"], onDelta)
@@ -293,24 +279,7 @@ describe("an assembled agent", () => {
       await new Promise<void>(() => {})
       return { kind: "complete", output: "late" }
     })
-    await mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
-      type: "MessageReceived",
-      id: "m1",
-      text: "wait",
-      at: 1
-    } as Event)
-    const driving = mind.host.drive()
-    await started
-    await mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
-      type: "CancellationRequested",
-      request: "x1",
-      invocation: { method: "message", id: "m1", epoch: 0 },
-      cause: "requested",
-      at: 2
-    } as Event)
-    await driving
-
-    const log = mind.host.read(ROOT_THREAD)
+    const log = await cancelAfter(mind, started)
     expect(log.filter((event) => event.type === "TextReturned"))
       .toEqual([expect.objectContaining({ text: "second try", turn: "m1" })])
     expect(textOutcomes(log, "m1")).toEqual([{ text: "second try", owner: 0, interrupted: true }])
@@ -329,10 +298,7 @@ describe("an assembled agent", () => {
   })
 
   test("a provider that settles on the abort signal journals its partial exactly once", async () => {
-    let markStarted!: () => void
-    const started = new Promise<void>((resolve) => {
-      markStarted = resolve
-    })
+    const { promise: started, resolve: markStarted } = Promise.withResolvers<void>()
     const mind = rlm(async (request, key, signal, onDelta) => {
       streamOf(request, key, "p1", ["half ", "an answer"], onDelta)
       markStarted()
@@ -346,24 +312,7 @@ describe("an assembled agent", () => {
         failure: { cause: "inference_error", attempts: 1 }
       }
     })
-    await mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
-      type: "MessageReceived",
-      id: "m1",
-      text: "wait",
-      at: 1
-    } as Event)
-    const driving = mind.host.drive()
-    await started
-    await mind.host.commitRoot(mind.host.self(ROOT_THREAD), {
-      type: "CancellationRequested",
-      request: "x1",
-      invocation: { method: "message", id: "m1", epoch: 0 },
-      cause: "requested",
-      at: 2
-    } as Event)
-    await driving
-
-    const log = mind.host.read(ROOT_THREAD)
+    const log = await cancelAfter(mind, started)
     const partials = log.filter(
       (event) => event.type === "TextReturned"
     )

--- a/packages/agent/src/inference/contract.ts
+++ b/packages/agent/src/inference/contract.ts
@@ -5,7 +5,7 @@ import type { ContextPolicy } from "../component/compaction"
 import type { OutputFallback } from "../output/contract"
 import type { ModelRef } from "./reference"
 import { DEFAULT_MODEL_POLICY_OVERRIDE, type ModelPolicy, type ModelPolicyOverride } from "./access"
-import type { InferenceIdentity } from "./observer"
+import type { InferDelta, InferenceIdentity } from "./observer"
 
 // InferPolicy states the process-crash ceiling and model authority applied by the inference machine. Output correction bounds belong to the mounted output component (component/repair.ts, RepairPolicy).
 export interface InferPolicy {
@@ -33,11 +33,16 @@ export interface ModelResolution {
   readonly models?: ModelPolicy
 }
 
-// Infer provides one model action per request; key identifies its ModelCalled attempt. Reused call IDs within a turn fail before dispatch (index.test.ts, "a turn rejects reused provider IDs before dispatch, including after resume").
+// Infer provides one model action per request; key identifies its ModelCalled attempt. Reused call IDs within a turn fail before dispatch (index.test.ts, "a turn rejects reused provider IDs before dispatch, including after resume"). onDelta synchronously reports normalized text for caller-owned accumulation (packages/model/src/model.test.ts).
 export class Infer extends Context.Service<
   Infer,
   {
-    readonly react: (request: InferRequest, key?: string, signal?: AbortSignal) => Effect.Effect<Action>
+    readonly react: (
+      request: InferRequest,
+      key?: string,
+      signal?: AbortSignal,
+      onDelta?: (delta: InferDelta) => void
+    ) => Effect.Effect<Action>
     readonly resolve?: (reference?: ModelRef) => ModelResolution
   }
 >()("agent/Infer") {}

--- a/packages/agent/src/inference/machine.ts
+++ b/packages/agent/src/inference/machine.ts
@@ -461,16 +461,9 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
             if (partialOutput === "" || partialPersisted) return Effect.void
             partialPersisted = true
             return Clock.currentTimeMillis.pipe(
-              Effect.flatMap((at) =>
-                events.append([
-                  textReturned({
-                    text: partialOutput,
-                    turn: input.turn,
-                    ...epochStamp(input.epoch),
-                    at
-                  })
-                ])
-              ),
+              Effect.flatMap((at) => events.append([textReturned({
+                text: partialOutput, turn: input.turn, ...epochStamp(input.epoch), at
+              })])),
               Effect.asVoid
             )
           }

--- a/packages/agent/src/inference/machine.ts
+++ b/packages/agent/src/inference/machine.ts
@@ -454,13 +454,51 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
           yield* events.append([mark])
           const actualRender = derived.renderAfter(mark)
           const trajectory = input.trajectory()
+          // An attempt stopped mid-stream journals what the model had already said. The deltas
+          // arrive through the binding's onDelta seam and accumulate per physical attempt, so a
+          // retried attempt's partial carries only its own text (index.test.ts, "a retried
+          // physical attempt journals only the text it streamed"). The terminal follows, so the
+          // prose precedes the state transition it explains (index.test.ts, "a cancelled
+          // inference journals the answer it had already streamed").
+          let partialOutput = ""
+          let physicalAttempt = ""
+          let partialPersisted = false
+          const persistPartialOutput = () => {
+            if (partialOutput === "" || partialPersisted) return Effect.void
+            partialPersisted = true
+            return Clock.currentTimeMillis.pipe(
+              Effect.flatMap((at) =>
+                events.append([
+                  textReturned({
+                    text: partialOutput,
+                    partial: true,
+                    turn: input.turn,
+                    ...epochStamp(input.epoch),
+                    at
+                  })
+                ])
+              ),
+              Effect.asVoid
+            )
+          }
           const action = yield* binding
-            .react({
-              trajectory,
-              identity: { ...self, turn: input.turn },
-              model: selected,
-              ...actualRender
-            }, input.attempt, signal)
+            .react(
+              {
+                trajectory,
+                identity: { ...self, turn: input.turn },
+                model: selected,
+                ...actualRender
+              },
+              input.attempt,
+              signal,
+              (delta) => {
+                if (physicalAttempt !== delta.physicalAttempt) {
+                  physicalAttempt = delta.physicalAttempt
+                  partialOutput = ""
+                }
+                partialOutput += delta.text
+              }
+            )
             .pipe(
               Effect.catchCause((cause) =>
                 Cause.hasInterruptsOnly(cause)
@@ -470,6 +508,14 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
                       error: failureMessage(cause),
                       failure: { cause: "inference_error", attempts: 1 }
                     })
+              ),
+              Effect.onInterrupt(persistPartialOutput),
+              // The provider can settle on the abort signal before Effect observes the
+              // interrupt. The shared guard makes both finalizers one durable write
+              // (index.test.ts, "a provider that settles on the abort signal journals its
+              // partial exactly once").
+              Effect.ensuring(
+                Effect.suspend(() => signal?.aborted === true ? persistPartialOutput() : Effect.void)
               )
             )
           const after = yield* Clock.currentTimeMillis

--- a/packages/agent/src/inference/machine.ts
+++ b/packages/agent/src/inference/machine.ts
@@ -454,12 +454,6 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
           yield* events.append([mark])
           const actualRender = derived.renderAfter(mark)
           const trajectory = input.trajectory()
-          // An attempt stopped mid-stream journals what the model had already said. The deltas
-          // arrive through the binding's onDelta seam and accumulate per physical attempt, so a
-          // retried attempt's partial carries only its own text (index.test.ts, "a retried
-          // physical attempt journals only the text it streamed"). The terminal follows, so the
-          // prose precedes the state transition it explains (index.test.ts, "a cancelled
-          // inference journals the answer it had already streamed").
           let partialOutput = ""
           let physicalAttempt = ""
           let partialPersisted = false
@@ -471,7 +465,6 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
                 events.append([
                   textReturned({
                     text: partialOutput,
-                    partial: true,
                     turn: input.turn,
                     ...epochStamp(input.epoch),
                     at
@@ -510,10 +503,7 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
                     })
               ),
               Effect.onInterrupt(persistPartialOutput),
-              // The provider can settle on the abort signal before Effect observes the
-              // interrupt. The shared guard makes both finalizers one durable write
-              // (index.test.ts, "a provider that settles on the abort signal journals its
-              // partial exactly once").
+              // Abort can settle the provider before interruption; both paths share the persistence guard (index.test.ts).
               Effect.ensuring(
                 Effect.suspend(() => signal?.aborted === true ? persistPartialOutput() : Effect.void)
               )

--- a/packages/agent/src/log/events.ts
+++ b/packages/agent/src/log/events.ts
@@ -90,11 +90,16 @@ export const ModelCalled = Schema.Struct({
   at: Schema.Finite
 })
 
-// TextReturned is the prose the model emitted alongside its decision: working commentary,
-// journaled and never delivered. The final answer is `TurnCompleted.output`, never this.
+// TextReturned is prose the model emitted alongside an action. partial marks the accumulated
+// output journaled when an in-flight inference is cancelled, so a stopped answer survives the
+// turn's terminal (index.test.ts, "a cancelled inference journals the answer it had already
+// streamed"). The final answer of a completed turn is `TurnCompleted.output`, never this.
 export const TextReturned = Schema.Struct({
   type: Schema.Literal("TextReturned"),
   text: Schema.String,
+  partial: Schema.optional(Schema.Boolean),
+  turn: Schema.optional(Schema.String),
+  epoch: Schema.optional(Schema.Finite),
   at: Schema.Finite
 })
 
@@ -475,9 +480,9 @@ export const modelCalled = (
     }
   } & EpochStamp
 ): Event => ({ type: "ModelCalled", ...fields }) as Event
-
-export const textReturned = (fields: { readonly text: string } & Stamp): Event =>
-  ({ type: "TextReturned", ...fields }) as Event
+export const textReturned = (
+  fields: { readonly text: string; readonly partial?: boolean } & EpochStamp
+): Event => ({ type: "TextReturned", ...fields }) as Event
 
 export const turnCompleted = (
   fields: {

--- a/packages/agent/src/log/events.ts
+++ b/packages/agent/src/log/events.ts
@@ -90,14 +90,10 @@ export const ModelCalled = Schema.Struct({
   at: Schema.Finite
 })
 
-// TextReturned is prose the model emitted alongside an action. partial marks the accumulated
-// output journaled when an in-flight inference is cancelled, so a stopped answer survives the
-// turn's terminal (index.test.ts, "a cancelled inference journals the answer it had already
-// streamed"). The final answer of a completed turn is `TurnCompleted.output`, never this.
+// TextReturned journals model prose; its following action or cancellation determines whether inference finished (index.test.ts, "text outcomes derive from the log when cancelling during %s"). The final answer lives on TurnCompleted.output.
 export const TextReturned = Schema.Struct({
   type: Schema.Literal("TextReturned"),
   text: Schema.String,
-  partial: Schema.optional(Schema.Boolean),
   turn: Schema.optional(Schema.String),
   epoch: Schema.optional(Schema.Finite),
   at: Schema.Finite
@@ -481,7 +477,7 @@ export const modelCalled = (
   } & EpochStamp
 ): Event => ({ type: "ModelCalled", ...fields }) as Event
 export const textReturned = (
-  fields: { readonly text: string; readonly partial?: boolean } & EpochStamp
+  fields: { readonly text: string } & EpochStamp
 ): Event => ({ type: "TextReturned", ...fields }) as Event
 
 export const turnCompleted = (

--- a/packages/model/src/model.test.ts
+++ b/packages/model/src/model.test.ts
@@ -707,6 +707,105 @@ describe("ephemeral inference deltas", () => {
     ])
   })
 
+  test("react streams onDelta text with no observer configured", async () => {
+    const deltas: InferDelta[] = []
+    const fetchImpl = (async () => sse([
+      { id: "stream-3", choices: [{ index: 0, delta: { role: "assistant", content: "hel" } }] },
+      { id: "stream-3", choices: [{ index: 0, delta: { content: "lo" } }] },
+      { id: "stream-3", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }
+    ])) as unknown as typeof globalThis.fetch
+    const layer = testInfer(
+      { baseUrl: "https://model.test/v1", apiKey: "k", model: "gpt-test", provider: "openai", fetch: fetchImpl },
+      { physicalAttemptId: () => "physical-1" }
+    )
+    const action = await Effect.runPromise(
+      Effect.flatMap(Infer, (model) =>
+        model.react(reqOf([
+          { type: "MessageReceived", id: "m1", text: "go", at: 1 }
+        ]), "m1/infer/0", undefined, (delta) => { deltas.push(delta) })
+      ).pipe(Effect.provide(layer)) as Effect.Effect<Action>
+    )
+    expect(action).toMatchObject({ kind: "complete", output: "hello" })
+    expect(deltas).toEqual([
+      {
+        actor: "test",
+        instance: "main",
+        thread: "root",
+        turn: "m1",
+        logicalAttempt: "m1/infer/0",
+        physicalAttempt: "physical-1",
+        model: { provider: "openai", model_id: "gpt-test" },
+        blockIndex: 0,
+        sequence: 0,
+        text: "hel"
+      },
+      {
+        actor: "test",
+        instance: "main",
+        thread: "root",
+        turn: "m1",
+        logicalAttempt: "m1/infer/0",
+        physicalAttempt: "physical-1",
+        model: { provider: "openai", model_id: "gpt-test" },
+        blockIndex: 0,
+        sequence: 1,
+        text: "lo"
+      }
+    ])
+  })
+
+  test("a retried attempt streams onDelta under a fresh physical identity", async () => {
+    let starts = 0
+    let physical = 0
+    const deltas: InferDelta[] = []
+    const adapter: ModelAdapter = {
+      id: "test/bedrock",
+      protocols: ["bedrock-converse"],
+      start: () => {
+        const current = starts++
+        return {
+          stream: {
+            async *[Symbol.asyncIterator]() {
+              yield { type: "TEXT_MESSAGE_START", messageId: `b${current}`, role: "assistant", timestamp: 1 } as never
+              yield {
+                type: "TEXT_MESSAGE_CONTENT",
+                messageId: `b${current}`,
+                delta: current === 0 ? "discarded" : "winner",
+                timestamp: 2
+              } as never
+              if (current === 0) throw Object.assign(new Error("429 from Bedrock"), { status: 429 })
+              yield { type: "TEXT_MESSAGE_END", messageId: `b${current}`, timestamp: 3 } as never
+            }
+          }
+        }
+      }
+    }
+    const layer = infer({
+      baseUrl: "https://bedrock.test/us-east-1",
+      apiKey: "k",
+      model: "anthropic.claude-test",
+      protocol: "bedrock-converse",
+      provider: "bedrock",
+      contextWindowTokens: 128_000,
+      throttleRetryDelaysMs: [1],
+      sleep: async () => {}
+    }, modelAdapters(adapter), {
+      physicalAttemptId: () => `physical-${physical++}`
+    })
+    const action = await Effect.runPromise(
+      Effect.flatMap(Infer, (model) =>
+        model.react(reqOf([
+          { type: "MessageReceived", id: "m1", text: "go", at: 1 }
+        ]), "m1/infer/0", undefined, (delta) => { deltas.push(delta) })
+      ).pipe(Effect.provide(layer)) as Effect.Effect<Action>
+    )
+    expect(action).toMatchObject({ kind: "complete", output: "winner" })
+    expect(deltas.map(({ logicalAttempt, physicalAttempt, text }) => ({ logicalAttempt, physicalAttempt, text }))).toEqual([
+      { logicalAttempt: "m1/infer/0", physicalAttempt: "physical-0", text: "discarded" },
+      { logicalAttempt: "m1/infer/0", physicalAttempt: "physical-1", text: "winner" }
+    ])
+  })
+
   test("observer failure and saturation leave inference unchanged", async () => {
     let deliveries = 0
     const fetchImpl = (async () => sse([

--- a/packages/model/src/model.test.ts
+++ b/packages/model/src/model.test.ts
@@ -726,32 +726,11 @@ describe("ephemeral inference deltas", () => {
       ).pipe(Effect.provide(layer)) as Effect.Effect<Action>
     )
     expect(action).toMatchObject({ kind: "complete", output: "hello" })
-    expect(deltas).toEqual([
-      {
-        actor: "test",
-        instance: "main",
-        thread: "root",
-        turn: "m1",
-        logicalAttempt: "m1/infer/0",
-        physicalAttempt: "physical-1",
-        model: { provider: "openai", model_id: "gpt-test" },
-        blockIndex: 0,
-        sequence: 0,
-        text: "hel"
-      },
-      {
-        actor: "test",
-        instance: "main",
-        thread: "root",
-        turn: "m1",
-        logicalAttempt: "m1/infer/0",
-        physicalAttempt: "physical-1",
-        model: { provider: "openai", model_id: "gpt-test" },
-        blockIndex: 0,
-        sequence: 1,
-        text: "lo"
-      }
-    ])
+    expect(deltas).toEqual(["hel", "lo"].map((text, sequence) => ({
+      actor: "test", instance: "main", thread: "root", turn: "m1",
+      logicalAttempt: "m1/infer/0", physicalAttempt: "physical-1",
+      model: { provider: "openai", model_id: "gpt-test" }, blockIndex: 0, sequence, text
+    })))
   })
 
   test("a retried attempt streams onDelta under a fresh physical identity", async () => {

--- a/packages/model/src/model.ts
+++ b/packages/model/src/model.ts
@@ -474,15 +474,18 @@ const deltaDelivery = (
   })
 
 // observed taps normalized text while preserving the stream consumed by the terminal accumulator.
+// onDelta is the synchronous seam the caller's own accumulator reads; delivery stays the host's
+// best-effort fan-out (model.test.ts, "react streams onDelta text with no observer configured").
 const observed = (
   stream: AsyncIterable<StreamChunk>,
   delivery: DeltaDelivery | undefined,
+  onDelta: ((delta: InferDelta) => void) | undefined,
   identity: InferRequest["identity"],
   logicalAttempt: string | undefined,
   physicalAttempt: string,
   model: { readonly provider: string; readonly model_id: string }
 ): AsyncIterable<StreamChunk> => {
-  if (delivery === undefined) return stream
+  if (delivery === undefined && onDelta === undefined) return stream
   if (logicalAttempt === undefined) throw new Error("an observed inference requires a logical attempt identity")
   let blockIndex = -1
   let sequence = 0
@@ -505,7 +508,8 @@ const observed = (
         sequence: sequence++,
         text: chunk.delta
       }
-      return delivery.offer(delta).pipe(Effect.asVoid)
+      if (onDelta !== undefined) onDelta(delta)
+      return delivery === undefined ? Effect.void : delivery.offer(delta).pipe(Effect.asVoid)
     }),
     Stream.toAsyncIterable
   )
@@ -598,6 +602,7 @@ export const infer = <const C extends ModelConfig>(
     rung: number,
     stats: { finish?: string },
     delivery: DeltaDelivery | undefined,
+    onDelta: ((delta: InferDelta) => void) | undefined,
     identity: InferRequest["identity"],
     physicalAttempt: string,
     signal?: AbortSignal
@@ -669,6 +674,7 @@ export const infer = <const C extends ModelConfig>(
       const normalized = observed(
         tapTokens(bounded(attempt.stream, bounds), held),
         delivery,
+        onDelta,
         identity,
         key,
         physicalAttempt,
@@ -724,7 +730,7 @@ export const infer = <const C extends ModelConfig>(
         "gen_ai.request.model": config.model,
         "gen_ai.provider.name": config.protocol === "bedrock-converse" ? "aws.bedrock" : (config.provider ?? config.protocol)
       }
-    })(function* (request: InferRequest, key?: string, signal?: AbortSignal) {
+    })(function* (request: InferRequest, key?: string, signal?: AbortSignal, onDelta?: (delta: InferDelta) => void) {
       // The retry ladder reads the wall clock to honour a provider's `Retry-After` date, and it
       // reads it from the Clock the caller supplied rather than the global one, so a test drives
       // the ladder without waiting on real time (model.test.ts, "infer: transient retry").
@@ -779,10 +785,10 @@ export const infer = <const C extends ModelConfig>(
             stats.rung = rung
             stats.attempts += 1
             const logicalAttempt = key ?? request.identity.turn
-            const physicalAttempt = delivery === undefined
+            const physicalAttempt = delivery === undefined && onDelta === undefined
               ? ""
               : options.physicalAttemptId?.(logicalAttempt) ?? randomPhysicalAttemptId(logicalAttempt)
-            const action = await attemptOnce(req, mode, key, ladder[rung]!, rung, stats, delivery, request.identity, physicalAttempt, signal)
+            const action = await attemptOnce(req, mode, key, ladder[rung]!, rung, stats, delivery, onDelta, request.identity, physicalAttempt, signal)
             remember(action.usage, true)
             return served(withSpend(action, spentOf(parts, missed)), action.endpoint ?? endpointOf(config, undefined))
           } catch (e) {


### PR DESCRIPTION
[👾 omp · openrouter/z-ai/glm-5.3 · agency: directed · intent: journal streamed text when a turn is cancelled mid inference]

## Change and reason

Cancelling a turn mid inference threw away everything the model had already streamed: the operator stopped a long answer, the journal recorded only `TurnCancelled`, and the prose the user had been watching on the live stream vanished from the durable log. On our multi tenant platform an operator stopping a runaway generation is routine, and after a stop we still need the stopped answer for audit and for the customer who watched half of it arrive. This PR journals the accumulated stream text as a `TextReturned` marked `partial: true` before the cancellation terminal, so the durable log keeps the same stopped answer the live stream showed.

The event grammar is unchanged in kind: prose precedes the state transition it explains, the same order a tool answer keeps (`index.test.ts`, "a cancelled inference journals the answer it had already streamed"). A partial is never an answer; the completed turn's answer stays `TurnCompleted.output`.

## What changed

- `TextReturned` gains an optional `partial` flag plus the optional `turn` and `epoch` stamps it was already being written with (`textReturned` now takes an `EpochStamp`). The schema now states the shape the journal actually holds.
- The `Infer` contract gains an optional `onDelta` callback on `react`, a synchronous seam beside the existing best effort `InferenceObserver`: the observer stays the host's ephemeral fan-out, while `onDelta` is the caller's own accumulator feeding a durable write. The model binding invokes it from the same normalized-text tap and mints per physical attempt ids whenever either consumer is present, so the seam works with no observer configured.
- The inference machine accumulates the streamed text per physical attempt, resetting when the physical attempt identity changes so a retried attempt's partial carries only its own text. When the attempt ends without settling, it journals the accumulation as a partial `TextReturned`. Two paths can end an attempt, a runtime interrupt and a provider that settles on the abort signal before Effect observes the interrupt, and one shared guard makes both exactly one durable write.
- The model binding threads `onDelta` through `react`, the physical retry ladder, and the stream tap.

## Design choice

The cancellation terminal carries no output. The journal event was chosen over an `output` field on `TurnCancelled` for two reasons: replay keeps one code path for `TextReturned` prose, and the terminal stays a pure state transition rather than growing a payload slot. The import mapping in `docs/how-to/migrate.md` already writes saved partial assistant text as `TextReturned` before the terminal, so this shape is the one the documentation already prescribes for stopped turns.

Rework offer: if reviewers prefer the terminal to carry what it stopped, the same behavior can land as `output` on `TurnCancelled` instead of a partial marked `TextReturned`. The accumulator and the exactly once guard stay identical; only the journaled shape moves. Say the word and I will rework the branch that way.

## Verification

- `bun install --frozen-lockfile` then `bun run gate` at head `ec3524e`: exit 0 (lint, prose lint, Effect lint, typecheck, per package tests, knip).
- `bun test packages/agent/src/index.test.ts`: 18 pass, 0 fail. Four new tests pin the behavior; three of them fail on the parent commit with the machine change reverted (the fourth is the negative guard that a completed turn writes no partial).
- `bun test platform/model/src/model.test.ts`: 62 pass, 0 fail. Two new tests pin the binding seam; both fail on the parent commit with the binding change reverted.
- The four machine tests, respectively: a cancelled mid stream inference journals its accumulated text with `partial: true`, the partial precedes `TurnCancelled`, and a fresh host seeded with that log replays without re-inferring or appending a second partial; a retried physical attempt journals only its own streamed text; a normally completing inference journals no partial; a provider that settles on the abort signal journals its partial exactly once and the turn ends in exactly one terminal.
- The two binding tests, respectively: `react` streams `onDelta` text with no observer configured, and a retried attempt streams under a fresh physical identity.