### PR TITLE
fix(model): trust normalized usage

### DIFF
--- a/platform/model/src/model.test.ts
+++ b/platform/model/src/model.test.ts
@@ -744,11 +744,12 @@ describe("infer: cost provenance", () => {
   ]
   const table = { promptUsdPerToken: 0.001, completionUsdPerToken: 0.002 }
 
-  test("a billed cost is provider, an omitted cost is table or unknown", async () => {
+  test("TanStack usage owns token accounting and provider cost", async () => {
     const rawUsage = {
       prompt_tokens: 10,
       completion_tokens: 4,
       total_tokens: 14,
+      cache_creation_input_tokens: 6,
       prompt_tokens_details: { cached_tokens: 4 },
       completion_tokens_details: { reasoning_tokens: 2 },
       cost: 0
@@ -833,7 +834,7 @@ describe("infer: cost provenance", () => {
     expect(unknown).toMatchObject({ kind: "complete", output: "ok" })
   })
 
-  test("multiple wire usage objects remain one lossless physical report", async () => {
+  test("multiple wire reports remain raw while TanStack owns normalized usage", async () => {
     const detailed = {
       prompt_tokens: 10,
       completion_tokens: 4,
@@ -860,12 +861,12 @@ describe("infer: cost provenance", () => {
       ) as Effect.Effect<Action>
     )
     expect(action.usage).toMatchObject({
-      cachedPromptTokens: 4,
-      reasoningTokens: 2,
       reportedCostUsd: 0,
-      estimatedCostUsd: 6 * 0.001 + 4 * 0.0001 + 4 * 0.002,
+      estimatedCostUsd: 10 * 0.001 + 4 * 0.002,
       providerReports: [{ provider: "openai", model: "test-model", providerSpecific: [detailed, billed] }]
     })
+    expect(action.usage).not.toHaveProperty("cachedPromptTokens")
+    expect(action.usage).not.toHaveProperty("reasoningTokens")
   })
 })
 

--- a/platform/model/src/model.ts
+++ b/platform/model/src/model.ts
@@ -27,7 +27,7 @@ import {
   fallbackSystemFor
 } from "./output"
 import type { OutputMode } from "tardie/output/contract"
-import { sumUsage, usageFrom, type Usage } from "tardie/inference/usage"
+import { costNumber, sumUsage, usageFrom, type Usage } from "tardie/inference/usage"
 import type {
   ModelAdapterRegistry,
   ModelConfig,
@@ -427,6 +427,13 @@ const tapTokens = (
   }
 })
 
+const reportedCostOf = (value: unknown): number | undefined => {
+  if (!Array.isArray(value)) return costNumber(value)
+  let reported: number | undefined
+  for (const part of value) reported = costNumber(part) ?? reported
+  return reported
+}
+
 interface DeltaDelivery {
   readonly offer: (delta: InferDelta) => Effect.Effect<boolean>
   readonly finish: Effect.Effect<void>
@@ -636,21 +643,28 @@ export const infer = <const C extends ModelConfig>(
       // Wire-reported provenance wins: a router that names the upstream it served from records
       // the true split; the configured stamp covers a wire that stays silent.
       const reportedUsage = attempt.reportedUsage?.()
-      const providerMetrics = wire?.usageReports ?? (reportedUsage === undefined ? [] : [reportedUsage])
-      const usage = usageFrom(
-        [...providerMetrics, held.tokens],
+      const reports = wire?.usageReports
+      const providerMetrics = reports?.length === 1 ? reports[0] : (reports ?? reportedUsage)
+      const stamp = {
+        ...stampOf(config),
+        ...(wire?.provider === undefined ? {} : { provider: wire.provider }),
+        ...(wire?.model === undefined ? {} : { model: wire.model })
+      }
+      const normalized = usageFrom(
+        held.tokens,
         config.pricing,
-        {
-          ...stampOf(config),
-          ...(wire?.provider === undefined ? {} : { provider: wire.provider }),
-          ...(wire?.model === undefined ? {} : { model: wire.model })
-        },
-        providerMetrics.length === 0
-          ? undefined
-          : providerMetrics.length === 1
-            ? providerMetrics[0]
-            : providerMetrics
+        stamp,
+        providerMetrics
       )
+      const reportedCostUsd = held.tokens?.cost ?? reportedCostOf(providerMetrics)
+      const usage = reportedCostUsd === undefined
+        ? normalized
+        : {
+            ...(normalized ?? { promptTokens: 0, completionTokens: 0, ...stamp }),
+            costUsd: reportedCostUsd,
+            costSource: "provider" as const,
+            reportedCostUsd
+          }
       return { usage, endpoint: endpointOf(config, wire), wire }
     }
     try {


### PR DESCRIPTION
TanStack adapters normalize provider usage into typed TokenUsage. Tardigrade also reparsed raw gateway fields and could add cache creation tokens to an inclusive prompt total, which inflated accounting.

This change makes TanStack usage the source of normalized token counts and details. Raw wire reports remain durable evidence and still supply gateway-reported cost and serving provenance. Fields omitted by TanStack stay absent.

The regression test covers a gateway response whose prompt total already contains cache creation tokens. It also verifies that multiple raw reports remain intact while their normalized view follows TanStack.

Validation: all 69 repository gate tasks pass. The platform model package passes 60 tests with 159 assertions.