### PR TITLE
fix(host): simplify thread creation

### DIFF
--- a/e2e/actor/developer-flow.test.ts
+++ b/e2e/actor/developer-flow.test.ts
@@ -49,9 +49,10 @@ test.each(["memory", "sqlite"] as const)("the developer flow allocates scoped th
     expect((yield* tardie.allocateRootThread({ instance: "rick", name: "main" })).address).toEqual(rickRef.address)
 
     const researcherRef = yield* tardie.allocateChildThread({ parent: rickRef, name: "researcher" })
-    const labResearcherRef = yield* tardie.allocateChildThread({ parent: rickLabRef, name: "researcher" })
+    const labResearcherRef = yield* tardie.allocateChildThread({ parent: rickLabRef, name: "lab-researcher" })
     const mortyResearcherRef = yield* tardie.allocateChildThread({ parent: mortyRef, name: "researcher" })
     const children = [researcherRef, labResearcherRef, mortyResearcherRef]
+    expect(children.map((ref) => ref.address.thread)).toEqual(["researcher", "lab-researcher", "researcher"])
     expect(new Set(children.map((ref) => JSON.stringify(ref.address))).size).toBe(3)
     expect((yield* tardie.allocateChildThread({ parent: rickRef, name: "researcher" })).address).toEqual(researcherRef.address)
     expect(researcherRef.address.instance).toBe("rick")

--- a/packages/agent/src/packages/agents.properties.test.ts
+++ b/packages/agent/src/packages/agents.properties.test.ts
@@ -33,7 +33,7 @@ const registeredAllocator = (): typeof ThreadAllocator.Service => {
   return { allocate: (request) => Effect.sync(() => {
     if (request.kind === "root") return request.coordinate
     const { parent, child } = request
-    const key = JSON.stringify([parent.actor, parent.instance, parent.thread, child])
+    const key = JSON.stringify([parent.actor, parent.instance, parent.thread, child, request.key])
     const existing = assignments.get(key)
     if (existing !== undefined) return existing
     const target = { ...parent, thread: `registered:${assignments.size}` }

--- a/packages/agent/src/packages/agents.test.ts
+++ b/packages/agent/src/packages/agents.test.ts
@@ -102,7 +102,7 @@ const legacyChild = (callId: string): Event => ({
 const expectedThread = async (turn: string, call: string) => (await Effect.runPromise(testAllocator.allocate({
   kind: "child",
   parent: parseThreadAddress("mem:main:ag.root"),
-  child: childKeyOf(JSON.stringify([turn, call]))
+  child: childKeyOf("unnamed"), key: JSON.stringify([turn, call])
 }))).thread
 
 describe("agentsPackage", () => {
@@ -115,7 +115,7 @@ describe("agentsPackage", () => {
     const invoke = () => agentsPackage().methods.run!({ text: "work", background: true }, { callId: "call" }).pipe(
       Effect.provideService(ThreadAllocator, { allocate: (request) => Effect.sync(() => {
         allocations++
-        expect(request).toEqual({ kind: "child", parent, child: childKeyOf(JSON.stringify(["turn", "call"])) })
+        expect(request).toEqual({ kind: "child", parent, child: childKeyOf("unnamed"), key: JSON.stringify(["turn", "call"]) })
         if (allocations > 1) throw new Error("replay must use its recorded coordinate")
         return target
       }) }),

--- a/packages/agent/src/packages/agents.ts
+++ b/packages/agent/src/packages/agents.ts
@@ -256,7 +256,7 @@ const childClaimOf = (
         ...(recorded.placement === undefined ? {} : { placement: recorded.placement })
       }
   const target = recorded?.address ?? (yield* allocateChildThread({
-    parent: source, child: childKeyOf(JSON.stringify([parentRunId, callId]))
+    parent: source, child: childKeyOf("unnamed"), key: JSON.stringify([parentRunId, callId])
   }))
   // clash rejects a derived address already claimed by another recorded child (agents.test.ts, "a derived address that names another child dies rather than delivering").
   if (recorded === undefined) {

--- a/packages/core/src/actor/events.test.ts
+++ b/packages/core/src/actor/events.test.ts
@@ -4,15 +4,27 @@ import { actorEventKeyOf, actorThreadsOf } from "./events"
 
 describe("actor events", () => {
   test("allocation and registration project into the same thread record", () => {
-    const allocated: Event = { type: "ThreadAllocated", thread: "quiet-fox-abcd", allocationKey: "spawn", parentThread: "main", depth: 1, at: 0 }
-    const requested: Event = { type: "ThreadRequested", thread: "quiet-fox-abcd", parentThread: "main", depth: 1, placement: "independent", at: 1 }
-    const registered: Event = { type: "ThreadRegistered", thread: "quiet-fox-abcd", at: 2 }
+    const requested: Event = { type: "ThreadRequested", thread: "quiet-fox-abcd", allocationKey: "spawn", parentThread: "main", depth: 1, at: 1 }
+    const registered: Event = { type: "ThreadRegistered", thread: "quiet-fox-abcd", placement: "independent", at: 2 }
     for (const [events, state] of [
-      [[allocated], "allocated"], [[allocated, requested], "requested"], [[allocated, requested, registered], "registered"]
+      [[requested], "requested"], [[requested, registered], "registered"]
     ] as const) {
       expect(actorThreadsOf(events)).toEqual([expect.objectContaining({ allocationKey: "spawn", thread: "quiet-fox-abcd", parentThread: "main", depth: 1, state })])
     }
-    expect(actorEventKeyOf(allocated)).toBe("thread:allocated:quiet-fox-abcd")
+    expect(actorThreadsOf([requested, registered])[0]?.placement).toBe("independent")
+    expect(actorEventKeyOf(requested)).toBe("thread:requested:quiet-fox-abcd")
+  })
+
+  test("legacy allocations retain their identity and registration metadata", () => {
+    const allocated: Event = { type: "ThreadAllocated", thread: "old-child", allocationKey: "spawn", parentThread: "main", depth: 1, at: 0 }
+    const requested: Event = { type: "ThreadRequested", thread: "old-child", parentThread: "main", depth: 1, placement: "independent", at: 1 }
+    const registered: Event = { type: "ThreadRegistered", thread: "old-child", at: 2 }
+    expect(actorThreadsOf([allocated])[0]).toMatchObject({ allocationKey: "spawn", state: "requested" })
+    for (const events of [[allocated, requested, registered], [requested, registered, allocated]]) {
+      expect(actorThreadsOf(events)).toEqual([{
+        allocationKey: "spawn", thread: "old-child", parentThread: "main", depth: 1, placement: "independent", state: "registered"
+      }])
+    }
   })
 
   test("projects thread registration", () => {

--- a/packages/core/src/actor/events.test.ts
+++ b/packages/core/src/actor/events.test.ts
@@ -15,18 +15,6 @@ describe("actor events", () => {
     expect(actorEventKeyOf(requested)).toBe("thread:requested:quiet-fox-abcd")
   })
 
-  test("legacy allocations retain their identity and registration metadata", () => {
-    const allocated: Event = { type: "ThreadAllocated", thread: "old-child", allocationKey: "spawn", parentThread: "main", depth: 1, at: 0 }
-    const requested: Event = { type: "ThreadRequested", thread: "old-child", parentThread: "main", depth: 1, placement: "independent", at: 1 }
-    const registered: Event = { type: "ThreadRegistered", thread: "old-child", at: 2 }
-    expect(actorThreadsOf([allocated])[0]).toMatchObject({ allocationKey: "spawn", state: "requested" })
-    for (const events of [[allocated, requested, registered], [requested, registered, allocated]]) {
-      expect(actorThreadsOf(events)).toEqual([{
-        allocationKey: "spawn", thread: "old-child", parentThread: "main", depth: 1, placement: "independent", state: "registered"
-      }])
-    }
-  })
-
   test("projects thread registration", () => {
     const events: ReadonlyArray<Event> = [
       { type: "ThreadRequested", thread: "child", parentThread: "root", depth: 1, at: 1 },

--- a/packages/core/src/actor/events.ts
+++ b/packages/core/src/actor/events.ts
@@ -38,7 +38,6 @@ export const actorEventKeyOf = (event: Event): string | undefined => {
 export const actorEventsOf = (events: ReadonlyArray<Event>): ReadonlyArray<ActorEvent> =>
   events.flatMap((event): ReadonlyArray<ActorEvent> => {
     if (typeof event.thread !== "string") return []
-    if (event.type === "ThreadAllocated") return [{ ...event, type: "ThreadRequested" } as ThreadRequested]
     return event.type === "ThreadRequested" || event.type === "ThreadRegistered" ? [event as ActorEvent] : []
   })
 
@@ -47,15 +46,13 @@ export const actorThreadsOf = (events: ReadonlyArray<Event>): ReadonlyArray<Acto
   for (const event of actorEventsOf(events)) {
     const current = entries.get(event.thread)
     if (event.type === "ThreadRequested") {
-      const allocationKey = event.allocationKey ?? current?.allocationKey
       entries.set(event.thread, {
-        ...current,
-        ...(allocationKey === undefined ? {} : { allocationKey }),
+        ...(event.allocationKey === undefined ? {} : { allocationKey: event.allocationKey }),
         thread: event.thread,
         ...(event.parentThread === undefined ? {} : { parentThread: event.parentThread }),
         depth: event.depth,
         ...(event.placement === undefined ? {} : { placement: event.placement }),
-        state: current?.state ?? "requested"
+        state: "requested"
       })
       continue
     }

--- a/packages/core/src/actor/events.ts
+++ b/packages/core/src/actor/events.ts
@@ -3,6 +3,7 @@ import type { ChildPlacement } from "../interaction/relations"
 
 export interface ThreadRequested extends Event {
   readonly type: "ThreadRequested"
+  readonly allocationKey?: string
   readonly thread: string
   readonly parentThread?: string
   readonly depth: number
@@ -10,22 +11,14 @@ export interface ThreadRequested extends Event {
   readonly at: number
 }
 
-export interface ThreadAllocated extends Event {
-  readonly type: "ThreadAllocated"
-  readonly thread: string
-  readonly allocationKey: string
-  readonly parentThread?: string
-  readonly depth: number
-  readonly at: number
-}
-
 export interface ThreadRegistered extends Event {
   readonly type: "ThreadRegistered"
+  readonly placement?: ChildPlacement
   readonly thread: string
   readonly at: number
 }
 
-export type ActorEvent = ThreadAllocated | ThreadRequested | ThreadRegistered
+export type ActorEvent = ThreadRequested | ThreadRegistered
 
 export interface ActorThreadRecord {
   readonly allocationKey?: string
@@ -33,47 +26,41 @@ export interface ActorThreadRecord {
   readonly parentThread?: string
   readonly depth: number
   readonly placement?: ChildPlacement
-  readonly state: "allocated" | "requested" | "registered"
+  readonly state: "requested" | "registered"
 }
 
 export const actorEventKeyOf = (event: Event): string | undefined => {
-  if (event.type === "ThreadAllocated" && typeof event.thread === "string") return `thread:allocated:${event.thread}`
   if (event.type === "ThreadRequested" && typeof event.thread === "string") return `thread:requested:${event.thread}`
   if (event.type === "ThreadRegistered" && typeof event.thread === "string") return `thread:registered:${event.thread}`
   return undefined
 }
 
 export const actorEventsOf = (events: ReadonlyArray<Event>): ReadonlyArray<ActorEvent> =>
-  events.filter((event): event is ActorEvent => {
-    if (typeof event.thread !== "string") return false
-    return event.type === "ThreadAllocated" || event.type === "ThreadRequested" || event.type === "ThreadRegistered"
+  events.flatMap((event): ReadonlyArray<ActorEvent> => {
+    if (typeof event.thread !== "string") return []
+    if (event.type === "ThreadAllocated") return [{ ...event, type: "ThreadRequested" } as ThreadRequested]
+    return event.type === "ThreadRequested" || event.type === "ThreadRegistered" ? [event as ActorEvent] : []
   })
 
 export const actorThreadsOf = (events: ReadonlyArray<Event>): ReadonlyArray<ActorThreadRecord> => {
   const entries = new Map<string, ActorThreadRecord>()
   for (const event of actorEventsOf(events)) {
     const current = entries.get(event.thread)
-    if (event.type === "ThreadAllocated") {
-      entries.set(event.thread, current === undefined ? {
-        thread: event.thread, allocationKey: event.allocationKey, depth: event.depth,
-        ...(event.parentThread === undefined ? {} : { parentThread: event.parentThread }),
-        state: "allocated"
-      } : { ...current, allocationKey: event.allocationKey })
-      continue
-    }
     if (event.type === "ThreadRequested") {
+      const allocationKey = event.allocationKey ?? current?.allocationKey
       entries.set(event.thread, {
-        ...(current?.allocationKey === undefined ? {} : { allocationKey: current.allocationKey }),
+        ...current,
+        ...(allocationKey === undefined ? {} : { allocationKey }),
         thread: event.thread,
         ...(event.parentThread === undefined ? {} : { parentThread: event.parentThread }),
         depth: event.depth,
         ...(event.placement === undefined ? {} : { placement: event.placement }),
-        state: "requested"
+        state: current?.state ?? "requested"
       })
       continue
     }
     if (current === undefined) throw new Error(`thread ${JSON.stringify(event.thread)} has no request`)
-    entries.set(event.thread, { ...current, state: "registered" })
+    entries.set(event.thread, { ...current, ...(event.placement === undefined ? {} : { placement: event.placement }), state: "registered" })
   }
   return [...entries.values()]
 }

--- a/packages/host/src/allocation-sql.ts
+++ b/packages/host/src/allocation-sql.ts
@@ -12,7 +12,7 @@ export const sqlThreadDirectory = (
   occupied: (target: ThreadCoordinate, existingRoot: boolean) => Effect.Effect<boolean>
 ): ThreadAllocationStore => {
   const get = (key: string) => sql<{ thread: string }>`SELECT json_extract(event, '$.thread') AS thread
-    FROM ${sql(table)} WHERE json_extract(event, '$.type') = 'ThreadAllocated'
+    FROM ${sql(table)} WHERE json_extract(event, '$.type') IN ('ThreadRequested', 'ThreadAllocated')
     AND json_extract(event, '$.allocationKey') = ${key}`.pipe(
     Effect.map((rows) => rows[0]?.thread), Effect.orDie
   )

--- a/packages/host/src/allocation-sql.ts
+++ b/packages/host/src/allocation-sql.ts
@@ -12,7 +12,7 @@ export const sqlThreadDirectory = (
   occupied: (target: ThreadCoordinate, existingRoot: boolean) => Effect.Effect<boolean>
 ): ThreadAllocationStore => {
   const get = (key: string) => sql<{ thread: string }>`SELECT json_extract(event, '$.thread') AS thread
-    FROM ${sql(table)} WHERE json_extract(event, '$.type') IN ('ThreadRequested', 'ThreadAllocated')
+    FROM ${sql(table)} WHERE json_extract(event, '$.type') = 'ThreadRequested'
     AND json_extract(event, '$.allocationKey') = ${key}`.pipe(
     Effect.map((rows) => rows[0]?.thread), Effect.orDie
   )

--- a/packages/host/src/allocation.properties.test.ts
+++ b/packages/host/src/allocation.properties.test.ts
@@ -56,6 +56,13 @@ const verify = (model: Model) => {
 const allocate = async (model: Model, real: Real, intent: Intent) => {
   const expected = model.entries.find((entry) => sameIntent(entry.intent, intent))
   const request = requestOf(model, intent)
+  const occupied = intent.mode === "name" && model.entries.some(({ target }) =>
+    target.actor === intent.actor && target.instance === intent.instance && target.thread === intent.local)
+  if (expected === undefined && occupied) {
+    await expect(Effect.runPromise(real.allocator.allocate(request))).rejects.toThrow("already taken")
+    verify(model)
+    return
+  }
   const targets = await Promise.all(Array.from({ length: 3 }, () => Effect.runPromise(real.allocator.allocate(request))))
   for (const target of targets) expect(target).toEqual(expected?.target ?? targets[0]!)
   if (expected === undefined) model.entries.push({ intent, target: targets[0]! })
@@ -161,6 +168,7 @@ test("allocation histories preserve thread and invocation identity across claims
     await allocate(model, real, { ...root, mode: "key" })
     await allocate(model, real, { ...root, parent: 0 })
     await allocate(model, real, { ...root, parent: 1 })
+    await allocate(model, real, { ...root, parent: 0, local: "researcher" })
     await allocate(model, real, { ...root, parent: 2 })
     await allocate(model, real, { ...root, instance: "morty" })
     await allocate(model, real, { ...root, actor: "other" })

--- a/packages/host/src/allocation.test.ts
+++ b/packages/host/src/allocation.test.ts
@@ -18,9 +18,24 @@ test("roots, children, and existing threads cannot claim each other's IDs", asyn
   const candidates = ["occupied", "main", "quiet-fox-abcd", "quiet-fox-abcd", "bright-owl-efgh"]
   const allocator = registeredThreadAllocator(store, { generate: () => candidates.shift()! })
   const root = await Effect.runPromise(allocator.allocate({ kind: "root", coordinate: parent }))
-  const spawned = await Effect.runPromise(allocator.allocate(child("researcher")))
+  const spawned = await Effect.runPromise(allocator.allocate({ ...child("researcher"), key: "spawn" }))
   const unnamed = await Effect.runPromise(allocator.allocate({ kind: "root", coordinate: { ...parent, thread: "" }, key: "create" }))
   expect([root.thread, spawned.thread, unnamed.thread]).toEqual(["main", "quiet-fox-abcd", "bright-owl-efgh"])
+})
+
+test("named allocations use the name and report conflicts without generating a replacement", async () => {
+  const store = memoryThreadDirectory((target) => target.thread === "occupied")
+  const allocator = registeredThreadAllocator(store, { generate: () => { throw new Error("named allocation must not generate") } })
+  const run = (request: ThreadAllocation) => Effect.runPromise(allocator.allocate(request))
+  expect((await run({ kind: "root", coordinate: parent })).thread).toBe("main")
+  const request = child("researcher")
+  expect((await run(request)).thread).toBe("researcher")
+  expect((await run(request)).thread).toBe("researcher")
+  await expect(run(child("main"))).rejects.toThrow('thread name "main" is already taken')
+  await expect(run(child("occupied"))).rejects.toThrow('thread name "occupied" is already taken')
+  await expect(run({ ...request, kind: "child", parent: { ...parent, thread: "other" }, child: childKeyOf("researcher") })).rejects.toThrow("already taken")
+  await expect(run({ kind: "root", coordinate: { ...parent, thread: "researcher" } })).rejects.toThrow("already taken")
+  await expect(run({ kind: "root", coordinate: { ...parent, thread: "occupied" } })).rejects.toThrow("already taken")
 })
 
 test("distinct scopes and names separate trees at every depth", async () => {
@@ -39,7 +54,7 @@ test("distinct scopes and names separate trees at every depth", async () => {
       let frontier = roots
       for (let level = 0; level < depth; level++) {
         const descendants = await Promise.all(frontier.flatMap((parent) => names.map(async (name) => {
-          const request: ThreadAllocation = { kind: "child", parent, child: childKeyOf(name) }
+          const request: ThreadAllocation = { kind: "child", parent, child: childKeyOf(name), key: name }
           const target = await Effect.runPromise(allocator.allocate(request))
           expect(await Effect.runPromise(registeredThreadAllocator(store).allocate(request))).toEqual(target)
           return target

--- a/packages/host/src/allocation.ts
+++ b/packages/host/src/allocation.ts
@@ -1,7 +1,7 @@
 import { Clock, Effect, Schema } from "effect"
 import { ThreadCoordinate, threadIdOf } from "@clavia/tardigrade-core/actor/coordinate"
 import { allocateThread, ThreadAllocator, type ThreadAllocation } from "@clavia/tardigrade-core/actor/allocation"
-import { actorThreadsOf, type ThreadAllocated } from "@clavia/tardigrade-core/actor/events"
+import { actorThreadsOf, type ThreadRequested } from "@clavia/tardigrade-core/actor/events"
 import type { Event } from "@clavia/tardigrade-core/event"
 
 // instanceThreadAllocator rejects assignments outside the owning actor instance.
@@ -68,16 +68,17 @@ export interface ThreadAllocationStore {
 // threadAllocationRecord keeps allocation identity in the actor's thread record (allocation.test.ts).
 export const threadAllocationRecord = (
   events: ReadonlyArray<Event>, request: ThreadAllocation, target: ThreadCoordinate, existingRoot: boolean, at: number
-): { readonly thread: string; readonly event?: ThreadAllocated } | undefined => {
+): { readonly thread: string; readonly event?: ThreadRequested } | undefined => {
   const key = threadAllocationKey(request)
   const records = actorThreadsOf(events)
   const assigned = records.find((record) => record.allocationKey === key)
   if (assigned !== undefined) return { thread: assigned.thread }
   const current = records.find((record) => record.thread === target.thread)
   if (current !== undefined && (current.allocationKey !== undefined || !existingRoot || current.parentThread !== undefined)) return undefined
+  if (current !== undefined) return { thread: current.thread }
   const parent = request.kind === "child" ? request.parent.thread : undefined
   return { thread: target.thread, event: {
-    type: "ThreadAllocated", thread: target.thread, allocationKey: key,
+    type: "ThreadRequested", thread: target.thread, allocationKey: key,
     ...(parent === undefined ? {} : { parentThread: parent }),
     depth: parent === undefined ? 0 : (records.find((record) => record.thread === parent)?.depth ?? 0) + 1,
     at
@@ -103,13 +104,19 @@ export const registeredThreadAllocator = (
     const key = threadAllocationKey(request)
     const recorded = yield* store.get(key)
     if (recorded !== undefined) return { ...parent, thread: recorded }
+    if (request.key === undefined) {
+      const name = threadIdOf(request.kind === "root" ? parent.thread : request.child)
+      const thread = request.kind === "child" && name === parent.thread ? undefined
+        : yield* store.claim(key, { ...parent, thread: name }, request.kind === "root", request)
+      if (thread !== undefined) return { ...parent, thread }
+      return yield* Effect.die(new Error(`thread name ${JSON.stringify(name)} is already taken in actor instance ${JSON.stringify([parent.actor, parent.instance])}`))
+    }
     const attempts = policy.maxAttempts ?? DEFAULT_THREAD_ALLOCATION_ATTEMPTS
     if (!Number.isSafeInteger(attempts) || attempts < 1) throw new Error("allocation attempts must be a positive integer")
-    const namedRoot = request.kind === "root" && request.key === undefined
     for (let attempt = 0; attempt < attempts; attempt++) {
-      const candidate = threadIdOf(namedRoot && attempt === 0 ? parent.thread : (policy.generate ?? (() => threadSlug(policy)))())
+      const candidate = threadIdOf((policy.generate ?? (() => threadSlug(policy)))())
       if (request.kind === "child" && candidate === parent.thread) continue
-      const thread = yield* store.claim(key, { ...parent, thread: candidate }, namedRoot && candidate === parent.thread, request)
+      const thread = yield* store.claim(key, { ...parent, thread: candidate }, false, request)
       if (thread !== undefined) return { ...parent, thread }
     }
     return yield* Effect.die(new Error(`thread allocation exhausted ${attempts} collision attempts`))

--- a/packages/host/tla/Identity.tla
+++ b/packages/host/tla/Identity.tla
@@ -37,7 +37,7 @@ Allocated == {n \in Nodes: assigned[n] # None}
 Available(n, token) == \A other \in Allocated:
   Address(n, token) # Address(other, assigned[other])
 
-(* Claim abstracts the atomic read, collision check, and ThreadAllocated append in allocation-sql.ts. *)
+(* Claim abstracts the atomic read, collision check, and ThreadRequested append in allocation-sql.ts. *)
 Claim(n) ==
   /\ Ready(n)
   /\ assigned[n] = None

--- a/platform/bun/src/allocation.test.ts
+++ b/platform/bun/src/allocation.test.ts
@@ -55,28 +55,3 @@ test("the actor directory retains root and child assignments across restarts", a
     await rm(directory, { recursive: true, force: true })
   }
 })
-
-test("legacy allocation records preserve retries and reserve their names after reopen", async () => {
-  const directory = await mkdtemp(join(tmpdir(), "tardigrade-legacy-allocation-"))
-  const options = { database: join(directory, "rick.sqlite"), actorName: "tardie", actorInstance: "rick", actorFor: () => undefined, workspaceSql: false as const,
-    allocation: { generate: () => { throw new Error("must recover legacy assignment") } } }
-  const parent = { actor: "tardie", instance: "rick", thread: "main" }
-  const request = { kind: "child" as const, parent, child: childKeyOf("researcher") }
-  let host = await createBunHost(options)
-  try {
-    await host.close()
-    const database = new Database(options.database)
-    try {
-      database.query("INSERT INTO actor_events (seq, key, event) VALUES (1, ?, ?)").run("thread:allocated:old-child", JSON.stringify({
-        type: "ThreadAllocated", thread: "old-child", allocationKey: threadAllocationKey(request), parentThread: "main", depth: 1, at: 1
-      }))
-    } finally { database.close() }
-    host = await createBunHost(options)
-    expect(await host.assignThread(request)).toEqual({ ...parent, thread: "old-child" })
-    await expect(host.assignThread({ ...request, child: childKeyOf("old-child") })).rejects.toThrow("already taken")
-    expect(await host.actorHead()).toBe(1)
-  } finally {
-    await host.close()
-    await rm(directory, { recursive: true, force: true })
-  }
-})

--- a/platform/bun/src/allocation.test.ts
+++ b/platform/bun/src/allocation.test.ts
@@ -23,16 +23,17 @@ test("the actor directory retains root and child assignments across restarts", a
     const spawn = { kind: "child" as const, parent: root, child: childKeyOf("researcher") }
     const children = await Promise.all(Array.from({ length: 10 }, () => host.allocate(spawn)))
     expect(new Set(children.map((child) => child.thread)).size).toBe(1)
-    expect(children[0]!.thread).not.toBe(root.thread)
+    expect(children[0]!.thread).toBe("researcher")
+    await expect(host.assignThread({ kind: "root", coordinate: { ...root, thread: "researcher" } })).rejects.toThrow("already taken")
     let retries = 0
     generate = () => retries++ === 0 ? children[0]!.thread : "calm-otter-cccc"
-    const siblingRequest = { ...spawn, child: childKeyOf("writer") }
+    const siblingRequest = { ...spawn, child: childKeyOf("unnamed"), key: "writer" }
     const sibling = await host.assignThread(siblingRequest)
     expect(sibling.thread).toBe("calm-otter-cccc")
     expect(retries).toBe(2)
     const allocated = actorThreadsOf((await host.readActorPage(0, 100)).map((row) => row.event))
     expect(allocated).toHaveLength(3)
-    expect(allocated.find((record) => record.thread === root.thread)).toMatchObject({ allocationKey: threadAllocationKey(request), state: "allocated" })
+    expect(allocated.find((record) => record.thread === root.thread)).toMatchObject({ allocationKey: threadAllocationKey(request), state: "requested" })
     await expect(host.assignThread({ ...request, coordinate: { ...request.coordinate, instance: "morty" } })).rejects.toThrow("owning actor directory")
     await host.close()
     host = await createBunHost({ ...options, allocation: { generate: () => { throw new Error("must read persisted assignment") } } })
@@ -49,6 +50,31 @@ test("the actor directory retains root and child assignments across restarts", a
     } finally {
       database.close()
     }
+  } finally {
+    await host.close()
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test("legacy allocation records preserve retries and reserve their names after reopen", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "tardigrade-legacy-allocation-"))
+  const options = { database: join(directory, "rick.sqlite"), actorName: "tardie", actorInstance: "rick", actorFor: () => undefined, workspaceSql: false as const,
+    allocation: { generate: () => { throw new Error("must recover legacy assignment") } } }
+  const parent = { actor: "tardie", instance: "rick", thread: "main" }
+  const request = { kind: "child" as const, parent, child: childKeyOf("researcher") }
+  let host = await createBunHost(options)
+  try {
+    await host.close()
+    const database = new Database(options.database)
+    try {
+      database.query("INSERT INTO actor_events (seq, key, event) VALUES (1, ?, ?)").run("thread:allocated:old-child", JSON.stringify({
+        type: "ThreadAllocated", thread: "old-child", allocationKey: threadAllocationKey(request), parentThread: "main", depth: 1, at: 1
+      }))
+    } finally { database.close() }
+    host = await createBunHost(options)
+    expect(await host.assignThread(request)).toEqual({ ...parent, thread: "old-child" })
+    await expect(host.assignThread({ ...request, child: childKeyOf("old-child") })).rejects.toThrow("already taken")
+    expect(await host.actorHead()).toBe(1)
   } finally {
     await host.close()
     await rm(directory, { recursive: true, force: true })

--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -222,23 +222,22 @@ describe("the bun host", () => {
     await first.commitRoot("bun:default:alpha", { type: "MessageReceived", id: "m1", at: 1 } as Event)
 
     expect(await waiting).toBeGreaterThan(0)
-    expect(await first.actorHead()).toBe(3)
+    expect(await first.actorHead()).toBe(2)
     expect(await first.readActorPage(0, 10)).toEqual([
-      { seq: 1, event: expect.objectContaining({ type: "ThreadAllocated", thread: "alpha" }) },
-      { seq: 2, event: expect.objectContaining({ type: "ThreadRequested", thread: "alpha" }) },
-      { seq: 3, event: expect.objectContaining({ type: "ThreadRegistered", thread: "alpha" }) }
+      { seq: 1, event: expect.objectContaining({ type: "ThreadRequested", thread: "alpha" }) },
+      { seq: 2, event: expect.objectContaining({ type: "ThreadRegistered", thread: "alpha" }) }
     ])
     expect(await first.actorThreads()).toEqual({
-      cursor: 3,
+      cursor: 2,
       threads: [{ thread: "alpha", allocationKey: expect.any(String), depth: 0, state: "registered" }]
     })
     expect(await first.actorThread("alpha")).toEqual({ thread: "alpha", allocationKey: expect.any(String), depth: 0, state: "registered" })
     await first.close()
 
     const reopened = await createBunHost(options(path))
-    expect(await reopened.actorHead()).toBe(3)
+    expect(await reopened.actorHead()).toBe(2)
     await reopened.commitRoot("bun:default:alpha", { type: "MessageReceived", id: "m2", at: 2 } as Event)
-    expect(await reopened.actorHead()).toBe(3)
+    expect(await reopened.actorHead()).toBe(2)
     await reopened.close()
   })
 

--- a/platform/bun/src/host.ts
+++ b/platform/bun/src/host.ts
@@ -295,7 +295,7 @@ export const createBunHost = async <R = never>(options: BunHostOptions<R>): Prom
     `.pipe(
       Effect.map((rows) => ({
         cursor: Number(rows.at(-1)?.seq ?? 0),
-        threads: actorThreadsOf(rows.map((row) => JSON.parse(row.event) as Event)).filter((record) => record.state !== "allocated")
+        threads: actorThreadsOf(rows.map((row) => JSON.parse(row.event) as Event))
       })),
       Effect.orDie
     ))
@@ -342,7 +342,7 @@ export const createBunHost = async <R = never>(options: BunHostOptions<R>): Prom
       }),
       at
     } satisfies ThreadRequested)
-    await appendActorEvent({ type: "ThreadRegistered", thread, at } satisfies ThreadRegistered)
+    await appendActorEvent({ type: "ThreadRegistered", thread, ...(lineage?.placement === undefined ? {} : { placement: lineage.placement }), at } satisfies ThreadRegistered)
   }
   const threads = (): Promise<ReadonlyArray<string>> => directoryRuntime.runPromise(
     directorySql<{ thread: string }>`SELECT thread FROM thread_directory ORDER BY thread`.pipe(Effect.map((rows) => rows.map((row) => row.thread)), Effect.orDie)

--- a/platform/cloudflare/src/actor.ts
+++ b/platform/cloudflare/src/actor.ts
@@ -44,17 +44,18 @@ const actorSupervisorOf = (
         key: registeredKeyOf(event.thread),
         input: event,
         act: (request) => Effect.gen(function* () {
-          yield* Effect.promise(async () => {
+          const registration = yield* Effect.promise(async () => {
             const stub = env.THREADS.getByName(threadObjectNameOf(identity.actor, identity.instance, request.thread))
             if (request.parentThread === undefined) {
-              if (!(await stub.exists(identity.actor, identity.instance, request.thread))) {
-                throw new Error(`root thread ${JSON.stringify(request.thread)} has no durable host`)
-              }
-            } else {
-              await stub.commitCreation()
+              await stub.init(identity.actor, identity.instance, request.thread)
+              await stub.initializeRoot()
+              return {}
             }
+            const created = await stub.commitCreation()
+            return created === undefined ? undefined : created.placement === undefined ? {} : { placement: created.placement }
           })
-          return [{ type: "ThreadRegistered", thread: request.thread, at: yield* Clock.currentTimeMillis }]
+          if (registration === undefined) return []
+          return [{ type: "ThreadRegistered", thread: request.thread, ...registration, at: yield* Clock.currentTimeMillis }]
         })
       })]
     })
@@ -220,12 +221,15 @@ export class ActorDO extends DurableObject<Env> {
         WHERE json_extract(event, '$.type') = 'ThreadRequested' AND json_extract(event, '$.thread') = ${target.thread}`.pipe(
         Effect.map((rows) => rows.length > 0 && (!existingRoot || rows.some((row) => row.parent !== null))), Effect.orDie
       ))
-    return Effect.runPromise(allocateThread(request).pipe(Effect.provideService(
+    const target = await Effect.runPromise(allocateThread(request).pipe(Effect.provideService(
       ThreadAllocator, mountedActor?.threadAllocator ?? registeredThreadAllocator({
         get: (key) => Effect.promise(() => this.database.runPromise(store.get(key))),
         claim: (key, target, existingRoot, request) => Effect.promise(() => this.database.runPromise(store.claim(key, target, existingRoot, request)))
       }, mountedActor?.allocation)
     )))
+    const at = armAt(await this.ctx.storage.getAlarm(), Date.now(), this.alarmPolicy.recoveryDelayMillis)
+    if (at !== null) await this.ctx.storage.setAlarm(at)
+    return target
   }
 
   async initializeRootThread(thread: string): Promise<void> {
@@ -261,7 +265,7 @@ export class ActorDO extends DurableObject<Env> {
     if (existing !== undefined && (
       existing.parentThread !== lineage.parent.thread ||
       Number(existing.depth) !== lineage.depth ||
-      (existing.state !== "allocated" && existing.placement !== placement)
+      ((existing.state === "registered" || existing.placement !== undefined) && (existing.placement ?? null) !== placement)
     )) {
       throw new Error("a child thread already has different lineage")
     }

--- a/platform/cloudflare/src/thread.ts
+++ b/platform/cloudflare/src/thread.ts
@@ -1,3 +1,4 @@
+import { threadCreatedOf, type ThreadCreated } from "@clavia/tardigrade-core/interaction/relations"
 import { cloudflareRpcTransport } from "./transport/rpc"
 import { DurableObject } from "cloudflare:workers"
 import { Effect, Layer, Schema } from "effect"
@@ -313,12 +314,16 @@ export class ThreadDO extends DurableObject<Env> {
     await this.ctx.storage.sync()
   }
 
-  async commitCreation(): Promise<void> {
+  async commitCreation(): Promise<ThreadCreated | undefined> {
+    if (!this.initialized()) return undefined
     const host = await this.host()
+    const created = threadCreatedOf(await host.read())
+    if (created === undefined) return undefined
     await this.arm()
     await this.commitTurn()
     host.publishStaged()
     this.kick(host)
+    return created
   }
 
   async deliver(envelope: ActorEnvelope): Promise<void> {

--- a/platform/cloudflare/test/actor.workers.ts
+++ b/platform/cloudflare/test/actor.workers.ts
@@ -1,3 +1,4 @@
+import { childKeyOf } from "@clavia/tardigrade-core/actor/coordinate"
 import { env, runInDurableObject, SELF } from "cloudflare:test"
 import { Effect, ManagedRuntime, Schema } from "effect"
 import { actor, actorMethod, component } from "tardie"
@@ -716,9 +717,12 @@ describe("cloudflare actor", () => {
     expect(results[0]!.thread).toMatch(/^[a-z]+-[a-z]+-[a-z2-7]{4}$/)
     expect(await directory.allocateThread(request)).toEqual(results[0])
     const rows = await runInDurableObject(directory, (_instance, state) =>
-      state.storage.sql.exec<{ thread: string }>("SELECT json_extract(event, '$.thread') AS thread FROM events WHERE json_extract(event, '$.type') = 'ThreadAllocated'").toArray())
+      state.storage.sql.exec<{ thread: string }>("SELECT json_extract(event, '$.thread') AS thread FROM events WHERE json_extract(event, '$.type') = 'ThreadRequested' AND json_extract(event, '$.allocationKey') IS NOT NULL").toArray())
     expect(rows.map((row) => row.thread)).toContain(results[0]!.thread)
     expect(rows.filter((row) => row.thread === results[0]!.thread)).toHaveLength(1)
+    expect(await runInDurableObject(directory, (_instance, state) => state.storage.getAlarm())).not.toBeNull()
+    await runInDurableObject(directory, (instance) => instance.alarm())
+    expect((await directory.threadTree()).some((node) => node.id === results[0]!.thread)).toBe(true)
     const tables = await runInDurableObject(directory, (_instance, state) =>
       state.storage.sql.exec<{ name: string }>("SELECT name FROM sqlite_master WHERE type = 'table'").toArray())
     expect(tables.map((row) => row.name)).not.toContain("thread_assignments")
@@ -890,6 +894,33 @@ describe("cloudflare actor", () => {
     expect((await native.events(target.thread))[0]).toMatchObject({ address: target })
   })
 
+  test("a child request reserves its name and registers after delivery with its placement", async () => {
+    const directory = controlStub()
+    await directory.init("echo", "main")
+    const parent = await directory.createThread("requested-parent")
+    const request = { kind: "child" as const, parent, child: childKeyOf("requested-child") }
+    const target = await directory.allocateThread(request)
+    expect(target.thread).toBe("requested-child")
+    await runInDurableObject(directory, (instance) => instance.alarm())
+    expect((await directory.threadTree()).find((node) => node.id === parent.thread)?.children).toEqual([])
+    await directory.createThread("requested-unrelated")
+    await directory.deliverChild({
+      link: { source: parent, target },
+      event: { type: "MessageReceived", id: "requested-brief", text: "hello", at: 1 },
+      lineage: { parent, depth: 1, placement: "independent" }
+    })
+    expect(await directory.allocateThread(request)).toEqual(target)
+    expect((await directory.threadTree()).find((node) => node.id === parent.thread)?.children).toEqual([
+      expect.objectContaining({ id: target.thread, parent: parent.thread, depth: 1, placement: "independent" })
+    ])
+    const rows = await runInDurableObject(directory, (_instance, state) =>
+      state.storage.sql.exec<{ event: string }>("SELECT event FROM events WHERE json_extract(event, '$.thread') = 'requested-child' ORDER BY seq").toArray())
+    expect(rows.map((row) => JSON.parse(row.event))).toEqual([
+      expect.objectContaining({ type: "ThreadRequested", allocationKey: expect.any(String), thread: target.thread }),
+      expect.objectContaining({ type: "ThreadRegistered", placement: "independent", thread: target.thread })
+    ])
+  })
+
   test("actor supervisor creates a child after durable acceptance", async () => {
     const directory = controlStub()
     await directory.init("echo", "main")
@@ -961,7 +992,6 @@ describe("cloudflare actor", () => {
       .map((row) => JSON.parse(row.event) as { readonly type: string; readonly thread: string })
       .filter((event) => event.thread.startsWith("ag.directory-"))
       .map((event) => event.type)).toEqual([
-      "ThreadAllocated",
       "ThreadRequested",
       "ThreadRegistered",
       "ThreadRequested",


### PR DESCRIPTION
Thread creation now reserves its name and idempotency key in `ThreadRequested`, then records completion with `ThreadRegistered`. This removes a separate allocation event for the same request.

Named root and child allocations use the supplied name exactly. A name owned by another allocation in the actor instance reports a conflict; unnamed allocations generate a name. Agent spawns pass their retry token as an idempotency key so they continue to receive generated names.

This is a breaking change with no legacy allocation compatibility or migration. `ThreadAllocated` records are ignored, so their reservations and idempotency mappings are not recovered. The exported `ThreadAllocated` type and the `allocated` record state are removed. Callers that relied on conflicting names receiving generated alternatives must choose another name or omit it.

Cloudflare recovery initializes requested roots and leaves children pending until delivery is staged. Registration records the child placement once it is known.

Validation: `bun run gate` passed, including the Cloudflare worker suites, restart tests, and allocation property tests.

