### PR TITLE
refactor(core): scope lifecycle transitions

### DIFF
--- a/packages/core/src/actor/definition.test.ts
+++ b/packages/core/src/actor/definition.test.ts
@@ -92,7 +92,7 @@ describe("actor", () => {
       deadlineAt: 21,
       at: 1
     }, alarmFired({ scheduledFor: 21, at: 21 })])
-    expect(transitions.some((transition) => transition.key === JSON.stringify([1, "actor.method-timeouts", "timeout"]))).toBe(true)
+    expect(transitions.some((transition) => transition.key === JSON.stringify([1, "actor.deadlines", "timeout"]))).toBe(true)
   })
 
   test("steps each method and component projection once per event", () => {

--- a/packages/core/src/actor/definition.test.ts
+++ b/packages/core/src/actor/definition.test.ts
@@ -92,7 +92,7 @@ describe("actor", () => {
       deadlineAt: 21,
       at: 1
     }, alarmFired({ scheduledFor: 21, at: 21 })])
-    expect(transitions.some((transition) => transition.key === "mterm:inspect-1")).toBe(true)
+    expect(transitions.some((transition) => transition.key === JSON.stringify([1, "actor.method-timeouts", "timeout"]))).toBe(true)
   })
 
   test("steps each method and component projection once per event", () => {

--- a/packages/core/src/component/compose.properties.test.ts
+++ b/packages/core/src/component/compose.properties.test.ts
@@ -3,6 +3,7 @@ import { Effect } from "effect"
 import fc from "fast-check"
 import { effect } from "@clavia/tardigrade-core/effect"
 import { intent } from "@clavia/tardigrade-core/intent"
+import { bindTransitionContext, type TransitionContext } from "../transition/transition"
 import { enabled } from "../runtime"
 import { actor } from "../actor"
 import {
@@ -14,7 +15,7 @@ import {
   type TransitionReconciler,
   type ViewAlgebra
 } from "./index"
-import type { Event } from "@clavia/tardigrade-core/event"
+import { eventAt, type Event } from "@clavia/tardigrade-core/event"
 
 interface Facts {
   readonly names: ReadonlyArray<string>
@@ -32,25 +33,15 @@ const facts: ViewAlgebra<Facts> = {
 
 const leafComponent = (leaf: Leaf): Component<Facts> => {
   const name = `leaf-${leaf.id}`
-  const key = `${name}:work`
   return legacyComponent({
     name,
-    keys: {
-      prefixes: [`${name}:`],
-      keyOf: (event) =>
-        event.type === "Committed" && Number((event as { owner?: unknown }).owner) === leaf.id
-          ? key
-          : undefined
-    },
     derive: (log) => {
-      const visible = log.some(
-        (event) => event.type === "Triggered" && String((event as { trigger?: unknown }).trigger) === leaf.trigger
-      )
+      const owner = log.find((event) => event.type === "Triggered" && String(event.trigger) === leaf.trigger)
       return {
-        view: { names: visible ? [name] : [] },
-        transitions: visible
-          ? [effect({ key, input: { owner: leaf.id }, act: () => Effect.succeed([]) })]
-          : []
+        view: { names: owner === undefined ? [] : [name] },
+        transitions: owner === undefined ? [] : [bindTransitionContext(owner, name).effect("commit", {
+          input: { owner: leaf.id }, act: (input) => Effect.succeed({ type: "Committed", ...input })
+        })]
       }
     }
   })
@@ -58,24 +49,16 @@ const leafComponent = (leaf: Leaf): Component<Facts> => {
 
 const incrementalLeafComponent = (leaf: Leaf): Component<Facts> => {
   const name = `leaf-${leaf.id}`
-  const key = `${name}:work`
   return component({
     name,
-    keys: {
-      prefixes: [`${name}:`],
-      keyOf: (event) =>
-        event.type === "Committed" && Number((event as { owner?: unknown }).owner) === leaf.id
-          ? key
-          : undefined
-    },
-    initial: () => false,
-    step: (visible: boolean, event: Event) => visible ||
-      event.type === "Triggered" && String((event as { trigger?: unknown }).trigger) === leaf.trigger,
-    output: (visible: boolean) => ({
-      view: { names: visible ? [name] : [] },
-      transitions: visible
-        ? [effect({ key, input: { owner: leaf.id }, act: () => Effect.succeed([]) })]
-        : []
+    initial: (): TransitionContext | undefined => undefined,
+    step: (owner, event, ctx) => owner ??
+      (event.type === "Triggered" && String(event.trigger) === leaf.trigger ? ctx : undefined),
+    output: (owner) => ({
+      view: { names: owner === undefined ? [] : [name] },
+      transitions: owner === undefined ? [] : [owner.effect("commit", {
+        input: { owner: leaf.id }, act: (input) => Effect.succeed({ type: "Committed", ...input })
+      })]
     })
   })
 }
@@ -142,8 +125,8 @@ describe("recursive component composition", () => {
 
           const event = log[length]
           if (event !== undefined) {
-            childStates = machines.map((machine, index) => machine.step(childStates[index]!, event))
-            composedState = composed.step(composedState, event)
+            childStates = machines.map((machine, index) => machine.step(childStates[index]!, eventAt(event, length + 1)))
+            composedState = composed.step(composedState, eventAt(event, length + 1))
           }
         }
       }),
@@ -209,8 +192,8 @@ describe("recursive component composition", () => {
             }
             const event = log[length]
             if (event !== undefined) {
-              flatState = flatProjection.step(flatState, event)
-              nestedState = nestedProjection.step(nestedState, event)
+              flatState = flatProjection.step(flatState, eventAt(event, length + 1))
+              nestedState = nestedProjection.step(nestedState, eventAt(event, length + 1))
             }
           }
         }

--- a/packages/core/src/component/compose.test.ts
+++ b/packages/core/src/component/compose.test.ts
@@ -1,7 +1,8 @@
+import type { TransitionContext } from "./machine"
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { effect } from "@clavia/tardigrade-core/effect"
-import type { Event } from "@clavia/tardigrade-core/event"
+import { eventAt, type Event } from "@clavia/tardigrade-core/event"
 import { intent } from "@clavia/tardigrade-core/intent"
 import { replayProjection } from "@clavia/tardigrade-core/projection"
 import {
@@ -161,19 +162,19 @@ describe("components", () => {
   test("composition preserves incremental child projections", () => {
     const member = (name: string) => defineComponent({
       name,
-      initial: () => false,
-      step: (ready: boolean, event: Event) => ready || event.type === "Ready",
-      output: (ready: boolean) => ({
+      initial: (): TransitionContext | undefined => undefined,
+      step: (ready, event, ctx) => ready ?? (event.type === "Ready" ? ctx : undefined),
+      output: (ready) => ({
         view: { names: ready ? [name] : [] },
-        transitions: ready ? [intent({ key: name, input: undefined, events: () => [] })] : []
+        transitions: ready ? [ready.intent("commit", { type: "Committed" })] : []
       })
     })
     const composed = composeComponents("incremental", facts, [member("left"), member("right")])
     const projection = transitionProjectionOf(composed)
-    const state = projection.step(projection.initial(), { type: "Ready" })
+    const state = projection.step(projection.initial(), eventAt({ type: "Ready" }, 1))
 
     expect(composed.machine).toBeDefined()
-    expect(projection.output(state).map((transition) => transition.key)).toEqual(["left", "right"])
+    expect(projection.output(state).map((transition) => transition.key)).toEqual([JSON.stringify([1, "left", "commit"]), JSON.stringify([1, "right", "commit"])])
     expect(deriveComponent(composed, [{ type: "Ready" }]).view).toEqual({ names: ["left", "right"] })
   })
 
@@ -189,13 +190,13 @@ describe("components", () => {
     }
     const member = (name: string, eventType: string) => defineComponent({
       name,
-      initial: () => false,
-      step: (ready: boolean, event: Event) => ready || event.type === eventType,
-      output: (ready: boolean) => {
+      initial: (): TransitionContext | undefined => undefined,
+      step: (ready, event, ctx) => ready ?? (event.type === eventType ? ctx : undefined),
+      output: (ready) => {
         derivations.set(name, (derivations.get(name) ?? 0) + 1)
         return {
           view: { names: ready ? [name] : [] },
-          transitions: ready ? [intent({ key: name, input: undefined, events: () => [] })] : []
+          transitions: ready ? [ready.intent("commit", { type: "Committed" })] : []
         }
       }
     })
@@ -220,7 +221,7 @@ describe("components", () => {
     ]))
     expect(combinations).toBe(3)
 
-    const changed = projection.step(ignored, { type: "LeftReady" })
+    const changed = projection.step(ignored, eventAt({ type: "LeftReady" }, 2))
 
     expect(changed).not.toBe(ignored)
     expect(projection.output(changed).view).toEqual({ names: ["left"] })
@@ -236,20 +237,20 @@ describe("components", () => {
   test("cached composition passes child state to cancellation projections", () => {
     const child = defineComponent({
       name: "cancellable",
-      initial: () => 0,
-      step: (count: number, event: Event) => event.type === "Observed" ? count + 1 : count,
+      initial: () => ({ count: 0, ctx: undefined as TransitionContext | undefined }),
+      step: (state, event, ctx) => event.type === "Observed" ? { count: state.count + 1, ctx } : state,
       output: () => ({ view: facts.empty, transitions: [] }),
-      cancelState: (count: number) => [intent({ key: `cancel:${count}`, input: undefined, events: () => [] })]
+      cancelState: (state) => state.ctx === undefined ? [] : [state.ctx.intent("cancel", { type: "Cancelled", count: state.count })]
     })
     const composed = composeComponents("cached-cancellation", facts, [child])
     const projection = composed.machine
-    const state = projection.step(projection.initial(), { type: "Observed" })
+    const state = projection.step(projection.initial(), eventAt({ type: "Observed" }, 1))
 
     expect(projection.cancel?.(state, {
       request: "x1",
       invocation: { method: "work", id: "w1", epoch: 0 },
       cause: "requested"
-    }).map((transition) => transition.key)).toEqual(["cancel:1"])
+    }).map((transition) => transition.kind === "intent" ? transition.events(transition.input, 0) : [])).toEqual([[{ type: "Cancelled", count: 1, transitionRef: { seq: 1, component: "cancellable", tag: "cancel" } }]])
   })
 
   test("composition refuses colliding key fragments", () => {

--- a/packages/core/src/component/refinement.test.ts
+++ b/packages/core/src/component/refinement.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import type { Event } from "@clavia/tardigrade-core/event"
 import { component as defineComponent } from "./machine"
 import { componentRefinementTrace } from "./refinement"
-import { intent } from "@clavia/tardigrade-core/intent"
+import { bindTransitionContext, type TransitionContext } from "../transition/transition"
 
 describe("component refinement trace", () => {
   test("pairs complete replay, incremental output, and cancellation at every prefix", () => {
@@ -11,22 +11,16 @@ describe("component refinement trace", () => {
         view: log.filter((event) => event.type === "Counted").length,
         transitions: []
       }),
-      cancel: (log: ReadonlyArray<Event>) => [intent({
-        key: `cancel:${log.length}`,
-        input: undefined,
-        events: () => []
-      })]
+      cancel: (log: ReadonlyArray<Event>) => log.length === 0 ? [] : [
+        bindTransitionContext(log.at(-1)!, "count").intent("cancel", { type: "Cancelled" })
+      ]
     }
     const component = defineComponent({
       name: "count",
-      initial: () => 0,
-      step: (count: number, event: Event) => count + (event.type === "Counted" ? 1 : 0),
-      output: (count: number) => ({ view: count, transitions: [] }),
-      cancelState: (_count, cancellation) => [intent({
-        key: `cancel:${cancellation.request}`,
-        input: undefined,
-        events: () => []
-      })]
+      initial: () => ({ count: 0, ctx: undefined as TransitionContext | undefined }),
+      step: (state, event, ctx) => ({ count: state.count + (event.type === "Counted" ? 1 : 0), ctx }),
+      output: (state) => ({ view: state.count, transitions: [] }),
+      cancelState: (state) => state.ctx === undefined ? [] : [state.ctx.intent("cancel", { type: "Cancelled" })]
     })
     const log: ReadonlyArray<Event> = [{ type: "Counted" }, { type: "Ignored" }, { type: "Counted" }]
     const trace = componentRefinementTrace(complete, component, log, (prefix) => [{
@@ -38,16 +32,16 @@ describe("component refinement trace", () => {
     expect(trace.map((step) => step.replay.view)).toEqual([0, 1, 1, 2])
     expect(trace.map((step) => step.incremental.view)).toEqual([0, 1, 1, 2])
     expect(trace.map((step) => step.cancellations[0]?.replay[0]?.key)).toEqual([
-      "cancel:0",
-      "cancel:1",
-      "cancel:2",
-      "cancel:3"
+      undefined,
+      JSON.stringify([1, "count", "cancel"]),
+      JSON.stringify([2, "count", "cancel"]),
+      JSON.stringify([3, "count", "cancel"])
     ])
     expect(trace.map((step) => step.cancellations[0]?.incremental[0]?.key)).toEqual([
-      "cancel:0",
-      "cancel:1",
-      "cancel:2",
-      "cancel:3"
+      undefined,
+      JSON.stringify([1, "count", "cancel"]),
+      JSON.stringify([2, "count", "cancel"]),
+      JSON.stringify([3, "count", "cancel"])
     ])
   })
 })

--- a/packages/core/src/component/refinement.ts
+++ b/packages/core/src/component/refinement.ts
@@ -1,4 +1,4 @@
-import type { Event } from "@clavia/tardigrade-core/event"
+import { eventAt, eventPositionOf, type Event } from "@clavia/tardigrade-core/event"
 import type { Transition } from "@clavia/tardigrade-core/transition"
 import type { InvocationCancellation } from "../interaction/events"
 import type { Component } from "./component"
@@ -32,11 +32,12 @@ export const componentRefinementTrace = <View, Requirements>(
   log: ReadonlyArray<Event>,
   cancellationsAt: (prefix: ReadonlyArray<Event>) => ReadonlyArray<InvocationCancellation> = () => []
 ): ReadonlyArray<ComponentRefinementStep<View, Requirements>> => {
+  const positioned = log.map((event, index) => eventAt(event, eventPositionOf(event) ?? index + 1))
   const machine = component.machine
   let state = machine.initial()
   const trace: Array<ComponentRefinementStep<View, Requirements>> = []
   for (let length = 0; length <= log.length; length++) {
-    const prefix = log.slice(0, length)
+    const prefix = positioned.slice(0, length)
     trace.push({
       prefix,
       replay: complete.derive(prefix),
@@ -47,7 +48,7 @@ export const componentRefinementTrace = <View, Requirements>(
         incremental: machine.cancel?.(state, cancellation) ?? []
       }))
     })
-    const event = log[length]
+    const event = positioned[length]
     if (event !== undefined) state = machine.step(state, event)
   }
   return trace

--- a/packages/core/src/interaction/cancellation.properties.test.ts
+++ b/packages/core/src/interaction/cancellation.properties.test.ts
@@ -249,7 +249,7 @@ describe("cancellation properties", () => {
         timeoutState = reduceMethodTimeoutState(timeoutState, event)
       }
       expect(methodTimeoutTransitions(methods, methodStates, timeoutState).map((transition) => transition.key), current.name)
-        .toEqual(current.cancellable ? [JSON.stringify([1, "actor.method-timeouts", "deadline"])] : [])
+        .toEqual(current.cancellable ? [JSON.stringify([1, "actor.deadlines", "cancel"])] : [])
     }
   })
 

--- a/packages/core/src/interaction/cancellation.properties.test.ts
+++ b/packages/core/src/interaction/cancellation.properties.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { Effect, Schema } from "effect"
 import fc from "fast-check"
-import type { Event } from "@clavia/tardigrade-core/event"
+import { eventAt, type Event } from "@clavia/tardigrade-core/event"
 import { effect } from "@clavia/tardigrade-core/effect"
 import { intent } from "@clavia/tardigrade-core/intent"
 import { replayProjection } from "@clavia/tardigrade-core/projection"
@@ -243,12 +243,13 @@ describe("cancellation properties", () => {
 
       let methodStates = initialMethodStates(methods)
       let timeoutState = initialMethodTimeoutState()
-      for (const event of [head, alarm]) {
+      for (const [index, raw] of [head, alarm].entries()) {
+        const event = eventAt(raw, index + 1)
         methodStates = reduceMethodStates(methods, methodStates, event)
         timeoutState = reduceMethodTimeoutState(timeoutState, event)
       }
       expect(methodTimeoutTransitions(methods, methodStates, timeoutState).map((transition) => transition.key), current.name)
-        .toEqual(current.cancellable ? [`cx:${JSON.stringify([parent.method, parent.id, parent.epoch])}`] : [])
+        .toEqual(current.cancellable ? [JSON.stringify([1, "actor.method-timeouts", "deadline"])] : [])
     }
   })
 

--- a/packages/core/src/interaction/respond.ts
+++ b/packages/core/src/interaction/respond.ts
@@ -88,7 +88,7 @@ const linkedCalls = (
 }
 
 const responseTransition = (response: ActorMethodResponse, link: Link<unknown, ThreadAddress>, owner: Event) =>
-  bindTransitionContext(owner, "actor.methods").effect("deliver", {
+  bindTransitionContext(owner, "actor.responses").effect("deliver", {
       invocation: null,
       input: { response, link },
       act: ({ response: current, link: accepted }) =>
@@ -191,7 +191,7 @@ export const methodResponseComponent = (methods: ActorMethods): Component<undefi
     readonly response: MethodResponseProjectionState
   }
   return component<State, undefined, Router | Self>({
-    name: "actor.methods",
+    name: "actor.responses",
     initial: () => ({
       methods: initialMethodStates(methods),
       response: initialMethodResponseState()

--- a/packages/core/src/interaction/respond.ts
+++ b/packages/core/src/interaction/respond.ts
@@ -1,7 +1,7 @@
 import { type ActorMethodResponse, type ResponseDelivered, type ResponseReceived } from "./events"
 import { Clock, Effect, Schema } from "effect"
-import { effect } from "@clavia/tardigrade-core/effect"
-import type { Event } from "@clavia/tardigrade-core/event"
+import { eventAt, eventPositionOf, type Event } from "@clavia/tardigrade-core/event"
+import { bindTransitionContext } from "../transition/transition"
 import { Self } from "../runtime/context"
 import type { CompleteTransitionDerivation } from "@clavia/tardigrade-core/transition"
 import type { KeyFragment } from "../log/index"
@@ -68,8 +68,8 @@ const delivered = (log: ReadonlyArray<Event>, response: ActorMethodResponse): bo
 const linkedCalls = (
   log: ReadonlyArray<Event>,
   methods: ActorMethods
-): ReadonlyArray<{ readonly response: ActorMethodResponse; readonly link: Link<unknown, ThreadAddress> }> => {
-  const calls: Array<{ readonly response: ActorMethodResponse; readonly link: Link<unknown, ThreadAddress> }> = []
+): ReadonlyArray<{ readonly response: ActorMethodResponse; readonly link: Link<unknown, ThreadAddress>; readonly owner: Event }> => {
+  const calls: Array<{ readonly response: ActorMethodResponse; readonly link: Link<unknown, ThreadAddress>; readonly owner: Event }> = []
   for (const event of log) {
     const call = responseCallOf(event)
     if (call === undefined) continue
@@ -80,40 +80,42 @@ const linkedCalls = (
       const state = declaration.state(log, invocation)
       if (state === undefined || state.status === "pending") continue
       const response = responseOf(terminalOf(name, declaration, state), invocation)
-      if (!delivered(log, response)) calls.push({ response, link: call.link })
+      if (!delivered(log, response)) calls.push({ response, link: call.link, owner: event })
       break
     }
   }
   return calls
 }
 
-const responseTransition = (response: ActorMethodResponse, link: Link<unknown, ThreadAddress>) =>
-  effect({
-      key: `mres:${invocationKey(response.invocation)}`,
+const responseTransition = (response: ActorMethodResponse, link: Link<unknown, ThreadAddress>, owner: Event) =>
+  bindTransitionContext(owner, "actor.methods").effect("deliver", {
+      invocation: null,
       input: { response, link },
       act: ({ response: current, link: accepted }) =>
         Effect.gen(function* () {
           const at = yield* Clock.currentTimeMillis
           yield* sendResponse(current, accepted, at)
-          return [{
+          return {
             type: "ResponseDelivered",
             method: current.invocation.method,
             call: current.invocation.id,
             ...(current.invocation.epoch === 0 ? {} : { epoch: current.invocation.epoch }),
             at
-          } satisfies ResponseDelivered]
+          } satisfies ResponseDelivered
         })
     })
 
 // methodResponseDerivation derives method reports from linked calls and their declared state projections.
 export const methodResponseDerivation = (methods: ActorMethods): CompleteTransitionDerivation<Router | Self> => (log) =>
-  linkedCalls(log, methods).slice(0, 1).map(({ response, link }) => responseTransition(response, link))
+  linkedCalls(log.map((event, index) => eventAt(event, eventPositionOf(event) ?? index + 1)), methods)
+    .slice(0, 1).map(({ response, link, owner }) => responseTransition(response, link, owner))
 
 /** @deprecated Use methodResponseDerivation. This compatibility name describes a complete-history transition derivation. */
 export const methodResponseReactor = (methods: ActorMethods): CompleteTransitionDerivation<Router | Self> =>
   methodResponseDerivation(methods)
 
 interface IncrementalResponseCall {
+  readonly owner: Event
   readonly id: string
   readonly invocation?: InvocationRef
   readonly link: Link<unknown, ThreadAddress>
@@ -130,7 +132,7 @@ const responseCallOf = (event: Event): IncrementalResponseCall | undefined => {
   const id = typeof invocation?.id === "string" ? invocation.id : candidate.id
   if (typeof id !== "string" || typeof candidate.link !== "object" || candidate.link === null ||
     !("source" in candidate.link) || !("target" in candidate.link) || !isThreadAddress(candidate.link.target)) return undefined
-  return { id, ...(invocation === undefined ? {} : { invocation }),
+  return { owner: event, id, ...(invocation === undefined ? {} : { invocation }),
     link: candidate.link as Link<unknown, ThreadAddress> }
 }
 
@@ -176,7 +178,7 @@ export const methodResponseTransitions = (
       const current = invocationStateOf(name, method, invocation)
       if (current === undefined || current.status === "pending" || state.delivered.has(invocationKey(invocation))) continue
       const response = responseOf(terminalOf(name, method, current), invocation)
-      return [responseTransition(response, call.link)]
+      return [responseTransition(response, call.link, call.owner)]
     }
   }
   return []
@@ -190,7 +192,6 @@ export const methodResponseComponent = (methods: ActorMethods): Component<undefi
   }
   return component<State, undefined, Router | Self>({
     name: "actor.methods",
-    keys: methodResponseKeys,
     initial: () => ({
       methods: initialMethodStates(methods),
       response: initialMethodResponseState()

--- a/packages/core/src/interaction/timeout.test.ts
+++ b/packages/core/src/interaction/timeout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import type { Event } from "@clavia/tardigrade-core/event"
+import { eventAt, type Event } from "@clavia/tardigrade-core/event"
 import {
   alarmFired,
   deadlineCancellationEventsAt,
@@ -144,14 +144,15 @@ describe("method alarms", () => {
     const complete = methodDeadlineCancellationDerivation(workMethods)(log)
     expect(complete).toHaveLength(1)
     expect(complete.map((transition) => transition.key))
-      .toEqual([`cx:${JSON.stringify(["work", "work-1", 0])}`])
+      .toEqual([JSON.stringify([1, "actor.method-timeouts", "deadline"])])
     const transition = complete[0]
     expect(transition?.kind).toBe("intent")
     if (transition?.kind !== "intent") return
-    expect(transition.events(transition.input, 50)).toEqual([deadlineCancellation("work-1", 40, 50)])
+    expect(transition.events(transition.input, 50)).toEqual([{ ...deadlineCancellation("work-1", 40, 50), transitionRef: { seq: 1, component: "actor.method-timeouts", tag: "deadline" } }])
     let methodStates = initialMethodStates(workMethods)
     let timeoutState = initialMethodTimeoutState()
-    for (const event of log) {
+    for (const [index, raw] of log.entries()) {
+      const event = eventAt(raw, index + 1)
       methodStates = reduceMethodStates(workMethods, methodStates, event)
       timeoutState = reduceMethodTimeoutState(timeoutState, event)
     }
@@ -176,7 +177,8 @@ describe("method alarms", () => {
       target: "inspector:main:shared",
       timeoutMs: 39,
       deadlineAt: 40,
-      at: 43
+      at: 43,
+      transitionRef: { seq: 1, component: "actor.method-timeouts", tag: "timeout" }
     }])
   })
 
@@ -201,18 +203,19 @@ describe("method alarms", () => {
     ])).toEqual([])
   })
 
-  test("alarm projection is independent of event order", () => {
+  test("alarm selection is independent of arrival order while references follow the owning dispatch", () => {
     const log: ReadonlyArray<Event> = [
       { type: "AlarmFired", scheduledFor: 45, at: 45 },
       { type: "AlarmFired", scheduledFor: 40, at: 43 },
       dispatched("inspect-1", 40)
     ]
-    const project = (events: ReadonlyArray<Event>) => methodTimeoutDerivation(events).map((transition) => ({
-      key: transition.key,
-      input: transition.input,
-      events: transition.kind === "intent" ? transition.events(transition.input, 999) : []
-    }))
-    expect(project(log)).toEqual(project([...log].reverse()))
+    const project = (events: ReadonlyArray<Event>) => methodTimeoutDerivation(events).flatMap((transition) =>
+      transition.kind === "intent" ? transition.events(transition.input, 999) : [])
+    const first = project(log)[0]!
+    const reversed = project([...log].reverse())[0]!
+    expect(first).toMatchObject({ type: "CallTimedOut", call: "inspect-1", at: 43,
+      transitionRef: { seq: 3, component: "actor.method-timeouts", tag: "timeout" } })
+    expect(reversed).toEqual({ ...first, transitionRef: { seq: 1, component: "actor.method-timeouts", tag: "timeout" } })
   })
 
   test("a response and timeout claim the same caller terminal key", () => {

--- a/packages/core/src/interaction/timeout.test.ts
+++ b/packages/core/src/interaction/timeout.test.ts
@@ -144,11 +144,11 @@ describe("method alarms", () => {
     const complete = methodDeadlineCancellationDerivation(workMethods)(log)
     expect(complete).toHaveLength(1)
     expect(complete.map((transition) => transition.key))
-      .toEqual([JSON.stringify([1, "actor.method-timeouts", "deadline"])])
+      .toEqual([JSON.stringify([1, "actor.deadlines", "cancel"])])
     const transition = complete[0]
     expect(transition?.kind).toBe("intent")
     if (transition?.kind !== "intent") return
-    expect(transition.events(transition.input, 50)).toEqual([{ ...deadlineCancellation("work-1", 40, 50), transitionRef: { seq: 1, component: "actor.method-timeouts", tag: "deadline" } }])
+    expect(transition.events(transition.input, 50)).toEqual([{ ...deadlineCancellation("work-1", 40, 50), transitionRef: { seq: 1, component: "actor.deadlines", tag: "cancel" } }])
     let methodStates = initialMethodStates(workMethods)
     let timeoutState = initialMethodTimeoutState()
     for (const [index, raw] of log.entries()) {
@@ -178,7 +178,7 @@ describe("method alarms", () => {
       timeoutMs: 39,
       deadlineAt: 40,
       at: 43,
-      transitionRef: { seq: 1, component: "actor.method-timeouts", tag: "timeout" }
+      transitionRef: { seq: 1, component: "actor.deadlines", tag: "timeout" }
     }])
   })
 
@@ -214,8 +214,8 @@ describe("method alarms", () => {
     const first = project(log)[0]!
     const reversed = project([...log].reverse())[0]!
     expect(first).toMatchObject({ type: "CallTimedOut", call: "inspect-1", at: 43,
-      transitionRef: { seq: 3, component: "actor.method-timeouts", tag: "timeout" } })
-    expect(reversed).toEqual({ ...first, transitionRef: { seq: 1, component: "actor.method-timeouts", tag: "timeout" } })
+      transitionRef: { seq: 3, component: "actor.deadlines", tag: "timeout" } })
+    expect(reversed).toEqual({ ...first, transitionRef: { seq: 1, component: "actor.deadlines", tag: "timeout" } })
   })
 
   test("a response and timeout claim the same caller terminal key", () => {

--- a/packages/core/src/interaction/timeout.ts
+++ b/packages/core/src/interaction/timeout.ts
@@ -1,6 +1,7 @@
 import { type AlarmFired, type CallTimedOut } from "./events"
-import type { Event } from "@clavia/tardigrade-core/event"
-import { intent } from "@clavia/tardigrade-core/intent"
+import { eventAt, eventPositionOf, type Event } from "@clavia/tardigrade-core/event"
+import { bindTransitionContext } from "../transition/transition"
+import type { Intent } from "@clavia/tardigrade-core/intent"
 import { replayProjection } from "@clavia/tardigrade-core/projection"
 import type { CompleteTransitionDerivation } from "@clavia/tardigrade-core/transition"
 import type { KeyFragment } from "../log/index"
@@ -47,12 +48,15 @@ const terminalCalls = (log: ReadonlyArray<Event>): ReadonlySet<string> => new Se
   return reference === undefined ? [] : [invocationCoordinateKey(reference)]
 }))
 
-const dispatchesOf = (log: ReadonlyArray<Event>): ReadonlyArray<RecordedDispatch> => log.flatMap((event) => {
+interface OwnedDispatch extends RecordedDispatch { readonly owner: Event }
+
+const dispatchesOf = (log: ReadonlyArray<Event>): ReadonlyArray<OwnedDispatch> => log.flatMap((event) => {
   const dispatch = recordedDispatchOf(event)
-  return dispatch === undefined ? [] : [dispatch]
+  return dispatch === undefined ? [] : [{ ...dispatch, owner: event }]
 })
 
 interface InvocationDeadline {
+  readonly owner: Event
   readonly invocation: InvocationRef
   readonly deadlineAt: number
 }
@@ -66,7 +70,7 @@ const invocationDeadlinesOf = (log: ReadonlyArray<Event>): ReadonlyArray<Invocat
     const key = invocationKey(invocation)
     if (seen.has(key)) return []
     seen.add(key)
-    return [{ invocation, deadlineAt: context.deadlineAt }]
+    return [{ owner: event, invocation, deadlineAt: context.deadlineAt }]
   })
 }
 
@@ -116,31 +120,16 @@ const alarmFor = (alarms: ReadonlyArray<AlarmFired>, deadlineAt: number): AlarmF
   return earliest
 }
 
-const timeoutTransition = (dispatch: RecordedDispatch, at: number) => intent({
-  key: terminalStorageKey(dispatch.terminal),
-  input: { dispatch, at },
-  events: ({ dispatch: current, at: firedAt }) => [{
-    type: "CallTimedOut",
-    ...current.terminal,
-    at: firedAt
-  } satisfies CallTimedOut]
-})
+const timeoutTransition = (dispatch: OwnedDispatch, at: number) =>
+  bindTransitionContext(dispatch.owner, "actor.method-timeouts").intent("timeout", {
+    type: "CallTimedOut", ...dispatch.terminal, at
+  } satisfies CallTimedOut, { invocation: null })
 
-const deadlineCancellationTransition = (invocation: InvocationRef, deadlineAt: number) => intent({
-  key: `cx:${invocationKey(invocation)}`,
-  input: {
+const deadlineCancellationTransition = ({ owner, invocation, deadlineAt }: InvocationDeadline) =>
+  bindTransitionContext(owner, "actor.method-timeouts").intent("deadline", (at) => cancellationRequested({
     request: `deadline/${invocation.method}/${invocation.id}/${invocation.epoch}/${deadlineAt}`,
-    invocation,
-    deadlineAt
-  },
-  events: (current, at) => [cancellationRequested({
-    request: current.request,
-    invocation: current.invocation,
-    cause: "deadline",
-    deadlineAt: current.deadlineAt,
-    at
-  })]
-})
+    invocation, cause: "deadline", deadlineAt, at
+  }), { invocation: null })
 
 // deadlineCancellationsAt selects crossed deadlines for running cancellable invocations (timeout.test.ts, "cancellation selection projects one cancellation from an eligible invocation").
 const deadlineCancellationsAt = (
@@ -149,7 +138,7 @@ const deadlineCancellationsAt = (
   at: number
 ): ReadonlyArray<InvocationDeadline> => {
   const views = new Map<string, ActorMethodView<unknown>>()
-  return invocationDeadlinesOf(log).flatMap(({ invocation, deadlineAt }) => {
+  return invocationDeadlinesOf(log).flatMap(({ owner, invocation, deadlineAt }) => {
     if (deadlineAt > at) return []
     const method = methods[invocation.method]
     if (method === undefined || method.cancellation === undefined || invocationSettled(log, invocation)) return []
@@ -158,7 +147,7 @@ const deadlineCancellationsAt = (
       view = replayProjection(method.projection, log)
       views.set(invocation.method, view)
     }
-    return cancellationStateOf(method, view, invocation) !== "running" ? [] : [{ invocation, deadlineAt }]
+    return cancellationStateOf(method, view, invocation) !== "running" ? [] : [{ owner, invocation, deadlineAt }]
   })
 }
 
@@ -179,7 +168,8 @@ export const deadlineCancellationEventsAt = (
   )
 
 // methodTimeoutDerivation turns alarm facts into method terminals without reading a clock.
-export const methodTimeoutDerivation: CompleteTransitionDerivation = (log) => {
+export const methodTimeoutDerivation: CompleteTransitionDerivation = (events) => {
+  const log = events.map((event, index) => eventAt(event, eventPositionOf(event) ?? index + 1))
   const terminal = terminalCalls(log)
   const alarms = alarmsOf(log)
   return dispatchesOf(log).flatMap((dispatch) => {
@@ -190,14 +180,15 @@ export const methodTimeoutDerivation: CompleteTransitionDerivation = (log) => {
 }
 
 // methodDeadlineCancellationDerivation repairs missing cancellations from recorded alarms (timeout.test.ts, "legacy recovery derives an alarm's missing cancellation exactly once").
-export const methodDeadlineCancellationDerivation = (methods: ActorMethods): CompleteTransitionDerivation => (log) => {
+export const methodDeadlineCancellationDerivation = (methods: ActorMethods): CompleteTransitionDerivation => (events) => {
+  const log = events.map((event, index) => eventAt(event, eventPositionOf(event) ?? index + 1))
   const latestAlarmAt = alarmsOf(log).reduce<number | undefined>(
     (latest, alarm) => latest === undefined ? alarm.at : Math.max(latest, alarm.at),
     undefined
   )
   if (latestAlarmAt === undefined) return []
   return deadlineCancellationsAt(log, methods, latestAlarmAt)
-    .map(({ invocation, deadlineAt }) => deadlineCancellationTransition(invocation, deadlineAt))
+    .map(deadlineCancellationTransition)
 }
 
 /** @deprecated Use methodTimeoutDerivation. This compatibility name describes a complete-history transition derivation. */
@@ -208,7 +199,7 @@ export const methodDeadlineCancellationReactor = (methods: ActorMethods): Comple
   methodDeadlineCancellationDerivation(methods)
 
 export interface MethodTimeoutProjectionState {
-  readonly dispatches: ReadonlyMap<string, RecordedDispatch>
+  readonly dispatches: ReadonlyMap<string, OwnedDispatch>
   readonly terminalCalls: ReadonlySet<string>
   readonly alarms: ReadonlyArray<AlarmFired>
   readonly deadlines: ReadonlyMap<string, InvocationDeadline>
@@ -268,8 +259,8 @@ export const methodTimeoutTransitions = (
   methods: ActorMethods,
   methodStates: ReadonlyMap<string, unknown>,
   state: MethodTimeoutProjectionState
-): ReadonlyArray<ReturnType<typeof intent>> => {
-  const transitions = [] as Array<ReturnType<typeof intent>>
+): ReadonlyArray<Intent<never>> => {
+  const transitions = [] as Array<Intent<never>>
   for (const dispatch of state.dispatches.values()) {
     if (state.terminalCalls.has(invocationCoordinateKey(dispatch.reference))) continue
     const alarm = alarmFor(state.alarms, dispatch.terminal.deadlineAt)
@@ -284,7 +275,7 @@ export const methodTimeoutTransitions = (
     if (state.settledInvocations.has(invocationKey(invocation)) || current?.status !== "pending") continue
     const alarm = alarmFor(state.alarms, deadline.deadlineAt)
     if (alarm === undefined || cancellationStateOf(method, view, invocation) !== "running") continue
-    transitions.push(deadlineCancellationTransition(invocation, deadline.deadlineAt))
+    transitions.push(deadlineCancellationTransition(deadline))
   }
   return transitions
 }
@@ -297,7 +288,6 @@ export const methodTimeoutComponent = (methods: ActorMethods): Component<undefin
   }
   return component<State, undefined>({
     name: "actor.method-timeouts",
-    keys: methodTimeoutKeys,
     initial: () => ({
       methods: initialMethodStates(methods),
       timeout: initialMethodTimeoutState()

--- a/packages/core/src/interaction/timeout.ts
+++ b/packages/core/src/interaction/timeout.ts
@@ -121,12 +121,12 @@ const alarmFor = (alarms: ReadonlyArray<AlarmFired>, deadlineAt: number): AlarmF
 }
 
 const timeoutTransition = (dispatch: OwnedDispatch, at: number) =>
-  bindTransitionContext(dispatch.owner, "actor.method-timeouts").intent("timeout", {
+  bindTransitionContext(dispatch.owner, "actor.deadlines").intent("timeout", {
     type: "CallTimedOut", ...dispatch.terminal, at
   } satisfies CallTimedOut, { invocation: null })
 
 const deadlineCancellationTransition = ({ owner, invocation, deadlineAt }: InvocationDeadline) =>
-  bindTransitionContext(owner, "actor.method-timeouts").intent("deadline", (at) => cancellationRequested({
+  bindTransitionContext(owner, "actor.deadlines").intent("cancel", (at) => cancellationRequested({
     request: `deadline/${invocation.method}/${invocation.id}/${invocation.epoch}/${deadlineAt}`,
     invocation, cause: "deadline", deadlineAt, at
   }), { invocation: null })
@@ -287,7 +287,7 @@ export const methodTimeoutComponent = (methods: ActorMethods): Component<undefin
     readonly timeout: MethodTimeoutProjectionState
   }
   return component<State, undefined>({
-    name: "actor.method-timeouts",
+    name: "actor.deadlines",
     initial: () => ({
       methods: initialMethodStates(methods),
       timeout: initialMethodTimeoutState()

--- a/packages/core/src/runtime/operation-graph.properties.test.ts
+++ b/packages/core/src/runtime/operation-graph.properties.test.ts
@@ -1,0 +1,280 @@
+import { expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+import fc from "fast-check"
+import { component, composeComponents, transitionProjectionOf, type TransitionContext } from "../component"
+import type { Event } from "../event"
+import { sameInvocation, type InvocationRef } from "../interaction/invocation"
+import { EventLog, withWatermark } from "../log"
+import { createActorReconciler, enabled, EffectInterruptions, effectInterruptionRegistry } from "./reconciler"
+
+type Defect = "none" | "any-prerequisite" | "provider-id" | "dependency-cancellation" | "reanchor"
+type Crash = "before-effect" | "after-effect" | "after-commit"
+interface Node { readonly id: number; readonly root: number; readonly tag: string; readonly owner: number; readonly needs: ReadonlyArray<number> }
+interface Interleave { readonly point: "before-start" | "during-effect" | "before-append"; readonly kind: "noise" | "own-cancel" | "other-cancel" }
+interface Command { readonly action: "attempt" | "cancel" | "replay" | "noise"; readonly choice: number; readonly point: Crash; readonly reverse: boolean; readonly owner: number }
+interface Operation { readonly scope: string; readonly id: number; readonly value: number }
+interface Model { readonly completed: Map<string, number>; readonly cancelled: Set<string> }
+const idOf = (scope: string, id: number): string => `${scope}/${id}`
+const invocation = (scope: string, epoch: number): InvocationRef => ({ method: "run", id: scope, epoch })
+const ownerKey = (scope: string, epoch: number): string => `${scope}/${epoch}`
+
+const graphArbitrary = fc.tuple(
+  fc.uniqueArray(fc.string({ minLength: 1, maxLength: 6 }), { minLength: 7, maxLength: 7 }),
+  fc.array(fc.record({ root: fc.integer({ min: 0, max: 1 }), owner: fc.integer({ min: 0, max: 1 }), needs: fc.array(fc.boolean(), { minLength: 7, maxLength: 7 }) }), { minLength: 4, maxLength: 7 })
+).map(([tags, nodes]): Node[] => nodes.map((node, id) => ({
+  id, tag: tags[id]!,
+  root: id < 3 ? 0 : id === 3 ? 1 : node.root,
+  owner: id < 4 ? id % 2 : node.owner,
+  needs: id === 2 ? [0, 1] : id < 4 ? [] : node.needs.flatMap((included, dependency) => included && dependency < id ? [dependency] : [])
+})))
+
+const oracle = (nodes: ReadonlyArray<Node>, scopes: ReadonlyArray<string>, model: Model): Operation[] =>
+  scopes.flatMap((scope) => nodes.flatMap((node) => {
+    if (model.completed.has(idOf(scope, node.id)) || model.cancelled.has(ownerKey(scope, node.owner)) ||
+      node.needs.some((dependency) => !model.completed.has(idOf(scope, dependency)))) return []
+    return [{ scope, id: node.id, value: node.id + 1 + node.needs.reduce((sum, dependency) => sum + model.completed.get(idOf(scope, dependency))!, 0) }]
+  }))
+
+const harness = (nodes: ReadonlyArray<Node>, scopes: ReadonlyArray<string>, defect: Defect) => {
+  const events: Event[] = []
+  const roots = new Map<number, number>()
+  const attempts: Operation[] = []
+  const performed: Operation[] = []
+  let crash: Crash = "after-commit"
+  const stop = () => { throw new Error("simulated pause") }
+  const registry = effectInterruptionRegistry()
+  let interleave: Interleave | undefined
+  const inject = (point: Interleave["point"]): void => {
+    if (interleave?.point !== point) return
+    const event: Event = interleave.kind === "noise" ? { type: "Unrelated" } : {
+      type: "CancellationRequested", request: "interleaved", cause: "requested",
+      invocation: invocation(scopes[0]!, interleave.kind === "own-cancel" ? 0 : 1)
+    }
+    interleave = undefined
+    events.push(event)
+    registry.interrupt([event])
+  }
+  for (const scope of scopes) for (const epoch of [0, 1]) {
+    events.push({ type: "Accepted", call: { invocation: invocation(scope, epoch), deadlineAt: 1000 } })
+  }
+  for (const root of [0, 1]) {
+    events.push({ type: "Unrelated" }, { type: "Requested", root, callId: "7" })
+    roots.set(root, events.length)
+  }
+  const makeActor = (members = scopes, order = nodes, grouped = false) => {
+    const components = members.map((scope) => component({
+      name: scope,
+      initial: () => ({ roots: new Map<number, TransitionContext>(), history: [] as ReadonlyArray<{ event: Event; ctx: TransitionContext }> }),
+      step: (state, event, ctx) => ({
+        roots: event.type === "Requested" ? new Map(state.roots).set(event.root as number, ctx) : state.roots,
+        history: [...state.history, { event, ctx }]
+      }),
+      output: (state) => {
+        const receipts = new Map<number, { event: Event; ctx: TransitionContext }>()
+        for (const node of nodes) {
+          const ctx = state.roots.get(node.root)
+          const receipt = ctx === undefined ? undefined : state.history.find(({ event }) => defect === "provider-id"
+            ? event.type === "Completed" && event.callId === "7" : ctx.matches(node.tag, event))
+          if (receipt !== undefined) receipts.set(node.id, receipt)
+        }
+        return {
+          view: undefined,
+          transitions: order.flatMap((node) => {
+            const original = state.roots.get(node.root)
+            if (original === undefined || receipts.has(node.id)) return []
+            const ready = node.needs.length === 0 || (defect === "any-prerequisite"
+              ? node.needs.some((dependency) => receipts.has(dependency))
+              : node.needs.every((dependency) => receipts.has(dependency)))
+            if (!ready) return []
+            if (defect === "dependency-cancellation" && node.needs.some((dependency) =>
+              state.history.some(({ event }) => event.type === "CancellationRequested" &&
+                sameInvocation(event.invocation as InvocationRef, invocation(scope, nodes[dependency]!.owner))))) return []
+            const ctx = defect === "reanchor" && node.needs.length > 0 ? receipts.get(node.needs[0]!)!.ctx : original
+            const input = { scope, id: node.id, value: node.id + 1 + node.needs.reduce((sum, dependency) => sum + Number(receipts.get(dependency)?.event.value ?? 0), 0) }
+            return [ctx.effect(node.tag, {
+              invocation: invocation(scope, node.owner), input,
+              act: (operation) => Effect.sync(() => {
+                attempts.push(operation)
+                if (crash === "before-effect") stop()
+                performed.push(operation)
+                inject("during-effect")
+                if (crash === "after-effect") stop()
+                return { type: "Completed", ...operation, callId: "7" }
+              })
+            })]
+          })
+        }
+      }
+    }))
+    const mounted = grouped ? [composeComponents("group", { empty: undefined, combine: () => undefined }, components)] : components
+    return { projections: mounted.map(transitionProjectionOf), keyOf: () => undefined, cancellationOf: () => "running" as const }
+  }
+  const log = Layer.succeed(EventLog, {
+    ...withWatermark({
+      read: Effect.sync(() => [...events]),
+      append: (tail) => Effect.sync(() => { inject("before-append"); events.push(...tail); stop() })
+    }),
+    head: Effect.sync(() => { inject("before-start"); return events.length })
+  })
+  return {
+    events, roots, attempts, performed, makeActor,
+    restart: () => {
+      const restored: Event[] = JSON.parse(JSON.stringify(events))
+      events.splice(0, events.length, ...restored)
+    },
+    attempt: async (operation: Operation, point: Crash, reverse: boolean) => {
+      crash = point
+      const members = [...scopes].sort((a, b) => Number(b === operation.scope) - Number(a === operation.scope))
+      const order = (reverse ? [...nodes].reverse() : [...nodes]).sort((a, b) => Number(b.id === operation.id) - Number(a.id === operation.id))
+      await expect(Effect.runPromise(createActorReconciler(makeActor(members, order)).settle.pipe(Effect.provide(log))))
+        .rejects.toThrow("simulated pause")
+    },
+    settle: () => Effect.runPromise(createActorReconciler(makeActor()).settle.pipe(Effect.provide(log))),
+    interleaved: async (change: Interleave) => {
+      interleave = change
+      crash = "after-commit"
+      try {
+        await Effect.runPromise(createActorReconciler(makeActor()).settle.pipe(
+          Effect.provide(log), Effect.provideService(EffectInterruptions, registry)
+        ))
+      } catch (error) {
+        if (!String(error).includes("simulated pause")) throw error
+      }
+    }
+  }
+}
+type Harness = ReturnType<typeof harness>
+
+// assertGraph compares operation eligibility, data, refs, and lifetime against an independent graph oracle (tla/runtime/OperationGraph.tla).
+const assertGraph = (nodes: ReadonlyArray<Node>, scopes: ReadonlyArray<string>, model: Model, real: Harness): void => {
+  const expected = oracle(nodes, scopes, model)
+  const variants = [real.makeActor(), real.makeActor([...scopes].reverse(), [...nodes].reverse(), true)]
+  for (const actor of variants) {
+    const transitions = enabled(actor, real.events)
+    const actual = transitions.map((transition) => idOf((transition.input as Operation).scope, (transition.input as Operation).id)).sort()
+    if (JSON.stringify(actual) !== JSON.stringify(expected.map((operation) => idOf(operation.scope, operation.id)).sort())) {
+      throw new Error("operation graph eligibility mismatch")
+    }
+    for (const transition of transitions) {
+      const input = transition.input as Operation
+      const node = nodes[input.id]!
+      expect(input).toEqual(expected.find((operation) => operation.scope === input.scope && operation.id === input.id)!)
+      if (transition.key !== JSON.stringify([real.roots.get(node.root), input.scope, node.tag])) throw new Error("operation graph identity changed")
+      expect(transition.invocation).toEqual(invocation(input.scope, node.owner))
+    }
+  }
+  const alone = enabled(real.makeActor([scopes[0]!]), real.events).map((transition) => transition.key).sort()
+  const together = enabled(real.makeActor(), real.events).filter((transition) => (transition.input as Operation).scope === scopes[0]).map((transition) => transition.key).sort()
+  expect(alone).toEqual(together)
+}
+
+const cancel = (scope: string, owner: number, model: Model, real: Harness): void => {
+  real.events.push({ type: "CancellationRequested", request: `stop/${scope}/${owner}`, invocation: invocation(scope, owner), cause: "requested" })
+  model.cancelled.add(ownerKey(scope, owner))
+}
+
+const advance = async (nodes: ReadonlyArray<Node>, scopes: ReadonlyArray<string>, model: Model, real: Harness, selected: Operation, point: Crash, reverse: boolean): Promise<void> => {
+  const before = { log: real.events.length, attempts: real.attempts.length, performed: real.performed.length }
+  await real.attempt(selected, point, reverse)
+  expect(real.attempts).toHaveLength(before.attempts + 1)
+  expect(real.attempts.at(-1)).toEqual(selected)
+  expect(real.performed).toHaveLength(before.performed + (point === "before-effect" ? 0 : 1))
+  expect(real.events).toHaveLength(before.log + (point === "after-commit" ? 1 : 0))
+  if (point === "after-commit") {
+    const node = nodes[selected.id]!
+    expect(real.events.at(-1)).toEqual({
+      type: "Completed", ...selected, callId: "7",
+      transitionRef: { seq: real.roots.get(node.root)!, component: selected.scope, tag: node.tag },
+      invocationRef: invocation(selected.scope, node.owner)
+    })
+    expect(model.completed.has(idOf(selected.scope, selected.id))).toBe(false)
+    model.completed.set(idOf(selected.scope, selected.id), selected.value)
+  }
+  assertGraph(nodes, scopes, model, real)
+}
+
+const traceArbitrary = fc.array(fc.record({
+  action: fc.constantFrom<Command["action"]>("attempt", "cancel", "replay", "noise"), choice: fc.nat({ max: 20 }),
+  point: fc.constantFrom<Crash>("before-effect", "after-effect", "after-commit"), reverse: fc.boolean(), owner: fc.integer({ min: 0, max: 1 })
+}), { maxLength: 12 })
+
+const exercise = async (nodes: ReadonlyArray<Node>, trace: ReadonlyArray<Command>, defect: Defect): Promise<void> => {
+  const scopes = ["files", "observer"]
+  const model: Model = { completed: new Map(), cancelled: new Set() }
+  const real = harness(nodes, scopes, defect)
+  assertGraph(nodes, scopes, model, real)
+  for (const id of [0, 1]) {
+    const selected = oracle(nodes, scopes, model).find((operation) => operation.scope === "files" && operation.id === id)!
+    await advance(nodes, scopes, model, real, selected, "after-effect", false)
+    real.restart()
+    await advance(nodes, scopes, model, real, selected, "after-commit", true)
+  }
+  cancel("files", 1, model, real)
+  assertGraph(nodes, scopes, model, real)
+  for (const command of trace) {
+    const ready = oracle(nodes, scopes, model)
+    if (command.action === "cancel") cancel(scopes[command.choice % scopes.length]!, command.owner, model, real)
+    else if (command.action === "replay") real.restart()
+    else if (command.action === "noise") real.events.push({ type: "Unrelated", value: command.choice })
+    else if (ready.length > 0) await advance(nodes, scopes, model, real, ready[command.choice % ready.length]!, command.point, command.reverse)
+    assertGraph(nodes, scopes, model, real)
+  }
+  while (oracle(nodes, scopes, model).length > 0) {
+    await advance(nodes, scopes, model, real, oracle(nodes, scopes, model)[0]!, "after-commit", false)
+  }
+  const before = { log: [...real.events], attempts: [...real.attempts] }
+  real.restart()
+  await real.settle()
+  expect(real.events).toEqual(before.log)
+  expect(real.attempts).toEqual(before.attempts)
+}
+
+test("operation graphs preserve prerequisites, identity, and invocation lifetime through composition and recovery", async () => {
+  await fc.assert(fc.asyncProperty(graphArbitrary, traceArbitrary, (nodes, trace) => exercise(nodes, trace, "none")), { numRuns: 60 })
+}, 30_000)
+
+test("operation graph controls expose premature work, miscorrelation, dependency cancellation, and reanchoring", async () => {
+  for (const defect of ["any-prerequisite", "provider-id", "dependency-cancellation", "reanchor"] as const) {
+    const result = await fc.check(fc.asyncProperty(graphArbitrary, (nodes) => exercise(nodes, [], defect)), { numRuns: 1 })
+    expect(result.failed).toBe(true)
+    expect(String(result.errorInstance)).toContain(defect === "reanchor" ? "operation graph identity changed" : "operation graph eligibility mismatch")
+  }
+})
+
+
+test("valid graph schedules preserve domain results when independent components are added", async () => {
+  await fc.assert(fc.asyncProperty(graphArbitrary, async (nodes) => {
+    const results: Array<ReadonlyArray<[string, number]>> = []
+    for (const scopes of [["files"], ["observer", "files"]]) {
+      const model: Model = { completed: new Map(), cancelled: new Set() }
+      const real = harness(nodes, scopes, "none")
+      while (oracle(nodes, scopes, model).length > 0) {
+        const ready = oracle(nodes, scopes, model)
+        const selected = scopes.length === 1 ? ready[0]! : ready.at(-1)!
+        await advance(nodes, scopes, model, real, selected, "after-commit", scopes.length > 1)
+        real.restart()
+      }
+      results.push([...model.completed].filter(([id]) => id.startsWith("files/")).sort(([a], [b]) => a.localeCompare(b)))
+    }
+    expect(results[0]).toEqual(results[1]!)
+  }), { numRuns: 30 })
+}, 30_000)
+
+test("cancellation publication follows the observed result check while unrelated appends remain compatible", async () => {
+  for (const point of ["before-start", "during-effect", "before-append"] as const) {
+    for (const kind of ["noise", "own-cancel", "other-cancel"] as const) {
+      const nodes: Node[] = [{ id: 0, root: 0, owner: 0, tag: "execute", needs: [] }]
+      const real = harness(nodes, ["files"], "none")
+      await real.interleaved({ point, kind })
+      const starts = kind === "own-cancel" && point === "before-start" ? 0 : 1
+      const commits = kind === "own-cancel" && point !== "before-append" ? 0 : 1
+      expect(real.attempts).toHaveLength(starts)
+      expect(real.events.filter((event) => event.type === "Completed")).toHaveLength(commits)
+      const before = { events: [...real.events], attempts: [...real.attempts] }
+      real.restart()
+      await real.settle()
+      expect(real.events).toEqual(before.events)
+      expect(real.attempts).toEqual(before.attempts)
+    }
+  }
+})

--- a/packages/core/src/runtime/reconciler.properties.test.ts
+++ b/packages/core/src/runtime/reconciler.properties.test.ts
@@ -653,3 +653,42 @@ test("tagged transitions reject conflicting invocation ownership", async () => {
     .rejects.toThrow("completion event already carries an invocation reference")
   expect(events).toHaveLength(1)
 })
+
+
+test("explicitly detached control transitions finish after invocation cancellation", async () => {
+  const invocation = { method: "run", id: "one", epoch: 0 }
+  const events: Event[] = [
+    { type: "Requested", call: { invocation } },
+    { type: "CancellationRequested", request: "stop", invocation, cause: "requested" }
+  ]
+  const worker = taggedComponent({
+    name: "control",
+    select: (event) => event.type === "Requested" ? event : undefined,
+    derive: (_event, ctx) => [ctx.effect("deliver", {
+      invocation: null,
+      input: undefined,
+      act: () => Effect.gen(function* () {
+        expect(Option.isNone(yield* Effect.serviceOption(InvocationScope))).toBe(true)
+        return { type: "Delivered" }
+      })
+    })]
+  })
+  const runtime = { ...runtimeOf(worker), cancellationOf: () => "running" as const }
+  expect(enabled(runtime, events)[0]!.invocation).toBeUndefined()
+  await Effect.runPromise(settleActor(runtime).pipe(Effect.provide(memory(events))))
+  expect(events.at(-1)).toEqual({ type: "Delivered", transitionRef: { seq: 1, component: "control", tag: "deliver" } })
+})
+
+test("tagged intents construct domain events at commit time", () => {
+  const worker = taggedComponent({
+    name: "control",
+    select: (event) => event.type === "Requested" ? event : undefined,
+    derive: (_event, ctx) => [ctx.intent("deliver", (at) => ({ type: "Delivered", at }), { invocation: null })]
+  })
+  const transition = enabled(runtimeOf(worker), [{ type: "Requested" }])[0]!
+  expect(transition.kind).toBe("intent")
+  if (transition.kind !== "intent") return
+  expect(transition.events(transition.input, 123)).toEqual([
+    { type: "Delivered", at: 123, transitionRef: { seq: 1, component: "control", tag: "deliver" } }
+  ])
+})

--- a/packages/core/src/runtime/transition-lifecycle.properties.test.ts
+++ b/packages/core/src/runtime/transition-lifecycle.properties.test.ts
@@ -1,0 +1,206 @@
+import { expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+import fc, { type AsyncCommand } from "fast-check"
+import { component, transitionProjectionOf, type TransitionContext } from "../component"
+import type { Event } from "../event"
+import { EventLog, withWatermark } from "../log"
+import { createActorReconciler, enabled } from "./reconciler"
+
+type Stage = "download" | "upload"
+type Ownership = "request" | "completion"
+type Crash = "before-effect" | "after-effect" | "after-commit"
+interface Operation { readonly request: number; readonly stage: Stage; readonly revision: number }
+const operationId = ({ request, stage }: Pick<Operation, "request" | "stage">): string => `${request}/${stage}`
+
+interface Model {
+  readonly requests: Map<number, number>
+  readonly completed: Set<string>
+  readonly references: Map<string, string>
+}
+
+const eligible = (model: Model): Operation[] => [...model.requests].flatMap(([request, revision]) => {
+  const stage = !model.completed.has(`${request}/download`) ? "download" : "upload"
+  return model.completed.has(`${request}/${stage}`) ? [] : [{ request, stage, revision }]
+})
+
+const harness = (ownership: Ownership, reuseTag: boolean) => {
+  const events: Event[] = []
+  const attempts: Operation[] = []
+  const performed: Operation[] = []
+  let crash: Crash = "before-effect"
+  const stop = () => { throw new Error("simulated crash") }
+  const tag = (stage: Stage) => ownership === "completion" || reuseTag ? "run" : stage
+  const actor = () => {
+    interface Pending extends Operation { readonly ctx: TransitionContext }
+    const worker = component({
+      name: "files",
+      initial: (): ReadonlyArray<Pending> => [],
+      step: (state, event, ctx) => {
+        if (event.type === "Requested") return [...state, { request: event.request as number, revision: 0, stage: "download" as const, ctx }]
+        if (event.type === "Revised") return state.map((pending) => pending.request === event.request
+          ? { ...pending, revision: pending.revision + 1 } : pending).reverse()
+        return state.flatMap((pending): Pending[] => {
+          if (!pending.ctx.matches(tag(pending.stage), event)) return [pending]
+          return pending.stage === "upload" ? [] : [{
+            ...pending, stage: "upload", ctx: ownership === "completion" ? ctx : pending.ctx
+          }]
+        })
+      },
+      output: (state) => ({
+        view: undefined,
+        transitions: state.map(({ ctx, ...input }) => ctx.effect(tag(input.stage), {
+          input,
+          act: (operation) => Effect.sync(() => {
+            attempts.push(operation)
+            if (crash === "before-effect") stop()
+            performed.push(operation)
+            if (crash === "after-effect") stop()
+            return { type: "Completed", ...operation, callId: "7" }
+          })
+        }))
+      })
+    })
+    return { projections: [transitionProjectionOf(worker)], keyOf: () => undefined }
+  }
+  let runtime = actor()
+  let reconciler = createActorReconciler(runtime)
+  const log = Layer.succeed(EventLog, withWatermark({
+    read: Effect.sync(() => [...events]),
+    append: (tail) => Effect.sync(() => {
+      events.push(...tail)
+      stop()
+    })
+  }))
+  return {
+    events, attempts, performed,
+    transitions: () => enabled(runtime, events),
+    attempt: async (point: Crash) => {
+      crash = point
+      await expect(Effect.runPromise(reconciler.settle.pipe(Effect.provide(log)))).rejects.toThrow("simulated crash")
+    },
+    restart: () => {
+      const replayed: Event[] = JSON.parse(JSON.stringify(events))
+      events.splice(0, events.length, ...replayed)
+      runtime = actor()
+      reconciler = createActorReconciler(runtime)
+    },
+    settleCompleted: () => Effect.runPromise(reconciler.settle.pipe(Effect.provide(log)))
+  }
+}
+type Harness = ReturnType<typeof harness>
+
+// assertRefinement compares runtime offers with logical operations identified independently of refs (tla/runtime/TransitionDeclarations.tla, UniqueRefs).
+const assertRefinement = (model: Model, real: Harness): void => {
+  const transitions = real.transitions()
+  const actual = transitions.map((transition) => operationId(transition.input as Operation)).sort()
+  const expected = eligible(model).map(operationId).sort()
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) throw new Error("enabled operations disagree with logical operations")
+  for (const transition of transitions) {
+    const input = transition.input as Operation
+    const id = operationId(input)
+    expect(input.revision).toBe(model.requests.get(input.request)!)
+    const prior = model.references.get(id)
+    if (prior !== undefined) expect(transition.key).toBe(prior)
+    for (const [other, key] of model.references) {
+      if (other !== id) expect(transition.key).not.toBe(key)
+    }
+    model.references.set(id, transition.key)
+  }
+}
+
+const request = (noise: number): AsyncCommand<Model, Harness> => ({
+  check: () => true,
+  run: async (model, real) => {
+    const id = model.requests.size
+    real.events.push(...Array.from({ length: noise }, () => ({ type: "Noise" })))
+    real.events.push({ type: "Requested", request: id, callId: "7" })
+    model.requests.set(id, 0)
+    assertRefinement(model, real)
+  },
+  toString: () => `request(noise=${noise})`
+})
+
+const revise = (choice: number): AsyncCommand<Model, Harness> => ({
+  check: (model) => eligible(model).length > 0,
+  run: async (model, real) => {
+    const pending = eligible(model)
+    const selected = pending[choice % pending.length]!
+    real.events.push({ type: "Revised", request: selected.request })
+    model.requests.set(selected.request, selected.revision + 1)
+    assertRefinement(model, real)
+  },
+  toString: () => `revise(${choice})`
+})
+
+const attempt = (point: Crash): AsyncCommand<Model, Harness> => ({
+  check: (model) => eligible(model).length > 0,
+  run: async (model, real) => {
+    const offered = eligible(model)
+    const before = { attempts: real.attempts.length, performed: real.performed.length, events: real.events.length }
+    await real.attempt(point)
+    expect(real.attempts).toHaveLength(before.attempts + 1)
+    const operation = real.attempts.at(-1)!
+    expect(offered).toContainEqual(operation)
+    expect(real.performed).toHaveLength(before.performed + (point === "before-effect" ? 0 : 1))
+    expect(real.events).toHaveLength(before.events + (point === "after-commit" ? 1 : 0))
+    if (point === "after-commit") {
+      const id = operationId(operation)
+      expect(model.completed.has(id)).toBe(false)
+      const key = model.references.get(id)!
+      const [seq, component, tag] = JSON.parse(key) as [number, string, string]
+      expect(real.events.at(-1)).toEqual({ type: "Completed", ...operation, callId: "7", transitionRef: { seq, component, tag } })
+      model.completed.add(id)
+    }
+    assertRefinement(model, real)
+  },
+  toString: () => `attempt(${point})`
+})
+
+const restart = (): AsyncCommand<Model, Harness> => ({
+  check: () => true,
+  run: async (model, real) => {
+    real.restart()
+    assertRefinement(model, real)
+  },
+  toString: () => "restart()"
+})
+
+const commands = fc.commands([
+  fc.integer({ min: 0, max: 2 }).map(request),
+  fc.nat({ max: 10 }).map(revise),
+  fc.constantFrom<Crash>("before-effect", "after-effect", "after-commit").map(attempt),
+  fc.constant(null).map(restart)
+], { maxCommands: 20 })
+
+const lifecycle = async (ownership: Ownership, trace: Iterable<AsyncCommand<Model, Harness>>, reuseTag = false): Promise<void> => {
+  const model: Model = { requests: new Map(), completed: new Set(), references: new Map() }
+  const real = harness(ownership, reuseTag)
+  await request(1).run(model, real)
+  await request(0).run(model, real)
+  await attempt("before-effect").run(model, real)
+  await revise(0).run(model, real)
+  await attempt("after-effect").run(model, real)
+  await restart().run(model, real)
+  await fc.asyncModelRun(() => ({ model, real }), trace)
+  while (eligible(model).length > 0) await attempt("after-commit").run(model, real)
+  const before = { events: [...real.events], attempts: [...real.attempts], performed: [...real.performed] }
+  await real.settleCompleted()
+  real.restart()
+  await real.settleCompleted()
+  expect(real.events).toEqual(before.events)
+  expect(real.attempts).toEqual(before.attempts)
+  expect(real.performed).toEqual(before.performed)
+}
+
+test("logical operations preserve refs through changing outputs, retries, completion, and cold replay", async () => {
+  await fc.assert(fc.asyncProperty(commands, async (trace) => {
+    await lifecycle("request", trace)
+    await lifecycle("completion", trace)
+  }), { numRuns: 100 })
+})
+
+test("sequential tag reuse is a counterexample to logical operation correlation", async () => {
+  const result = await fc.check(fc.asyncProperty(commands, (trace) => lifecycle("request", trace, true)), { numRuns: 10 })
+  expect(result.failed).toBe(true)
+  expect(String(result.errorInstance)).toContain("enabled operations disagree with logical operations")
+})

--- a/packages/core/src/transition/transition.ts
+++ b/packages/core/src/transition/transition.ts
@@ -39,7 +39,7 @@ export const transitionKeyOf = (event: Event): string | undefined => "transition
 interface TaggedEffectOptions<Input, Result extends Event, Requirements = never> {
   readonly key?: never
   readonly ref?: never
-  readonly invocation?: InvocationRef
+  readonly invocation?: InvocationRef | null
   readonly concurrent?: boolean
   readonly interrupts?: (input: Input, event: Event) => boolean
   readonly input: Input
@@ -50,7 +50,7 @@ interface TaggedEffectOptions<Input, Result extends Event, Requirements = never>
 export interface TransitionContext {
   readonly invocation?: InvocationRef
   readonly effect: <Input, Result extends Event, Requirements = never>(tag: string, options: TaggedEffectOptions<Input, Result, Requirements>) => ExternalEffect<never, Requirements>
-  readonly intent: (tag: string, completion: Event, options?: { readonly invocation?: InvocationRef }) => Intent<never>
+  readonly intent: (tag: string, completion: Event | ((at: number) => Event), options?: { readonly invocation?: InvocationRef | null }) => Intent<never>
   readonly matches: (tag: string, event: Event) => boolean
 }
 
@@ -65,7 +65,9 @@ export const bindTransitionContext = (event: Event, component: string): Transiti
   }
   const owner = recorded ?? accepted
   const inherited = owner === undefined ? undefined : Object.freeze({ ...owner })
-  const invocationOf = (explicit: InvocationRef | undefined): InvocationRef | undefined => {
+  // invocationOf permits explicit detachment for control delivery after cancellation (runtime/reconciler.properties.test.ts).
+  const invocationOf = (explicit: InvocationRef | null | undefined): InvocationRef | undefined => {
+    if (explicit === null) return undefined
     if (explicit === undefined) return inherited
     const decoded = Schema.decodeSync(InvocationRef)(explicit)
     if (inherited !== undefined && !sameInvocation(inherited, decoded)) {
@@ -101,13 +103,13 @@ export const bindTransitionContext = (event: Event, component: string): Transiti
       references.set(transition, ref)
       return transition
     },
-    intent: (tag: string, result: Event, options?: { readonly invocation?: InvocationRef }) => {
+    intent: (tag: string, result: Event | ((at: number) => Event), options?: { readonly invocation?: InvocationRef | null }) => {
       const ref = reference(tag)
       const invocation = invocationOf(options?.invocation)
       const transition = Object.freeze(intent({
         key: transitionKey(ref), input: result,
         ...(invocation === undefined ? {} : { invocation }),
-        events: (input) => [complete(ref, invocation, input)]
+        events: (input, at) => [complete(ref, invocation, typeof input === "function" ? input(at) : input)]
       }))
       references.set(transition, ref)
       return transition

--- a/packages/core/src/transition/transition.ts
+++ b/packages/core/src/transition/transition.ts
@@ -46,7 +46,8 @@ interface TaggedEffectOptions<Input, Result extends Event, Requirements = never>
   readonly act: (input: Input, context: { readonly signal: AbortSignal }) => Effect.Effect<Result, never, EventLog | Requirements>
 }
 
-// TransitionContext binds tagged declarations and result queries to one component and event, inheriting invocation ownership when present (runtime/reconciler.properties.test.ts).
+// TransitionContext binds declarations and result queries to one component and event, inheriting invocation ownership when present (runtime/reconciler.properties.test.ts).
+// Tags must keep identifying the same logical operation across outputs for that owner; retries reuse the tag, while new operations need a different tag or owner (tla/runtime/TransitionDeclarations.tla, AuthorAllows; runtime/transition-lifecycle.properties.test.ts).
 export interface TransitionContext {
   readonly invocation?: InvocationRef
   readonly effect: <Input, Result extends Event, Requirements = never>(tag: string, options: TaggedEffectOptions<Input, Result, Requirements>) => ExternalEffect<never, Requirements>
@@ -118,7 +119,7 @@ export const bindTransitionContext = (event: Event, component: string): Transiti
   })
 }
 
-// validateTransitions enforces component ownership and a shared intent/effect tag namespace (tla/runtime/TransitionDeclarations.tla, UniqueRefs; runtime/reconciler.properties.test.ts).
+// validateTransitions enforces component ownership and rejects duplicate intent/effect tags within the supplied output (tla/runtime/TransitionDeclarations.tla, RuntimeAllows; runtime/reconciler.properties.test.ts).
 export const validateTransitions = <R>(
   transitions: ReadonlyArray<Transition<never, R>>,
   component?: string

--- a/packages/core/tla/runtime/OperationGraph.cfg
+++ b/packages/core/tla/runtime/OperationGraph.cfg
@@ -1,0 +1,12 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  CheckDependencies = TRUE
+  MatchRef = TRUE
+  CancelByDependencies = FALSE
+  StableRefs = TRUE
+  CheckCancellation = TRUE
+  MaxCrashes = 1
+  Fair = FALSE
+INVARIANTS TypeOK IdentityStable ExactResolution CancellationIsolation
+           NoPrematureStart NoCancelledStart NoObservedCancelledPublication

--- a/packages/core/tla/runtime/OperationGraph.tla
+++ b/packages/core/tla/runtime/OperationGraph.tla
@@ -1,0 +1,120 @@
+--------------------------- MODULE OperationGraph ---------------------------
+EXTENDS Naturals, FiniteSets
+
+(* OperationGraph separates operation identity, data prerequisites, and invocation lifetime. The fixture has two downloads, a join, and independent audit work; logical operation names are independent of refs. Declaration stability is assumed from TransitionDeclarations.tla. This model trusts runtime-produced receipts and does not model arbitrary ingress metadata. *)
+CONSTANTS CheckDependencies, MatchRef, CancelByDependencies, StableRefs,
+          CheckCancellation, MaxCrashes, Fair
+Ops == {"a", "b", "join", "audit"}
+Needs(o) == IF o = "join" THEN {"a", "b"} ELSE {}
+OwnerSeq(o) == IF o = "audit" THEN 2 ELSE 1
+Component(o) == IF o = "b" THEN "right" ELSE "left"
+Tag(o) == IF o = "join" THEN "combine" ELSE "fetch"
+Invocation(epoch) == [method |-> "run", id |-> "same", epoch |-> epoch]
+Invocations == {Invocation(0), Invocation(1)}
+Owner(o) == Invocation(IF o \in {"a", "join"} THEN 0 ELSE 1)
+ExpectedRef(o) == <<OwnerSeq(o), Component(o), Tag(o)>>
+Phases == {"pending", "running", "returned", "checked"}
+Refs == (1..(3 + Cardinality(Ops))) \X {"left", "right"} \X {"fetch", "combine"}
+
+VARIABLES refs, phase, receipts, resolved, cancelled, crashes,
+          prematureStart, cancelledStart, observedCancellation, cancelledPublication
+vars == <<refs, phase, receipts, resolved, cancelled, crashes,
+          prematureStart, cancelledStart, observedCancellation, cancelledPublication>>
+
+Completed == {r.operation : r \in receipts}
+OwnerCancelled(o) == Owner(o) \in cancelled
+Suppressed(o) == OwnerCancelled(o) \/
+  (CancelByDependencies /\ \E p \in Needs(o) : OwnerCancelled(p))
+DependenciesReady(o) == IF CheckDependencies THEN Needs(o) \subseteq resolved
+  ELSE Needs(o) = {} \/ Needs(o) \cap resolved # {}
+Matches(o, receipt) == IF MatchRef THEN refs[o] = receipt.ref ELSE TRUE
+Resolve(rs) == {o \in Ops : \E r \in rs : Matches(o, r)}
+Ready(o) == o \notin resolved /\ ~Suppressed(o) /\ DependenciesReady(o)
+
+Init ==
+  /\ refs = [o \in Ops |-> ExpectedRef(o)]
+  /\ phase = [o \in Ops |-> "pending"]
+  /\ receipts = {} /\ resolved = {} /\ cancelled = {} /\ crashes = 0
+  /\ prematureStart = FALSE /\ cancelledStart = FALSE /\ cancelledPublication = FALSE
+  /\ observedCancellation = [o \in Ops |-> FALSE]
+
+Start(o) ==
+  /\ phase[o] = "pending" /\ Ready(o)
+  /\ phase' = [phase EXCEPT ![o] = "running"]
+  /\ prematureStart' = (prematureStart \/ ~(Needs(o) \subseteq Completed))
+  /\ cancelledStart' = (cancelledStart \/ OwnerCancelled(o))
+  /\ UNCHANGED <<refs, receipts, resolved, cancelled, crashes, observedCancellation, cancelledPublication>>
+
+(* Return abstracts an external attempt that returns; an external side effect before durable completion may repeat after Crash. *)
+Return(o) ==
+  /\ phase[o] = "running"
+  /\ phase' = [phase EXCEPT ![o] = "returned"]
+  /\ UNCHANGED <<refs, receipts, resolved, cancelled, crashes, prematureStart,
+                   cancelledStart, observedCancellation, cancelledPublication>>
+
+(* CheckResult observes cancellation before append; Cancel may still occur between this action and Commit. *)
+CheckResult(o) ==
+  /\ phase[o] = "returned"
+  /\ observedCancellation' = [observedCancellation EXCEPT ![o] = OwnerCancelled(o)]
+  /\ phase' = [phase EXCEPT ![o] = IF CheckCancellation /\ Suppressed(o) THEN "pending" ELSE "checked"]
+  /\ UNCHANGED <<refs, receipts, resolved, cancelled, crashes, prematureStart, cancelledStart, cancelledPublication>>
+
+Commit(o) ==
+  /\ phase[o] = "checked"
+  /\ receipts' = receipts \cup {[operation |-> o, ref |-> refs[o]]}
+  /\ resolved' = Resolve(receipts')
+  /\ phase' = [phase EXCEPT ![o] = "pending"]
+  /\ cancelledPublication' = (cancelledPublication \/ observedCancellation[o])
+  /\ UNCHANGED <<refs, cancelled, crashes, prematureStart, cancelledStart, observedCancellation>>
+
+Cancel(invocation) ==
+  /\ invocation \notin cancelled
+  /\ cancelled' = cancelled \cup {invocation}
+  /\ UNCHANGED <<refs, phase, receipts, resolved, crashes, prematureStart,
+                   cancelledStart, observedCancellation, cancelledPublication>>
+
+(* Crash discards an uncommitted attempt while retaining its declaration and receipts. A crash after commit is represented by Replay. *)
+Crash(o) ==
+  /\ phase[o] # "pending" /\ crashes < MaxCrashes
+  /\ crashes' = crashes + 1
+  /\ phase' = [phase EXCEPT ![o] = "pending"]
+  /\ UNCHANGED <<refs, receipts, resolved, cancelled, prematureStart,
+                   cancelledStart, observedCancellation, cancelledPublication>>
+
+Replay ==
+  /\ resolved' = Resolve(receipts)
+  /\ UNCHANGED <<refs, phase, receipts, cancelled, crashes, prematureStart,
+                   cancelledStart, observedCancellation, cancelledPublication>>
+
+(* Reoffer exposes a defect that makes an operation's identity follow prerequisite progress. The correct declaration remains anchored to its original owner. *)
+Reoffer(o) ==
+  /\ phase[o] = "pending" /\ Needs(o) \cap resolved # {}
+  /\ refs' = [refs EXCEPT ![o] = IF StableRefs THEN @
+       ELSE <<3 + Cardinality(Completed), Component(o), Tag(o)>>]
+  /\ UNCHANGED <<phase, receipts, resolved, cancelled, crashes, prematureStart,
+                   cancelledStart, observedCancellation, cancelledPublication>>
+
+Next == Replay \/ (\E i \in Invocations : Cancel(i)) \/
+  (\E o \in Ops : Start(o) \/ Return(o) \/ CheckResult(o) \/ Commit(o) \/ Crash(o) \/ Reoffer(o))
+Progress == \A o \in Ops : WF_vars(Start(o)) /\ WF_vars(Return(o))
+  /\ WF_vars(CheckResult(o)) /\ WF_vars(Commit(o))
+Spec == Init /\ [][Next]_vars /\ (IF Fair THEN Progress ELSE TRUE)
+
+TypeOK ==
+  /\ refs \in [Ops -> Refs] /\ phase \in [Ops -> Phases]
+  /\ receipts \subseteq [operation : Ops, ref : Refs] /\ resolved \subseteq Ops
+  /\ cancelled \subseteq Invocations /\ crashes \in 0..MaxCrashes
+  /\ observedCancellation \in [Ops -> BOOLEAN]
+  /\ prematureStart \in BOOLEAN /\ cancelledStart \in BOOLEAN /\ cancelledPublication \in BOOLEAN
+IdentityStable == \A o \in Ops : refs[o] = ExpectedRef(o)
+ExactResolution == resolved = Completed
+CancellationIsolation == \A o \in Ops : Suppressed(o) = OwnerCancelled(o)
+NoPrematureStart == ~prematureStart
+NoCancelledStart == ~cancelledStart
+NoObservedCancelledPublication == ~cancelledPublication
+ReadySettles == \A o \in Ops : Ready(o) ~> (o \in Completed \/ OwnerCancelled(o))
+
+(* Safety follows by induction when all checks are enabled and CancelByDependencies is FALSE. ExpectedRef is injective on the fixture, so Resolve adds exactly the receipt's operation. Start checks actual completed prerequisites through ExactResolution. Cancel changes only invocation lifetime. CheckResult prevents publication when cancellation was observed there. Replay preserves resolution and Reoffer preserves refs. This is a written argument over the model, not a mechanically checked refinement proof of TypeScript. *)
+
+(* ReadySettles follows under Progress and bounded crashes. Once ready, prerequisites remain completed. Cancellation either settles the obligation's lifetime or it stays eligible. After the final crash, weak fairness advances pending, running, returned, and checked phases to commit. A join with a cancelled, uncompleted prerequisite can remain blocked; it is not thereby cancelled. Effect termination and available storage are fairness assumptions here, not scheduler guarantees inferred from identity. *)
+=============================================================================

--- a/packages/core/tla/runtime/OperationGraphCancellation.cfg
+++ b/packages/core/tla/runtime/OperationGraphCancellation.cfg
@@ -1,0 +1,12 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  CheckDependencies = TRUE
+  MatchRef = TRUE
+  CancelByDependencies = TRUE
+  StableRefs = TRUE
+  CheckCancellation = TRUE
+  MaxCrashes = 1
+  Fair = FALSE
+INVARIANTS TypeOK IdentityStable ExactResolution CancellationIsolation
+           NoPrematureStart NoCancelledStart NoObservedCancelledPublication

--- a/packages/core/tla/runtime/OperationGraphCorrelation.cfg
+++ b/packages/core/tla/runtime/OperationGraphCorrelation.cfg
@@ -1,0 +1,12 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  CheckDependencies = TRUE
+  MatchRef = FALSE
+  CancelByDependencies = FALSE
+  StableRefs = TRUE
+  CheckCancellation = TRUE
+  MaxCrashes = 1
+  Fair = FALSE
+INVARIANTS TypeOK IdentityStable ExactResolution CancellationIsolation
+           NoPrematureStart NoCancelledStart NoObservedCancelledPublication

--- a/packages/core/tla/runtime/OperationGraphLive.cfg
+++ b/packages/core/tla/runtime/OperationGraphLive.cfg
@@ -1,0 +1,13 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  CheckDependencies = TRUE
+  MatchRef = TRUE
+  CancelByDependencies = FALSE
+  StableRefs = TRUE
+  CheckCancellation = TRUE
+  MaxCrashes = 1
+  Fair = TRUE
+INVARIANTS TypeOK IdentityStable ExactResolution CancellationIsolation
+           NoPrematureStart NoCancelledStart NoObservedCancelledPublication
+PROPERTY ReadySettles

--- a/packages/core/tla/runtime/OperationGraphPremature.cfg
+++ b/packages/core/tla/runtime/OperationGraphPremature.cfg
@@ -1,0 +1,12 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  CheckDependencies = FALSE
+  MatchRef = TRUE
+  CancelByDependencies = FALSE
+  StableRefs = TRUE
+  CheckCancellation = TRUE
+  MaxCrashes = 1
+  Fair = FALSE
+INVARIANTS TypeOK IdentityStable ExactResolution CancellationIsolation
+           NoPrematureStart NoCancelledStart NoObservedCancelledPublication

--- a/packages/core/tla/runtime/OperationGraphReanchor.cfg
+++ b/packages/core/tla/runtime/OperationGraphReanchor.cfg
@@ -1,0 +1,12 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  CheckDependencies = TRUE
+  MatchRef = TRUE
+  CancelByDependencies = FALSE
+  StableRefs = FALSE
+  CheckCancellation = TRUE
+  MaxCrashes = 1
+  Fair = FALSE
+INVARIANTS TypeOK IdentityStable ExactResolution CancellationIsolation
+           NoPrematureStart NoCancelledStart NoObservedCancelledPublication

--- a/packages/core/tla/runtime/OperationGraphUnchecked.cfg
+++ b/packages/core/tla/runtime/OperationGraphUnchecked.cfg
@@ -1,0 +1,12 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  CheckDependencies = TRUE
+  MatchRef = TRUE
+  CancelByDependencies = FALSE
+  StableRefs = TRUE
+  CheckCancellation = FALSE
+  MaxCrashes = 1
+  Fair = FALSE
+INVARIANTS TypeOK IdentityStable ExactResolution CancellationIsolation
+           NoPrematureStart NoCancelledStart NoObservedCancelledPublication

--- a/packages/core/tla/runtime/OperationGraphUnfair.cfg
+++ b/packages/core/tla/runtime/OperationGraphUnfair.cfg
@@ -1,0 +1,13 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  CheckDependencies = TRUE
+  MatchRef = TRUE
+  CancelByDependencies = FALSE
+  StableRefs = TRUE
+  CheckCancellation = TRUE
+  MaxCrashes = 1
+  Fair = FALSE
+INVARIANTS TypeOK IdentityStable ExactResolution CancellationIsolation
+           NoPrematureStart NoCancelledStart NoObservedCancelledPublication
+PROPERTY ReadySettles

--- a/packages/core/tla/runtime/TransitionDeclarations.cfg
+++ b/packages/core/tla/runtime/TransitionDeclarations.cfg
@@ -10,5 +10,6 @@ CONSTANTS
   MaxDeclarations = 2
   CheckNames = TRUE
   CheckTags = TRUE
+  StableTagsAcrossOutputs = TRUE
   SharedNamespace = TRUE
 INVARIANTS TypeOK UniqueRefs

--- a/packages/core/tla/runtime/TransitionDeclarations.tla
+++ b/packages/core/tla/runtime/TransitionDeclarations.tla
@@ -3,12 +3,12 @@ EXTENDS Naturals, FiniteSets
 
 (* TransitionDeclarations separates logical objects from their declared strings so UniqueRefs can detect aliasing (TransitionDeclarations.cfg). TransitionIdentity.tla checks downstream completion and replay behavior once references are unique. *)
 CONSTANTS ComponentSlots, TransitionSlots, Names, Tags, MaxOwners, MaxNoise,
-          MaxDeclarations, CheckNames, CheckTags, SharedNamespace
+          MaxDeclarations, CheckNames, CheckTags, SharedNamespace, StableTagsAcrossOutputs
 ASSUME /\ Names \subseteq (STRING \ {""})
        /\ Tags \subseteq (STRING \ {""})
 
-VARIABLES nextSeq, owners, noise, components, declarations
-vars == <<nextSeq, owners, noise, components, declarations>>
+VARIABLES nextSeq, owners, noise, components, declarations, offered
+vars == <<nextSeq, owners, noise, components, declarations, offered>>
 Kinds == {"intent", "effect"}
 
 Init ==
@@ -17,41 +17,69 @@ Init ==
   /\ noise = 0
   /\ components = {}
   /\ declarations = {}
+  /\ offered = {}
 
 AppendOwner ==
   /\ Cardinality(owners) < MaxOwners
   /\ owners' = owners \cup {nextSeq}
   /\ nextSeq' = nextSeq + 1
-  /\ UNCHANGED <<noise, components, declarations>>
+  /\ UNCHANGED <<noise, components, declarations, offered>>
 
 AppendNoise ==
   /\ noise < MaxNoise
   /\ noise' = noise + 1
   /\ nextSeq' = nextSeq + 1
-  /\ UNCHANGED <<owners, components, declarations>>
+  /\ UNCHANGED <<owners, components, declarations, offered>>
 
 (* DeclareComponent binds a logical component slot to an immutable declared string. CheckNames enforces uniqueness across the composition. *)
 DeclareComponent(slot, name) ==
   /\ ~\E c \in components : c.slot = slot
   /\ CheckNames => ~\E c \in components : c.name = name
   /\ components' = components \cup {[slot |-> slot, name |-> name]}
-  /\ UNCHANGED <<nextSeq, owners, noise, declarations>>
+  /\ UNCHANGED <<nextSeq, owners, noise, declarations, offered>>
 
-(* Declare binds a logical transition slot to a stable tag for its owner's lifetime. SharedNamespace makes intents and effects participate in the same duplicate check. Completed declarations are retained here because completing an obligation does not permit its tag to name a different obligation. *)
+(* RuntimeAllows models the duplicate check within the current output. Intent and effect tags share a namespace when SharedNamespace is TRUE (src/transition/transition.ts, validateTransitions). *)
+RuntimeAllows(owner, component, kind, tag) ==
+  CheckTags => ~\E d \in offered :
+    /\ d.owner = owner /\ d.component = component /\ d.tag = tag
+    /\ SharedNamespace \/ d.kind = kind
+
+(* AuthorAllows states the stable-tag contract across outputs; the runtime does not retain this history. A different logical slot cannot acquire the tag of a declaration absent from the current output. Simultaneous declarations are checked separately by RuntimeAllows. *)
+AuthorAllows(owner, component, tag) ==
+  StableTagsAcrossOutputs => ~\E d \in declarations \ offered :
+    d.owner = owner /\ d.component = component /\ d.tag = tag
+
+(* Declare introduces a new logical operation, keeping its slot independent of its physical reference. Repeated offers of that operation use Reoffer. *)
 Declare(owner, component, slot, kind, tag) ==
   /\ Cardinality(declarations) < MaxDeclarations
   /\ ~\E d \in declarations :
-       /\ d.owner = owner /\ d.component = component /\ d.slot = slot
-  /\ CheckTags => ~\E d \in declarations :
-       /\ d.owner = owner /\ d.component = component /\ d.tag = tag
-       /\ SharedNamespace \/ d.kind = kind
-  /\ declarations' = declarations \cup {
-       [owner |-> owner, component |-> component, slot |-> slot, kind |-> kind, tag |-> tag]}
+       d.owner = owner /\ d.component = component /\ d.slot = slot
+  /\ RuntimeAllows(owner, component, kind, tag)
+  /\ AuthorAllows(owner, component, tag)
+  /\ LET declaration == [owner |-> owner, component |-> component,
+                          slot |-> slot, kind |-> kind, tag |-> tag]
+     IN /\ declarations' = declarations \cup {declaration}
+        /\ offered' = offered \cup {declaration}
   /\ UNCHANGED <<nextSeq, owners, noise, components>>
+
+(* NextOutput clears the runtime's duplicate set after a state update or replay; the logical history remains available only to the specification. Completion and retry behavior are modeled in TransitionIdentity.tla and runtime/transition-lifecycle.properties.test.ts. *)
+NextOutput ==
+  /\ offered # {}
+  /\ offered' = {}
+  /\ UNCHANGED <<nextSeq, owners, noise, components, declarations>>
+
+(* Reoffer preserves an existing operation's identity across outputs without treating it as a new declaration. Inputs and action bodies are outside the identity model and may vary between offers (runtime/transition-lifecycle.properties.test.ts). *)
+Reoffer(d) ==
+  /\ d \notin offered
+  /\ RuntimeAllows(d.owner, d.component, d.kind, d.tag)
+  /\ offered' = offered \cup {d}
+  /\ UNCHANGED <<nextSeq, owners, noise, components, declarations>>
 
 Next ==
   \/ AppendOwner
   \/ AppendNoise
+  \/ NextOutput
+  \/ \E d \in declarations : Reoffer(d)
   \/ \E s \in ComponentSlots, n \in Names : DeclareComponent(s, n)
   \/ \E o \in owners, c \in {x.slot : x \in components},
         s \in TransitionSlots, k \in Kinds, t \in Tags : Declare(o, c, s, k, t)
@@ -70,13 +98,14 @@ TypeOK ==
   /\ declarations \subseteq [owner : owners, component : {c.slot : c \in components},
                               slot : TransitionSlots, kind : Kinds, tag : Tags]
   /\ Cardinality(declarations) <= MaxDeclarations
+  /\ offered \subseteq declarations
 
 ComponentSlotsUnique == \A a, b \in components : a.slot = b.slot => a = b
 ComponentNamesUnique == \A a, b \in components : a.name = b.name => a = b
 LocalTagsUnique == \A a, b \in declarations :
   (a.owner = b.owner /\ a.component = b.component /\ a.tag = b.tag) => a = b
 
-(* UniqueRefs follows for arbitrary finite bounds when CheckNames, CheckTags, and SharedNamespace are TRUE. The induction invariant is TypeOK /\ ComponentSlotsUnique /\ ComponentNamesUnique /\ LocalTagsUnique. Init satisfies it on empty sets. AppendOwner uses nextSeq greater than every prior owner position; AppendNoise changes no declarations. DeclareComponent preserves the two component uniqueness predicates through its slot and name guards and cannot change existing names. Declare preserves LocalTagsUnique through its owner/component/tag guard, independent of kind. Existing declarations are immutable. These facts also preserve the invariant under stuttering and establish it for every finite prefix of Spec. *)
+(* UniqueRefs follows for arbitrary finite bounds when CheckNames, CheckTags, SharedNamespace, and StableTagsAcrossOutputs are TRUE. The induction invariant is TypeOK /\ ComponentSlotsUnique /\ ComponentNamesUnique /\ LocalTagsUnique. Init satisfies it on empty sets. AppendOwner uses a fresh position; AppendNoise changes no declarations. DeclareComponent preserves component uniqueness through its guards. For Declare, every prior declaration is either offered or absent from offered. RuntimeAllows excludes a same-ref declaration in offered; AuthorAllows excludes one in declarations \ offered. Together they preserve LocalTagsUnique. NextOutput and Reoffer change no logical declarations. This argument explicitly depends on an author contract in addition to runtime checks (TransitionDeclarationsTagReuse.cfg removes only that contract). *)
 
 (* UniqueRefs then follows by extensional equality: let a and b be declarations with equal references. Tuple equality gives equal owners, equal component names, and equal tags. ComponentSlotsUnique makes ComponentName well-defined; ComponentNamesUnique gives a.component = b.component. LocalTagsUnique now gives a = b. Conversely, a = b gives equal references by substitution. Therefore two declarations have the same reference exactly when they are the same logical transition, and replay of that transition preserves its reference. The proof is written here; TLC checks the configured finite instances, without mechanically checking this general induction argument. *)
 

--- a/packages/core/tla/runtime/TransitionDeclarationsDuplicateNames.cfg
+++ b/packages/core/tla/runtime/TransitionDeclarationsDuplicateNames.cfg
@@ -10,5 +10,6 @@ CONSTANTS
   MaxDeclarations = 2
   CheckNames = FALSE
   CheckTags = TRUE
+  StableTagsAcrossOutputs = TRUE
   SharedNamespace = TRUE
 INVARIANTS TypeOK UniqueRefs

--- a/packages/core/tla/runtime/TransitionDeclarationsSplitKinds.cfg
+++ b/packages/core/tla/runtime/TransitionDeclarationsSplitKinds.cfg
@@ -10,5 +10,6 @@ CONSTANTS
   MaxDeclarations = 2
   CheckNames = TRUE
   CheckTags = TRUE
+  StableTagsAcrossOutputs = TRUE
   SharedNamespace = FALSE
 INVARIANTS TypeOK UniqueRefs

--- a/packages/core/tla/runtime/TransitionDeclarationsTagReuse.cfg
+++ b/packages/core/tla/runtime/TransitionDeclarationsTagReuse.cfg
@@ -1,15 +1,15 @@
 SPECIFICATION Spec
 CHECK_DEADLOCK FALSE
 CONSTANTS
-  ComponentSlots = {componentA, componentB}
+  ComponentSlots = {componentA}
   TransitionSlots = {transitionA, transitionB}
-  Names = {"code", "tools"}
-  Tags = {"execute", "audit"}
-  MaxOwners = 2
-  MaxNoise = 1
+  Names = {"files"}
+  Tags = {"run"}
+  MaxOwners = 1
+  MaxNoise = 0
   MaxDeclarations = 2
   CheckNames = TRUE
-  CheckTags = FALSE
-  StableTagsAcrossOutputs = TRUE
+  CheckTags = TRUE
   SharedNamespace = TRUE
+  StableTagsAcrossOutputs = FALSE
 INVARIANTS TypeOK UniqueRefs

--- a/packages/core/tla/runtime/TransitionOwnership.cfg
+++ b/packages/core/tla/runtime/TransitionOwnership.cfg
@@ -2,6 +2,7 @@ SPECIFICATION Spec
 CHECK_DEADLOCK FALSE
 CONSTANTS
   None = noInvocation
+  Detach = detachedControl
   MaxEvents = 3
   CarryDeclaration = TRUE
   CarryCompletion = TRUE

--- a/packages/core/tla/runtime/TransitionOwnership.tla
+++ b/packages/core/tla/runtime/TransitionOwnership.tla
@@ -2,7 +2,7 @@
 EXTENDS Naturals, Sequences, FiniteSets
 
 (* TransitionOwnership checks invocation inheritance across an intent/effect event chain (DeclarationOwner, EventOwner, ScopeCorrect, CancellationObserved). TransitionDeclarations.tla establishes reference uniqueness separately. Expected ownership is tracked independently from carried metadata. *)
-CONSTANTS None, MaxEvents, CarryDeclaration, CarryCompletion, RejectOverride,
+CONSTANTS None, Detach, MaxEvents, CarryDeclaration, CarryCompletion, RejectOverride,
           BindScope, KeepScopeDetails, MatchMode, CheckStart, SignalActive,
           CheckResult, Fair
 
@@ -28,7 +28,7 @@ Same(a, b) == CASE MatchMode = "exact" -> a = b
                [] MatchMode = "noMethod" -> a.id = b.id /\ a.epoch = b.epoch
                [] MatchMode = "noId" -> a.method = b.method /\ a.epoch = b.epoch
 IsCancelled(owner) == IF owner = None THEN FALSE ELSE \E c \in cancelled : Same(owner, c)
-Inherited(event, explicit) == IF explicit = None THEN event.owner ELSE explicit
+Inherited(event, explicit) == IF explicit = Detach THEN None ELSE IF explicit = None THEN event.owner ELSE explicit
 Carried(event, explicit) == IF CarryDeclaration THEN Inherited(event, explicit) ELSE None
 Last == events[Len(events)]
 
@@ -44,13 +44,13 @@ Init ==
   /\ badStart = FALSE
   /\ badPublication = FALSE
 
-(* Declare models bindTransitionContext and both tagged constructors. An unowned event may acquire explicit ownership; an owned event rejects a different explicit invocation, including a different epoch. *)
+(* Declare models bindTransitionContext and both tagged constructors. An unowned event may acquire explicit ownership; an owned event rejects a different explicit invocation, including a different epoch. Detach explicitly removes invocation ownership for control delivery after cancellation, while preserving transition identity. *)
 Declare(kind, explicit) ==
   /\ phase = "idle" /\ Len(events) < MaxEvents
-  /\ RejectOverride => (Last.owner = None \/ explicit = None \/ explicit = Last.owner)
+  /\ RejectOverride => (Last.owner = None \/ explicit = None \/ explicit = Detach \/ explicit = Last.owner)
   /\ transition' = [source |-> Len(events), ref |-> <<Last.seq, "worker", "step">>,
        kind |-> kind, explicit |-> explicit,
-       expected |-> IF Last.expected = None THEN explicit ELSE Last.expected,
+       expected |-> IF explicit = Detach THEN None ELSE IF Last.expected = None THEN explicit ELSE Last.expected,
        owner |-> Carried(Last, explicit)]
   /\ phase' = "ready"
   /\ signalled' = FALSE
@@ -117,7 +117,7 @@ CommitIntent ==
   /\ UNCHANGED <<transition, cancelled, signalled, scopes, checkedCancellation, badPublication>>
 
 Next ==
-  \/ \E kind \in Kinds, explicit \in Owners : Declare(kind, explicit)
+  \/ \E kind \in Kinds, explicit \in Owners \cup {Detach} : Declare(kind, explicit)
   \/ Replay \/ Suppress \/ StartEffect \/ CheckCompletion \/ CommitEffect \/ CommitIntent
   \/ \E target \in Invocations : Cancel(target)
 Progress == WF_vars(Suppress) /\ WF_vars(StartEffect) /\ WF_vars(CheckCompletion)
@@ -134,7 +134,7 @@ TypeOK ==
   /\ badStart \in BOOLEAN /\ badPublication \in BOOLEAN
   /\ transition = None \/
        (transition.source \in 1..Len(events) /\ transition.kind \in Kinds
-        /\ transition.owner \in Owners /\ transition.expected \in Owners /\ transition.explicit \in Owners)
+        /\ transition.owner \in Owners /\ transition.expected \in Owners /\ transition.explicit \in Owners \cup {Detach})
 
 ReferenceStable == IF transition = None THEN TRUE ELSE
   transition.ref = <<events[transition.source].seq, "worker", "step">>
@@ -148,7 +148,7 @@ NoCancelledStart == ~badStart
 NoObservedCancelledResults == ~badPublication
 PendingSettles == phase \in {"ready", "running", "checked"} ~> phase \in {"idle", "finished"}
 
-(* DeclarationOwner and EventOwner hold by mutual induction when metadata is preserved and conflicting overrides are rejected. Init agrees on root ownership. Declare either preserves an owned event's expected owner or supplies the explicit owner of an unowned event. AppendCompletion copies that expected owner to the next event. Replay reconstructs the same declaration. Every other action preserves both owners. This argument includes None and treats intent and effect declarations identically. *)
+(* DeclarationOwner and EventOwner hold by mutual induction when metadata is preserved and conflicting overrides are rejected. Init agrees on root ownership. Declare preserves an owned event's expected owner, supplies the explicit owner of an unowned event, or explicitly detaches control delivery to None. AppendCompletion copies that expected owner to the next event. Replay reconstructs the same declaration. Every other action preserves both owners. This argument includes None and treats intent and effect declarations identically. *)
 
 (* ScopeCorrect follows because StartEffect binds the full accepted Context of the carried owner and DeclarationOwner equates that owner to the expected owner. CancellationIsolation follows from exact equality on method, id, and epoch. CheckStart blocks already cancelled owners; Cancel signals an active effect of exactly its target invocation. CheckCompletion suppresses results when the observed prefix includes cancellation. These arguments depend on the corresponding switches being enabled and do not establish cancellation/append atomicity or exactly-once execution. *)
 

--- a/packages/core/tla/runtime/TransitionOwnershipBareScope.cfg
+++ b/packages/core/tla/runtime/TransitionOwnershipBareScope.cfg
@@ -2,6 +2,7 @@ SPECIFICATION Spec
 CHECK_DEADLOCK FALSE
 CONSTANTS
   None = noInvocation
+  Detach = detachedControl
   MaxEvents = 3
   CarryDeclaration = TRUE
   CarryCompletion = TRUE

--- a/packages/core/tla/runtime/TransitionOwnershipDropCompletion.cfg
+++ b/packages/core/tla/runtime/TransitionOwnershipDropCompletion.cfg
@@ -2,6 +2,7 @@ SPECIFICATION Spec
 CHECK_DEADLOCK FALSE
 CONSTANTS
   None = noInvocation
+  Detach = detachedControl
   MaxEvents = 3
   CarryDeclaration = TRUE
   CarryCompletion = FALSE

--- a/packages/core/tla/runtime/TransitionOwnershipDropDeclaration.cfg
+++ b/packages/core/tla/runtime/TransitionOwnershipDropDeclaration.cfg
@@ -2,6 +2,7 @@ SPECIFICATION Spec
 CHECK_DEADLOCK FALSE
 CONSTANTS
   None = noInvocation
+  Detach = detachedControl
   MaxEvents = 3
   CarryDeclaration = FALSE
   CarryCompletion = TRUE

--- a/packages/core/tla/runtime/TransitionOwnershipLive.cfg
+++ b/packages/core/tla/runtime/TransitionOwnershipLive.cfg
@@ -2,6 +2,7 @@ SPECIFICATION Spec
 CHECK_DEADLOCK FALSE
 CONSTANTS
   None = noInvocation
+  Detach = detachedControl
   MaxEvents = 2
   CarryDeclaration = TRUE
   CarryCompletion = TRUE

--- a/packages/core/tla/runtime/TransitionOwnershipNoEpoch.cfg
+++ b/packages/core/tla/runtime/TransitionOwnershipNoEpoch.cfg
@@ -2,6 +2,7 @@ SPECIFICATION Spec
 CHECK_DEADLOCK FALSE
 CONSTANTS
   None = noInvocation
+  Detach = detachedControl
   MaxEvents = 3
   CarryDeclaration = TRUE
   CarryCompletion = TRUE

--- a/packages/core/tla/runtime/TransitionOwnershipNoId.cfg
+++ b/packages/core/tla/runtime/TransitionOwnershipNoId.cfg
@@ -2,6 +2,7 @@ SPECIFICATION Spec
 CHECK_DEADLOCK FALSE
 CONSTANTS
   None = noInvocation
+  Detach = detachedControl
   MaxEvents = 3
   CarryDeclaration = TRUE
   CarryCompletion = TRUE

--- a/packages/core/tla/runtime/TransitionOwnershipNoMethod.cfg
+++ b/packages/core/tla/runtime/TransitionOwnershipNoMethod.cfg
@@ -2,6 +2,7 @@ SPECIFICATION Spec
 CHECK_DEADLOCK FALSE
 CONSTANTS
   None = noInvocation
+  Detach = detachedControl
   MaxEvents = 3
   CarryDeclaration = TRUE
   CarryCompletion = TRUE

--- a/packages/core/tla/runtime/TransitionOwnershipNoResultCheck.cfg
+++ b/packages/core/tla/runtime/TransitionOwnershipNoResultCheck.cfg
@@ -2,6 +2,7 @@ SPECIFICATION Spec
 CHECK_DEADLOCK FALSE
 CONSTANTS
   None = noInvocation
+  Detach = detachedControl
   MaxEvents = 3
   CarryDeclaration = TRUE
   CarryCompletion = TRUE

--- a/packages/core/tla/runtime/TransitionOwnershipNoScope.cfg
+++ b/packages/core/tla/runtime/TransitionOwnershipNoScope.cfg
@@ -2,6 +2,7 @@ SPECIFICATION Spec
 CHECK_DEADLOCK FALSE
 CONSTANTS
   None = noInvocation
+  Detach = detachedControl
   MaxEvents = 3
   CarryDeclaration = TRUE
   CarryCompletion = TRUE

--- a/packages/core/tla/runtime/TransitionOwnershipNoSignal.cfg
+++ b/packages/core/tla/runtime/TransitionOwnershipNoSignal.cfg
@@ -2,6 +2,7 @@ SPECIFICATION Spec
 CHECK_DEADLOCK FALSE
 CONSTANTS
   None = noInvocation
+  Detach = detachedControl
   MaxEvents = 3
   CarryDeclaration = TRUE
   CarryCompletion = TRUE

--- a/packages/core/tla/runtime/TransitionOwnershipNoStartCheck.cfg
+++ b/packages/core/tla/runtime/TransitionOwnershipNoStartCheck.cfg
@@ -2,6 +2,7 @@ SPECIFICATION Spec
 CHECK_DEADLOCK FALSE
 CONSTANTS
   None = noInvocation
+  Detach = detachedControl
   MaxEvents = 3
   CarryDeclaration = TRUE
   CarryCompletion = TRUE

--- a/packages/core/tla/runtime/TransitionOwnershipOverride.cfg
+++ b/packages/core/tla/runtime/TransitionOwnershipOverride.cfg
@@ -2,6 +2,7 @@ SPECIFICATION Spec
 CHECK_DEADLOCK FALSE
 CONSTANTS
   None = noInvocation
+  Detach = detachedControl
   MaxEvents = 3
   CarryDeclaration = TRUE
   CarryCompletion = TRUE

--- a/packages/core/tla/runtime/TransitionOwnershipUnfair.cfg
+++ b/packages/core/tla/runtime/TransitionOwnershipUnfair.cfg
@@ -2,6 +2,7 @@ SPECIFICATION Spec
 CHECK_DEADLOCK FALSE
 CONSTANTS
   None = noInvocation
+  Detach = detachedControl
   MaxEvents = 2
   CarryDeclaration = TRUE
   CarryCompletion = TRUE

--- a/tools/tla.ts
+++ b/tools/tla.ts
@@ -58,6 +58,7 @@ export const checks: ReadonlyArray<Check> = [
   counterexample("runtime", "TransitionDeclarations", "TransitionDeclarationsDuplicateNames.cfg", "Invariant UniqueRefs is violated"),
   counterexample("runtime", "TransitionDeclarations", "TransitionDeclarationsDuplicateTags.cfg", "Invariant UniqueRefs is violated"),
   counterexample("runtime", "TransitionDeclarations", "TransitionDeclarationsSplitKinds.cfg", "Invariant UniqueRefs is violated"),
+  counterexample("runtime", "TransitionDeclarations", "TransitionDeclarationsTagReuse.cfg", "Invariant UniqueRefs is violated"),
   pass("runtime", "TransitionIdentity", "TransitionIdentity.cfg"),
   pass("runtime", "TransitionIdentity", "TransitionIdentityLive.cfg"),
   counterexample("runtime", "TransitionIdentity", "TransitionIdentityNoOwner.cfg", "Invariant ExactResolution is violated"),

--- a/tools/tla.ts
+++ b/tools/tla.ts
@@ -40,6 +40,14 @@ const counterexample = (
 ): CounterexampleCheck => ({ directory, module, config, outcome: "counterexample", evidence })
 
 export const checks: ReadonlyArray<Check> = [
+  pass("runtime", "OperationGraph", "OperationGraph.cfg"),
+  pass("runtime", "OperationGraph", "OperationGraphLive.cfg"),
+  counterexample("runtime", "OperationGraph", "OperationGraphPremature.cfg", "Invariant NoPrematureStart is violated"),
+  counterexample("runtime", "OperationGraph", "OperationGraphCorrelation.cfg", "Invariant ExactResolution is violated"),
+  counterexample("runtime", "OperationGraph", "OperationGraphCancellation.cfg", "Invariant CancellationIsolation is violated"),
+  counterexample("runtime", "OperationGraph", "OperationGraphReanchor.cfg", "Invariant IdentityStable is violated"),
+  counterexample("runtime", "OperationGraph", "OperationGraphUnchecked.cfg", "Invariant NoObservedCancelledPublication is violated"),
+  counterexample("runtime", "OperationGraph", "OperationGraphUnfair.cfg", "ReadySettles was violated"),
   pass("runtime", "TransitionOwnership", "TransitionOwnership.cfg"),
   pass("runtime", "TransitionOwnership", "TransitionOwnershipLive.cfg"),
   counterexample("runtime", "TransitionOwnership", "TransitionOwnershipDropDeclaration.cfg", "Invariant DeclarationOwner is violated"),


### PR DESCRIPTION
Stacked on #400. This is the core lifecycle migration layer; agent and code-execution callers follow separately.

## Problem

Core method responses and deadlines still construct transition keys manually. They must retain their owning event when replay advances, and cancellation must leave terminal response delivery possible.

## Change

Derive their refs from the recorded owner, component name, and local tag:

```text
accepted call at seq 12
  actor.responses / deliver -> [12, "actor.responses", "deliver"]

outgoing dispatch at seq 18
  actor.deadlines / timeout -> [18, "actor.deadlines", "timeout"]

accepted call with deadline at seq 24
  actor.deadlines / cancel -> [24, "actor.deadlines", "cancel"]
```

- Preserve owner positions in response/timeout state and replay refinement helpers.
- Allow explicit `invocation: null` for control delivery after cancellation, while preserving the transition ref.
- Let tagged intents construct events at commit time, preserving deadline timestamps.
- Extend the ownership model to cover explicit detachment and migrate core composition fixtures.
- Separate per-output duplicate checks from the author contract that a tag keeps its meaning across outputs. The declaration model permits repeated offers and includes sequential tag reuse as a negative control.

- Model operation identity, prerequisites, and invocation lifetime separately. Generated graph tests cover joins, independent component composition, valid execution orders, retries, and cold replay. Prerequisites remain component-declared behavior; this adds no scheduling API.

## Validation

Focused core checks pass: 189 tests, typecheck, Effect lint, and boundary lint. Host checks pass: 51 tests, typecheck, and Effect lint. All 14 ownership, five declaration, and eight operation-graph model configurations produce their expected outcomes, including negative controls.

A stateful property test tracks logical operations independently of refs across changing inputs and outputs, failures before and after an external effect, failure after durable completion, and cold replay. It covers distinct tags under the original owner and repeated tags under successive completion owners. Reusing a tag for different work under the same owner produces the expected counterexample. These checks preserve the conditional guarantee: authors provide stable local tags, and the runtime provides scope and completion correlation.

The operation-graph model includes conditional liveness under fair scheduling, returning attempts, available storage, and bounded crashes. Its negative controls expose premature execution, result miscorrelation, cancellation following dependencies, changed identity anchors, unchecked publication, and unfair scheduling. An execution-boundary test covers cancellation and unrelated appends before dispatch, during an effect, and between the result check and append. Cancellation after the result check can coexist with a committed result; these checks make no atomic check-and-append or exactly-once execution claim.

The full gate remains red on unmigrated agent callers and dependent integrations. It also timed out the tag-only identity property test at five seconds under parallel load; that test passed in the focused core run. This draft is not release-ready and does not yet fix cross-turn tool-result lookups.
