### PR TITLE
fix(core): retain operation ownership

### DIFF
--- a/packages/agent/src/component/code.ts
+++ b/packages/agent/src/component/code.ts
@@ -6,7 +6,7 @@ import { composeComponents, inheritComponentContract, component as defineCompone
 import { type InvocationCancellation } from "@clavia/tardigrade-core/interaction/events"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import { composeKeys, type KeyFragment } from "@clavia/tardigrade-core/log"
-import { codeDispatched, codeKeys, codeSettled } from "@clavia/tardigrade-code/execution/events"
+import { executionKeyOf, executionRefOf, codeDispatched, codeKeys, codeSettled } from "@clavia/tardigrade-code/execution/events"
 import { eventEpochOf } from "@clavia/tardigrade-code/execution/turns"
 import { codeReactorFor, type CodePolicy, type CodeProjectionState } from "@clavia/tardigrade-code/execution/reactor"
 import { renderShape, renderSignature } from "@clavia/tardigrade-code/execution/contract"
@@ -61,7 +61,7 @@ const settleFor = (
   log: ReadonlyArray<Event>,
   callId: string
 ): { result?: unknown; error?: string; logs?: ReadonlyArray<string> } | undefined => {
-  const settle = log.find((e) => e.type === "CodeSettled" && String((e as { execId?: unknown }).execId) === callId) as
+  const settle = log.find((e) => e.type === "CodeSettled" && executionKeyOf(e) === callId) as
     | { result?: unknown; error?: unknown; logs?: ReadonlyArray<string>; tmp?: unknown; size?: unknown; preview?: unknown; note?: unknown }
     | undefined
   if (settle === undefined) return undefined
@@ -80,7 +80,7 @@ const serveCode = (log: ReadonlyArray<Event>, call: PendingCall, answer: Answer)
   }
   const dispatched = log.find((event) => event.type === "CodeDispatched" && call.context.matches("dispatch", event))
   if (dispatched !== undefined) {
-    const outcome = settleFor(log, String(dispatched.execId))
+    const outcome = settleFor(log, executionKeyOf(dispatched))
     return outcome === undefined ? [] : [answer(outcome)]
   }
   const code = String((call.arguments as { code?: unknown } | undefined)?.code ?? "")
@@ -115,6 +115,7 @@ const codeCancellationTransition = <R>(
   dispatch: Event,
   cancellation: InvocationCancellation
 ): ReadonlyArray<Transition<never, R>> => [bindTransitionContext(dispatch, "code").intent("execute", (at) => codeSettled({
+  ...(executionRefOf(dispatch) === undefined ? {} : { executionRef: executionRefOf(dispatch)! }),
   execId: String(dispatch.execId),
   error: cancellation.reason === undefined ? "cancelled" : `cancelled: ${cancellation.reason}`,
   turn: cancellation.invocation.id,

--- a/packages/agent/src/packages/agents.test.ts
+++ b/packages/agent/src/packages/agents.test.ts
@@ -698,7 +698,7 @@ describe("a child is named by its parent address, run, and call", () => {
     expect(sent).toHaveLength(0)
   })
 
-  test("a background child inherits the owning turn deadline without a parent link", async () => {
+  test("a background child retains its invocation owner without waiting for its response", async () => {
     const events: Event[] = [
       threadCreated(parseThreadAddress("mem:main:ag.root"), undefined, 0),
       turnWithDeadline("m1", 86_400_002),
@@ -710,7 +710,11 @@ describe("a child is named by its parent address, run, and call", () => {
       invocation: { method: "message", id: "bg-1", epoch: 0 },
       deadlineAt: 86_400_002
     })
-    expect(events.some((event) => event.type === "InvocationLinked")).toBe(false)
+    const linked = events.find((event) => event.type === "InvocationLinked")
+    expect(linked).toMatchObject({
+      parent: { method: "message", id: "m1", epoch: 0 },
+      child: { invocation: { method: "message", id: "bg-1", epoch: 0 } }
+    })
   })
 
   test("a run with no parent turn dies rather than naming a child", async () => {

--- a/packages/agent/src/packages/agents.ts
+++ b/packages/agent/src/packages/agents.ts
@@ -1,3 +1,4 @@
+import { OperationScope } from "@clavia/tardigrade-core/runtime/context"
 import { Clock, Effect, Schema } from "effect"
 import { Router } from "@clavia/tardigrade-core/transport/router"
 import { Self } from "@clavia/tardigrade-core/runtime"
@@ -478,8 +479,9 @@ export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self
           const actor = actorNameOf()
           const shadow = shadowOf()
           const world = worldOf()
-          // owner supplies the deadline for both dispatch modes (agents.test.ts, "a background child inherits the owning turn deadline without a parent link").
+          // owner retains cancellation ownership in both dispatch modes (agents.test.ts, "a background child retains its invocation owner without waiting for its response").
           const owner = { method: "message", id: parentRun.turn, epoch: parentRun.epoch }
+          const operation = yield* Effect.serviceOption(OperationScope)
           const parent = a?.background === true ? undefined : owner
           const parentDeadline = events.find((event) => {
             const context = (event as { readonly call?: unknown }).call as Partial<ActorInvocationContext> | undefined
@@ -501,8 +503,9 @@ export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self
             const records: Event[] = recordedChild === undefined
               ? [childCreated(ctx.callId, target, lineage, at, parentRun.turn, reference.invocation)]
               : []
-            if (childContext.parent !== undefined) records.push(invocationLinked({
-              parent: childContext.parent, child: childContext, target: formatThreadAddress(target), lineage, at
+            records.push(invocationLinked({
+              parent: owner,
+              owner: operation._tag === "Some" ? operation.value : { type: "invocation", ref: owner }, child: childContext, target: formatThreadAddress(target), lineage, at
             }))
             if (records.length > 0) yield* log.append(records)
             yield* sendInvocation({ target, context: childContext, lineage, event: {

--- a/packages/agent/src/runtime/turn.test.ts
+++ b/packages/agent/src/runtime/turn.test.ts
@@ -186,6 +186,7 @@ describe("the agent with execute as the only tool", () => {
       { type: "CodeDispatched", transitionRef: { seq: 2, component: "agent.tools", tag: "dispatch" }, execId: "t1", code: "return await docs.read()", turn: "m1", at: 3 },
       {
         type: "CodeSettled",
+        executionRef: { seq: 2, component: "agent.tools", tag: "dispatch" },
         execId: "t1",
         tmp: "t1.result",
         size: big.length,
@@ -219,8 +220,8 @@ describe("the agent with execute as the only tool", () => {
       { type: "MessageReceived", id: "m1", text: "add the JD and search candidates", at: 1 },
       { type: "ToolCalled", callId: "t1", name: "execute", arguments: { code: CODE }, turn: "m1", at: 2 },
       { type: "CodeDispatched", transitionRef: { seq: 2, component: "agent.tools", tag: "dispatch" }, execId: "t1", code: CODE, turn: "m1", at: 3 },
-      { type: "PackageCalled", callId: "t1.0", name: "zohorecruit.insert_record", arguments: { title: "IC design lead" }, turn: "m1", at: 4 },
-      { type: "PackageReturned", callId: "t1.0", result: { id: "jd-91" }, turn: "m1", at: 5 }
+      { type: "PackageCalled", executionRef: { seq: 2, component: "agent.tools", tag: "dispatch" }, ordinal: 0, callId: "t1.0", name: "zohorecruit.insert_record", arguments: { title: "IC design lead" }, turn: "m1", at: 4 },
+      { type: "PackageReturned", executionRef: { seq: 2, component: "agent.tools", tag: "dispatch" }, ordinal: 0, callId: "t1.0", result: { id: "jd-91" }, turn: "m1", at: 5 }
     ]
     const count = { calls: 0 }
     const spies = { insert: 0, search: 0 }

--- a/packages/code/src/execution/events.ts
+++ b/packages/code/src/execution/events.ts
@@ -1,3 +1,5 @@
+import type { OwnerRef } from "@clavia/tardigrade-core/runtime/context"
+import { TransitionRef } from "@clavia/tardigrade-core/transition/transition"
 import { Schema } from "effect"
 import type { KeyFragment } from "@clavia/tardigrade-core/log"
 import type { Event } from "@clavia/tardigrade-core/log/event"
@@ -77,17 +79,16 @@ export type CodeEvent = typeof CodeEvent.Type
 export const codeKeys: KeyFragment = {
   prefixes: ["cd:", "cs:", "pr:", "bk:"],
   keyOf: (e) => {
-    const v = e as Record<string, unknown>
     switch (e.type) {
       case "CodeDispatched":
-        return `cd:${String(v.execId)}`
+        return `cd:${executionKeyOf(e)}`
       case "CodeSettled":
-        return `cs:${String(v.execId)}`
+        return `cs:${executionKeyOf(e)}`
       case "PackageReturned":
-        return `pr:${String(v.callId)}`
+        return `pr:${packageKeyOf(e)}`
       case "BlockedOn":
         // One row per blocked call: a re-parking attempt redelivers the same key and absorbs.
-        return `bk:${String(v.callId)}`
+        return `bk:${packageKeyOf(e)}`
       default:
         return undefined
     }
@@ -101,7 +102,7 @@ export const codeKeys: KeyFragment = {
 // Event, so nothing downstream changes. `at` is a parameter, never a clock read, so an
 // emission stays a pure function of the log and the timestamp the runtime hands it.
 
-type Stamped = { readonly turn?: string; readonly epoch?: number; readonly at: number }
+type Stamped = { readonly ownerRef?: OwnerRef; readonly executionRef?: TransitionRef; readonly ordinal?: number; readonly turn?: string; readonly epoch?: number; readonly at: number }
 
 export const codeDispatched = (fields: { readonly execId: string; readonly code: string } & Stamped): Event =>
   ({ type: "CodeDispatched", ...fields }) as Event
@@ -132,3 +133,23 @@ export const packageReturned = (
 
 export const blockedOn = (fields: { readonly callId: string; readonly awaiting: string } & Stamped): Event =>
   ({ type: "BlockedOn", ...fields }) as Event
+
+// executionRefOf reads the recorded dispatch identity (projections.test.ts).
+export const executionRefOf = (event: Event): TransitionRef | undefined => {
+  const candidate = event.type === "CodeDispatched" ? event.transitionRef : event.executionRef
+  return candidate === undefined ? undefined : Schema.decodeUnknownSync(TransitionRef)(candidate)
+}
+
+// executionKeyOf scopes execution facts to their dispatch reference, retaining unstamped log identities (projections.test.ts).
+export const executionKeyOf = (event: Event): string => {
+  const ref = executionRefOf(event)
+  return ref === undefined ? String(event.execId ?? "") : JSON.stringify([ref.seq, ref.component, ref.tag])
+}
+
+// packageKeyOf scopes a positional call to its recorded execution (reactor.test.ts).
+export const packageKeyOf = (event: Event): string => {
+  const ref = executionRefOf(event)
+  if (ref === undefined) return String(event.callId ?? "")
+  if (!Number.isSafeInteger(event.ordinal) || Number(event.ordinal) < 0) throw new Error("package call needs a non-negative ordinal")
+  return JSON.stringify([ref.seq, ref.component, ref.tag, event.ordinal])
+}

--- a/packages/code/src/execution/ownership.properties.test.ts
+++ b/packages/code/src/execution/ownership.properties.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test"
+import fc from "fast-check"
+import type { Event } from "@clavia/tardigrade-core/event"
+import { factsOf } from "./projections"
+
+const ref = fc.record({
+  seq: fc.integer({ min: 1, max: 100 }),
+  component: fc.string({ minLength: 1, maxLength: 8 }),
+  tag: fc.string({ minLength: 1, maxLength: 8 })
+})
+const execution = fc.record({
+  ref,
+  settled: fc.boolean(),
+  calls: fc.array(fc.constantFrom("blocked", "ready", "returned"), { minLength: 1, maxLength: 4 })
+})
+const executions = fc.uniqueArray(execution, {
+  minLength: 2, maxLength: 6,
+  selector: (value) => JSON.stringify(value.ref)
+})
+
+const scenario = executions.chain((operations) => {
+  const events: Event[] = operations.flatMap((operation, index) => [
+    { type: "CodeDispatched", execId: "same", turn: "same", transitionRef: operation.ref, at: index + 1 },
+    ...operation.calls.flatMap((state, ordinal): Event[] => [
+      { type: "PackageCalled", callId: "same", executionRef: operation.ref, ordinal },
+      { type: "BlockedOn", callId: "same", executionRef: operation.ref, ordinal, awaiting: `${index}:${ordinal}` },
+      ...(state === "returned" ? [{ type: "PackageReturned", callId: "same", executionRef: operation.ref, ordinal }] : []),
+      ...(state === "ready" ? [{ type: "ResponseReceived", id: `${index}:${ordinal}` }] : [])
+    ]),
+    ...(operation.settled ? [{ type: "CodeSettled", execId: "same", turn: "same", executionRef: operation.ref }] : [])
+  ])
+  return fc.shuffledSubarray(events, { minLength: events.length, maxLength: events.length })
+    .map((shuffled) => ({ operations, events, shuffled }))
+})
+
+test("operation refs isolate colliding payload IDs through permutation, redelivery, and cold replay", () => {
+  fc.assert(fc.property(scenario, ({ operations, events, shuffled }) => {
+    const expected = operations.map((operation) => ({
+      settled: operation.settled,
+      called: true,
+      open: operation.calls.filter((state) => state !== "returned").length,
+      home: operation.calls.filter((state) => state === "ready").length
+    }))
+    for (const history of [events, shuffled, [...shuffled, ...events], JSON.parse(JSON.stringify(shuffled)) as Event[]]) {
+      expect(factsOf(history).map((fact) => ({
+        settled: fact.settled, called: fact.called, open: fact.open.size, home: fact.home.size
+      }))).toEqual(expected)
+    }
+  }), { numRuns: 200 })
+})

--- a/packages/code/src/execution/projections.test.ts
+++ b/packages/code/src/execution/projections.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test"
+import type { Event } from "@clavia/tardigrade-core/log/event"
+import { factsOf } from "./projections"
+
+test("distinct transition owners keep executions separate when payload IDs repeat within a turn", () => {
+  const events: Event[] = [
+    {
+      type: "CodeDispatched", execId: "same", code: "1", turn: "turn", at: 1,
+      transitionRef: { seq: 12, component: "code", tag: "dispatch" }
+    },
+    {
+      type: "CodeDispatched", execId: "same", code: "2", turn: "turn", at: 2,
+      transitionRef: { seq: 19, component: "code", tag: "dispatch" }
+    }
+  ]
+
+  expect(factsOf(events)).toHaveLength(2)
+  events.push({ type: "CodeSettled", execId: "same", turn: "turn", at: 3,
+    executionRef: { seq: 12, component: "code", tag: "dispatch" } })
+  expect(factsOf(events).map((execution) => execution.settled)).toEqual([true, false])
+})

--- a/packages/code/src/execution/projections.ts
+++ b/packages/code/src/execution/projections.ts
@@ -1,3 +1,4 @@
+import { executionKeyOf, executionRefOf, packageKeyOf } from "./events"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import { turnTerminalOf } from "./turns"
 
@@ -33,11 +34,12 @@ export const factsOf = (events: ReadonlyArray<Event>): ReadonlyArray<ExecFacts> 
   const calls = new Set<string>()
   const returned = new Set<string>()
   const replies = new Set<string>()
+  const owners = new Map<string, string>()
   for (const e of events) {
     const v = e as { execId?: unknown; callId?: unknown; id?: unknown; at?: unknown; awaiting?: unknown; turn?: unknown }
     switch (e.type) {
       case "CodeDispatched": {
-        const id = str(v.execId)
+        const id = executionKeyOf(e)
         const at = typeof v.at === "number" ? v.at : 0
         const prior = dispatched.get(id)
         if (prior === undefined || at < prior.at) {
@@ -46,16 +48,17 @@ export const factsOf = (events: ReadonlyArray<Event>): ReadonlyArray<ExecFacts> 
         break
       }
       case "CodeSettled":
-        settled.add(str(v.execId))
+        settled.add(executionKeyOf(e))
         break
       case "PackageCalled":
-        calls.add(str(v.callId))
+        calls.add(packageKeyOf(e))
+        if (executionRefOf(e) !== undefined) owners.set(packageKeyOf(e), executionKeyOf(e))
         break
       case "BlockedOn":
-        awaiting.set(str(v.callId), str(v.awaiting))
+        awaiting.set(packageKeyOf(e), str(v.awaiting))
         break
       case "PackageReturned":
-        returned.add(str(v.callId))
+        returned.add(packageKeyOf(e))
         break
       case "MessageReceived":
       case "ResponseReceived":
@@ -68,6 +71,8 @@ export const factsOf = (events: ReadonlyArray<Event>): ReadonlyArray<ExecFacts> 
   // an attribute the event carries, never from log position.
   const execIds = [...dispatched.keys()]
   const ownerOf = (callId: string): string => {
+    const explicit = owners.get(callId)
+    if (explicit !== undefined) return explicit
     let owner = ""
     for (const execId of execIds) {
       if (callId.startsWith(`${execId}.`) && execId.length > owner.length) owner = execId

--- a/packages/code/src/execution/reactor.test.ts
+++ b/packages/code/src/execution/reactor.test.ts
@@ -1,3 +1,4 @@
+import { OperationScope } from "@clavia/tardigrade-core/runtime/context"
 import { describe, expect, expectTypeOf, test } from "bun:test"
 import { Context, Effect, Layer, Ref } from "effect"
 import { KeyValueStore } from "effect/unstable/persistence"
@@ -448,4 +449,41 @@ describe("a package's requirements ride its type", () => {
       'package "ticker" declared twice'
     )
   })
+})
+
+test("execution refs isolate package replay and spill storage when payload IDs repeat", async () => {
+  let calls = 0
+  const owners: unknown[] = []
+  const pkg = definePackage({
+    name: "counter",
+    description: "records calls",
+    methods: { read: () => Effect.gen(function* () {
+      owners.push(yield* Effect.serviceOption(OperationScope))
+      return { value: ++calls, padding: "x".repeat(100) }
+    }) }
+  })
+  const history: Event[] = [
+    { type: "MessageReceived", id: "turn", text: "go", at: 1 },
+    { type: "CodeDispatched", execId: "same", code: "return (await counter.read({})).value", turn: "turn", at: 2,
+      transitionRef: { seq: 12, component: "agent.code", tag: "dispatch" } },
+    { type: "CodeDispatched", execId: "same", code: "return (await counter.read({})).value", turn: "turn", at: 3,
+      transitionRef: { seq: 19, component: "agent.code", tag: "dispatch" } }
+  ]
+  const events = await Effect.runPromise(Effect.gen(function* () {
+    const definition = { projections: [codeReactorFor({ spill: { spillBytes: 10, previewChars: 4 } }, [pkg])], keyOf: composeKeys(messageKeys, codeKeys) }
+    yield* settleActor(definition)
+    yield* settleActor(definition)
+    return yield* Effect.flatMap(EventLog, (log) => log.read)
+  }).pipe(Effect.provide(Layer.mergeAll(memoryLog(history), jsSandbox, KeyValueStore.layerMemory))) as Effect.Effect<ReadonlyArray<Event>>)
+  expect(calls).toBe(2)
+  expect(events.filter((event) => event.type === "CodeSettled").map((event) => event.result)).toEqual([
+    1, 2
+  ])
+  const returned = events.filter((event) => event.type === "PackageReturned")
+  expect(returned).toHaveLength(2)
+  expect(returned[0]!.tmp).not.toBe(returned[1]!.tmp)
+  expect(owners).toMatchObject([
+    { _tag: "Some", value: { type: "transition", ref: { seq: 4, component: "code.packages", tag: "invoke" } } },
+    { _tag: "Some", value: { type: "transition", ref: { seq: 7, component: "code.packages", tag: "invoke" } } }
+  ])
 })

--- a/packages/code/src/execution/reactor.ts
+++ b/packages/code/src/execution/reactor.ts
@@ -1,4 +1,6 @@
-import { bindTransitionContext } from "@clavia/tardigrade-core/transition/transition"
+import { OperationScope } from "@clavia/tardigrade-core/runtime/context"
+import { eventPositionOf } from "@clavia/tardigrade-core/event"
+import { bindTransitionContext, type TransitionRef } from "@clavia/tardigrade-core/transition/transition"
 import { Clock, Deferred, Effect, Fiber } from "effect"
 import type { KeyValueStore } from "effect/unstable/persistence"
 import { EventLog } from "@clavia/tardigrade-core/log"
@@ -24,7 +26,7 @@ import {
   type SpillPolicy
 } from "../storage/store"
 import { callId as callIdOf } from "./ids"
-import { blockedOn, codeSettled, packageCalled, packageReturned } from "./events"
+import { executionKeyOf, executionRefOf, packageKeyOf, blockedOn, codeSettled, packageCalled, packageReturned } from "./events"
 
 // The code reactor: durable execution of one body (tla/runtime/Reconcile.tla is the model;
 // ./projections.ts derives the owed work). An attempt re-runs the body from the top; committed
@@ -98,10 +100,12 @@ const executeRecorded = <R = never>(
   packages: ReadonlyArray<Package<R>>,
   turn?: string,
   epoch = 0,
-  dispatchedAt?: number
+  dispatchedAt?: number,
+  executionRef?: TransitionRef
 ): Effect.Effect<ReadonlyArray<Event>, never, EventLog | KeyValueStore.KeyValueStore | R> =>
   Effect.gen(function* () {
-    const stamp = turn === undefined ? {} : { turn, ...(epoch === 0 ? {} : { epoch }) }
+    const scope = yield* Effect.serviceOption(OperationScope)
+    const stamp = { ...(scope._tag === "Some" ? { ownerRef: scope.value } : {}), ...(executionRef === undefined ? {} : { executionRef }), ...(turn === undefined ? {} : { turn, ...(epoch === 0 ? {} : { epoch }) }) }
     const log = yield* EventLog
     const events = yield* log.read
     // The shadow reading rides the turn's own brief, folded once here: it never changes
@@ -123,7 +127,7 @@ const executeRecorded = <R = never>(
     // The calls one attempt observed blocked, with what they await: returned as BlockedOn
     // evidence when the attempt closes, so the derivation reads the awaited ids from the log
     // (no method table; the raiser carries `awaiting` on Park).
-    const blocked: Array<{ readonly callId: string; readonly awaiting?: string }> = []
+    const blocked: Array<{ readonly callId: string; readonly ordinal: number; readonly awaiting?: string }> = []
     const parkGate = yield* Deferred.make<void>()
     // finishCall releases a mixed attempt after every host-side call has completed. The call
     // scope guarantees it as a finalizer because the last call may return or park
@@ -137,7 +141,9 @@ const executeRecorded = <R = never>(
       const methods: Record<string, SandboxCall> = {}
       for (const [method, fn] of Object.entries(pkg.methods)) {
         methods[method] = (args: unknown, ordinal: number) => {
-          const callId = callIdOf(execId, ordinal)
+          const callId = callIdOf(executionKeyOf({ type: "CodeSettled", execId, ...stamp }), ordinal)
+          const callStamp = { ...stamp, ordinal }
+          const callKey = packageKeyOf({ type: "PackageCalled", callId, ...callStamp })
           inFlight++
           return Effect.runPromiseWith(context)(
             Effect.gen(function* () {
@@ -148,7 +154,7 @@ const executeRecorded = <R = never>(
               // instead (tla/runtime/Replay.tla: Trusting fails RightAnswer, Guarded holds it and
               // refusal is drift's only reachable outcome).
               const sent = events.find(
-                (e) => e.type === "PackageCalled" && (e as { callId?: unknown }).callId === callId
+                (e) => e.type === "PackageCalled" && packageKeyOf(e) === callKey
               ) as { name?: unknown; arguments?: unknown } | undefined
               if (sent !== undefined) {
                 const askedName = `${pkg.name}.${method}`
@@ -168,7 +174,7 @@ const executeRecorded = <R = never>(
                 }
               }
               const recorded = events.find(
-                (e) => e.type === "PackageReturned" && (e as { callId?: unknown }).callId === callId
+                (e) => e.type === "PackageReturned" && packageKeyOf(e) === callKey
               )
               if (recorded) {
                 const r = recorded as { result?: unknown; tmp?: unknown }
@@ -186,12 +192,12 @@ const executeRecorded = <R = never>(
               // here: this attempt still asks the method again, because only the method knows
               // whether the answer has landed, but the log never grows a second send for it.
               const alreadySent = events.some(
-                (e) => e.type === "PackageCalled" && (e as { callId?: unknown }).callId === callId
+                (e) => e.type === "PackageCalled" && packageKeyOf(e) === callKey
               )
               if (!alreadySent) {
                 const askedAt = yield* Clock.currentTimeMillis
                 yield* log.append([
-                  packageCalled({ callId, name: `${pkg.name}.${method}`, arguments: args, ...stamp, at: askedAt })
+                  packageCalled({ callId, name: `${pkg.name}.${method}`, arguments: args, ...callStamp, at: askedAt })
                 ])
               }
               // The shadow rule, over the method's own annotation: a read runs (live reads are
@@ -206,7 +212,7 @@ const executeRecorded = <R = never>(
               if (refused) {
                 const result = { error: `shadow run: ${pkg.name}.${method} is an open-world write and does not execute in a shadow run` }
                 const answeredAt = yield* Clock.currentTimeMillis
-                yield* log.append([packageReturned({ callId, result, ...stamp, at: answeredAt })])
+                yield* log.append([packageReturned({ callId, result, ...callStamp, at: answeredAt })])
                 return { parked: false, result }
               }
               // The contract gate: a declared input schema is checked at this funnel, after the
@@ -224,14 +230,14 @@ const executeRecorded = <R = never>(
                     error: `${pkg.name}.${method}: ${issues.join("; ")}. Signature: ${renderSignature(method, declared)}`
                   }
                   const answeredAt = yield* Clock.currentTimeMillis
-                  yield* log.append([packageReturned({ callId, result, ...stamp, at: answeredAt })])
+                  yield* log.append([packageReturned({ callId, result, ...callStamp, at: answeredAt })])
                   return { parked: false, result }
                 }
               }
               const parkOut = (awaiting?: string): Effect.Effect<CallOutcome, never, never> =>
                 Effect.gen(function* () {
                   parked = true
-                  blocked.push({ callId, ...(awaiting === undefined ? {} : { awaiting }) })
+                  blocked.push({ callId, ordinal, ...(awaiting === undefined ? {} : { awaiting }) })
                   return { parked: true }
                 })
               // A transient defect or timeout retries inside the recorded call. Exhaustion is a
@@ -239,6 +245,11 @@ const executeRecorded = <R = never>(
               // its actor-wait meaning and never consumes the infrastructure retry schedule
               // (reactor.test.ts, "a transiently failing call retries before the body sees an
               // answer"; "a hanging call exhausts its deadline and backoff as one durable error").
+              const recordedEvents = yield* log.read
+              const recordedIndex = recordedEvents.findIndex((event) => event.type === "PackageCalled" && packageKeyOf(event) === callKey)
+              const seq = recordedIndex < 0 ? undefined : eventPositionOf(recordedEvents[recordedIndex]!) ?? recordedIndex + 1
+              if (seq === undefined) throw new Error("package execution requires a recorded call position")
+              const owner = { type: "transition" as const, ref: { seq, component: "code.packages", tag: "invoke" } }
               const invoke = (attemptIndex: number): Effect.Effect<CallOutcome, never, R> => {
                 const fail = (reason: string): Effect.Effect<CallOutcome, never, R> => {
                   const delay = callPolicy.retryDelaysMs[attemptIndex]
@@ -254,6 +265,7 @@ const executeRecorded = <R = never>(
                   })
                 }
                 return fn(args, { callId }).pipe(
+                  Effect.provideService(OperationScope, owner),
                   Effect.timeout(callPolicy.attemptTimeoutMs),
                   Effect.map((result): CallOutcome => ({ parked: false, result })),
                   Effect.catchTags({
@@ -270,17 +282,17 @@ const executeRecorded = <R = never>(
               const answeredAt = yield* Clock.currentTimeMillis
               const json = JSON.stringify(attempt.result ?? null)
               if (json.length > spill.spillBytes) {
-                yield* Effect.orDie(spillTo(callId, json))
+                yield* Effect.orDie(spillTo(callKey, json))
                 yield* log.append([
                   packageReturned({
                     callId,
-                    ...spillPointer(callId, json.length, json.slice(0, spill.previewChars), spill.note),
-                    ...stamp,
+                    ...spillPointer(callKey, json.length, json.slice(0, spill.previewChars), spill.note),
+                    ...callStamp,
                     at: answeredAt
                   })
                 ])
               } else {
-                yield* log.append([packageReturned({ callId, result: attempt.result, ...stamp, at: answeredAt })])
+                yield* log.append([packageReturned({ callId, result: attempt.result, ...callStamp, at: answeredAt })])
               }
               return attempt
             }).pipe(
@@ -331,7 +343,7 @@ const executeRecorded = <R = never>(
       // and records nothing; the alarm re-drives it.
       return blocked
         .filter((b) => b.awaiting !== undefined)
-        .map((b) => blockedOn({ callId: b.callId, awaiting: b.awaiting!, ...stamp, at }))
+        .map((b) => blockedOn({ callId: b.callId, ordinal: b.ordinal, awaiting: b.awaiting!, ...stamp, at }))
     }
     const outcome = yield* Fiber.join(fiber)
     // Console output rides the settle, capped by the sandbox: the model reads it beside the
@@ -342,7 +354,7 @@ const executeRecorded = <R = never>(
       // carries the pointer, so no result can nuke the turn context.
       const json = JSON.stringify(outcome.result ?? null)
       if (json.length > spill.spillBytes) {
-        const ref = `${execId}.result`
+        const ref = `${executionKeyOf({ type: "CodeSettled", execId, ...stamp })}.result`
         yield* Effect.orDie(spillTo(ref, json))
         return [
           codeSettled({
@@ -442,21 +454,21 @@ export const codeReactorFor = <const P extends ReadonlyArray<Package<never>> | R
       const replies = new Set(state.replies)
       const value = event as { readonly execId?: unknown; readonly callId?: unknown; readonly awaiting?: unknown; readonly id?: unknown; readonly at?: unknown }
       if (event.type === "CodeDispatched") {
-        const execId = String(value.execId ?? "")
+        const execId = executionKeyOf(event)
         const prior = dispatches.get(execId) as { readonly at?: unknown } | undefined
         if (prior === undefined || Number(value.at ?? 0) < Number(prior.at ?? 0)) dispatches.set(execId, event)
       }
-      if (event.type === "CodeSettled") settled.add(String(value.execId ?? ""))
+      if (event.type === "CodeSettled") settled.add(executionKeyOf(event))
       if (event.type === "PackageCalled") {
-        const callId = String(value.callId ?? "")
-        calls.set(callId, { execId: ownerOf(dispatches, callId) })
+        const callId = packageKeyOf(event)
+        calls.set(callId, { execId: (executionRefOf(event) === undefined ? ownerOf(dispatches, callId) : executionKeyOf(event)) })
       }
       if (event.type === "BlockedOn") {
-        const callId = String(value.callId ?? "")
+        const callId = packageKeyOf(event)
         const prior = calls.get(callId)
-        calls.set(callId, { execId: prior?.execId ?? ownerOf(dispatches, callId), awaiting: String(value.awaiting ?? "") })
+        calls.set(callId, { execId: prior?.execId ?? (executionRefOf(event) === undefined ? ownerOf(dispatches, callId) : executionKeyOf(event)), awaiting: String(value.awaiting ?? "") })
       }
-      if (event.type === "PackageReturned") returned.add(String(value.callId ?? ""))
+      if (event.type === "PackageReturned") returned.add(packageKeyOf(event))
       if (event.type === "MessageReceived" || event.type === "ResponseReceived") replies.add(String(value.id ?? ""))
       return {
         turns: reduceTurnProjection(state.turns, event),
@@ -483,20 +495,21 @@ export const codeReactorFor = <const P extends ReadonlyArray<Package<never>> | R
         break
       }
       if (selected === undefined) return []
-      const { execId, dispatch } = selected
+      const { dispatch } = selected
       const turn = turnOf(dispatch)
       const epoch = eventEpochOf(dispatch)
       return [bindTransitionContext(dispatch, "code").effect("execute", {
         ...(turn === undefined ? {} : { invocation: { method: "message", id: turn, epoch } }),
         input: {
-          execId,
+          execId: String(dispatch.execId ?? ""),
+          executionRef: executionRefOf(dispatch),
           code: String(dispatch.code ?? ""),
           turn,
           epoch,
           at: typeof dispatch.at === "number" ? dispatch.at : undefined
         },
         act: (input) => Effect.gen(function* () {
-          const result = yield* executeRecorded<R>(input.execId, input.code, spill, callPolicy, mounted, input.turn, input.epoch, input.at)
+          const result = yield* executeRecorded<R>(input.execId, input.code, spill, callPolicy, mounted, input.turn, input.epoch, input.at, input.executionRef)
           if (result.some((event) => event.type === "CodeSettled")) return result
           const log = yield* EventLog
           if (result.length > 0) yield* log.append(result)

--- a/packages/core/src/interaction/cancellation.test.ts
+++ b/packages/core/src/interaction/cancellation.test.ts
@@ -318,3 +318,37 @@ describe("actor cancellation", () => {
     expect(cancellationTransitionsOf([unsupported, missing], { work }, [], () => undefined)).toBeUndefined()
   })
 })
+
+test("a completed owner remains cancellable while its background child is open", () => {
+  const parent = { method: "work", id: "parent", epoch: 0 }
+  const history: Event[] = [
+    { type: "WorkStarted", id: "parent", at: 1 },
+    { type: "InvocationLinked", parent,
+      owner: { type: "transition", ref: { seq: 1, component: "work", tag: "spawn" } },
+      child: { invocation: { method: "work", id: "child", epoch: 0 } },
+      target: "worker:main:child", at: 2 },
+    { type: "WorkCompleted", id: "parent", at: 3 }
+  ]
+  expect(cancellationDispositionOf(history, work, parent)).toBe("requestable")
+  const cancel = cancellationMethodFor({ work })
+  const request = cancel.event({
+    invocation: { method: "$cancel", id: "cancel-parent", epoch: 0 },
+    input: { invocation: parent }, at: 4
+  })
+  history.push(request)
+  expect(cancel.state(history, { method: "$cancel", id: "cancel-parent", epoch: 0 })).toEqual({ status: "pending" })
+  const transitions = cancellationTransitionsOf(history, { work }, [], cancellationKeys.keyOf)
+  expect(transitions).toHaveLength(1)
+  expect(transitions?.[0]?.kind).toBe("effect")
+  expect(transitions?.[0]?.key).toBe(JSON.stringify([2, "actor.cancellations", "cancel"]))
+  history.push({
+    type: "ResponseReceived",
+    reference: { target: { actor: "worker", instance: "main", thread: "child" }, invocation: { method: "work", id: "child", epoch: 0 } },
+    id: "child-reply", from: "worker:main:child", method: "work", call: "child", epoch: 0,
+    status: "completed", output: "done", at: 5
+  })
+  expect(cancellationDispositionOf(history, work, parent)).toBe("settled")
+  expect(cancel.state(history, { method: "$cancel", id: "cancel-parent", epoch: 0 }))
+    .toEqual({ status: "completed", output: { cancelled: false } })
+  expect(cancellationTransitionsOf(history, { work }, [], cancellationKeys.keyOf)).toBeUndefined()
+})

--- a/packages/core/src/interaction/cancellation.ts
+++ b/packages/core/src/interaction/cancellation.ts
@@ -87,6 +87,9 @@ export const cancellationDispositionOf = (
 ): CancellationDisposition | undefined => {
   const state = cancellationStateOf(method, replayProjection(method.projection, events), invocation)
   if (state === undefined) return undefined
+  if (hasUnsettledInvocationChildren(events, invocation)) {
+    return events.some((event) => cancelsInvocation(event, invocation)) ? "requested" : "requestable"
+  }
   if (state === "cancelled") return "cancelled"
   if (state === "terminal") return "settled"
   return events.some((event) => cancelsInvocation(event, invocation)) ? "requested" : "requestable"
@@ -114,7 +117,8 @@ const pendingCancellationsOf = (
     const current = method === undefined
       ? undefined
       : cancellationStateOf(method, replayProjection(method.projection, events), cancellation.invocation)
-    const pending = current === "running" && (before === undefined || before === "running")
+    const pending = (current === "running" && (before === undefined || before === "running")) ||
+      (method?.cancellation !== undefined && hasUnsettledInvocationChildren(events, cancellation.invocation))
     if (!pending) return []
     const key = invocationKey(cancellation.invocation)
     if (seen.has(key)) return []
@@ -163,6 +167,26 @@ const childLinksOf = (
   return link !== undefined && sameInvocation(link.parent, parent) ? [link] : []
 })
 
+const childCancellationRef = (cancellation: InvocationCancellation, reference: InvocationCoordinate): InvocationCoordinate => ({
+  target: reference.target,
+  invocation: {
+    method: CANCELLATION_CONTROL_METHOD,
+    id: `cancel:${JSON.stringify([cancellation.request, formatThreadAddress(reference.target), reference.invocation.method, reference.invocation.id, reference.invocation.epoch])}`,
+    epoch: 0
+  }
+})
+
+// hasUnsettledInvocationChildren retains cancellation after an owner returns (cancellation.test.ts).
+export const hasUnsettledInvocationChildren = (events: ReadonlyArray<Event>, parent: InvocationRef): boolean => {
+  const requests = events.flatMap((event) => {
+    const request = cancellationRequestedOf(event)
+    return request !== undefined && sameInvocation(request.invocation, parent) ? [request] : []
+  })
+  return childLinksOf(events, parent).some(({ reference }) =>
+    invocationTerminalOf(events, reference) === undefined &&
+    !requests.some((request) => invocationTerminalOf(events, childCancellationRef(request, reference)) !== undefined))
+}
+
 const childCancellationTransitions = <R>(
   children: ReadonlyArray<ChildCancellationLink>,
   cancellation: InvocationCancellation,
@@ -171,12 +195,7 @@ const childCancellationTransitions = <R>(
 ): ReadonlyArray<Transition<never, R | Router | Self>> => children.flatMap(({ reference, lineage, owner }) => {
     const context = bindTransitionContext(owner, "actor.cancellations")
     const child = reference.invocation
-    const target = formatThreadAddress(reference.target)
-    const request = `cancel:${JSON.stringify([cancellation.request, target, child.method, child.id, child.epoch])}`
-    const cancel: InvocationCoordinate = {
-      target: reference.target,
-      invocation: { method: CANCELLATION_CONTROL_METHOD, id: request, epoch: 0 }
-    }
+    const cancel = childCancellationRef(cancellation, reference)
     const disposition = dispositionOf(reference, cancel)
     if (disposition === "done") return []
     if (disposition === "dispatched") {
@@ -259,6 +278,11 @@ interface ActorCancellationProjectionState {
   readonly dispatchedCancellations: ReadonlySet<string>
   readonly recorded: ReadonlySet<string>
 }
+
+const projectedChildSettled = (state: { readonly settledCalls: ReadonlySet<string>; readonly requests: ReadonlyArray<{ readonly cancellation: InvocationCancellation }> }, link: ProjectedChildLink): boolean =>
+  state.settledCalls.has(invocationCoordinateKey(link.reference)) || state.requests.some(({ cancellation }) =>
+    sameInvocation(cancellation.invocation, link.parent) &&
+    state.settledCalls.has(invocationCoordinateKey(childCancellationRef(cancellation, link.reference))))
 
 // actorCancellationMethodStates exposes the method states owned by the actor control projection.
 export const actorCancellationMethodStates = (state: unknown): ReadonlyMap<string, unknown> =>
@@ -360,7 +384,9 @@ export const actorCancellationProjection = <R>(
     for (const record of state.requests) {
       const invocation = record.cancellation.invocation
       const current = cancellationOf(state, invocation)
-      if (current !== "running" || (record.accepted !== undefined && record.accepted !== "running")) continue
+      if (methods[invocation.method]?.cancellation === undefined) continue
+      if ((current !== "running" || (record.accepted !== undefined && record.accepted !== "running")) &&
+        !state.links.some((link) => sameInvocation(link.parent, invocation) && !projectedChildSettled(state, link))) continue
       const key = invocationKey(invocation)
       if (seen.has(key)) continue
       seen.add(key)
@@ -379,7 +405,7 @@ export const actorCancellationProjection = <R>(
         entry.machine.cancel?.(state.components[index], cancellation) ?? []
       )
       const outstanding = [...child, ...component].filter((transition) => !state.recorded.has(transition.key))
-      if (outstanding.length === 0) terminals.push(terminalTransitionOf(cancellation, methods, event))
+      if (outstanding.length === 0 && cancellationOf(state, cancellation.invocation) === "running") terminals.push(terminalTransitionOf(cancellation, methods, event))
       else obligations.push(...outstanding)
     }
     return [...terminals, ...obligations]
@@ -427,7 +453,10 @@ export const cancellationTransitionsOf = <R>(
     ]
       .filter((transition) => !recorded.has(transition.key))
     if (pending.length === 0) {
-      terminals.push(terminalTransitionOf(cancellation, methods, event))
+      const method = methodCancellationOf(methods, cancellation)
+      if (method !== undefined && cancellationStateOf(method, replayProjection(method.projection, events), cancellation.invocation) === "running") {
+        terminals.push(terminalTransitionOf(cancellation, methods, event))
+      }
     } else {
       obligations.push(...pending)
     }
@@ -437,6 +466,8 @@ export const cancellationTransitionsOf = <R>(
 
 // cancellationMethodFor constructs the internal control method paired with an actor's cancellable methods.
 interface CancellationMethodState {
+  readonly links: ReadonlyArray<ProjectedChildLink>
+  readonly settledCalls: ReadonlySet<string>
   readonly methods: ReadonlyMap<string, unknown>
   readonly requests: ReadonlyMap<string, {
     readonly cancellation: InvocationCancellation
@@ -448,10 +479,12 @@ const cancellationMethodState = (
   target: InvocationRef,
   cancellable: boolean,
   accepted: ActorMethodCancellationState | undefined,
-  current: ActorMethodCancellationState | undefined
+  current: ActorMethodCancellationState | undefined,
+  hasChildren = false
 ) => {
   if (!cancellable) return { status: "failed" as const, error: `method ${JSON.stringify(target.method)} is not cancellable` }
   if (accepted === undefined) return { status: "failed" as const, error: `invocation ${JSON.stringify(target.id)} does not exist` }
+  if (hasChildren) return { status: "pending" as const }
   if (accepted === "terminal") return { status: "completed" as const, output: { cancelled: false } }
   if (accepted === "cancelled") return { status: "completed" as const, output: { cancelled: true } }
   if (current === "running") return { status: "pending" as const }
@@ -476,7 +509,7 @@ export const cancellationMethodStateOf = (
         method.projection.output(projected.methods.get(target.method)),
         target
       )
-  return cancellationMethodState(target, method?.cancellation !== undefined, record.accepted, current)
+  return cancellationMethodState(target, method?.cancellation !== undefined, record.accepted, current, projected.links.some((link) => sameInvocation(link.parent, target) && !projectedChildSettled(projected, link)))
 }
 
 export const cancellationMethodFor = (methods: ActorMethods) => actorMethod({
@@ -491,6 +524,8 @@ export const cancellationMethodFor = (methods: ActorMethods) => actorMethod({
   }),
   projection: {
     initial: (): CancellationMethodState => ({
+      links: [],
+      settledCalls: new Set(),
       methods: initialMethodStates(methods),
       requests: new Map()
     }),
@@ -510,7 +545,11 @@ export const cancellationMethodFor = (methods: ActorMethods) => actorMethod({
               )
         })
       }
+      const link = childLinkOf(event)
+      const terminal = terminalInvocationRefOf(event)
       return {
+        links: link === undefined ? state.links : [...state.links, link],
+        settledCalls: terminal === undefined ? state.settledCalls : new Set([...state.settledCalls, invocationCoordinateKey(terminal)]),
         methods: reduceMethodStates(methods, state.methods, event),
         requests
       }
@@ -533,7 +572,8 @@ export const cancellationMethodFor = (methods: ActorMethods) => actorMethod({
           target,
           method?.cancellation !== undefined,
           record.accepted,
-          current
+          current,
+          state.links.some((link) => sameInvocation(link.parent, target) && !projectedChildSettled({ settledCalls: state.settledCalls, requests: [...state.requests.values()] }, link))
         )
       }
     })

--- a/packages/core/src/interaction/execution.test.ts
+++ b/packages/core/src/interaction/execution.test.ts
@@ -90,3 +90,20 @@ test("method namespaces preserve metadata and promise assimilation", async () =>
     expect(Object.hasOwn(ref, "then")).toBe(false)
   }
 })
+
+test("sibling transition owners isolate the same nested invocation key", () => {
+  const firstOwner = { type: "transition" as const, ref: { seq: 12, component: "weather", tag: "fetch" } }
+  const secondOwner = { type: "transition" as const, ref: { seq: 19, component: "weather", tag: "fetch" } }
+  const call = (owner: typeof firstOwner) => actorCall([], {
+    target: reference, method: "research", input: { topic: "weather" },
+    parent, context: { invocation: parent.invocation }, key: "lookup", owner
+  })
+  const first = call(firstOwner)
+  const second = call(secondOwner)
+  expect(first.reference).not.toEqual(second.reference)
+  expect(call(firstOwner).reference).toEqual(first.reference)
+  const plan = first.transitions[0]!
+  if (plan.kind !== "intent") throw new Error("expected invocation plan")
+  expect(plan.events(plan.input, 1).find((event) => event.type === "InvocationLinked"))
+    .toMatchObject({ owner: firstOwner, parent: parent.invocation })
+})

--- a/packages/core/src/interaction/execution.ts
+++ b/packages/core/src/interaction/execution.ts
@@ -1,6 +1,6 @@
-import { Clock, Data, Effect } from "effect"
+import { Clock, Data, Effect, Option } from "effect"
 import { EventLog } from "../log"
-import { Self } from "../runtime/context"
+import { Self, OperationScope } from "../runtime/context"
 import { actorCall } from "./invoke"
 import type { InvocationCoordinate } from "./invocation"
 import type { ActorMethods, ActorMethodInput, ActorMethodOutput } from "../actor/method"
@@ -38,6 +38,7 @@ export const invokeMethod = <Methods extends ActorMethods, Name extends Extract<
   creationParent?: ThreadCoordinate
 ) => Effect.gen(function* () {
   const scope = yield* InvocationScope
+  const operation = yield* Effect.serviceOption(OperationScope)
   const self = yield* Self
   const log = yield* EventLog
   const events = yield* log.read
@@ -48,6 +49,7 @@ export const invokeMethod = <Methods extends ActorMethods, Name extends Extract<
     target, method, input,
     parent: { target: self, invocation: scope.context.invocation },
     context: scope.context,
+    owner: Option.isSome(operation) ? operation.value : { type: "invocation", ref: scope.context.invocation },
     key: options.key,
     ...(lineage === undefined ? {} : { lineage }),
     ...(options.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs })

--- a/packages/core/src/interaction/invoke.ts
+++ b/packages/core/src/interaction/invoke.ts
@@ -1,3 +1,4 @@
+import { ownerKey, type OwnerRef } from "../runtime/context"
 import type { CallDispatched, CallPlanned, CallSkipped, CancellationResult, CallTimedOut } from "./events"
 import { Clock, Effect, Schema } from "effect"
 import { effect } from "@clavia/tardigrade-core/effect"
@@ -53,6 +54,7 @@ export type ActorCallOptions<
   readonly target: ThreadTarget<Methods>
   readonly method: Name
   readonly input: ActorMethodInput<Methods[Name]>
+  readonly owner?: OwnerRef
   readonly context?: ActorInvocationContext
   readonly timeoutMs?: number
   readonly lineage?: ThreadLineage
@@ -116,7 +118,8 @@ export const actorCall = <
   const parent = request.parent === undefined ? undefined : decodeInvocationCoordinate(request.parent)
   const options = parent === undefined ? { ...request, id: request.id! } : {
     ...request,
-    id: invocationIdForKey(parent, request.key!),
+    id: invocationIdForKey(parent, request.owner?.type === "transition"
+      ? JSON.stringify([ownerKey(request.owner), request.key!]) : request.key!),
     context: request.context ?? { invocation: parent.invocation }
   }
   if (parent !== undefined) {
@@ -242,6 +245,7 @@ export const actorCall = <
             ? [plan]
             : [plan, invocationLinked({
                 parent: current.context.invocation,
+                owner: current.owner ?? { type: "invocation", ref: current.context.invocation },
                 child: context,
                 target,
                 ...(current.lineage === undefined ? {} : { lineage: current.lineage }),

--- a/packages/core/src/interaction/ownership.properties.test.ts
+++ b/packages/core/src/interaction/ownership.properties.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test"
+import fc from "fast-check"
+import { Schema } from "effect"
+import { eventAt, type Event } from "../event"
+import { legacyActorMethod } from "../actor/method-compat"
+import { replayProjection } from "@clavia/tardigrade-core/projection"
+import { invocationKey, type InvocationRef } from "./invocation"
+import { actorCancellationProjection, cancellationDispositionOf, cancellationKeys, cancellationMethodFor, cancellationTransitionsOf } from "./cancellation"
+
+const work = legacyActorMethod({
+  input: Schema.String,
+  output: Schema.String,
+  event: ({ invocation, at }) => ({ type: "Started", invocation, at }),
+  state: () => ({ status: "pending" }),
+  cancellation: {
+    state: (events, invocation) => {
+      const owned = events.filter((event) => event.invocation !== undefined && invocationKey(event.invocation as InvocationRef) === invocationKey(invocation))
+      if (!owned.some((event) => event.type === "Started")) return undefined
+      return owned.some((event) => event.type === "Completed") ? "terminal" : "running"
+    },
+    event: (cancellation, at) => ({ type: "Cancelled", invocation: cancellation.invocation, at })
+  }
+})
+
+const scenario = fc.record({
+  id: fc.string({ minLength: 1, maxLength: 12 }),
+  epoch: fc.nat({ max: 20 }),
+  count: fc.integer({ min: 1, max: 6 })
+}).chain((value) => fc.shuffledSubarray(Array.from({ length: value.count }, (_, index) => index), {
+  minLength: value.count, maxLength: value.count
+}).map((order) => ({ ...value, order })))
+
+test("completed parents retain exact child obligations through every completion order and replay", () => {
+  fc.assert(fc.property(scenario, ({ id, epoch, count, order }) => {
+    const parent = { method: "work", id, epoch }
+    const child = { method: "work", id, epoch }
+    const controlRef = { method: "$cancel", id: "request", epoch: 0 }
+    const methods = { work }
+    const cancel = cancellationMethodFor(methods)
+    const target = (index: number) => ({ actor: "worker", instance: "main", thread: `child-${index}` })
+    const response = (index: number): Event => ({
+      type: "ResponseReceived", reference: { target: target(index), invocation: child },
+      id: `reply-${index}`, from: `worker:main:child-${index}`, method: "work", call: id, epoch,
+      status: "completed", output: "done", at: 10
+    })
+    const history: Event[] = [
+      { type: "Started", invocation: parent, at: 1 },
+      ...Array.from({ length: count }, (_, index): Event => ({
+        type: "InvocationLinked", parent,
+        owner: { type: "transition", ref: { seq: 1, component: "work", tag: `spawn-${index}` } },
+        child: { invocation: child }, target: `worker:main:child-${index}`, at: 2
+      })),
+      { type: "Completed", invocation: parent, at: 3 },
+      cancel.event({ invocation: controlRef, input: { invocation: parent }, at: 4 }),
+      response(count)
+    ]
+    for (let completed = 0; completed <= count; completed++) {
+      const expected = count - completed
+      for (const log of [history, JSON.parse(JSON.stringify(history)) as Event[]]) {
+        expect(cancellationDispositionOf(log, work, parent)).toBe(expected > 0 ? "requested" : "settled")
+        const residuals = cancellationTransitionsOf(log, methods, [], cancellationKeys.keyOf)
+        expect(residuals?.length ?? 0).toBe(expected)
+        expect(residuals?.every((transition) => transition.kind === "effect") ?? true).toBe(true)
+        const projection = actorCancellationProjection(methods, [], cancellationKeys.keyOf)!
+        const state = log.map((event, index) => eventAt(event, index + 1)).reduce(projection.step, projection.initial())
+        expect(projection.output(state).residuals?.map((transition) => transition.key))
+          .toEqual(residuals?.map((transition) => transition.key))
+        expect(replayProjection(cancel.projection, log).invocationState(controlRef))
+          .toEqual(expected > 0 ? { status: "pending" } : { status: "completed", output: { cancelled: false } })
+      }
+      if (completed < count) history.push(response(order[completed]!))
+    }
+  }), { numRuns: 200 })
+})

--- a/packages/core/src/interaction/relations.ts
+++ b/packages/core/src/interaction/relations.ts
@@ -1,3 +1,4 @@
+import type { OwnerRef } from "../runtime/context"
 import { Schema } from "effect"
 import { formatThreadAddress, isThreadAddress, ThreadAddress, type ThreadAddress as ThreadAddressType } from "../transport/endpoint"
 import type { Event } from "@clavia/tardigrade-core/event"
@@ -157,6 +158,7 @@ export const threadKeys: KeyFragment = {
 export interface InvocationLinked extends Event {
   readonly type: "InvocationLinked"
   readonly parent: InvocationRef
+  readonly owner: OwnerRef
   readonly child: ActorInvocationContext
   readonly target: string
   readonly lineage?: ThreadLineage
@@ -165,8 +167,9 @@ export interface InvocationLinked extends Event {
 
 export const invocationLinked = (fields: {
   readonly parent: InvocationRef
+  readonly owner?: OwnerRef
   readonly child: ActorInvocationContext
   readonly target: string
   readonly lineage?: ThreadLineage
   readonly at: number
-}): InvocationLinked => ({ type: "InvocationLinked", ...fields })
+}): InvocationLinked => ({ type: "InvocationLinked", ...fields, owner: fields.owner ?? { type: "invocation", ref: fields.parent } })

--- a/packages/core/src/runtime/context.ts
+++ b/packages/core/src/runtime/context.ts
@@ -1,3 +1,5 @@
+import type { InvocationRef } from "../interaction/invocation"
+import type { TransitionRef } from "../transition/transition"
 import { Context } from "effect"
 import type { ThreadAddress } from "../transport/endpoint"
 import type { ActorInvocationContext } from "../interaction/invocation"
@@ -19,3 +21,16 @@ export class ThreadAllocationScope extends Context.Service<ThreadAllocationScope
   readonly key: (explicit?: string) => string
 }>()("tardigrade/ThreadAllocationScope") {}
 
+
+// OwnerRef identifies the invocation or transition that owns nested work (tla/runtime/OperationOwnership.tla, OwnershipComplete).
+export type OwnerRef =
+  | { readonly type: "invocation"; readonly ref: InvocationRef }
+  | { readonly type: "transition"; readonly ref: TransitionRef }
+
+// OperationScope supplies runtime-owned identity to nested dispatch (tla/runtime/OperationOwnership.tla, ExactResolution).
+export class OperationScope extends Context.Service<OperationScope, OwnerRef>()("tardigrade/OperationScope") {}
+
+// ownerKey scopes nested operation names to their runtime owner (interaction/execution.test.ts).
+export const ownerKey = (owner: OwnerRef): string => owner.type === "invocation"
+  ? JSON.stringify([owner.type, owner.ref.method, owner.ref.id, owner.ref.epoch])
+  : JSON.stringify([owner.type, owner.ref.seq, owner.ref.component, owner.ref.tag])

--- a/packages/core/src/runtime/reconciler.properties.test.ts
+++ b/packages/core/src/runtime/reconciler.properties.test.ts
@@ -10,7 +10,7 @@ import {
 } from "./index"
 import { component, cancelComponent, composeComponents, deriveComponent, transitionProjectionOf, type Component, type TransitionContext } from "../component"
 import { actorRuntimeOf } from "./actor"
-import { InvocationScope } from "./context"
+import { InvocationScope, OperationScope } from "./context"
 import { EffectInterruptions, effectInterruptionRegistry } from "./reconciler"
 import { effect } from "@clavia/tardigrade-core/effect"
 import type { Event } from "@clavia/tardigrade-core/event"
@@ -568,6 +568,9 @@ test("tagged transitions inherit invocation ownership through completions and re
         act: () => Effect.gen(function* () {
           const scope = yield* Effect.serviceOption(InvocationScope)
           observed.push(Option.isSome(scope) ? scope.value.context : undefined)
+          expect(Option.getOrUndefined(yield* Effect.serviceOption(OperationScope))).toEqual({
+            type: "transition", ref: { seq: 2, component: "worker", tag: "execute" }
+          })
           return { type: "Completed" }
         })
       })]

--- a/packages/core/src/transition/transition.ts
+++ b/packages/core/src/transition/transition.ts
@@ -1,3 +1,4 @@
+import { OperationScope } from "../runtime/context"
 import { Effect, Schema } from "effect"
 import { effect, type ExternalEffect } from "../effect"
 import { intent, type Intent } from "../intent"
@@ -106,7 +107,9 @@ export const bindTransitionContext = (event: Event, component: string): Transiti
         ...(invocation === undefined ? {} : { invocation }),
         ...(options.concurrent === undefined ? {} : { concurrent: options.concurrent }),
         ...(options.interrupts === undefined ? {} : { interrupts: options.interrupts }),
-        act: (input: Input, signal: AbortSignal) => Effect.map(options.act(input, { signal }), (result) => complete(ref, invocation, result))
+        act: (input: Input, signal: AbortSignal) => Effect.map(options.act(input, { signal }), (result) => complete(ref, invocation, result)).pipe(
+          Effect.provideService(OperationScope, { type: "transition", ref })
+        )
       }))
       references.set(transition, ref)
       return transition

--- a/packages/core/tla/runtime/OperationOwnership.cfg
+++ b/packages/core/tla/runtime/OperationOwnership.cfg
@@ -1,0 +1,8 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  ExactRefs = TRUE
+  KeepBackgroundOwner = TRUE
+  TraverseCompleted = TRUE
+  Fair = FALSE
+INVARIANTS TypeOK UniqueIdentity OwnershipComplete ExactResolution CancellationClosure

--- a/packages/core/tla/runtime/OperationOwnership.tla
+++ b/packages/core/tla/runtime/OperationOwnership.tla
@@ -1,0 +1,66 @@
+------------------------- MODULE OperationOwnership -------------------------
+EXTENDS Naturals, FiniteSets
+
+(* OperationOwnership models a durably admitted operation family. Admission is
+   assumed to record identity and ownership atomically. Refs are scoped to a
+   thread/log; payload IDs deliberately collide. It abstracts external actions,
+   ingress validation, and allocation. TLC checks this bounded graph, not the
+   TypeScript implementation. *)
+CONSTANTS ExactRefs, KeepBackgroundOwner, TraverseCompleted, Fair
+Ops == {"rootA", "rootB", "effectA", "effectB", "child"}
+None == "none"
+Parent(o) == CASE o = "effectA" -> "rootA"
+               [] o = "effectB" -> "rootB"
+               [] o = "child" -> "effectA"
+               [] OTHER -> None
+Ref(o) == CASE o = "rootA" -> <<"invocation", "threadA", "message", "same", 0>>
+            [] o = "rootB" -> <<"invocation", "threadB", "message", "same", 0>>
+            [] o = "effectA" -> <<"transition", "threadA", 12, "code", "execute">>
+            [] o = "effectB" -> <<"transition", "threadA", 19, "code", "execute">>
+            [] OTHER -> <<"invocation", "childThread", "message", "same", 0>>
+Key(o) == IF ExactRefs THEN Ref(o) ELSE <<"same">>
+ExpectedOwners == [o \in Ops |-> IF Parent(o) = None THEN <<>> ELSE Ref(Parent(o))]
+
+VARIABLES owners, completed, cancelled, receipts, resolved
+vars == <<owners, completed, cancelled, receipts, resolved>>
+Children(nodes, traverse) == {o \in Ops : \E p \in nodes :
+  owners[o] = Ref(p) /\ (traverse \/ p \notin completed)}
+Family(root, traverse) ==
+  LET one == {root} \cup Children({root}, traverse)
+      two == one \cup Children(one, traverse)
+  IN two \cup Children(two, traverse)
+ExpectedFamily(root) == CASE root = "rootA" -> {"rootA", "effectA", "child"}
+                         [] root = "effectA" -> {"effectA", "child"}
+                         [] root = "rootB" -> {"rootB", "effectB"}
+                         [] OTHER -> {root}
+
+Init ==
+  /\ owners = [o \in Ops |-> IF o = "child" /\ ~KeepBackgroundOwner
+                              THEN <<>> ELSE ExpectedOwners[o]]
+  /\ completed = {} /\ cancelled = {} /\ receipts = {} /\ resolved = {}
+
+Finish(o) ==
+  /\ o \notin completed \cup cancelled
+  /\ completed' = completed \cup {o}
+  /\ receipts' = receipts \cup {[operation |-> o, ref |-> Key(o)]}
+  /\ resolved' = {p \in Ops : \E r \in receipts' : r.ref = Key(p)}
+  /\ UNCHANGED <<owners, cancelled>>
+
+Cancel(o) ==
+  /\ o \notin cancelled
+  /\ cancelled' = cancelled \cup Family(o, TraverseCompleted)
+  /\ UNCHANGED <<owners, completed, receipts, resolved>>
+
+Next == (\E o \in Ops : Finish(o)) \/ (\E o \in Ops : Cancel(o))
+Spec == Init /\ [][Next]_vars /\
+  (IF Fair THEN \A o \in Ops : WF_vars(Finish(o)) ELSE TRUE)
+
+TypeOK == /\ owners \in [Ops -> ({<<>>} \cup {Ref(o) : o \in Ops})]
+          /\ completed \subseteq Ops /\ cancelled \subseteq Ops /\ resolved \subseteq Ops
+          /\ receipts \subseteq [operation : Ops, ref : {Key(o) : o \in Ops}]
+UniqueIdentity == \A a, b \in Ops : Key(a) = Key(b) => a = b
+OwnershipComplete == owners = ExpectedOwners
+ExactResolution == resolved = {r.operation : r \in receipts}
+CancellationClosure == \A o \in cancelled : ExpectedFamily(o) \subseteq cancelled
+AllSettled == <>(completed \cup cancelled = Ops)
+=============================================================================

--- a/packages/core/tla/runtime/OperationOwnershipBareIds.cfg
+++ b/packages/core/tla/runtime/OperationOwnershipBareIds.cfg
@@ -1,0 +1,8 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  ExactRefs = FALSE
+  KeepBackgroundOwner = TRUE
+  TraverseCompleted = TRUE
+  Fair = FALSE
+INVARIANTS TypeOK ExactResolution

--- a/packages/core/tla/runtime/OperationOwnershipCompletedParent.cfg
+++ b/packages/core/tla/runtime/OperationOwnershipCompletedParent.cfg
@@ -1,0 +1,8 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  ExactRefs = TRUE
+  KeepBackgroundOwner = TRUE
+  TraverseCompleted = FALSE
+  Fair = FALSE
+INVARIANTS TypeOK CancellationClosure

--- a/packages/core/tla/runtime/OperationOwnershipDroppedOwner.cfg
+++ b/packages/core/tla/runtime/OperationOwnershipDroppedOwner.cfg
@@ -1,0 +1,8 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  ExactRefs = TRUE
+  KeepBackgroundOwner = FALSE
+  TraverseCompleted = TRUE
+  Fair = FALSE
+INVARIANTS TypeOK OwnershipComplete

--- a/packages/core/tla/runtime/OperationOwnershipLive.cfg
+++ b/packages/core/tla/runtime/OperationOwnershipLive.cfg
@@ -1,0 +1,9 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+CONSTANTS
+  ExactRefs = TRUE
+  KeepBackgroundOwner = TRUE
+  TraverseCompleted = TRUE
+  Fair = TRUE
+INVARIANTS TypeOK UniqueIdentity OwnershipComplete ExactResolution CancellationClosure
+PROPERTY AllSettled

--- a/tools/tla.ts
+++ b/tools/tla.ts
@@ -40,6 +40,11 @@ const counterexample = (
 ): CounterexampleCheck => ({ directory, module, config, outcome: "counterexample", evidence })
 
 export const checks: ReadonlyArray<Check> = [
+  pass("runtime", "OperationOwnership", "OperationOwnership.cfg"),
+  pass("runtime", "OperationOwnership", "OperationOwnershipLive.cfg"),
+  counterexample("runtime", "OperationOwnership", "OperationOwnershipBareIds.cfg", "Invariant ExactResolution is violated"),
+  counterexample("runtime", "OperationOwnership", "OperationOwnershipDroppedOwner.cfg", "Invariant OwnershipComplete is violated"),
+  counterexample("runtime", "OperationOwnership", "OperationOwnershipCompletedParent.cfg", "Invariant CancellationClosure is violated"),
   pass("runtime", "OperationGraph", "OperationGraph.cfg"),
   pass("runtime", "OperationGraph", "OperationGraphLive.cfg"),
   counterexample("runtime", "OperationGraph", "OperationGraphPremature.cfg", "Invariant NoPrematureStart is violated"),


### PR DESCRIPTION
## Problem

Background children lost cancellation ownership when their parent returned. Code replay also joined execution and package facts by payload IDs, allowing distinct operations to share results when those IDs repeated.

## Change

Carry runtime operation refs into nested work and persist ownership independently of whether the caller waits:

```text
method invocation
└─ transition ref
   └─ package operation ref
      └─ child invocation
```

- Scope nested invocation keys, code replay, and spill storage to operation references.
- Retain background-child ownership and cancellation obligations after the parent completes.
- Release those obligations when the child or its cancellation settles, preserving the parent's recorded outcome.

Unstamped historical code events retain their existing ID-based replay path. This addresses part of #377; it does not claim to replace that PR in full.

## Validation

- Full 77-task gate.
- Two fast-check properties, 200 cases each: deliberate ID collisions, reordered and duplicated facts, JSON replay, and child completion order. Both fail against the previous implementations and pass with the fix.
- Five TLA+ configurations: bounded safety and liveness checks plus expected counterexamples for bare IDs, dropped ownership, and cancellation stopping at completed parents.
