### PR TITLE
fix(agent): require invocation handles

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -177,6 +177,9 @@
         "@clavia/tardigrade-core": "workspace:*",
         "effect": "4.0.0-rc.110",
       },
+      "devDependencies": {
+        "fast-check": "^4.9.0",
+      },
     },
     "packages/code": {
       "name": "@clavia/tardigrade-code",

--- a/e2e/actor/graph.test.ts
+++ b/e2e/actor/graph.test.ts
@@ -68,7 +68,7 @@ test("an actor graph covers concurrent calls, budget negotiation, structured out
             agents.run({ text: "worker " + worker, budget: 1, escalatable: true, output: "worker" })
           ));
           const background = await agents.run({ text: "background", background: true });
-          const later = await agents.result({ id: background.callId });
+          const later = await agents.result({ handle: background.handle });
           return { foreground: foreground.map((answer) => answer.output), background: later.output };`
         }
       }

--- a/e2e/actor/mortyplicity.test.ts
+++ b/e2e/actor/mortyplicity.test.ts
@@ -161,7 +161,7 @@ const mindFor = (missions: ReadonlyMap<string, Mission>, jitter: ReadonlyArray<n
             }));
             return await Promise.all(launched.map(async ({ mission, answer }) => {
               const terminal = mission.background
-                ? await agents.result({ id: answer.callId })
+                ? await agents.result({ handle: answer.handle })
                 : answer;
               return JSON.parse(terminal.output);
             }));`

--- a/packages/agent/src/packages/agents-compat.test.ts
+++ b/packages/agent/src/packages/agents-compat.test.ts
@@ -1,12 +1,13 @@
 import { expect, test } from "bun:test"
 import { childCreated } from "@clavia/tardigrade-core/interaction/relations"
-import { legacyChildHandle } from "./agents-compat"
+import { childInvocationRef } from "./agents-compat"
 
-test("legacy handles resolve one recorded dispatch and reject missing or ambiguous owners", () => {
+test("recorded child handles retain their target and invocation through replay", () => {
   const parent = { actor: "agent", instance: "main", thread: "root" }
-  const first = childCreated("c1", { ...parent, thread: "first" }, { parent, depth: 1 }, 1, "turn-a")
-  const second = childCreated("c1", { ...parent, thread: "second" }, { parent, depth: 1 }, 2, "turn-b")
-  expect(legacyChildHandle([first], "c1")).toEqual(first)
-  expect(legacyChildHandle([], "c1")).toHaveProperty("error")
-  expect(legacyChildHandle([first, second], "c1")).toHaveProperty("error", expect.stringContaining("ambiguous"))
+  const address = { ...parent, thread: "child" }
+  const legacy = childCreated("c1", address, { parent, depth: 1 }, 1, "turn")
+  expect(childInvocationRef(legacy)).toEqual({ target: address, invocation: { method: "message", id: "c1", epoch: 0 } })
+  const invocation = { method: "research", id: "c1", epoch: 2 }
+  const recorded = childCreated("c1", address, { parent, depth: 1 }, 1, "turn", invocation)
+  expect(childInvocationRef(JSON.parse(JSON.stringify(recorded)))).toEqual({ target: address, invocation })
 })

--- a/packages/agent/src/packages/agents-compat.ts
+++ b/packages/agent/src/packages/agents-compat.ts
@@ -1,5 +1,3 @@
-import { Schema } from "effect"
-import type { Event } from "@clavia/tardigrade-core/event"
 import { ChildCreated } from "@clavia/tardigrade-core/interaction/relations"
 import { invocationCoordinateOf, type InvocationCoordinate } from "@clavia/tardigrade-core/interaction"
 
@@ -7,11 +5,3 @@ import { invocationCoordinateOf, type InvocationCoordinate } from "@clavia/tardi
 export const childInvocationRef = (record: ChildCreated): InvocationCoordinate => invocationCoordinateOf(
   record.address, record.invocation ?? { method: "message", id: record.callId, epoch: 0 }
 )
-
-// legacyChildHandle resolves a call-ID-only handle only when one recorded dispatch owns it (agents-compat.test.ts).
-export const legacyChildHandle = (events: ReadonlyArray<Event>, id: string): ChildCreated | { readonly error: string } => {
-  const candidates = events.filter((event): event is ChildCreated => Schema.is(ChildCreated)(event) && event.callId === id)
-  if (candidates.length === 0) return { error: `no recorded child dispatch for ${JSON.stringify(id)}` }
-  if (candidates.length !== 1) return { error: `ambiguous child dispatch ${JSON.stringify(id)}; pass the invocation handle returned by agents.run` }
-  return candidates[0]!
-}

--- a/packages/agent/src/packages/agents.test.ts
+++ b/packages/agent/src/packages/agents.test.ts
@@ -99,6 +99,11 @@ const legacyChild = (callId: string): Event => ({
   address: { actor: "mem", instance: "main", thread: `ag.${callId}` }, depth: 1, at: 2
 })
 
+const recordedHandle = (id: string): InvocationCoordinate => ({
+  target: { actor: "mem", instance: "main", thread: `ag.${id}` },
+  invocation: { method: "message", id, epoch: 0 }
+})
+
 const expectedThread = async (turn: string, call: string) => (await Effect.runPromise(testAllocator.allocate({
   kind: "child",
   parent: parseThreadAddress("mem:main:ag.root"),
@@ -439,10 +444,19 @@ describe("agentsPackage", () => {
       "ag.root": [legacyChild("c8"), response("c8", "cancelled", "")]
     } as Readonly<Record<string, ReadonlyArray<Event>>>
     const answer = await Effect.runPromise(
-      pkg.methods.result!({ id: "c8" }, { callId: "r8" }).pipe(Effect.provide(env("mem:main:ag.root", sent, threads)))
+      pkg.methods.result!({ handle: recordedHandle("c8") }, { callId: "r8" }).pipe(Effect.provide(env("mem:main:ag.root", sent, threads)))
     )
     expect(answer).toEqual({ error: "cancelled" })
     expect(sent.length).toBe(0)
+  })
+
+  test("result requires an invocation handle even when a bare ID has one match", async () => {
+    const pkg = agentsPackage()
+    const threads = { "ag.root": [legacyChild("c6"), response("c6", "completed", "answer")] }
+    const result = await Effect.runPromise(pkg.methods.result!({ id: "c6" }, { callId: "read" }).pipe(
+      Effect.provide(env("mem:main:ag.root", [], threads))
+    ))
+    expect(result).toEqual({ error: "agents.result needs a valid invocation handle" })
   })
 
   test("result reads the response from its own log", async () => {
@@ -454,7 +468,7 @@ describe("agentsPackage", () => {
       ]
     } as Readonly<Record<string, ReadonlyArray<Event>>>
     const answer = await Effect.runPromise(
-      pkg.methods.result!({ id: "c6" }, { callId: "c7" }).pipe(Effect.provide(env("mem:main:ag.root", sent, threads)))
+      pkg.methods.result!({ handle: recordedHandle("c6") }, { callId: "c7" }).pipe(Effect.provide(env("mem:main:ag.root", sent, threads)))
     )
     expect(answer).toEqual({ error: "nope" })
   })
@@ -592,7 +606,7 @@ describe("a child is named by its parent address, run, and call", () => {
     expect(sent).toHaveLength(3)
   })
 
-  test("handles distinguish reused calls while ambiguous legacy handles fail", async () => {
+  test("handles distinguish reused calls while bare IDs fail", async () => {
     const events: Event[] = [
       threadCreated(parseThreadAddress("mem:main:ag.root"), undefined, 0),
       turn("parent-a"), called("same", "parent-a")
@@ -615,7 +629,7 @@ describe("a child is named by its parent address, run, and call", () => {
     expect(parked).toBeInstanceOf(Park)
     expect((parked as Park).awaiting).toBe(invocationResponseId(second.handle))
     const legacy = await Effect.runPromise(pkg.methods.result!({ id: "same" }, { callId: "legacy" }).pipe(Effect.provide(environment)))
-    expect(legacy).toHaveProperty("error", expect.stringContaining("ambiguous"))
+    expect(legacy).toHaveProperty("error", expect.stringContaining("invocation handle"))
     events.push({
       ...response("same", "cancelled", "stopped"),
       id: invocationResponseId(second.handle), reference: second.handle,
@@ -824,7 +838,7 @@ describe("a run stays bound to the schema it was started under", () => {
     const sent: Array<Sent> = []
     const pkg = agentsPackage({ outputs })
     return Effect.runPromise(
-      pkg.methods.result!({ id: "b1" }, { callId: "later" }).pipe(Effect.provide(env("mem:main:ag.root", sent, threadsFor)))
+      pkg.methods.result!({ handle: recordedHandle("b1") }, { callId: "later" }).pipe(Effect.provide(env("mem:main:ag.root", sent, threadsFor)))
     )
   }
 

--- a/packages/agent/src/packages/agents.ts
+++ b/packages/agent/src/packages/agents.ts
@@ -12,7 +12,7 @@ import { definePackage, type Package } from "@clavia/tardigrade-code/package/def
 import { eventEpochOf, turnOf, turnView } from "@clavia/tardigrade-code/execution/turns"
 import { budgetPolicyOf, type BudgetPolicy } from "../component/budget"
 import { Park } from "@clavia/tardigrade-code/execution/errors"
-import { childInvocationRef, legacyChildHandle } from "./agents-compat"
+import { childInvocationRef } from "./agents-compat"
 import { ChildCreated, childCreated, childLineageOf, ChildPlacement, threadCreatedOf, type ThreadCreated, type ThreadLineage } from "@clavia/tardigrade-core/interaction/relations"
 import { childKeyOf } from "@clavia/tardigrade-core/actor/coordinate"
 import { allocateChildCoordinate as allocateChildThread, ThreadAllocator } from "@clavia/tardigrade-core/actor/allocation"
@@ -377,9 +377,10 @@ export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self
         input: {
           type: "object",
           properties: {
-            handle: { ...invocationCoordinateJsonSchema, description: "the invocation handle returned by agents.run" },
-            id: { type: "string", description: "legacy callId; accepted only when one recorded dispatch matches" }
-          }
+            handle: { ...invocationCoordinateJsonSchema, description: "the invocation handle returned by agents.run" }
+          },
+          required: ["handle"],
+          additionalProperties: false
         },
         output: {
           type: "object",
@@ -535,24 +536,14 @@ export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self
       // result validates a background response against its recorded output contract (agents.test.ts, "a later call cannot invent a contract the run never declared").
       result: (args, ctx) =>
         Effect.gen(function* () {
-          const a = args as { id?: unknown; handle?: unknown } | undefined
+          const a = args as { handle?: unknown } | undefined
+          if (!Schema.is(InvocationCoordinate)(a?.handle)) return { error: "agents.result needs a valid invocation handle" }
+          const handle = a.handle
           const log = yield* EventLog
           const events = yield* log.read
-          let record: ChildCreated
-          if (a?.handle !== undefined) {
-            if (!Schema.is(InvocationCoordinate)(a.handle)) return { error: "agents.result needs a valid invocation handle" }
-            const handle = a.handle
-            const found = events.find((event): event is ChildCreated => Schema.is(ChildCreated)(event) &&
-              invocationCoordinateKey(childInvocationRef(event)) === invocationCoordinateKey(handle))
-            if (found === undefined) return { error: "no recorded child dispatch for this invocation handle" }
-            record = found
-          } else {
-            const id = String(a?.id ?? "")
-            if (id === "") return { error: "agents.result needs { handle } or a legacy { id }" }
-            const found = legacyChildHandle(events, id)
-            if ("error" in found) return found
-            record = found
-          }
+          const record = events.find((event): event is ChildCreated => Schema.is(ChildCreated)(event) &&
+            invocationCoordinateKey(childInvocationRef(event)) === invocationCoordinateKey(handle))
+          if (record === undefined) return { error: "no recorded child dispatch for this invocation handle" }
           const reference = childInvocationRef(record)
           const id = reference.invocation.id
           const reply = childResultOf(events, reference)

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -35,6 +35,9 @@
     "@clavia/tardigrade-agent": "workspace:*",
     "@clavia/tardigrade-code": "workspace:*"
   },
+  "devDependencies": {
+    "fast-check": "^4.9.0"
+  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "bun test"

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test"
 import { Schema } from "effect"
+import fc from "fast-check"
 import { ACTOR_ARTIFACT_VERSION, agentMethods } from "@clavia/tardigrade-agent"
 import type { ActorMethodState } from "@clavia/tardigrade-core/interaction/state"
 
@@ -395,12 +396,23 @@ describe("resuming a turn", () => {
   const failed = { type: "TurnFailed", turn: "m1", error: "boom" }
   const client = () => makeActorClient({ baseUrl: "http://localhost:4111", fetch: stub })
 
-  test("a failed turn resumes without a turns projection", async () => {
-    answer = accepting([message, failed])
-    expect(await client().resume("main", "root", "m1")).toEqual({ actor: "main", thread: "root" })
-    expect(calls).toHaveLength(3)
-    expect(calls.every((call) => new URL(call.url).pathname === "/v1/actors/main/threads/root/events")).toBe(true)
-    expect(JSON.parse(calls.at(-1)!.body!)).toEqual({ type: "TurnResumed", turn: "m1", failedEpoch: 0, epoch: 1 })
+  test("resuming a failed turn is invariant under consistent ID renaming", async () => {
+    await fc.assert(fc.asyncProperty(
+      fc.string({ minLength: 1 }), fc.string({ minLength: 1 }),
+      async (original, renamed) => {
+        const resume = async (turn: string) => {
+          calls.length = 0
+          answer = accepting([{ ...message, id: turn }, { ...failed, turn }])
+          const result = await client().resume("main", "root", turn)
+          expect(calls).toHaveLength(3)
+          expect(calls.every((call) => new URL(call.url).pathname === "/v1/actors/main/threads/root/events")).toBe(true)
+          const event = JSON.parse(calls.at(-1)!.body!)
+          expect(event).toEqual({ type: "TurnResumed", turn, failedEpoch: 0, epoch: 1 })
+          return { result, event: { ...event, turn: "<turn>" } }
+        }
+        expect(await resume(renamed)).toEqual(await resume(original))
+      }
+    ), { numRuns: 200 })
   })
 
   test("resume follows every event page", async () => {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,5 +1,4 @@
 import type { Event } from "@clavia/tardigrade-core/log/event"
-import { REPLY_SUFFIX } from "@clavia/tardigrade-core/interaction/provider-message"
 import { boundaryOf } from "@clavia/tardigrade-agent/output/boundary"
 import { turnEpochOf } from "@clavia/tardigrade-code/execution/turns"
 import { Effect, type Schema } from "effect"
@@ -436,7 +435,7 @@ export const makeActorClient = <const P extends Projections = {}, const M extend
     // agentKeys).
     resume: async (actor, thread, turn) => {
       const log = await logOf(actor, thread)
-      if (turn.endsWith(REPLY_SUFFIX) || !log.some((event) => event.type === "MessageReceived" && String((event as { id?: unknown }).id ?? "") === turn)) {
+      if (!log.some((event) => event.type === "MessageReceived" && String((event as { id?: unknown }).id ?? "") === turn)) {
         throw new ProblemError({
           ...ResumeRefused.of(`No turn named ${JSON.stringify(turn)} has been served on this thread.`)
         })

--- a/packages/code/src/execution/turn-projection.test.ts
+++ b/packages/code/src/execution/turn-projection.test.ts
@@ -36,11 +36,12 @@ describe("incremental turn projection", () => {
     ), { numRuns: 500 })
   })
 
-  test("a parked package reply does not become a turn head", () => {
+  test("an invocation response does not become a turn head", () => {
     const log: ReadonlyArray<Event> = [
       { type: "MessageReceived", id: "m0" } as Event,
       { type: "PackageCalled", callId: "run-1", turn: "m0" } as Event,
-      { type: "MessageReceived", id: "run-1/reply" } as Event,
+      { type: "BlockedOn", callId: "run-1", turn: "m0", awaiting: "run-1/reply" },
+      { type: "ResponseReceived", id: "run-1/reply" } as Event,
       { type: "PackageReturned", callId: "run-1", turn: "m0" } as Event,
       { type: "TurnCompleted", turn: "m0" } as Event
     ]
@@ -74,4 +75,44 @@ describe("incremental turn projection", () => {
     expect(turnViewFrom(state)).toEqual(turnView(log))
     expect(trajectoryFrom(state)).toEqual(trajectoryOf(log))
   })
+})
+
+test("message and response event types determine whether a turn starts", () => {
+  const check = (events: ReadonlyArray<Event>, expected: string | undefined) => {
+    expect(turnView(events)[0]?.id).toBe(expected)
+    expect(turnViewFrom(events.reduce(reduceTurnProjection, initialTurnProjection()))[0]?.id).toBe(expected)
+  }
+  const call: Event = { type: "PackageCalled", callId: "same", turn: "owner" }
+  check([call, { type: "MessageReceived", id: "same.reply" }], "same.reply")
+  check([call, { type: "BlockedOn", callId: "same", turn: "owner", awaiting: "opaque-response" },
+    { type: "MessageReceived", id: "opaque-response" }], "opaque-response")
+  check([call, { type: "BlockedOn", callId: "same", turn: "other", awaiting: "opaque-response" },
+    { type: "MessageReceived", id: "opaque-response" }], "opaque-response")
+  check([call, { type: "ResponseReceived", id: "same.reply" }], undefined)
+})
+
+test("event types preserve turn attribution regardless of waits, ID suffixes, and replay", () => {
+  fc.assert(fc.property(
+    fc.string({ minLength: 1, maxLength: 20 }), fc.boolean(), fc.boolean(), fc.boolean(),
+    (base, waited, closed, isMessage) => {
+      const reply = `${base}.reply`
+      const first = { seq: 12, component: "code", tag: "dispatch" }
+      const second = { seq: 19, component: "code", tag: "dispatch" }
+      const call: Event = { type: "PackageCalled", executionRef: first, ordinal: 0, callId: base, turn: "owner" }
+      const returned: Event = { type: "PackageReturned", executionRef: first, ordinal: 0, callId: base, turn: "owner" }
+      const history: Event[] = [
+        call,
+        { type: "PackageCalled", executionRef: second, ordinal: 0, callId: base, turn: "owner" },
+        { type: "PackageReturned", executionRef: second, ordinal: 0, callId: base, turn: "owner" },
+        ...(waited ? [{ type: "BlockedOn", executionRef: first, ordinal: 0, callId: base, turn: "owner", awaiting: reply }] : []),
+        ...(closed ? [returned] : []),
+        { type: isMessage ? "MessageReceived" : "ResponseReceived", id: reply }
+      ]
+      const expected = isMessage ? reply : undefined
+      for (const log of [history, [...history, returned], JSON.parse(JSON.stringify(history)) as Event[]]) {
+        expect(turnView(log)[0]?.id).toBe(expected)
+        expect(turnViewFrom(log.reduce(reduceTurnProjection, initialTurnProjection()))[0]?.id).toBe(expected)
+      }
+    }
+  ), { numRuns: 200 })
 })

--- a/packages/code/src/execution/turn-projection.ts
+++ b/packages/code/src/execution/turn-projection.ts
@@ -1,6 +1,5 @@
 import { Chunk, HashMap, HashSet, Option } from "effect"
 import type { Event } from "@clavia/tardigrade-core/log/event"
-import { REPLY_SUFFIX } from "./ids"
 import { eventEpochOf, turnOf } from "./turns"
 
 interface TurnRecord {
@@ -22,7 +21,6 @@ export interface TurnProjectionState {
   readonly heads: HashMap.HashMap<string, TurnHeadRecord>
   readonly open: HashMap.HashMap<string, number>
   readonly turns: HashMap.HashMap<string, TurnRecord>
-  readonly openPackages: HashSet.HashSet<string>
   readonly served: HashSet.HashSet<string>
   readonly trajectory: Chunk.Chunk<Event>
 }
@@ -41,7 +39,6 @@ export const initialTurnProjection = (): TurnProjectionState => ({
   heads: HashMap.empty(),
   open: HashMap.empty(),
   turns: HashMap.empty(),
-  openPackages: HashSet.empty(),
   served: HashSet.empty(),
   trajectory: Chunk.empty()
 })
@@ -52,30 +49,14 @@ const field = (event: Event, name: string): string =>
 const terminal = (event: Event): boolean =>
   event.type === "TurnCompleted" || event.type === "TurnFailed" || event.type === "TurnCancelled"
 
-const claimedReply = (state: TurnProjectionState, event: Event): boolean => {
-  const id = field(event, "id")
-  return id.endsWith(REPLY_SUFFIX) && HashSet.has(state.openPackages, id.slice(0, -REPLY_SUFFIX.length))
-}
-
 const advanceEpoch = (record: TurnRecord): number => {
   let epoch = record.epoch
   while (HashSet.has(record.failed, epoch) && HashSet.has(record.resumed, epoch)) epoch += 1
   return epoch
 }
 
-const reducePackageCalls = (state: TurnProjectionState, event: Event): TurnProjectionState => {
-  if (event.type !== "PackageCalled" && event.type !== "PackageReturned") return state
-  const call = field(event, "callId")
-  return {
-    ...state,
-    openPackages: event.type === "PackageCalled"
-      ? HashSet.add(state.openPackages, call)
-      : HashSet.remove(state.openPackages, call)
-  }
-}
-
 const reduceHead = (state: TurnProjectionState, event: Event): TurnProjectionState => {
-  if (event.type !== "MessageReceived" || claimedReply(state, event)) return state
+  if (event.type !== "MessageReceived") return state
   const id = field(event, "id")
   if (HashMap.has(state.heads, id)) return state
   const turn = Option.getOrElse(HashMap.get(state.turns, id), emptyTurn)
@@ -138,8 +119,7 @@ const reduceTrajectory = (state: TurnProjectionState, event: Event): TurnProject
 
 // reduceTurnProjection advances the quotient by one durable event.
 export const reduceTurnProjection = (state: TurnProjectionState, event: Event): TurnProjectionState => {
-  const packages = reducePackageCalls(state, event)
-  const headed = reduceHead(packages, event)
+  const headed = reduceHead(state, event)
   const turned = reduceTurn(headed, event)
   return reduceTrajectory(turned, event)
 }

--- a/packages/code/src/execution/turns.test.ts
+++ b/packages/code/src/execution/turns.test.ts
@@ -2,25 +2,17 @@ import { describe, expect, test } from "bun:test"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import { trajectoryOf, turnEpochOf, turnHead, turnTerminalOf, turnView } from "./turns"
 
-// `heads()` (private to this module) is what `turnHead`/`turnView` fold over: every
-// `MessageReceived`, except a reply a package call was still parked on when it landed. That
-// exclusion is what stops a foreground `agents.run`/`tasks.fire` park from also spawning a ghost
-// turn once its outer turn completes and the reply row is still sitting on the log, unconsumed by
-// anything turnHead itself understands. A background spawn's reply is the opposite case: the call
-// that fired it has already returned by the time the reply lands, so it is NOT excluded, and
-// heads its own turn exactly as `agents.run({background:true})`/`tasks.fire({background:true})`
-// promise.
-
-describe("turnHead: a reply claimed by a still-open package call", () => {
-  test("is excluded: it never heads a turn on its own", () => {
+describe("turnHead: message and response events", () => {
+  test("an invocation response never heads a turn", () => {
     const log: ReadonlyArray<Event> = [
       { type: "PackageCalled", callId: "c1", name: "agents.run", arguments: {}, turn: "m1", at: 1 },
-      { type: "MessageReceived", id: "c1.reply", outcome: "completed", text: "4", from: "child", at: 2 }
+      { type: "BlockedOn", callId: "c1", turn: "m1", awaiting: "c1.reply", at: 2 },
+      { type: "ResponseReceived", id: "c1.reply", status: "completed", output: "4", from: "child", at: 3 }
     ]
     expect(turnHead(log)).toBeUndefined()
   })
 
-  test("a reply for a call that had already returned is not excluded: it heads its own turn", () => {
+  test("a message starts a turn after a package returns", () => {
     const log: ReadonlyArray<Event> = [
       { type: "PackageCalled", callId: "c1", name: "agents.run", arguments: {}, turn: "m1", at: 1 },
       { type: "PackageReturned", callId: "c1", result: { dispatched: true }, turn: "m1", at: 2 },
@@ -35,10 +27,7 @@ describe("turnHead: a reply claimed by a still-open package call", () => {
     expect(turnHead(log)).toMatchObject({ id: "m1" })
   })
 
-  test("a reply id from a different package's minted scheme (run-prefixed) is unaffected", () => {
-    // `tasks.fire` mints `run-<callId>` (`mintedRunId`), never the bare call id, so its own
-    // reply's id never matches a `PackageCalled.callId` verbatim: this predicate structurally
-    // never claims it, whatever the call's own open/closed state.
+  test("a reply-shaped message ID starts a turn", () => {
     const log: ReadonlyArray<Event> = [
       { type: "PackageCalled", callId: "c1", name: "tasks.fire", arguments: {}, turn: "m1", at: 1 },
       { type: "MessageReceived", id: "run-c1.reply", outcome: "completed", text: "done", from: "child", at: 2 }

--- a/packages/code/src/execution/turns.ts
+++ b/packages/code/src/execution/turns.ts
@@ -1,5 +1,4 @@
 import type { Event } from "@clavia/tardigrade-core/log/event"
-import { REPLY_SUFFIX } from "./ids"
 
 // Turn attribution. A turn is headed by one MessageReceived; every event serving it carries
 // turn: <head id>. Attribution is a fact the event carries, never a derivation from position,
@@ -51,29 +50,8 @@ const activeStamped = (log: ReadonlyArray<Event>, turn: string): ReadonlyArray<E
   return stamped(log, turn).filter((event) => !isTerminal(event) || eventEpochOf(event) === epoch)
 }
 
-// claimedByPark: a reply an open package call was awaiting when it landed belongs to that call,
-// never to a fresh turn of its own; the awaiting body harvests it, and nothing else may react
-// to it as inbound. The verdict reads only events before the reply's own position, so later
-// appends cannot rewrite it (tla/projection/Projection.tla, PrefixFaithful). A background spawn's reply is
-// the opposite case and is meant to head its own turn: its call returned at once, so no call is
-// open for it. Only agents.run ids can ever match: tasks.fire mints run- prefixed ids
-// (mintedRunId, src/grammar/grammar.ts), so a task reply is structurally never claimed.
-const claimedByPark = (log: ReadonlyArray<Event>, index: number): boolean => {
-  const id = idOf(log[index]!)
-  if (!id.endsWith(REPLY_SUFFIX)) return false
-  const callId = id.slice(0, -REPLY_SUFFIX.length)
-  let open = false
-  for (let i = 0; i < index; i++) {
-    const e = log[i]!
-    if (e.type !== "PackageCalled" && e.type !== "PackageReturned") continue
-    if (String((e as { callId?: unknown }).callId) !== callId) continue
-    open = e.type === "PackageCalled"
-  }
-  return open
-}
-
 const heads = (log: ReadonlyArray<Event>): ReadonlyArray<Event> =>
-  log.filter((e, i) => e.type === "MessageReceived" && !claimedByPark(log, i))
+  log.filter((event) => event.type === "MessageReceived")
 
 // turnHead returns the current turn's head: the earliest message with no stamped terminal.
 export const turnHead = (log: ReadonlyArray<Event>): Event | undefined =>


### PR DESCRIPTION
## Problem

A bare child call ID does not identify its target and invocation. Turn detection also guessed whether a message was a reply from its ID and pending package calls, even though actor replies already arrive as `ResponseReceived` with an invocation reference.

## Change

Require the handle returned by `agents.run` when calling `agents.result`. Remove bare-ID lookup and update callers.

Use event types to determine turn creation: `MessageReceived` starts a turn, and `ResponseReceived` follows invocation correlation. Remove reply guessing from both turn projections and the client's suffix-based resume restriction.

Builds on #403 and addresses the remaining result lookup and reply classification work from #377. Structured child-input inheritance remains a separate follow-up.

## Validation

Full repository gate passed. After replacing the suffix-specific resume regression with a generated ID-renaming property, all 33 client tests and typecheck passed. Generated tests cover turn attribution through replay and resume invariance under consistent ID renaming.
