### PR TITLE
fix(agent): remove placement input

### DIFF
--- a/packages/agent/src/packages/agents.properties.test.ts
+++ b/packages/agent/src/packages/agents.properties.test.ts
@@ -16,14 +16,12 @@ interface CallPlan {
   readonly callId: string
   readonly failures: number
   readonly failurePoint: "record" | "before" | "after"
-  readonly placement: "colocated" | "independent" | undefined
 }
 
 const callPlan = fc.record({
   callId: fc.stringMatching(/^[a-z][a-z0-9_]{0,12}$/),
   failures: fc.integer({ min: 0, max: 4 }),
-  failurePoint: fc.constantFrom<CallPlan["failurePoint"]>("record", "before", "after"),
-  placement: fc.option(fc.constantFrom<"colocated" | "independent">("colocated", "independent"), { nil: undefined })
+  failurePoint: fc.constantFrom<CallPlan["failurePoint"]>("record", "before", "after")
 })
 
 const plans = fc.uniqueArray(callPlan, { selector: (plan) => plan.callId, minLength: 1, maxLength: 7 })
@@ -109,7 +107,7 @@ const childProtocol = async (calls: ReadonlyArray<CallPlan>): Promise<void> => {
     for (let attempt = 0; attempt <= plan.failures; attempt++) {
       const result = await Effect.runPromise(
         run(
-          { text: plan.callId, background: true, ...(plan.placement === undefined ? {} : { placement: plan.placement }) },
+          { text: plan.callId, background: true },
           { callId: plan.callId }
         ).pipe(Effect.provide(environment), Effect.exit)
       )

--- a/packages/agent/src/packages/agents.test.ts
+++ b/packages/agent/src/packages/agents.test.ts
@@ -123,12 +123,12 @@ describe("agentsPackage", () => {
         const parent = parseThreadAddress("mem:main:rejected-spawn")
         const invocation = { method: "message", id, epoch: 0 }
         const events: Event[] = [threadCreated(parent, undefined, 0), { ...turn(id), call: { invocation } }]
-        const rejected = new Error('Bun host does not support "independent" thread placement')
+        const rejected = new Error("child delivery rejected")
         let unboundedDelivery = false
         const servicesFor = (log: Event[]) => Layer.mergeAll(
           liveEnv(log, []),
           Layer.succeed(Router, { send: (envelope) => Effect.suspend(() => {
-            if (!isActorEnvelope(envelope) || envelope.lineage?.placement !== "independent") return Effect.void
+            if (!isActorEnvelope(envelope)) return Effect.void
             if (envelope.event.type === "CancellationRequested") {
               unboundedDelivery ||= !log.some((event) => event.type === "CancellationDispatched" &&
                 event.request === envelope.event.request)
@@ -140,7 +140,7 @@ describe("agentsPackage", () => {
           const callId = `${id}/${child}`
           events.push(called(callId, id))
           const outcome = await Effect.runPromise(agentsPackage().methods.run!({
-            text: "work", placement: "independent"
+            text: "work"
           }, { callId }).pipe(Effect.exit, Effect.provide(servicesFor(events))))
           expect(outcome._tag).toBe("Failure")
           events.push({ type: "PackageReturned", callId, turn: id, result: { error: rejected.message }, at: 3 })
@@ -240,7 +240,7 @@ describe("agentsPackage", () => {
     expect(system).not.toContain("agents.continue")
     expect(system).toContain("agents.providers({cursor?: string, search?: string, limit?: number})")
     expect(system).toContain("agents.models({cursor?: string, search?: string, limit?: number, provider?: string, sort?: \"promptUsdPerToken\" | \"completionUsdPerToken\" | \"cachedPromptUsdPerToken\" | \"cacheWritePromptUsdPerToken\", order?: \"asc\" | \"desc\", unpriced?: \"first\" | \"last\"})")
-    expect(system).toContain("agents.run({text: string, background?: boolean, output?: unknown, model?: {provider: string, model_id: string}, budget?: number, placement?: \"colocated\" | \"independent\", escalatable?: boolean}) -> {output?: unknown, error?: string, dispatched?: boolean, callId?: string, handle?: {target: object, invocation: object}}")
+    expect(system).toContain("agents.run({text: string, background?: boolean, output?: unknown, model?: {provider: string, model_id: string}, budget?: number, escalatable?: boolean}) -> {output?: unknown, error?: string, dispatched?: boolean, callId?: string, handle?: {target: object, invocation: object}}")
   })
 
   test("catalog searches return the host API pages", async () => {
@@ -331,22 +331,14 @@ describe("agentsPackage", () => {
     expect(sent[0]?.event).toMatchObject({ escalatable: true })
   })
 
-  test("a run carries its requested thread placement", async () => {
+  test("a run leaves new child placement to the host", async () => {
     const sent: Array<Sent> = []
     const pkg = agentsPackage()
     await Effect.runPromise(
       pkg.methods.run!({ text: "scout", background: true, placement: "independent" }, { callId: "independent-child" })
         .pipe(Effect.provide(env("mem:main:ag.root", sent, { "ag.root": [turn("m1"), called("independent-child", "m1")] })))
     )
-    expect(sent[0]?.lineage?.placement).toBe("independent")
-  })
-
-  test("a run refuses an unknown thread placement", async () => {
-    const result = await Effect.runPromise(
-      agentsPackage().methods.run!({ text: "scout", background: true, placement: "nearby" }, { callId: "bad-placement" })
-        .pipe(Effect.provide(env("mem:main:ag.root", [], { "ag.root": [turn("m1"), called("bad-placement", "m1")] })))
-    )
-    expect(result).toEqual({ error: "agents.run placement must be colocated or independent" })
+    expect(sent[0]?.lineage?.placement).toBeUndefined()
   })
 
   test("the callId identifies the child invocation and the link returns to the parent", async () => {

--- a/packages/agent/src/packages/agents.ts
+++ b/packages/agent/src/packages/agents.ts
@@ -13,7 +13,7 @@ import { eventEpochOf, turnOf, turnView } from "@clavia/tardigrade-code/executio
 import { budgetPolicyOf, type BudgetPolicy } from "../component/budget"
 import { Park } from "@clavia/tardigrade-code/execution/errors"
 import { childInvocationRef } from "./agents-compat"
-import { ChildCreated, childCreated, childLineageOf, ChildPlacement, threadCreatedOf, type ThreadCreated, type ThreadLineage } from "@clavia/tardigrade-core/interaction/relations"
+import { ChildCreated, childCreated, childLineageOf, threadCreatedOf, type ThreadCreated, type ThreadLineage } from "@clavia/tardigrade-core/interaction/relations"
 import { childKeyOf } from "@clavia/tardigrade-core/actor/coordinate"
 import { allocateChildCoordinate as allocateChildThread, ThreadAllocator } from "@clavia/tardigrade-core/actor/allocation"
 import {
@@ -223,16 +223,12 @@ const parentRunOf = (call: Event): { readonly turn: string; readonly epoch: numb
 
 // childClaimOf scopes a child to its parent turn and call, preserving recorded addresses on replay (agents.test.ts).
 const childClaimOf = (
-  placement: unknown,
   events: ReadonlyArray<Event>,
   parent: ThreadCreated,
   parentRunId: string,
   callId: string,
   source: ThreadAddress
 ) => Effect.gen(function* () {
-  if (placement !== undefined && !Schema.is(ChildPlacement)(placement)) {
-    return { error: "agents.run placement must be colocated or independent" }
-  }
   const sent = events.findLastIndex((event) =>
     event.type === "PackageCalled" &&
     event.callId === callId &&
@@ -250,7 +246,7 @@ const childClaimOf = (
     throw new Error(`child ${callId} has an invalid creation record`)
   }
   const lineage: ThreadLineage = recorded === undefined
-    ? childLineageOf(parent, placement as ChildPlacement | undefined)
+    ? childLineageOf(parent)
     : {
         parent: parent.address,
         depth: recorded.depth,
@@ -357,7 +353,6 @@ export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self
               additionalProperties: false
             },
             budget: { type: "integer", description: "max tool calls before the agent must answer, a whole number of calls; keeps a research agent bounded" },
-            placement: { type: "string", enum: ["colocated", "independent"], description: "place the child relative to this thread's host" },
             escalatable: { type: "boolean", description: "true: at its budget the child may ask its parent's budget authority for more before answering" }
           },
           required: ["text"]
@@ -434,7 +429,7 @@ export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self
           }
           const self = formatThreadAddress(source)
           const a = args as
-            | { text?: unknown; background?: unknown; output?: unknown; outputSchema?: unknown; model?: unknown; budget?: unknown; escalatable?: unknown; placement?: unknown }
+            | { text?: unknown; background?: unknown; output?: unknown; outputSchema?: unknown; model?: unknown; budget?: unknown; escalatable?: unknown }
             | undefined
           const text = String(a?.text ?? "")
           if (text === "") return { error: "agents.run needs { text }" }
@@ -445,8 +440,7 @@ export const agentsPackage = (options: SpawnOptions = {}): Package<Router | Self
           if (parentRun === undefined) {
             return yield* Effect.die(new Error(`agents.run ${ctx.callId} has no parent turn`))
           }
-          const child = yield* childClaimOf(a?.placement, events, created, parentRun.turn, ctx.callId, source)
-          if ("error" in child) return child
+          const child = yield* childClaimOf(events, created, parentRun.turn, ctx.callId, source)
           const { lineage, recorded: recordedChild, target } = child
           const reference: InvocationCoordinate = recordedChild === undefined
             ? invocationCoordinateOf(target, { method: "message", id: ctx.callId, epoch: 0 })


### PR DESCRIPTION
## Problem

The model-facing `agents.run` schema exposed host placement. A model could request `independent` placement on Bun, which cannot serve that request.

## Change

Remove `placement` from the input schema, generated signature, and argument handling. New children leave placement unspecified so the host chooses its default. Replay preserves placement already recorded in child creation events.

Update the creation tests and keep the cancellation regression independent of placement by injecting a generic delivery rejection.

Validation: full gate passes.
