### PR TITLE
fix: support parallel tool calls

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -131,6 +131,12 @@ const weather = tool({
 ```
 
 When the model selects `get_weather`, Tardigrade records `ToolCalled`. The inference component finds the handler in the current view, runs its Effect, and records `ToolReturned`. The next model request includes the result.
+
+A model response can request several tools. Tardigrade records every call before dispatch, runs native tools concurrently by default, and waits for every result before the next model request. Each call has its own result. The response contributes usage once. Replay reuses committed results and retries unfinished work.
+
+`DEFAULT_TOOL_CONCURRENCY` is `"unbounded"`. Set `infer(components, { toolConcurrency: 4 })` to admit at most four pending calls at a time. Additional calls wait in recorded order. Set `concurrency: 1` on a native tool binding to serialize calls to that tool. These limits appear in the model instructions or tool description.
+
+Code mode defaults to `DEFAULT_CODE_TOOL_CONCURRENCY`, which is `1`. Set `codeMode(components, { toolConcurrency })` to control admission of `execute` calls. Code execution follows the code scheduler. Custom `Infer` bindings return `{ kind: "calls", calls: [...] }` for a batch, with a nonempty array of `{ callId, name, arguments }` entries. Single calls use `{ kind: "call", callId, name, arguments }`.
 </Tip>
 
 ### Running it locally

--- a/packages/agent/src/component/budget.ts
+++ b/packages/agent/src/component/budget.ts
@@ -270,15 +270,20 @@ const guardedTool = <R>(
   toolNames: ReadonlySet<string>,
   policy: BudgetPolicy
 ): AgentTool<R> => ({
-  spec: tool.spec,
+  ...tool,
   serve: (call, log, answer): ReadonlyArray<Transition<never, R>> => {
     const trajectory = turnView(log)
-    if (budgetSpent(trajectory)) {
+    const callIndex = trajectory.findIndex((event) => event.type === "ToolCalled" && event.callId === call.callId)
+    const admitted = callIndex === -1 ? trajectory : trajectory.slice(0, callIndex + 1)
+    const used = usedBy(admitted, toolNames)
+    const admittedBatchCall = callIndex !== -1 && trajectory[callIndex]!.batchId !== undefined &&
+      !budgetSpent(admitted) && used <= budgetOf(trajectory, policy)
+    if (budgetSpent(trajectory) && !admittedBatchCall) {
       return [answer({
         error: "Tool budget reached. Do not call this tool again. Answer now with your best result from what you have already gathered."
       })] as ReadonlyArray<Transition<never, R>>
     }
-    const wall = wallFor(trajectory, policy, usedBy(trajectory, toolNames), call.context)
+    const wall = wallFor(trajectory, policy, used, call.context)
     if (wall !== undefined) return [wall]
     return tool.serve(call, log, answer)
   }

--- a/packages/agent/src/component/code.ts
+++ b/packages/agent/src/component/code.ts
@@ -16,10 +16,12 @@ import {
   type Package
 } from "@clavia/tardigrade-code/package/definition"
 import type { AgentComponent, AgentView } from "../runtime/composition"
-import type { Answer, PendingCall } from "../runtime/tools"
+import { toolConcurrencyOf, type ToolConcurrency, type Answer, type PendingCall } from "../runtime/tools"
 import type { ToolSpec } from "../inference/request"
 
 export const DEFAULT_CODE_SUMMARY_MAX_LENGTH = 240
+// DEFAULT_CODE_TOOL_CONCURRENCY serializes execute admission (runtime/batches.test.ts).
+export const DEFAULT_CODE_TOOL_CONCURRENCY: ToolConcurrency = 1
 
 const executeTool = (summaryMaxLength: number): ToolSpec => ({
   name: "execute",
@@ -90,6 +92,7 @@ const serveCode = (log: ReadonlyArray<Event>, call: PendingCall, answer: Answer)
 }
 
 export interface CodeModeOptions {
+  readonly toolConcurrency?: ToolConcurrency
   readonly policy?: Partial<CodePolicy>
   readonly system?: string | ((log: ReadonlyArray<Event>) => string)
   readonly summaryMaxLength?: number
@@ -133,6 +136,7 @@ export const codeMode = <
   type ComponentR = ComponentRequirements<Cs[number]>
   type R = KeyValueStore.KeyValueStore | ComponentR
   const summaryMaxLength = summaryMaxLengthOf(options.summaryMaxLength)
+  const toolConcurrency = toolConcurrencyOf(options.toolConcurrency ?? DEFAULT_CODE_TOOL_CONCURRENCY)
   const combined = composeComponents("code.children", CODE_VIEW_ALGEBRA, components) as CodeComponent<ComponentR>
   const childMachine = combined.machine
   const packagesOf = (state: unknown): ReadonlyArray<Package<ComponentR>> =>
@@ -185,6 +189,7 @@ export const codeMode = <
               system: [dynamicSystem?.(Chunk.toReadonlyArray(state.history)) ?? staticSystem ?? codeSystemFor(packages)],
               tools: [{
                 spec: executeTool(summaryMaxLength),
+                concurrency: toolConcurrency,
                 serve: (call: PendingCall, current: ReadonlyArray<Event>, answer: Answer) => serveCode(current, call, answer)
               }],
               context: [],

--- a/packages/agent/src/component/compaction.ts
+++ b/packages/agent/src/component/compaction.ts
@@ -226,7 +226,10 @@ export const keepFromIndex = (events: ReadonlyArray<Event>, keepFrom: string): n
   for (let i = 0; i < events.length; i++) {
     const e = events[i]!
     const v = e as { callId?: unknown; id?: unknown }
-    if (keepFrom.startsWith("c:") && e.type === "ToolCalled" && JSON.stringify([e.turn ?? null, v.callId]) === keepFrom.slice(2)) return i
+    if (keepFrom.startsWith("c:") && e.type === "ToolCalled" && JSON.stringify([e.turn ?? null, v.callId]) === keepFrom.slice(2)) {
+      if (e.batchId === undefined) return i
+      return events.findIndex((event) => event.type === "ToolCalled" && event.turn === e.turn && event.epoch === e.epoch && event.batchId === e.batchId)
+    }
     if (keepFrom.startsWith("m:") && e.type === "MessageReceived" && String(v.id) === keepFrom.slice(2)) return i
   }
   return 0
@@ -259,7 +262,7 @@ const atRoundBoundary = (log: ReadonlyArray<Event>): boolean => {
 // names an event the projection cannot see, so it is no boundary.
 const boundaryIdOf = (e: Event, served: ReadonlySet<string>): string | undefined => {
   const v = e as { callId?: unknown; id?: unknown }
-  if (e.type === "ToolCalled") return `c:${JSON.stringify([e.turn ?? null, v.callId])}`
+  if (e.type === "ToolCalled" && (e.batchIndex === undefined || e.batchIndex === 0)) return `c:${JSON.stringify([e.turn ?? null, v.callId])}`
   if (e.type === "MessageReceived" && served.has(String(v.id))) return `m:${String(v.id)}`
   return undefined
 }

--- a/packages/agent/src/component/permissions.ts
+++ b/packages/agent/src/component/permissions.ts
@@ -35,7 +35,7 @@ const permissionCallId = (turn: string, callId: string): string =>
   `permission/${turn}/${callId}`
 
 const guardedTool = <R>(tool: AgentTool<R>, options: PermissionsOptions): AgentTool<R | Router | Self> => ({
-  spec: tool.spec,
+  ...tool,
   serve: (pending, log, answer): ReadonlyArray<Transition<never, R | Router | Self>> => {
     const subject = options.request({
       callId: pending.callId,

--- a/packages/agent/src/component/tool.ts
+++ b/packages/agent/src/component/tool.ts
@@ -4,9 +4,11 @@ import type { Event } from "@clavia/tardigrade-core/log/event"
 import { toolReturned } from "../log/events"
 import type { ToolSpec } from "../inference/request"
 import type { AgentComponent, AgentTool } from "../runtime/composition"
+import { toolConcurrencyOf, type ToolConcurrency } from "../runtime/tools"
 
 // NativeTool describes one named tool whose effect returns its model-visible result.
 export interface NativeTool<R = never> {
+  readonly concurrency?: ToolConcurrency
   readonly spec: ToolSpec
   readonly run: (input: unknown, context: { readonly callId: string; readonly turn?: string; readonly signal: AbortSignal }) => Effect.Effect<unknown, never, R>
 }
@@ -28,10 +30,12 @@ export const tool = <R = never>(
         ],
         tools: tools.map((tool): AgentTool<R> => ({
           spec: tool.spec,
+          concurrency: toolConcurrencyOf(tool.concurrency),
           serve: (call) => {
             const stamp = call.turn === undefined ? {} : { turn: call.turn }
             return [
               call.context.effect("answer", {
+                concurrent: true,
                 ...(call.turn === undefined
                   ? {}
                   : { invocation: { method: "message", id: call.turn, epoch: call.epoch ?? 0 } }),

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -104,7 +104,7 @@ export {
 } from "./component/repair"
 export { nativeOutput } from "./component/native-output"
 export { DEFAULT_BUDGET_POLICY, type BudgetPolicy } from "./component/budget"
-export { toolsReactorFrom, type Answer, type PendingCall, type Serve } from "./runtime/tools"
+export { toolsReactorFrom, DEFAULT_TOOL_CONCURRENCY, type ToolConcurrency, type Answer, type PendingCall, type Serve } from "./runtime/tools"
 export {
   compactionReactor,
   contextPolicyOf,
@@ -160,6 +160,7 @@ export {
   CODE_SYSTEM,
   codeSystemFor,
   DEFAULT_CODE_SUMMARY_MAX_LENGTH,
+  DEFAULT_CODE_TOOL_CONCURRENCY,
   type CodeModeOptions
 } from "./component/code"
 export { system, type SystemProjection, type SystemText } from "./component/system"

--- a/packages/agent/src/inference/machine.ts
+++ b/packages/agent/src/inference/machine.ts
@@ -173,7 +173,7 @@ const completionOf = (action: Action & { readonly kind: "complete" }, usage: unk
 // usageIn reads the spend as unknown rather than absent (usage.test.ts, "unknown is sticky").
 // `endpoint` is separate from spend on purpose: an endpoint that reports no tokens still has to
 // be named in the log (events.ts, Endpoint).
-const consequenceOf = (action: Action, ctx: Consequence): Event => {
+const consequenceOf = (action: Exclude<Action, { readonly kind: "calls" }>, ctx: Consequence): Event => {
   const usage = action.usage ?? {}
   if (action.kind === "call" && ctx.contract !== undefined && action.mode === undefined) {
     return {
@@ -222,6 +222,19 @@ const consequenceOf = (action: Action, ctx: Consequence): Event => {
           ...stampOf(action),
           at: ctx.at
         } as Event)
+}
+
+// consequencesOf records a batch in provider order with one usage entry (runtime/batches.test.ts).
+const consequencesOf = (action: Action, ctx: Consequence): ReadonlyArray<Event> => {
+  if (action.kind !== "calls") return [consequenceOf(action, ctx)]
+  if (ctx.contract !== undefined && action.mode === undefined) {
+    return [consequenceOf({ ...action, ...action.calls[0], kind: "call" }, ctx)]
+  }
+  return action.calls.map((call, index) => {
+    const event = consequenceOf({ ...action, ...call, kind: "call" }, ctx)
+    const { usage, ...rest } = event
+    return { ...rest, batchId: ctx.attempt, batchIndex: index, ...(index === 0 ? { usage } : {}) } as Event
+  })
 }
 
 const failureMessage = (cause: Cause.Cause<never>): string => {
@@ -308,7 +321,7 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
   // A rejected response is a spent logical attempt: the next ask must not reuse the idempotency
   // key, or a deduping provider answers the correction with the response it just refused.
   const rejected = rejectionsIn(slice).length
-  const logicalAttempt = slice.filter((e) => e.type === "ToolCalled").length + modelFailures + rejected
+  const logicalAttempt = slice.filter((e) => e.type === "ToolCalled" && (e.batchIndex === undefined || e.batchIndex === 0)).length + modelFailures + rejected
   const attempt = `${turn}/infer/${logicalAttempt}`
   const rendered = derived.rendered
   const fallback = rendered.output?.fallback
@@ -502,22 +515,28 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
               )
             )
           const after = yield* Clock.currentTimeMillis
-          const duplicate = action.kind === "call" && trajectory.some((event) =>
-            event.type === "ToolCalled" && event.turn === input.turn && event.callId === action.callId)
-          const checked: Action = duplicate ? {
-            kind: "fail", error: `duplicate tool call ID ${JSON.stringify(action.callId)} within turn ${JSON.stringify(input.turn)}`,
+          const calls = action.kind === "calls" ? action.calls : action.kind === "call" ? [action] : []
+          const seen = new Set(trajectory.filter((event) => event.type === "ToolCalled" && event.turn === input.turn).map((event) => String(event.callId)))
+          const duplicate = calls.find((call) => {
+            if (seen.has(call.callId)) return true
+            seen.add(call.callId)
+            return false
+          })
+          const invalid = action.kind === "calls" && calls.length === 0
+          const checked: Action = duplicate !== undefined || invalid ? {
+            kind: "fail", error: duplicate === undefined ? "the model returned an empty tool batch" : `duplicate tool call ID ${JSON.stringify(duplicate.callId)} within turn ${JSON.stringify(input.turn)}`,
             ...(action.usage === undefined ? {} : { usage: action.usage }),
             ...(action.endpoint === undefined ? {} : { endpoint: action.endpoint }),
             failure: { cause: "inference_error", attempts: 1 }
           } : action
-          const consequence = consequenceOf(checked, {
+          const consequences = consequencesOf(checked, {
             turn: input.turn,
             epoch: input.epoch,
             attempt: input.attempt,
             at: after,
             contract: input.contract
           })
-          const repaired = consequence.type === "TurnCompleted"
+          const repaired = consequences.some((event) => event.type === "TurnCompleted")
             ? trajectory.filter((event) => {
                 if (event.type !== "OutputRejected") return false
                 const value = event as { readonly turn?: unknown; readonly epoch?: unknown; readonly mode?: unknown }
@@ -529,7 +548,7 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
               })
             : []
           return [
-            ...(action.kind === "call" && action.text !== undefined && action.text !== ""
+            ...((action.kind === "call" || action.kind === "calls") && action.text !== undefined && action.text !== ""
               ? [textReturned({ text: action.text, turn: input.turn, at: after })]
               : []),
             ...repaired.map((event) => outputRepaired({
@@ -539,7 +558,7 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
               ...epochStamp(input.epoch),
               at: after
             })),
-            consequence
+            ...consequences
           ]
         })
     })

--- a/packages/agent/src/log/events.ts
+++ b/packages/agent/src/log/events.ts
@@ -49,6 +49,8 @@ export const ToolCalled = Schema.Struct({
   callId: Schema.String,
   name: Schema.String,
   arguments: Schema.Unknown,
+  batchId: Schema.optional(Schema.String),
+  batchIndex: Schema.optional(Schema.Finite),
   // The spend of the attempt this call answered (packages/agent/src/inference/usage.ts). An empty object
   // is an attempt with unreported spend; an absent field is an event no attempt produced.
   usage: Schema.optional(Schema.Unknown),
@@ -380,8 +382,16 @@ type Served = {
   readonly mode?: import("../output/contract").OutputMode
 }
 
+// ToolCall identifies one requested tool operation within a model response.
+export interface ToolCall {
+  readonly callId: string
+  readonly name: string
+  readonly arguments: unknown
+}
+
 export type Action =
   | ({ readonly kind: "call"; readonly callId: string; readonly name: string; readonly arguments: unknown; readonly text?: string } & Served)
+  | ({ readonly kind: "calls"; readonly calls: readonly [ToolCall, ...ToolCall[]]; readonly text?: string } & Served)
   | ({ readonly kind: "complete"; readonly output: string } & Served)
   | ({
       readonly kind: "fail"

--- a/packages/agent/src/projection/messages.ts
+++ b/packages/agent/src/projection/messages.ts
@@ -72,6 +72,23 @@ const messagesFrom = (
   )
   if (openHead !== -1 && openHead < from) messages.push(userMessageOf(projected[openHead]!, resolved))
   if (checkpoint.summary !== "") messages.push({ role: "user", content: `Summary of earlier work:\n${checkpoint.summary}` })
+  const batchKey = (event: Event): string | undefined => event.batchId === undefined
+    ? undefined
+    : JSON.stringify([event.turn ?? null, event.epoch ?? 0, event.batchId])
+  const batches = new Map<string, AgentToolCall[]>()
+  const callOf = (event: Event): AgentToolCall => ({
+    id: String(event.callId),
+    name: String(event.name),
+    arguments: JSON.stringify(event.arguments ?? {})
+  })
+  for (const event of projected.slice(from)) {
+    const key = batchKey(event)
+    if (event.type !== "ToolCalled" || key === undefined) continue
+    const calls = batches.get(key) ?? []
+    calls.push(callOf(event))
+    batches.set(key, calls)
+  }
+  const emitted = new Set<string>()
   let pendingText: string | null = null
   for (const event of projected.slice(from)) {
     const value = event as Record<string, unknown>
@@ -82,18 +99,18 @@ const messagesFrom = (
       case "TextReturned":
         pendingText = String(value.text ?? "")
         break
-      case "ToolCalled":
+      case "ToolCalled": {
+        const key = batchKey(event)
+        if (key !== undefined && emitted.has(key)) break
+        if (key !== undefined) emitted.add(key)
         messages.push({
           role: "assistant",
           content: pendingText,
-          toolCalls: [{
-            id: String(value.callId),
-            name: String(value.name),
-            arguments: JSON.stringify(value.arguments ?? {})
-          }]
+          toolCalls: key === undefined ? [callOf(event)] : batches.get(key)!
         })
         pendingText = null
         break
+      }
       case "ToolReturned": {
         const body = JSON.stringify(value.result ?? null)
         messages.push({

--- a/packages/agent/src/runtime/batches.test.ts
+++ b/packages/agent/src/runtime/batches.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+import { KeyValueStore } from "effect/unstable/persistence"
+import { actor } from "@clavia/tardigrade-core/actor"
+import type { Event } from "@clavia/tardigrade-core/log/event"
+import { createHost } from "@clavia/tardigrade-host/host"
+import { agentMethods, budget, codeMode, infer, nativeOutput, tool } from "../index"
+import { jsSandboxFor } from "@clavia/tardigrade-code/sandbox/defaults"
+import { Infer, NativeOutputSupport, type InferRequest } from "../inference/contract"
+import { usageIn } from "../inference/usage"
+import type { Action, ToolCall } from "../log/events"
+import { renderMessages } from "../projection/messages"
+import { compactionReactor, keepFromIndex } from "../component/compaction"
+import { boundaryOf } from "../output/boundary"
+import { cancellationRequested } from "@clavia/tardigrade-core/interaction/cancellation"
+import type { AgentComponent, InferOptions } from "./composition"
+import type { AgentR } from "./turn"
+
+const MODEL = { models: { default: { provider: "test", model_id: "batch" }, allow: "*" } } as const
+const ROOT = "ag.root"
+const TURN = "m1"
+const call = (callId: string, name = "read"): ToolCall => ({ callId, name, arguments: { path: callId } })
+const batch = (...calls: [ToolCall, ...ToolCall[]]): Action => ({ kind: "calls", calls, usage: { promptTokens: 100, completionTokens: 20, costUsd: 0.01 } })
+const spec = { name: "read", description: "Read a file.", inputSchema: {} }
+
+const setup = (
+  components: ReadonlyArray<AgentComponent<never> | AgentComponent<AgentR>>,
+  mind: (request: InferRequest, key?: string) => Action,
+  options: InferOptions = {},
+  seed: ReadonlyArray<Event> = []
+) => {
+  const assembled = actor({ name: "batch-agent", methods: agentMethods, components: [infer([...components, nativeOutput], { ...MODEL, ...options })] })
+  const host = createHost<AgentR | NativeOutputSupport>({
+    actorName: "batch-agent",
+    actorFor: () => assembled,
+    layersFor: () => Layer.mergeAll(
+      KeyValueStore.layerMemory,
+      jsSandboxFor({}),
+      Layer.succeed(Infer, { react: (request, key) => Effect.sync(() => mind(request, key)) }),
+      Layer.succeed(NativeOutputSupport, { withTools: true })
+    )
+  })
+  if (seed.length > 0) host.seed(ROOT, seed)
+  return {
+    host,
+    read: () => host.read(ROOT),
+    start: async () => {
+      await host.commitRoot(host.self(ROOT), { type: "MessageReceived", id: TURN, text: "Read the files", at: 1 })
+      await host.drive()
+    }
+  }
+}
+
+const complete = (): Action => ({ kind: "complete", output: "done", usage: { promptTokens: 50, completionTokens: 5, costUsd: 0.005 } })
+
+describe("tool batches", () => {
+  test("default dispatch overlaps calls and waits for every result before inference", async () => {
+    const first = Promise.withResolvers<void>()
+    const second = Promise.withResolvers<void>()
+    const bothStarted = Promise.withResolvers<void>()
+    const started: string[] = []
+    const keys: Array<string | undefined> = []
+    const run = setup([tool({ spec, run: (_input, context) => Effect.promise(async () => {
+      started.push(context.callId)
+      if (started.length === 2) bothStarted.resolve()
+      await (context.callId === "lease" ? first.promise : second.promise)
+      return context.callId
+    }) })], (request, key) => {
+      keys.push(key)
+      if (keys.length === 1) return { ...batch(call("lease"), call("amendment")), text: "Reading both files." }
+      expect(request.trajectory.filter((event) => event.type === "ToolReturned")).toHaveLength(2)
+      return complete()
+    })
+    const driving = run.start()
+    try {
+      await bothStarted.promise
+      expect(started).toEqual(["lease", "amendment"])
+      second.resolve()
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      expect(keys).toHaveLength(1)
+      expect(run.read().filter((event) => event.type === "ToolReturned").map((event) => event.callId)).toEqual(["amendment"])
+    } finally {
+      first.resolve()
+      second.resolve()
+      await driving
+    }
+    expect(keys).toEqual(["m1/infer/0", "m1/infer/1"])
+    expect(usageIn(run.read(), TURN)).toMatchObject({ promptTokens: 150, completionTokens: 25, costUsd: 0.015 })
+    expect(renderMessages(run.read()).filter((message) => message.role !== "user")).toEqual([
+      { role: "assistant", content: "Reading both files.", toolCalls: [
+        { id: "lease", name: "read", arguments: '{"path":"lease"}' },
+        { id: "amendment", name: "read", arguments: '{"path":"amendment"}' }
+      ] },
+      { role: "tool", toolCallId: "amendment", content: '"amendment"' },
+      { role: "tool", toolCallId: "lease", content: '"lease"' },
+      { role: "assistant", content: "done" }
+    ])
+  })
+
+  test.each(["root", "tool"] as const)("the %s concurrency limit queues every excess call", async (surface) => {
+    let active = 0
+    let peak = 0
+    const order: string[] = []
+    const run = setup([tool({
+      spec,
+      ...(surface === "tool" ? { concurrency: 1 } : {}),
+      run: (_input, context) => Effect.promise(async () => {
+        active += 1
+        peak = Math.max(peak, active)
+        order.push(context.callId)
+        await new Promise((resolve) => setTimeout(resolve, 1))
+        active -= 1
+        return context.callId
+      })
+    })], (request) => {
+      const instruction = surface === "root" ? request.system : request.tools[0]!.description
+      expect(instruction).toContain("at most 1 pending call")
+      return request.trajectory.some((event) => event.type === "ToolCalled") ? complete() : batch(call("z"), call("a"), call("b"))
+    }, surface === "root" ? { toolConcurrency: 1 } : {})
+    await run.start()
+    expect(peak).toBe(1)
+    expect(order).toEqual(["z", "a", "b"])
+    expect(run.read().filter((event) => event.type === "ToolReturned")).toHaveLength(3)
+  })
+
+  test("replay reuses committed results and runs only unfinished calls", async () => {
+    const hold = Promise.withResolvers<void>()
+    const bothStarted = Promise.withResolvers<void>()
+    let started = 0
+    const original = setup([tool({ spec, run: (_input, context) => Effect.promise(async () => {
+      started += 1
+      if (started === 2) bothStarted.resolve()
+      if (context.callId === "second") await hold.promise
+      return context.callId
+    }) })], (request) => request.trajectory.some((event) => event.type === "ToolCalled") ? complete() : batch(call("first"), call("second")))
+    const driving = original.start()
+    try {
+      await bothStarted.promise
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      const saved = original.read()
+      expect(saved.filter((event) => event.type === "ToolReturned").map((event) => event.callId)).toEqual(["first"])
+      const rerun: string[] = []
+      const recovered = setup([tool({ spec, run: (_input, context) => Effect.sync(() => {
+        rerun.push(context.callId)
+        return context.callId
+      }) })], (request, key) => {
+        expect(key).toBe("m1/infer/1")
+        expect(request.trajectory.filter((event) => event.type === "ToolReturned")).toHaveLength(2)
+        return complete()
+      }, {}, saved)
+      await recovered.host.wake(ROOT)
+      await recovered.host.drive()
+      expect(rerun).toEqual(["second"])
+      expect(boundaryOf(recovered.read(), TURN)?.kind).toBe("completed")
+    } finally {
+      hold.resolve()
+      await driving
+    }
+  })
+
+  test("duplicate IDs reject the whole response before dispatch", async () => {
+    let ran = 0
+    const run = setup([tool({ spec, run: () => Effect.sync(() => ++ran) })], () => batch(call("same"), call("same")))
+    await run.start()
+    expect(ran).toBe(0)
+    expect(run.read().filter((event) => event.type === "ToolCalled")).toHaveLength(0)
+    expect(boundaryOf(run.read(), TURN)).toMatchObject({ kind: "failed", error: 'duplicate tool call ID "same" within turn "m1"' })
+    expect(usageIn(run.read(), TURN).promptTokens).toBe(100)
+  })
+
+  test("cancellation settles every open batch call and excludes late results", async () => {
+    const started = Promise.withResolvers<void>()
+    const release = Promise.withResolvers<void>()
+    let count = 0
+    let inferred = 0
+    const run = setup([tool({ spec, run: () => Effect.promise(async () => {
+      count += 1
+      if (count === 2) started.resolve()
+      await release.promise
+      return "late"
+    }) })], () => {
+      inferred += 1
+      return batch(call("a"), call("b"))
+    })
+    const driving = run.start()
+    try {
+      await started.promise
+      await run.host.commitRoot(run.host.self(ROOT), cancellationRequested({
+        request: "cancel-1", invocation: { method: "message", id: TURN, epoch: 0 }, cause: "requested", at: 2
+      }))
+      await driving
+      expect(inferred).toBe(1)
+      expect(run.read().filter((event) => event.type === "ToolReturned").map((event) => event.result)).toEqual([{ error: "cancelled" }, { error: "cancelled" }])
+      expect(run.read().filter((event) => event.type === "TurnCancelled")).toHaveLength(1)
+    } finally {
+      release.resolve()
+      await driving
+    }
+  })
+
+  test("an unknown tool and a returned error each settle without losing sibling results", async () => {
+    const run = setup([tool({ spec, run: () => Effect.succeed({ error: "file missing" }) })], (request) =>
+      request.trajectory.some((event) => event.type === "ToolCalled") ? complete() : batch(call("missing", "unknown"), call("known")))
+    await run.start()
+    const results = run.read().filter((event) => event.type === "ToolReturned")
+    expect(results).toHaveLength(2)
+    expect(results[0]!.result).toMatchObject({ error: "unknown tool: unknown. Call one of: read." })
+    expect(results[1]!.result).toEqual({ error: "file missing" })
+    expect(boundaryOf(run.read(), TURN)?.kind).toBe("completed")
+  })
+
+  test("a batch crossing the budget runs its allowed prefix and answers every call", async () => {
+    const ran: string[] = []
+    const run = setup([budget([tool({ spec, run: (_input, context) => Effect.sync(() => {
+      ran.push(context.callId)
+      return context.callId
+    }) })], { limit: 2 })], (request) => request.trajectory.some((event) => event.type === "ToolCalled") ? complete() : batch(call("1"), call("2"), call("3")))
+    await run.start()
+    expect(ran).toEqual(["1", "2"])
+    expect(run.read().filter((event) => event.type === "ToolReturned")).toHaveLength(3)
+    expect(run.read().filter((event) => event.type === "BudgetExhausted")).toHaveLength(1)
+  })
+
+  test("code mode retains and settles every execute call", async () => {
+    const run = setup([codeMode()], (request) => request.trajectory.some((event) => event.type === "ToolCalled") ? complete() : batch(
+      { callId: "code-1", name: "execute", arguments: { code: "return 1" } },
+      { callId: "code-2", name: "execute", arguments: { code: "return 2" } }
+    ))
+    await run.start()
+    expect(run.read().filter((event) => event.type === "ToolReturned").map((event) => event.result)).toEqual([{ result: 1 }, { result: 2 }])
+  })
+
+  test("a budget wall lets admitted code finish beside refused batch calls", async () => {
+    const run = setup([budget([codeMode(), tool({ spec, run: () => Effect.succeed("read") })], { limit: 1 })], (request) =>
+      request.trajectory.some((event) => event.type === "ToolCalled") ? complete() : batch(
+        { callId: "code", name: "execute", arguments: { code: "return 42" } }, call("refused")
+      ))
+    await run.start()
+    expect(run.read().find((event) => event.type === "ToolReturned" && event.callId === "code")?.result).toEqual({ result: 42 })
+    expect(run.read().filter((event) => event.type === "ToolReturned")).toHaveLength(2)
+  })
+
+  test("compaction keeps a complete batch even when a checkpoint names a later call", () => {
+    const history: Event[] = [
+      { type: "MessageReceived", id: TURN, text: "work", at: 0 },
+      { type: "ToolCalled", turn: TURN, callId: "a", name: "read", arguments: {}, batchId: "m1/infer/0", batchIndex: 0, at: 1 },
+      { type: "ToolCalled", turn: TURN, callId: "b", name: "read", arguments: {}, batchId: "m1/infer/0", batchIndex: 1, at: 1 },
+      { type: "ToolReturned", turn: TURN, callId: "b", result: "x".repeat(500), at: 2 }
+    ]
+    const reactor = compactionReactor({ contextWindowTokens: 100, fireRatio: 0.5, keepRatio: 0.1 })
+    expect(reactor(history)).toEqual([])
+    history.push({ type: "ToolReturned", turn: TURN, callId: "a", result: "x".repeat(500), at: 3 })
+    const transitions = reactor(history)
+    expect(transitions).toHaveLength(1)
+    expect(transitions[0]!.input).toMatchObject({ keepFrom: 'c:["m1","a"]' })
+    expect(keepFromIndex(history, 'c:["m1","b"]')).toBe(1)
+    history.push({ type: "CompactionCompleted", keepFrom: 'c:["m1","b"]', summary: "Earlier work", at: 4 })
+    expect(renderMessages(history).find((message) => message.toolCalls)?.toolCalls?.map((entry) => entry.id)).toEqual(["a", "b"])
+  })
+
+  test.each([0, -1, 1.5, Infinity, NaN])("invalid concurrency %s fails at construction", (value) => {
+    expect(() => infer([nativeOutput], { ...MODEL, toolConcurrency: value })).toThrow("tool concurrency")
+    expect(() => infer([tool({ spec, concurrency: value, run: () => Effect.void }), nativeOutput], MODEL)).toThrow("tool concurrency")
+  })
+})

--- a/packages/agent/src/runtime/composition.ts
+++ b/packages/agent/src/runtime/composition.ts
@@ -10,7 +10,7 @@ import { agentKeys } from "../log/events"
 import type { InferPolicy } from "../inference/contract"
 import { inferenceMachine } from "../inference/machine"
 import { modelPolicyOverrideOf, type ModelPolicyOverride } from "../inference/access"
-import { incrementalToolsComponentFrom, type Answer, type PendingCall } from "./tools"
+import { incrementalToolsComponentFrom, toolConcurrencyOf, toolConcurrencyInstruction, DEFAULT_TOOL_CONCURRENCY, type ToolConcurrency, type Answer, type PendingCall } from "./tools"
 import type { ContextPolicy } from "../component/compaction"
 import type { AgentR } from "./turn"
 import { agentMessageMethod } from "../actor/message"
@@ -18,6 +18,7 @@ import { agentMessageMethod } from "../actor/message"
 // AgentTool pairs one model-visible tool specification with the handler for calls to that tool.
 // A derived tool is therefore advertised and routable from the same value.
 export interface AgentTool<R = never> {
+  readonly concurrency?: ToolConcurrency
   readonly spec: ToolSpec
   readonly serve: (
     call: PendingCall,
@@ -134,6 +135,7 @@ const contextOf = (fragments: ReadonlyArray<ContextFragment>): Partial<ContextPo
 const checkedTools = (tools: ReadonlyArray<AgentTool<unknown>>): ReadonlyArray<AgentTool<unknown>> => {
   const names = new Set<string>()
   for (const tool of tools) {
+    toolConcurrencyOf(tool.concurrency)
     if (names.has(tool.spec.name)) throw new Error(`tool "${tool.spec.name}" declared more than once`)
     names.add(tool.spec.name)
   }
@@ -156,11 +158,14 @@ export interface Rendered {
   readonly output?: { readonly fallback: OutputFallback; readonly system?: string }
 }
 
-const renderView = (view: AgentView): Rendered => {
+const renderView = (view: AgentView, concurrency: ToolConcurrency = DEFAULT_TOOL_CONCURRENCY): Rendered => {
   const fragment = outputFrom(view.output)
   return {
-    system: view.system.filter((piece) => piece !== "").join("\n"),
-    tools: checkedTools(view.tools).map((tool) => tool.spec),
+    system: [...view.system, toolConcurrencyInstruction(toolConcurrencyOf(concurrency))].filter((piece) => piece !== "").join("\n"),
+    tools: checkedTools(view.tools).map((tool) => {
+      const instruction = toolConcurrencyInstruction(toolConcurrencyOf(tool.concurrency))
+      return instruction === "" ? tool.spec : { ...tool.spec, description: `${tool.spec.description}\n${instruction}` }
+    }),
     context: contextOf(view.context),
     ...(fragment.kind === "native"
       ? {}
@@ -176,9 +181,10 @@ const renderView = (view: AgentView): Rendered => {
 // renderOf derives the model request from the same component view that routing reads.
 export const renderOf = <const Cs extends ReadonlyArray<AgentComponent<never> | AgentComponent<unknown>>>(
   components: Cs,
-  log: ReadonlyArray<Event>
+  log: ReadonlyArray<Event>,
+  options: Pick<InferOptions, "toolConcurrency"> = {}
 ): Rendered =>
-  renderView(viewFrom(components, log))
+  renderView(viewFrom(components, log), options.toolConcurrency)
 
 const rootKeys = (children: KeyFragment | undefined): KeyFragment => {
   const fragments = [messageKeys, agentKeys, ...(children === undefined ? [] : [children])]
@@ -188,9 +194,10 @@ const rootKeys = (children: KeyFragment | undefined): KeyFragment => {
   }
 }
 
-// InferOptions declares model authority and retry policy for an infer root.
+// InferOptions declares model authority, retry policy, and tool admission for an infer root.
 export interface InferOptions extends Partial<Omit<InferPolicy, "models">> {
   readonly models?: ModelPolicyOverride
+  readonly toolConcurrency?: ToolConcurrency
 }
 
 // infer composes an agent's child components and adds the model loop over their final view.
@@ -206,19 +213,20 @@ export const infer = <
   type R = AgentR | ComponentR
   const combined = composeComponents("infer.children", AGENT_VIEW_ALGEBRA, components) as AgentComponent<ComponentR>
   const childMachine = combined.machine
-  renderView(childMachine.output(childMachine.initial()).view)
-  const { models: rawModels, ...policy } = options
+  const { models: rawModels, toolConcurrency, ...policy } = options
+  renderView(childMachine.output(childMachine.initial()).view, toolConcurrency)
   const models = modelPolicyOverrideOf(rawModels)
   const inferPolicy = { ...policy, models }
   const incrementalInference = inferenceMachine(inferPolicy, {
     initial: childMachine.initial,
     step: childMachine.step,
-    output: (state) => renderView(childMachine.output(state).view)
+    output: (state) => renderView(childMachine.output(state).view, toolConcurrency)
   }) as TransitionProjection<unknown, R>
   const incrementalTools = incrementalToolsComponentFrom(
     AGENT_VIEW_ALGEBRA.empty,
     childMachine,
-    (view) => checkedTools(view.tools) as ReadonlyArray<AgentTool<R>>
+    (view) => checkedTools(view.tools) as ReadonlyArray<AgentTool<R>>,
+    toolConcurrency
   )
   const toolsMachine = incrementalTools.machine
   const root = component({

--- a/packages/agent/src/runtime/refinement.properties.test.ts
+++ b/packages/agent/src/runtime/refinement.properties.test.ts
@@ -146,11 +146,12 @@ const completeAgent = (
   const tools = toolsComponentFrom(
     AGENT_VIEW_ALGEBRA.empty,
     serve,
-    (log, call) => offeredTools(log, call).map((tool) => tool.spec)
+    (log, call) => offeredTools(log, call).map((tool) => ({ ...tool.spec, ...(tool.concurrency === undefined ? {} : { concurrency: tool.concurrency }) })),
+    options.toolConcurrency
   ) as AgentComponent<unknown>
   const inference = inferenceFromHistory(
     { ...options, models: options.models ?? {} },
-    (log) => renderOf(components, log)
+    (log) => renderOf(components, log, options)
   )
   return {
     derive: (log) => {
@@ -171,13 +172,24 @@ const completeAgent = (
   }
 }
 
-type TurnKind = "complete" | "tool" | "failed" | "cancelled" | "compacted"
+type TurnKind = "complete" | "tool" | "batch" | "failed" | "cancelled" | "compacted"
 
 const eventsFor = (kinds: ReadonlyArray<TurnKind>): ReadonlyArray<Event> => kinds.flatMap((kind, index) => {
   const turn = `m${index}`
   const at = index * 20
   const head = { type: "MessageReceived", id: turn, text: `request ${index}`, model: MODEL, at } as Event
   const called = { type: "ModelCalled", callId: `${turn}/infer/0`, turn, model: MODEL, at: at + 1 } as Event
+  if (kind === "batch") {
+    return [
+      head, called,
+      { type: "ToolCalled", callId: "z", name: "execute", arguments: { code: "return 1" }, turn, batchId: `${turn}/infer/0`, batchIndex: 0, at: at + 2 },
+      { type: "ToolCalled", callId: "a", name: "execute", arguments: { code: "return 2" }, turn, batchId: `${turn}/infer/0`, batchIndex: 1, at: at + 2 },
+      { type: "ToolReturned", callId: "a", result: 2, turn, at: at + 3 },
+      { type: "ToolReturned", callId: "z", result: 1, turn, at: at + 4 },
+      { type: "ModelCalled", callId: `${turn}/infer/1`, turn, model: MODEL, at: at + 5 },
+      { type: "TurnCompleted", turn, output: `answer ${index}`, at: at + 6 }
+    ] as ReadonlyArray<Event>
+  }
   if (kind === "complete") {
     return [head, called, { type: "TurnCompleted", turn, output: `answer ${index}`, at: at + 2 } as Event]
   }
@@ -210,7 +222,7 @@ const eventsFor = (kinds: ReadonlyArray<TurnKind>): ReadonlyArray<Event> => kind
 })
 
 const historyArbitrary = fc.array(
-  fc.constantFrom<TurnKind>("complete", "tool", "failed", "cancelled", "compacted"),
+  fc.constantFrom<TurnKind>("complete", "tool", "batch", "failed", "cancelled", "compacted"),
   { maxLength: 5 }
 ).map(eventsFor)
 

--- a/packages/agent/src/runtime/tools.ts
+++ b/packages/agent/src/runtime/tools.ts
@@ -17,7 +17,45 @@ import {
   type TurnProjectionState
 } from "@clavia/tardigrade-code/execution/turn-projection"
 
-// PendingCall identifies the head unanswered ToolCalled event.
+// ToolConcurrency limits admitted calls while the remaining calls stay pending (batches.test.ts).
+export type ToolConcurrency = number | "unbounded"
+
+// DEFAULT_TOOL_CONCURRENCY admits every pending call unless the consumer supplies a limit.
+export const DEFAULT_TOOL_CONCURRENCY: ToolConcurrency = "unbounded"
+
+// toolConcurrencyOf validates the dispatch limit at construction.
+export const toolConcurrencyOf = (value: ToolConcurrency = DEFAULT_TOOL_CONCURRENCY): ToolConcurrency => {
+  if (value !== "unbounded" && (!Number.isSafeInteger(value) || value < 1)) {
+    throw new Error("tool concurrency must be a positive safe integer or unbounded")
+  }
+  return value
+}
+
+// toolConcurrencyInstruction describes the queue policy applied to model requests.
+export const toolConcurrencyInstruction = (value: ToolConcurrency): string =>
+  value === "unbounded" ? "" : `Tool execution admits at most ${value} pending call${value === 1 ? "" : "s"} at a time. Additional calls wait in order and each receives a result.`
+
+const admitted = <T>(
+  records: ReadonlyArray<T>,
+  concurrency: ToolConcurrency,
+  callOf: (record: T) => PendingCall,
+  limitOf: (record: T) => ToolConcurrency | undefined
+): ReadonlyArray<T> => {
+  const counts = new Map<string, number>()
+  const selected: T[] = []
+  for (const record of records) {
+    if (concurrency !== "unbounded" && selected.length >= concurrency) break
+    const name = callOf(record).name
+    const count = counts.get(name) ?? 0
+    const limit = toolConcurrencyOf(limitOf(record))
+    if (limit !== "unbounded" && count >= limit) continue
+    counts.set(name, count + 1)
+    selected.push(record)
+  }
+  return selected
+}
+
+// PendingCall identifies an unanswered ToolCalled event.
 export interface PendingCall {
   readonly callId: string
   readonly context: TransitionContext
@@ -44,32 +82,20 @@ const contextFor = (event: Event): TransitionContext => bindTransitionContext(ev
 
 const str = (v: unknown): string => String(v ?? "")
 
-// pendingCall returns the earliest unanswered ToolCalled event by time and call ID.
-const pendingCall = (log: ReadonlyArray<Event>): PendingCall | undefined => {
-  const answered = new Set(
-    log.filter((e) => e.type === "ToolReturned").map(callKey)
-  )
-  const head = log
-    .filter((e) => {
-      if (e.type !== "ToolCalled" || answered.has(callKey(e))) return false
-      const turn = (e as { turn?: unknown }).turn
-      return turn === undefined || turnTerminalOf(log, String(turn)) === undefined
-    })
-    .sort((a, b) => {
-      const d = Number((a as { at?: unknown }).at ?? 0) - Number((b as { at?: unknown }).at ?? 0)
-      const ai = str((a as { callId?: unknown }).callId)
-      const bi = str((b as { callId?: unknown }).callId)
-      return d !== 0 ? d : ai < bi ? -1 : 1
-    })[0] as Event | undefined
-  if (head === undefined) return undefined
-  return {
-    callId: str(head.callId),
-    context: contextFor(head),
-    name: str(head.name),
-    arguments: head.arguments,
-    ...(head.turn === undefined ? {} : { turn: str(head.turn) }),
-    ...(typeof head.epoch === "number" ? { epoch: head.epoch } : {})
-  }
+// pendingCalls returns unanswered calls in recorded order.
+const pendingCalls = (log: ReadonlyArray<Event>): ReadonlyArray<PendingCall> => {
+  const answered = new Set(log.filter((e) => e.type === "ToolReturned").map(callKey))
+  return log.filter((e) => {
+    if (e.type !== "ToolCalled" || answered.has(callKey(e))) return false
+    return e.turn === undefined || turnTerminalOf(log, String(e.turn)) === undefined
+  }).map((event) => ({
+    callId: str(event.callId),
+    context: contextFor(event),
+    name: str(event.name),
+    arguments: event.arguments,
+    ...(event.turn === undefined ? {} : { turn: str(event.turn) }),
+    ...(typeof event.epoch === "number" ? { epoch: event.epoch } : {})
+  }))
 }
 
 const unknownToolError = (name: string, offered: ReadonlyArray<{ readonly name: string }>): string => {
@@ -80,23 +106,24 @@ const unknownToolError = (name: string, offered: ReadonlyArray<{ readonly name: 
   return `unknown tool: ${name}. Call one of: ${available.join(", ")}.`
 }
 
-// toolsReactorFrom routes the head pending call through its derived tool view.
+// toolsReactorFrom routes admitted pending calls through their derived tool views.
 export const toolsReactorFrom = <R = never>(
   serve: Serve<R>,
-  toolsFor: (log: ReadonlyArray<Event>, call: PendingCall) => ReadonlyArray<{ readonly name: string }>
-): CompleteTransitionDerivation<R> => (history) => {
-  const log = positioned(history)
-  const call = pendingCall(log)
-  if (call === undefined) return []
-  const stamp = call.turn === undefined ? {} : { turn: call.turn }
-  const answering = (result: unknown): Intent<never> => call.context.intent("answer", (at) =>
-    toolReturned({ callId: call.callId, result, ...stamp, at }), (call.turn === undefined ? {} : { invocation: { method: "message", id: call.turn, epoch: call.epoch ?? 0 } }))
-
-  const served = serve(call, log, answering)
-  if (served === undefined) {
-    return [answering({ error: unknownToolError(call.name, toolsFor(log, call)) })]
+  toolsFor: (log: ReadonlyArray<Event>, call: PendingCall) => ReadonlyArray<{ readonly name: string; readonly concurrency?: ToolConcurrency }>,
+  concurrency: ToolConcurrency = DEFAULT_TOOL_CONCURRENCY
+): CompleteTransitionDerivation<R> => {
+  const limit = toolConcurrencyOf(concurrency)
+  return (history) => {
+    const log = positioned(history)
+    return admitted(pendingCalls(log), limit, (call) => call,
+      (call) => toolsFor(log, call).find((tool) => tool.name === call.name)?.concurrency
+    ).flatMap((call) => {
+      const stamp = call.turn === undefined ? {} : { turn: call.turn }
+      const answering = (result: unknown): Intent<never> => call.context.intent("answer", (at) =>
+        toolReturned({ callId: call.callId, result, ...stamp, at }), (call.turn === undefined ? {} : { invocation: { method: "message", id: call.turn, epoch: call.epoch ?? 0 } }))
+      return serve(call, log, answering) ?? [answering({ error: unknownToolError(call.name, toolsFor(log, call)) })]
+    })
   }
-  return served
 }
 
 // cancelTools settles every open tool call owned by the cancelled message invocation.
@@ -136,9 +163,10 @@ const cancelTools = (
 export const toolsComponentFrom = <V, R = never>(
   empty: V,
   serve: Serve<R>,
-  toolsFor: (log: ReadonlyArray<Event>, call: PendingCall) => ReadonlyArray<{ readonly name: string }>
+  toolsFor: (log: ReadonlyArray<Event>, call: PendingCall) => ReadonlyArray<{ readonly name: string; readonly concurrency?: ToolConcurrency }>,
+  concurrency: ToolConcurrency = DEFAULT_TOOL_CONCURRENCY
 ): Component<V, R> => {
-  const dispatch = toolsReactorFrom(serve, toolsFor)
+  const dispatch = toolsReactorFrom(serve, toolsFor, concurrency)
   return legacyComponent({
     name: "agent.tools",
     cancel: cancelTools,
@@ -147,6 +175,7 @@ export const toolsComponentFrom = <V, R = never>(
 }
 
 interface ProjectedTool<R = never> {
+  readonly concurrency?: ToolConcurrency
   readonly spec: { readonly name: string }
   readonly serve: Serve<R>
 }
@@ -172,118 +201,119 @@ interface IncrementalToolsState<R = never> {
 export const incrementalToolsComponentFrom = <V, R = never>(
   empty: V,
   child: ComponentMachine<V, R>,
-  toolsOf: (view: V) => ReadonlyArray<ProjectedTool<R>>
-): Component<V, R> => component<IncrementalToolsState<R>, V, R>({
-  name: "agent.tools",
-  initial: (): IncrementalToolsState => ({
-    child: child.initial(),
-    turns: initialTurnProjection(),
-    nextOrder: 0,
-    pending: HashMap.empty(),
-    offers: HashMap.empty(),
-    heads: HashMap.empty()
-  }),
-  step: (state, event, context) => {
-    const eventTurn = String((event as { readonly turn?: unknown }).turn ?? "")
-    let before: ReadonlyArray<ProjectedTool<R>> | undefined
-    const offeredBefore = (): ReadonlyArray<ProjectedTool<R>> => {
-      before ??= toolsOf(child.output(state.child).view)
-      return before
-    }
-    const offers = event.type === "ModelCalled" && eventTurn !== ""
-      ? HashMap.set(state.offers, eventTurn, offeredBefore())
-      : state.offers
-    const heads = event.type === "MessageReceived"
-      ? HashMap.set(state.heads, String((event as { readonly id?: unknown }).id ?? ""), event)
-      : state.heads
-    const thread = event.type === "ThreadCreated" ? event : state.thread
-    let pending: HashMap.HashMap<string, PendingRecord<R>> = HashMap.map(
-      state.pending,
-      (record): PendingRecord<R> => ({ ...record, log: Chunk.append(record.log, event) })
-    )
-    let nextOrder = state.nextOrder
-    if (event.type === "ToolCalled") {
-      const callId = str((event as { readonly callId?: unknown }).callId)
-      if (!HashMap.has(pending, callKey(event))) {
-        const currentTurn = turnViewFrom(state.turns)
-        const turn = (event as { readonly turn?: unknown }).turn
-        const turnId = turn === undefined ? undefined : str(turn)
-        const epoch = (event as { readonly epoch?: unknown }).epoch
-        const call: PendingCall = {
-          callId,
-          context,
-          name: str((event as { readonly name?: unknown }).name),
-          arguments: (event as { readonly arguments?: unknown }).arguments,
-          ...(turnId === undefined ? {} : { turn: turnId }),
-          ...(typeof epoch === "number"
-            ? { epoch }
-            : {})
-        }
-        const prefix = [
-          ...(thread === undefined ? [] : [thread]),
-          ...(turnId === undefined
-            ? []
-            : currentTurn.length > 0 && String((currentTurn[0] as { readonly id?: unknown }).id) === turnId
-              ? currentTurn
-              : Option.match(HashMap.get(heads, turnId), { onNone: () => [], onSome: (head) => [head] }))
-        ]
-        const callOffer = turnId === undefined
-          ? offeredBefore()
-          : Option.getOrElse(HashMap.get(offers, turnId), offeredBefore)
-        const record: PendingRecord<R> = {
-          call,
-          offered: callOffer,
-          log: Chunk.fromIterable([...prefix, event]),
-          order: nextOrder
-        }
-        pending = HashMap.set(pending, callKey(event), record)
-        nextOrder += 1
+  toolsOf: (view: V) => ReadonlyArray<ProjectedTool<R>>,
+  concurrency: ToolConcurrency = DEFAULT_TOOL_CONCURRENCY
+): Component<V, R> => {
+  const limit = toolConcurrencyOf(concurrency)
+  return component<IncrementalToolsState<R>, V, R>({
+    name: "agent.tools",
+    initial: (): IncrementalToolsState => ({
+      child: child.initial(),
+      turns: initialTurnProjection(),
+      nextOrder: 0,
+      pending: HashMap.empty(),
+      offers: HashMap.empty(),
+      heads: HashMap.empty()
+    }),
+    step: (state, event, context) => {
+      const eventTurn = String((event as { readonly turn?: unknown }).turn ?? "")
+      let before: ReadonlyArray<ProjectedTool<R>> | undefined
+      const offeredBefore = (): ReadonlyArray<ProjectedTool<R>> => {
+        before ??= toolsOf(child.output(state.child).view)
+        return before
       }
-    }
-    if (event.type === "ToolReturned") {
-      pending = HashMap.remove(pending, callKey(event))
-    }
-    if (event.type === "TurnCompleted" || event.type === "TurnFailed" || event.type === "TurnCancelled") {
-      pending = HashMap.filter(pending, (record) =>
-        record.call.turn !== eventTurn || (record.call.epoch ?? 0) !== eventEpochOf(event)
+      const offers = event.type === "ModelCalled" && eventTurn !== ""
+        ? HashMap.set(state.offers, eventTurn, offeredBefore())
+        : state.offers
+      const heads = event.type === "MessageReceived"
+        ? HashMap.set(state.heads, String((event as { readonly id?: unknown }).id ?? ""), event)
+        : state.heads
+      const thread = event.type === "ThreadCreated" ? event : state.thread
+      let pending: HashMap.HashMap<string, PendingRecord<R>> = HashMap.map(
+        state.pending,
+        (record): PendingRecord<R> => ({ ...record, log: Chunk.append(record.log, event) })
       )
+      let nextOrder = state.nextOrder
+      if (event.type === "ToolCalled") {
+        const callId = str((event as { readonly callId?: unknown }).callId)
+        if (!HashMap.has(pending, callKey(event))) {
+          const currentTurn = turnViewFrom(state.turns)
+          const turn = (event as { readonly turn?: unknown }).turn
+          const turnId = turn === undefined ? undefined : str(turn)
+          const epoch = (event as { readonly epoch?: unknown }).epoch
+          const call: PendingCall = {
+            callId,
+            context,
+            name: str((event as { readonly name?: unknown }).name),
+            arguments: (event as { readonly arguments?: unknown }).arguments,
+            ...(turnId === undefined ? {} : { turn: turnId }),
+            ...(typeof epoch === "number"
+              ? { epoch }
+              : {})
+          }
+          const prefix = [
+            ...(thread === undefined ? [] : [thread]),
+            ...(turnId === undefined
+              ? []
+              : currentTurn.length > 0 && String((currentTurn[0] as { readonly id?: unknown }).id) === turnId
+                ? currentTurn
+                : Option.match(HashMap.get(heads, turnId), { onNone: () => [], onSome: (head) => [head] }))
+          ]
+          const callOffer = turnId === undefined
+            ? offeredBefore()
+            : Option.getOrElse(HashMap.get(offers, turnId), offeredBefore)
+          const record: PendingRecord<R> = {
+            call,
+            offered: callOffer,
+            log: Chunk.fromIterable([...prefix, event]),
+            order: nextOrder
+          }
+          pending = HashMap.set(pending, callKey(event), record)
+          nextOrder += 1
+        }
+      }
+      if (event.type === "ToolReturned") {
+        pending = HashMap.remove(pending, callKey(event))
+      }
+      if (event.type === "TurnCompleted" || event.type === "TurnFailed" || event.type === "TurnCancelled") {
+        pending = HashMap.filter(pending, (record) =>
+          record.call.turn !== eventTurn || (record.call.epoch ?? 0) !== eventEpochOf(event)
+        )
+      }
+      return {
+        child: child.step(state.child, event),
+        turns: reduceTurnProjection(state.turns, event),
+        nextOrder,
+        pending,
+        offers,
+        heads,
+        ...(thread === undefined ? {} : { thread })
+      }
+    },
+    cancelState: (state, cancellation) => {
+      if (cancellation.invocation.method !== "message") return []
+      const calls = [...HashMap.values(state.pending)]
+        .filter((record) =>
+          record.call.turn === cancellation.invocation.id &&
+          (record.call.epoch ?? 0) === cancellation.invocation.epoch
+        )
+        .map((record) => record.call)
+      return toolCancellationTransitions(calls, cancellation)
+    },
+    output: (state) => {
+      const pending = [...HashMap.values(state.pending)].sort((a, b) => a.order - b.order)
+      const selected = admitted(pending, limit, (record) => record.call,
+        (record) => record.offered.find((tool) => tool.spec.name === record.call.name)?.concurrency)
+      const transitions = selected.flatMap((current) => {
+        const tool = current.offered.find((candidate) => candidate.spec.name === current.call.name)
+        const log = Chunk.toReadonlyArray(current.log)
+        const stamp = current.call.turn === undefined ? {} : { turn: current.call.turn }
+        const call = current.call
+        const answering = (result: unknown): Intent<never> => call.context.intent("answer", (at) =>
+          toolReturned({ callId: call.callId, result, ...stamp, at }), (call.turn === undefined ? {} : { invocation: { method: "message", id: call.turn, epoch: call.epoch ?? 0 } }))
+        return tool?.serve(call, log, answering) ?? [answering({ error: unknownToolError(call.name, current.offered.map((tool) => tool.spec)) })]
+      })
+      return { view: empty, transitions }
     }
-    return {
-      child: child.step(state.child, event),
-      turns: reduceTurnProjection(state.turns, event),
-      nextOrder,
-      pending,
-      offers,
-      heads,
-      ...(thread === undefined ? {} : { thread })
-    }
-  },
-  cancelState: (state, cancellation) => {
-    if (cancellation.invocation.method !== "message") return []
-    const calls = [...HashMap.values(state.pending)]
-      .filter((record) =>
-        record.call.turn === cancellation.invocation.id &&
-        (record.call.epoch ?? 0) === cancellation.invocation.epoch
-      )
-      .map((record) => record.call)
-    return toolCancellationTransitions(calls, cancellation)
-  },
-  output: (state) => {
-    let current: PendingRecord<R> | undefined
-    for (const record of HashMap.values(state.pending)) {
-      if (current === undefined || record.order < current.order) current = record
-    }
-    if (current === undefined) return { view: empty, transitions: [] }
-    const tool = current.offered.find((candidate) => candidate.spec.name === current!.call.name)
-    const log = Chunk.toReadonlyArray(current.log)
-    const stamp = current.call.turn === undefined ? {} : { turn: current.call.turn }
-    const call = current.call
-    const answering = (result: unknown): Intent<never> => call.context.intent("answer", (at) =>
-      toolReturned({ callId: call.callId, result, ...stamp, at }), (call.turn === undefined ? {} : { invocation: { method: "message", id: call.turn, epoch: call.epoch ?? 0 } }))
-    const transitions = tool?.serve(current.call, log, answering)
-    return {
-      view: empty,
-      transitions: transitions ?? [answering({ error: unknownToolError(current.call.name, current.offered.map((tool) => tool.spec)) })]
-    }
-  }
-})
+  })
+}

--- a/packages/model/src/model.test.ts
+++ b/packages/model/src/model.test.ts
@@ -65,6 +65,17 @@ const testInfer = <const C extends Omit<ModelConfig, "protocol" | "provider" | "
 // and tested in agent/request.test.ts.
 
 describe("actionOf", () => {
+  test("multiple calls preserve provider order including calls beside execute", () => {
+    expect(actionOf({ content: "Reading files", toolCalls: [
+      { id: "read-1", type: "function", function: { name: "read", arguments: '{"path":"lease"}' } },
+      { id: "exec-2", type: "function", function: { name: "execute", arguments: '{"code":"return 2"}' } },
+      { id: "read-3", type: "function", function: { name: "read", arguments: '{"path":"amendment"}' } }
+    ] } as never)).toEqual({ kind: "calls", text: "Reading files", calls: [
+      { callId: "read-1", name: "read", arguments: { path: "lease" } },
+      { callId: "exec-2", name: "execute", arguments: { code: "return 2" } },
+      { callId: "read-3", name: "read", arguments: { path: "amendment" } }
+    ] })
+  })
   test("a tool call acts, with its prose riding along", () => {
     const action = actionOf({
       content: "let me check",
@@ -269,6 +280,27 @@ const sse = (events: ReadonlyArray<unknown>): Response => {
 }
 
 describe("infer end to end", () => {
+  test("interleaved streamed calls become one complete batch", async () => {
+    const fetchImpl = (async () => sse([
+      { id: "r1", choices: [{ index: 0, delta: { role: "assistant", tool_calls: [
+        { index: 0, id: "a", type: "function", function: { name: "read", arguments: '{"path":' } },
+        { index: 1, id: "b", type: "function", function: { name: "read", arguments: '{"path":' } }
+      ] } }] },
+      { id: "r1", choices: [{ index: 0, delta: { tool_calls: [
+        { index: 1, function: { arguments: '"amendment"}' } },
+        { index: 0, function: { arguments: '"lease"}' } }
+      ] } }] },
+      { id: "r1", choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] }
+    ])) as unknown as typeof globalThis.fetch
+    const layer = testInfer({ baseUrl: "https://model.test/v1", apiKey: "k", model: "test-model", fetch: fetchImpl })
+    const action = await Effect.runPromise(Effect.flatMap(Infer, (model) =>
+      model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "read", at: 1 }]))
+    ).pipe(Effect.provide(layer)))
+    expect(action).toMatchObject({ kind: "calls", calls: [
+      { callId: "a", name: "read", arguments: { path: "lease" } },
+      { callId: "b", name: "read", arguments: { path: "amendment" } }
+    ] })
+  })
   test("a streamed tool call becomes a call action", async () => {
     let requested: { url: string; body: unknown } | null = null
     const fetchImpl = (async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {

--- a/packages/model/src/model.ts
+++ b/packages/model/src/model.ts
@@ -128,8 +128,7 @@ const toTool = (t: ToolSpec): Tool => ({
 export const actionOf = (result: ProcessorResult): Action => {
   const calls = result.toolCalls ?? []
   const text = (result.content ?? "").trim()
-  const call = calls.find((c) => c.function.name === "execute") ?? calls[0]
-  if (call !== undefined) {
+  const decoded = calls.map((call) => {
     let args: unknown
     try {
       args = JSON.parse(call.function.arguments)
@@ -137,12 +136,17 @@ export const actionOf = (result: ProcessorResult): Action => {
       args = { code: call.function.arguments }
     }
     return {
-      kind: "call",
       callId: call.id,
       name: call.function.name,
-      arguments: args,
-      ...(text === "" ? {} : { text })
+      arguments: args
     }
+  })
+  const first = decoded[0]
+  if (first !== undefined) {
+    const prose = text === "" ? {} : { text }
+    return decoded.length === 1
+      ? { kind: "call", ...first, ...prose }
+      : { kind: "calls", calls: [first, ...decoded.slice(1)], ...prose }
   }
   if (text !== "") return { kind: "complete", output: text }
   // A provider that declined leaves neither: content_filter is the finish reason that says so,


### PR DESCRIPTION
A model response that requests several tools loses all calls except the selected call. This change preserves the full response and runs native tools concurrently by default, so each requested call receives a result before inference continues.

- Add a batch action while retaining the single-call action. Record every call together, validate duplicate IDs before dispatch, and count model usage once per response.
- Expose root and per-tool concurrency limits that queue excess calls and appear in the model instructions. Preserve code mode's configurable serial admission and tool limits through budget and permission wrappers.
- Keep batches together in the model transcript and across compaction. Replay reuses committed results, cancellation settles open calls, and budget refusal lets admitted work finish.

Validation: `bun run gate`. Regression coverage includes interleaved provider streams, actual execution overlap, queued calls, partial replay, cancellation, usage, budget boundaries, and compaction. Property tests compare incremental projections with complete replay for batch histories.

Consumers with custom inference bindings can return `{ kind: "calls", calls: [...] }`. The benchmark harness must adopt this response shape and remove its own one-call filter after upgrading.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/0b8492dc-58ec-4312-82a2-df2259c0fb9f)
