### PR TITLE
fix(agent): preserve response decisions

### DIFF
--- a/apps/server/src/api.test.ts
+++ b/apps/server/src/api.test.ts
@@ -57,12 +57,7 @@ const scripted = ({ trajectory }: InferRequest): Action => {
     | { result?: { result?: unknown } }
     | undefined
   if (returned !== undefined) return { kind: "complete", output: JSON.stringify(returned.result?.result ?? null) }
-  return {
-    kind: "call",
-    callId: brief.slice("spawn ".length),
-    name: "execute",
-    arguments: { code: `const a = await agents.run({ text: "hello child" }); return a.output;` }
-  }
+  return { kind: "calls", calls: [{ callId: brief.slice("spawn ".length), name: "execute", arguments: { code: `const a = await agents.run({ text: "hello child" }); return a.output;` } }] }
 }
 
 const testModel = { provider: "openai", model_id: "gpt-mini" } as const

--- a/apps/voyager/dev/fixture.ts
+++ b/apps/voyager/dev/fixture.ts
@@ -62,28 +62,18 @@ const scripted = ({ trajectory }: InferRequest): Action => {
     | undefined
   if (brief === ONBOARDING_BRIEF) {
     if (returned !== undefined) return { kind: "complete", output: ONBOARDING_FINDINGS }
-    return {
-      kind: "call",
-      callId: "research-repository",
-      name: "execute",
-      arguments: {
+    return { kind: "calls", calls: [{ callId: "research-repository", name: "execute", arguments: {
         summary: "Research the repository in parallel and synthesize its architecture.",
         code: "const findings = await Promise.all([agents.run({ text: 'Read the documentation and summarize the framework contract.' }), agents.run({ text: 'Inspect the packages and platforms, then summarize the actor runtime.' })]); return findings.map((finding) => finding.output);"
-      }
-    }
+      } }] }
   }
   if (!brief.startsWith(SPAWN_BRIEF)) return { kind: "complete", output: `ok: ${brief}` }
   if (returned !== undefined) return { kind: "complete", output: JSON.stringify(returned.result?.result ?? null) }
-  return {
-    kind: "call",
-    callId: brief.slice(SPAWN_BRIEF.length),
-    name: "execute",
-    arguments: {
+  return { kind: "calls", calls: [{ callId: brief.slice(SPAWN_BRIEF.length), name: "execute", arguments: {
       code: `const kids = await Promise.all([${
         Array.from({ length: FIXTURE_FANOUT }, (_, i) => `agents.run({ text: "survey shard ${i + 1}" })`).join(", ")
       }]); return kids.map((k) => k.output);`
-    }
-  }
+    } }] }
 }
 
 const testModel = { provider: "test", model_id: "scripted" } as const

--- a/bun.lock
+++ b/bun.lock
@@ -288,6 +288,9 @@
         "@effect/sql-sqlite-bun": "4.0.0-rc.110",
         "effect": "4.0.0-rc.110",
       },
+      "devDependencies": {
+        "fast-check": "^4.9.0",
+      },
     },
     "platform/cloudflare": {
       "name": "@clavia/tardigrade-cloudflare",

--- a/docs/examples/rlm.mdx
+++ b/docs/examples/rlm.mdx
@@ -55,6 +55,8 @@ const rlm = actor({
 })
 ```
 
+The `budget` component records its starting allowance as `BudgetGranted` before inference. Set `{ limit: 20, authority: caller() }` to start with 20 tool calls; the default is `DEFAULT_BUDGET_POLICY.limit`, which is 40. Further grants add to that allowance. Each tool call uses only the grants recorded before it, so a later grant cannot admit an earlier refused call. Restarting with a different default leaves a recorded allowance unchanged.
+
 ## How it is assembled
 
 <div className="rlm-parts">

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -130,13 +130,13 @@ const weather = tool({
 })
 ```
 
-When the model selects `get_weather`, Tardigrade records `ToolCalled`. The inference component finds the handler in the current view, runs its Effect, and records `ToolReturned`. The next model request includes the result.
+Tardigrade records each model response as `ModelReturned`, which carries its usage. When the model selects `get_weather`, Tardigrade also records `ToolCalled`, linked to the response by `responseId`. The inference component finds the handler in the current view, runs its Effect, and records `ToolReturned`. The next model request includes the result.
 
 A model response can request several tools. Tardigrade records every call before dispatch, runs native tools concurrently by default, and waits for every result before the next model request. Each call has its own result. The response contributes usage once. Replay reuses committed results and retries unfinished work.
 
 `DEFAULT_TOOL_CONCURRENCY` is `"unbounded"`. Set `infer(components, { toolConcurrency: 4 })` to admit at most four pending calls at a time. Additional calls wait in recorded order. Set `concurrency: 1` on a native tool binding to serialize calls to that tool. These limits appear in the model instructions or tool description.
 
-Code mode defaults to `DEFAULT_CODE_TOOL_CONCURRENCY`, which is `1`. Set `codeMode(components, { toolConcurrency })` to control admission of `execute` calls. Code execution follows the code scheduler. Custom `Infer` bindings return `{ kind: "calls", calls: [...] }` for a batch, with a nonempty array of `{ callId, name, arguments }` entries. Single calls use `{ kind: "call", callId, name, arguments }`.
+Code mode defaults to `DEFAULT_CODE_TOOL_CONCURRENCY`, which is `1`. Set `codeMode(components, { toolConcurrency })` to control admission of `execute` calls. Code execution follows the code scheduler. Custom `Infer` bindings return `{ kind: "calls", calls: [...] }`, with a nonempty array of `{ callId, name, arguments }` entries. A single call uses an array of one entry. Response usage stays outside the array.
 </Tip>
 
 ### Running it locally

--- a/e2e/actor/graph.test.ts
+++ b/e2e/actor/graph.test.ts
@@ -59,19 +59,14 @@ test("an actor graph covers concurrent calls, budget negotiation, structured out
       if (returned !== undefined) {
         return { kind: "complete", output: JSON.stringify(returned.result?.result) }
       }
-      return {
-        kind: "call",
-        callId: "cover",
-        name: "execute",
-        arguments: {
+      return { kind: "calls", calls: [{ callId: "cover", name: "execute", arguments: {
           code: `const foreground = await Promise.all(Array.from({ length: 5 }, (_, worker) =>
             agents.run({ text: "worker " + worker, budget: 1, escalatable: true, output: "worker" })
           ));
           const background = await agents.run({ text: "background", background: true });
           const later = await agents.result({ handle: background.handle });
           return { foreground: foreground.map((answer) => answer.output), background: later.output };`
-        }
-      }
+        } }] }
     }
     if (brief === "background") return { kind: "complete", output: "background-ok" }
     const worker = Number(brief.slice("worker ".length))
@@ -82,24 +77,19 @@ test("an actor graph covers concurrent calls, budget negotiation, structured out
       event.type === "ToolReturned" && String((event as { readonly callId?: unknown }).callId) === id
     )
     if (!called(`${turn}-first`)) {
-      return action({ kind: "call", callId: `${turn}-first`, name: "execute", arguments: { code: `return "first-${worker}";` } })
+      return action({ kind: "calls", calls: [{ callId: `${turn}-first`, name: "execute", arguments: { code: `return "first-${worker}";` } }] })
     }
     if (!called(`${turn}-wall`)) {
-      return action({ kind: "call", callId: `${turn}-wall`, name: "execute", arguments: { code: `return "wall-${worker}";` } })
+      return action({ kind: "calls", calls: [{ callId: `${turn}-wall`, name: "execute", arguments: { code: `return "wall-${worker}";` } }] })
     }
     if (!called(`${turn}-budget`)) {
-      return action({
-        kind: "call",
-        callId: `${turn}-budget`,
-        name: "request_budget",
-        arguments: { reason: `worker ${worker} needs one verified follow-up`, amount: 2 }
-      })
+      return action({ kind: "calls", calls: [{ callId: `${turn}-budget`, name: "request_budget", arguments: { reason: `worker ${worker} needs one verified follow-up`, amount: 2 } }] })
     }
     if (slice.some((event) => event.type === "BudgetDenied")) {
       return action({ kind: "complete", output: JSON.stringify({ worker, status: "denied" }) })
     }
     if (!called(`${turn}-after`)) {
-      return action({ kind: "call", callId: `${turn}-after`, name: "execute", arguments: { code: `return "after-${worker}";` } })
+      return action({ kind: "calls", calls: [{ callId: `${turn}-after`, name: "execute", arguments: { code: `return "after-${worker}";` } }] })
     }
     if (returned(`${turn}-after`)) {
       return action({ kind: "complete", output: JSON.stringify({ worker, status: "granted" }) })

--- a/e2e/actor/mortyplicity.test.ts
+++ b/e2e/actor/mortyplicity.test.ts
@@ -116,9 +116,7 @@ test.each([false, true])("Mortys inherit Rick's depth ceiling with background=%s
         readonly result?: { readonly result?: unknown }
       } | undefined
       if (returned !== undefined) return { kind: "complete", output: JSON.stringify(returned.result?.result) }
-      return {
-        kind: "call", callId: `${turn}-replicate`, name: "execute",
-        arguments: {
+      return { kind: "calls", calls: [{ callId: `${turn}-replicate`, name: "execute", arguments: {
           code: `return await Promise.all(Array.from({ length: ${siblings} }, async (_, index) => {
             const name = ${JSON.stringify(path)} + "-" + index;
             const answer = await agents.run({ text: ${JSON.stringify(String(generation + 1) + ":")} + name, background: ${background}, ...(${named} ? { name } : {}) });
@@ -126,8 +124,7 @@ test.each([false, true])("Mortys inherit Rick's depth ceiling with background=%s
             const terminal = ${background} ? await agents.result({ handle: answer.handle }) : answer;
             return JSON.parse(terminal.output);
           }));`
-        }
-      }
+        } }] }
     }
     let pick = 0
     const scenario = actorScenario(rootActor, mind, {
@@ -228,11 +225,7 @@ const mindFor = (missions: ReadonlyMap<string, Mission>, jitter: ReadonlyArray<n
         key: mission.key,
         background: mission.background
       })))
-      return {
-        kind: "call",
-        callId: `${turn}-rick-plan`,
-        name: "execute",
-        arguments: {
+      return { kind: "calls", calls: [{ callId: `${turn}-rick-plan`, name: "execute", arguments: {
           code: `const missions = ${manifest};
             const launched = await Promise.all(missions.map(async (mission) => {
               const answer = await agents.run({
@@ -249,8 +242,7 @@ const mindFor = (missions: ReadonlyMap<string, Mission>, jitter: ReadonlyArray<n
                 : answer;
               return JSON.parse(terminal.output);
             }));`
-        }
-      }
+        } }] }
     }
 
     const missionKey = brief.slice("Morty mission ".length)
@@ -268,7 +260,7 @@ const mindFor = (missions: ReadonlyMap<string, Mission>, jitter: ReadonlyArray<n
     )
 
     if (!called(first)) {
-      return action({ kind: "call", callId: first, name: "execute", arguments: { code: portalCode(mission.key, 1) } })
+      return action({ kind: "calls", calls: [{ callId: first, name: "execute", arguments: { code: portalCode(mission.key, 1) } }] })
     }
     const firstResponse = responseFor(trajectory, turn, first)
     if (firstResponse !== undefined && outcomeOf(firstResponse) !== "grant") {
@@ -278,24 +270,19 @@ const mindFor = (missions: ReadonlyMap<string, Mission>, jitter: ReadonlyArray<n
       return action({ kind: "fail", error: `Morty ${mission.key} resumed before the first portal settled` })
     }
     if (!called(wall)) {
-      return action({ kind: "call", callId: wall, name: "execute", arguments: { code: `return "budget-wall:${mission.key}";` } })
+      return action({ kind: "calls", calls: [{ callId: wall, name: "execute", arguments: { code: `return "budget-wall:${mission.key}";` } }] })
     }
     if (slice.some((event) => event.type === "BudgetDenied")) {
       return action({ kind: "complete", output: JSON.stringify({ key: mission.key, status: `budget-${mission.budget}` }) })
     }
-    if (!slice.some((event) => event.type === "BudgetGranted")) {
+    if (!slice.some((event) => event.type === "BudgetGranted" && event.initial !== true)) {
       if (!called(budgetCall)) {
-        return action({
-          kind: "call",
-          callId: budgetCall,
-          name: "request_budget",
-          arguments: { reason: `budget:${mission.key}`, amount: 2 }
-        })
+        return action({ kind: "calls", calls: [{ callId: budgetCall, name: "request_budget", arguments: { reason: `budget:${mission.key}`, amount: 2 } }] })
       }
       return action({ kind: "fail", error: `Morty ${mission.key} resumed before the budget authority answered` })
     }
     if (!called(second)) {
-      return action({ kind: "call", callId: second, name: "execute", arguments: { code: portalCode(mission.key, 2) } })
+      return action({ kind: "calls", calls: [{ callId: second, name: "execute", arguments: { code: portalCode(mission.key, 2) } }] })
     }
     const secondResponse = responseFor(trajectory, turn, second)
     if (secondResponse !== undefined && outcomeOf(secondResponse) !== "grant") {
@@ -543,16 +530,11 @@ const cancelForegroundMortys = async ({ children, headroom, schedule }: {
       if (brief === "cancel every Morty") {
         const returned = trajectory.some((event) => event.type === "ToolReturned")
         if (returned) return { kind: "complete", output: "too late" }
-        return {
-          kind: "call",
-          callId: "cancel-fanout",
-          name: "execute",
-          arguments: {
+        return { kind: "calls", calls: [{ callId: "cancel-fanout", name: "execute", arguments: {
             code: `return await Promise.all(Array.from({ length: ${children} }, (_, morty) =>
               agents.run({ text: "held Morty " + morty })
             ));`
-          }
-        }
+          } }] }
       }
       if (!observedChild) {
         observedChild = true
@@ -676,14 +658,9 @@ test("Rick settles when a foreground Morty is cancelled", async () => {
       if (returned !== undefined) {
         return { kind: "complete", output: JSON.stringify(returned.result?.result) }
       }
-      return {
-        kind: "call",
-        callId: "wait-for-morty",
-        name: "execute",
-        arguments: {
+      return { kind: "calls", calls: [{ callId: "wait-for-morty", name: "execute", arguments: {
           code: `return await agents.run({ text: "held Morty" });`
-        }
-      }
+        } }] }
     }
     startedChild()
     await childReleased

--- a/packages/agent/src/component/budget.test.ts
+++ b/packages/agent/src/component/budget.test.ts
@@ -227,6 +227,15 @@ const granted = (amount: number): Event => ({ type: "BudgetGranted", amount, tur
 const denied: Event = { type: "BudgetDenied", reason: "no", turn: "m1", at: 101 }
 
 describe("the escalation lifecycle", () => {
+  test("an initial grant replaces the implicit allowance and has a turn key", () => {
+    const head: Event = { type: "MessageReceived", id: "m1", text: "work", budget: 99, at: 0 }
+    const grant: Event = { type: "BudgetGranted", turn: "m1", initial: true, amount: 2, at: 1 }
+    expect(budgetOf([head, grant, granted(3)], { limit: 100 })).toBe(5)
+    expect(agentKeys.keyOf(grant)).toBe("bi:m1")
+    expect(agentKeys.keyOf({ ...grant, amount: 100, at: 2 })).toBe("bi:m1")
+    expect(agentKeys.keyOf({ ...grant, turn: "m2" })).toBe("bi:m2")
+  })
+
   test("a grant and denial for one request share a decision key", () => {
     const grant: Event = { type: "BudgetGranted", amount: 2, callId: "request-1", turn: "m1", at: 1 }
     const denial: Event = { type: "BudgetDenied", reason: "no", callId: "request-1", turn: "m1", at: 2 }

--- a/packages/agent/src/component/budget.ts
+++ b/packages/agent/src/component/budget.ts
@@ -1,3 +1,4 @@
+import { startingBudget, needsInitialBudget } from "../log/budget"
 import { bindTransitionContext, type TransitionContext } from "@clavia/tardigrade-core/transition/transition"
 import { Self, type Transition, type Intent } from "@clavia/tardigrade-core/runtime"
 import { actorCall } from "@clavia/tardigrade-core/interaction/invoke"
@@ -62,14 +63,9 @@ export const budgetPolicyOf = (policy: Partial<BudgetPolicy> = {}): BudgetPolicy
   })()
 })
 
-// budgetOf returns the turn's declared or default budget plus every recorded grant
-// (budget.test.ts, "a grant raises the ceiling, so budgetOf grows and the machine reopens").
+// budgetOf sums recorded grants, including the initial allowance, with a fallback for historical turns (budget.test.ts).
 export const budgetOf = (view: ReadonlyArray<Event>, policy: Partial<BudgetPolicy> = {}): number => {
-  const head = turnHead(view) as { budget?: unknown } | undefined
-  const base =
-    typeof head?.budget === "number" && head.budget > 0
-      ? Math.floor(head.budget)
-      : budgetPolicyOf(policy).limit
+  const base = startingBudget(view, budgetPolicyOf(policy).limit)
   const granted = view.reduce((n, e) => (e.type === "BudgetGranted" ? n + Number((e as { amount?: unknown }).amount ?? 0) : n), 0)
   return base + granted
 }
@@ -260,10 +256,19 @@ const budgetCommunication = (
       }), { invocation })]
 }
 
-const usedBy = (trajectory: ReadonlyArray<Event>, toolNames: ReadonlySet<string>): number =>
-  trajectory.filter(
-    (event) => event.type === "ToolCalled" && toolNames.has(String((event as { name?: unknown }).name))
-  ).length
+// admissionOf fixes each call's budget decision from preceding grants and calls (runtime/batches.test.ts).
+const admissionOf = (trajectory: ReadonlyArray<Event>, toolNames: ReadonlySet<string>, policy: BudgetPolicy, callId: string) => {
+  let remaining = startingBudget(trajectory, policy.limit)
+  let used = 0
+  for (const event of trajectory) {
+    if (event.type === "BudgetGranted") remaining += Number(event.amount ?? 0)
+    if (event.type !== "ToolCalled" || !toolNames.has(String(event.name))) continue
+    const admitted = remaining > 0
+    if (admitted) { remaining -= 1; used += 1 }
+    if (event.callId === callId) return { admitted, used: admitted ? used : used + 1 }
+  }
+  return { admitted: false, used: used + 1 }
+}
 
 const guardedTool = <R>(
   tool: AgentTool<R>,
@@ -273,19 +278,13 @@ const guardedTool = <R>(
   ...tool,
   serve: (call, log, answer): ReadonlyArray<Transition<never, R>> => {
     const trajectory = turnView(log)
-    const callIndex = trajectory.findIndex((event) => event.type === "ToolCalled" && event.callId === call.callId)
-    const admitted = callIndex === -1 ? trajectory : trajectory.slice(0, callIndex + 1)
-    const used = usedBy(admitted, toolNames)
-    const admittedBatchCall = callIndex !== -1 && trajectory[callIndex]!.batchId !== undefined &&
-      !budgetSpent(admitted) && used <= budgetOf(trajectory, policy)
-    if (budgetSpent(trajectory) && !admittedBatchCall) {
-      return [answer({
-        error: "Tool budget reached. Do not call this tool again. Answer now with your best result from what you have already gathered."
-      })] as ReadonlyArray<Transition<never, R>>
-    }
-    const wall = wallFor(trajectory, policy, used, call.context)
-    if (wall !== undefined) return [wall]
-    return tool.serve(call, log, answer)
+    const admission = admissionOf(trajectory, toolNames, policy, call.callId)
+    if (admission.admitted) return tool.serve(call, log, answer)
+    const wall = wallFor(trajectory, policy, admission.used, call.context)
+    return [
+      ...(wall === undefined ? [] : [wall]),
+      answer({ error: "Tool budget reached. Do not call this tool again. Answer now with your best result from what you have already gathered." })
+    ] as ReadonlyArray<Transition<never, R>>
   }
 })
 
@@ -307,6 +306,12 @@ export const budget = <
     children: [combined]
   }
   const derived = (children: ReturnType<typeof childMachine.output>, trajectory: ReadonlyArray<Event>, log: ReadonlyArray<Event>) => {
+    const head = turnHead(trajectory)
+    const initial = head !== undefined && needsInitialBudget(trajectory)
+      ? [bindTransitionContext(head, "budget").intent("budget.initial", (at) => budgetGranted({
+          amount: startingBudget(trajectory, resolved.limit), initial: true, turn: String(head.id), at
+        }))]
+      : []
     const spent = budgetSpent(trajectory)
     const turn = String((turnHead(trajectory) as { readonly id?: unknown } | undefined)?.id ?? "")
     const canRequest = canRequestBudget(trajectory) && authorityFor(log, turn, options.authority) !== undefined
@@ -322,7 +327,7 @@ export const budget = <
         context: children.view.context,
         output: children.view.output
       },
-      transitions: [...budgetCommunication(log, options.authority), ...children.transitions] as ReadonlyArray<Transition<never, R | Router | Self>>
+      transitions: [...initial, ...budgetCommunication(log, options.authority), ...children.transitions] as ReadonlyArray<Transition<never, R | Router | Self>>
     }
   }
   const communicationEvent = (event: Event): boolean =>

--- a/packages/agent/src/component/budget.ts
+++ b/packages/agent/src/component/budget.ts
@@ -264,7 +264,10 @@ const admissionOf = (trajectory: ReadonlyArray<Event>, toolNames: ReadonlySet<st
     if (event.type === "BudgetGranted") remaining += Number(event.amount ?? 0)
     if (event.type !== "ToolCalled" || !toolNames.has(String(event.name))) continue
     const admitted = remaining > 0
-    if (admitted) { remaining -= 1; used += 1 }
+    if (admitted) {
+      remaining -= 1
+      used += 1
+    }
     if (event.callId === callId) return { admitted, used: admitted ? used : used + 1 }
   }
   return { admitted: false, used: used + 1 }
@@ -313,7 +316,7 @@ export const budget = <
         }))]
       : []
     const spent = budgetSpent(trajectory)
-    const turn = String((turnHead(trajectory) as { readonly id?: unknown } | undefined)?.id ?? "")
+    const turn = String(head?.id ?? "")
     const canRequest = canRequestBudget(trajectory) && authorityFor(log, turn, options.authority) !== undefined
     const toolNames = new Set(children.view.tools.map((tool) => tool.spec.name))
     return {

--- a/packages/agent/src/component/compaction.ts
+++ b/packages/agent/src/component/compaction.ts
@@ -1,3 +1,4 @@
+import { firstResponseCallIndex } from "../log/response"
 import { bindTransitionContext } from "@clavia/tardigrade-core/transition/transition"
 import { eventAt, eventPositionOf } from "@clavia/tardigrade-core/event"
 import { Clock, Effect, HashSet } from "effect"
@@ -227,8 +228,7 @@ export const keepFromIndex = (events: ReadonlyArray<Event>, keepFrom: string): n
     const e = events[i]!
     const v = e as { callId?: unknown; id?: unknown }
     if (keepFrom.startsWith("c:") && e.type === "ToolCalled" && JSON.stringify([e.turn ?? null, v.callId]) === keepFrom.slice(2)) {
-      if (e.batchId === undefined) return i
-      return events.findIndex((event) => event.type === "ToolCalled" && event.turn === e.turn && event.epoch === e.epoch && event.batchId === e.batchId)
+      return firstResponseCallIndex(events, e)
     }
     if (keepFrom.startsWith("m:") && e.type === "MessageReceived" && String(v.id) === keepFrom.slice(2)) return i
   }
@@ -260,9 +260,9 @@ const atRoundBoundary = (log: ReadonlyArray<Event>): boolean => {
 // boundaryIdOf returns the identity a cut at this event would record: a ToolCalled keeps its
 // return beside it, and a served head opens its turn whole. Any other position splits a pair or
 // names an event the projection cannot see, so it is no boundary.
-const boundaryIdOf = (e: Event, served: ReadonlySet<string>): string | undefined => {
+const boundaryIdOf = (e: Event, served: ReadonlySet<string>, log: ReadonlyArray<Event>): string | undefined => {
   const v = e as { callId?: unknown; id?: unknown }
-  if (e.type === "ToolCalled" && (e.batchIndex === undefined || e.batchIndex === 0)) return `c:${JSON.stringify([e.turn ?? null, v.callId])}`
+  if (e.type === "ToolCalled" && log[firstResponseCallIndex(log, e)] === e) return `c:${JSON.stringify([e.turn ?? null, v.callId])}`
   if (e.type === "MessageReceived" && served.has(String(v.id))) return `m:${String(v.id)}`
   return undefined
 }
@@ -288,11 +288,11 @@ const cutOf = (
     }
   }
   for (let i = Math.min(raw, log.length - 1); i > priorIndex; i--) {
-    const id = boundaryIdOf(log[i]!, served)
+    const id = boundaryIdOf(log[i]!, served, log)
     if (id !== undefined) return { keepFrom: id, index: i }
   }
   for (let i = Math.max(raw + 1, priorIndex + 1); i < log.length; i++) {
-    const id = boundaryIdOf(log[i]!, served)
+    const id = boundaryIdOf(log[i]!, served, log)
     if (id !== undefined) return { keepFrom: id, index: i }
   }
   return undefined

--- a/packages/agent/src/component/compaction.ts
+++ b/packages/agent/src/component/compaction.ts
@@ -1,4 +1,4 @@
-import { firstResponseCallIndex } from "../log/response"
+import { responsesOf } from "../log/response"
 import { bindTransitionContext } from "@clavia/tardigrade-core/transition/transition"
 import { eventAt, eventPositionOf } from "@clavia/tardigrade-core/event"
 import { Clock, Effect, HashSet } from "effect"
@@ -228,7 +228,7 @@ export const keepFromIndex = (events: ReadonlyArray<Event>, keepFrom: string): n
     const e = events[i]!
     const v = e as { callId?: unknown; id?: unknown }
     if (keepFrom.startsWith("c:") && e.type === "ToolCalled" && JSON.stringify([e.turn ?? null, v.callId]) === keepFrom.slice(2)) {
-      return firstResponseCallIndex(events, e)
+      return events.indexOf(responsesOf(events).firstCalls.get(e)!)
     }
     if (keepFrom.startsWith("m:") && e.type === "MessageReceived" && String(v.id) === keepFrom.slice(2)) return i
   }
@@ -260,9 +260,9 @@ const atRoundBoundary = (log: ReadonlyArray<Event>): boolean => {
 // boundaryIdOf returns the identity a cut at this event would record: a ToolCalled keeps its
 // return beside it, and a served head opens its turn whole. Any other position splits a pair or
 // names an event the projection cannot see, so it is no boundary.
-const boundaryIdOf = (e: Event, served: ReadonlySet<string>, log: ReadonlyArray<Event>): string | undefined => {
+const boundaryIdOf = (e: Event, served: ReadonlySet<string>, firstCalls: ReadonlyMap<Event, Event>): string | undefined => {
   const v = e as { callId?: unknown; id?: unknown }
-  if (e.type === "ToolCalled" && log[firstResponseCallIndex(log, e)] === e) return `c:${JSON.stringify([e.turn ?? null, v.callId])}`
+  if (e.type === "ToolCalled" && firstCalls.get(e) === e) return `c:${JSON.stringify([e.turn ?? null, v.callId])}`
   if (e.type === "MessageReceived" && served.has(String(v.id))) return `m:${String(v.id)}`
   return undefined
 }
@@ -276,6 +276,7 @@ const cutOf = (
   policy: ContextPolicy,
   knownServed?: ReadonlySet<string>
 ): { readonly keepFrom: string; readonly index: number } | undefined => {
+  const firstCalls = responsesOf(log).firstCalls
   const priorIndex = keepFromIndex(log, checkpointOf(log).keepFrom)
   const served = knownServed ?? new Set(log.map(turnOf).filter((t): t is string => t !== undefined))
   let tokens = 0
@@ -288,11 +289,11 @@ const cutOf = (
     }
   }
   for (let i = Math.min(raw, log.length - 1); i > priorIndex; i--) {
-    const id = boundaryIdOf(log[i]!, served, log)
+    const id = boundaryIdOf(log[i]!, served, firstCalls)
     if (id !== undefined) return { keepFrom: id, index: i }
   }
   for (let i = Math.max(raw + 1, priorIndex + 1); i < log.length; i++) {
-    const id = boundaryIdOf(log[i]!, served, log)
+    const id = boundaryIdOf(log[i]!, served, firstCalls)
     if (id !== undefined) return { keepFrom: id, index: i }
   }
   return undefined

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -133,17 +133,12 @@ const scripted = async ({ trajectory }: { trajectory: ReadonlyArray<Event> }): P
     return { kind: "complete", output: JSON.stringify(returned.result?.result ?? null) }
   }
   const turns = trajectory.filter((e) => e.type === "MessageReceived").length
-  return {
-    kind: "call",
-    callId: `t${turns}`,
-    name: "execute",
-    arguments: {
+  return { kind: "calls", calls: [{ callId: `t${turns}`, name: "execute", arguments: {
       code: `const [a, b] = await Promise.all([
         agents.run({ text: "sum 2+2" }),
         agents.run({ text: "sum 3+3" })
       ]); return a.output + "," + b.output;`
-    }
-  }
+    } }] }
 }
 
 describe("an assembled agent", () => {
@@ -242,7 +237,7 @@ describe("an assembled agent", () => {
       }
     })]
     const mind = rlm(async (request, key, _signal, onDelta) => {
-      if (inferred++ === 0) return { kind: "call", callId: "read-1", name: "read", arguments: {}, text: "Let me check." }
+      if (inferred++ === 0) return { kind: "calls", calls: [{ callId: "read-1", name: "read", arguments: {} }], text: "Let me check." }
       streamOf(request, key, "p1", ["hello ", "world"], onDelta)
       markStarted()
       await new Promise<void>(() => {})
@@ -501,7 +496,7 @@ describe("an assembled agent", () => {
     const mind = rlm(async ({ trajectory }) => {
       const returned = trajectory.find((e) => e.type === "ToolReturned") as { result?: unknown } | undefined
       if (returned !== undefined) return { kind: "complete", output: String(returned.result) }
-      return { kind: "call", callId: "n1", name: "read", arguments: { path: "/contract.md" } }
+      return { kind: "calls", calls: [{ callId: "n1", name: "read", arguments: { path: "/contract.md" } }] }
     }, components)
     const answer = await mind.run("read the contract")
     expect(answer.output).toBe("contents of /contract.md")
@@ -532,7 +527,7 @@ describe("an assembled agent", () => {
       keys.push(String(key))
       failureInRequest.push(trajectory.some((event) => event.type === "TurnFailed"))
       const returned = trajectory.find((event) => event.type === "ToolReturned")
-      if (returned === undefined) return { kind: "call", callId: "read-1", name: "read", arguments: {} }
+      if (returned === undefined) return { kind: "calls", calls: [{ callId: "read-1", name: "read", arguments: {} }] }
       postToolCalls += 1
       if (postToolCalls === 1) throw new Error("provider connection ended")
       return { kind: "complete", output: String((returned as { result?: unknown }).result) }
@@ -595,7 +590,7 @@ describe("an assembled agent", () => {
     const mind = rlm(async ({ trajectory }) => {
       const returned = trajectory.find((e) => e.type === "ToolReturned") as { result?: { error?: string } } | undefined
       if (returned !== undefined) return { kind: "complete", output: String(returned.result?.error) }
-      return { kind: "call", callId: "x1", name: "execute", arguments: { code: "return 1" } }
+      return { kind: "calls", calls: [{ callId: "x1", name: "execute", arguments: { code: "return 1" } }] }
     }, components)
     const answer = await mind.run("go")
     expect(answer.output).toContain("unknown tool: execute")
@@ -609,20 +604,15 @@ describe("an assembled agent", () => {
       const start = trajectory.reduce((n, e, i) => (e.type === "MessageReceived" ? i : n), 0)
       const returns = trajectory.slice(start).filter((e) => e.type === "ToolReturned") as ReadonlyArray<{ result?: { result?: unknown } }>
       if (returns.length === 0) {
-        return { kind: "call", callId: "w1", name: "execute", arguments: { code: `return "a".repeat(20000) + "NEEDLE";` } }
+        return { kind: "calls", calls: [{ callId: "w1", name: "execute", arguments: { code: `return "a".repeat(20000) + "NEEDLE";` } }] }
       }
       if (returns.length === 1) {
-        return {
-          kind: "call",
-          callId: "w2",
-          name: "execute",
-          arguments: {
+        return { kind: "calls", calls: [{ callId: "w2", name: "execute", arguments: {
             code: `const found = await workspace.grep({ pattern: "NEEDLE" });
                 const hit = found.matches[0];
                 const back = await workspace.read({ ref: hit.ref, offset: hit.offset, length: 6 });
                 return hit.ref + ":" + hit.offset + ":" + back.slice + ":" + back.size;`
-          }
-        }
+          } }] }
       }
       return { kind: "complete", output: String(returns[1]!.result?.result ?? "") }
     })
@@ -645,8 +635,7 @@ test("reused provider IDs execute and correlate independently across turns and c
       const returned = request.trajectory.find((event) => event.type === "ToolReturned" && event.turn === turn)
       if (returned !== undefined) return { kind: "complete", output: JSON.stringify(returned.result) }
       const head = request.trajectory.find((event) => event.type === "MessageReceived" && event.id === turn)!
-      return { kind: "call", callId: "7", name: mode === "native" ? "echo" : "execute",
-        arguments: mode === "native" ? head.text : { code: "return await probe.echo(brief)" }, text: "working" }
+      return { kind: "calls", calls: [{ callId: "7", name: mode === "native" ? "echo" : "execute", arguments: mode === "native" ? head.text : { code: "return await probe.echo(brief)" } }], text: "working" }
     }
     const first = hosted(assembled, react)
     const expected = (value: string) => JSON.stringify(mode === "native" ? value : { result: value })
@@ -676,12 +665,14 @@ test("a turn rejects reused provider IDs before dispatch, including after resume
   const assembled = actor({ name: "test-agent", methods: agentMethods, components: [infer([surface, nativeOutput], TEST_MODEL)] })
   const usage = { promptTokens: 3, completionTokens: 2 }
   const endpoint = { provider: "test", model: "test-model" }
-  const mind = hosted(assembled, async () => ({ kind: "call", callId: "7", name: "echo", arguments: {}, usage, endpoint }))
+  const mind = hosted(assembled, async () => ({ kind: "calls", calls: [{ callId: "7", name: "echo", arguments: {} }], usage, endpoint }))
   const first = await mind.run("go")
   expect(first.error).toContain("duplicate tool call ID")
   expect(dispatched).toBe(1)
   expect(mind.host.read(ROOT_THREAD).findLast((event) => event.type === "TurnFailed"))
-    .toMatchObject({ cause: "inference_error", usage, endpoint })
+    .toMatchObject({ cause: "inference_error", endpoint })
+  expect(mind.host.read(ROOT_THREAD).findLast((event) => event.type === "ModelReturned"))
+    .toMatchObject({ outcome: "returned", usage, endpoint })
   expect((await mind.resume(first.turn)).error).toContain("duplicate tool call ID")
   expect(dispatched).toBe(1)
   await mind.host.drive()

--- a/packages/agent/src/inference/action-compat.test.ts
+++ b/packages/agent/src/inference/action-compat.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test"
+import { normalizeAction, type LegacyCallAction } from "./action-compat"
+
+test("legacy action conversion retains response metadata outside the calls array", () => {
+  const legacy: LegacyCallAction = { kind: "call", callId: "a", name: "read", arguments: {}, text: "Reading", usage: { promptTokens: 12, completionTokens: 2 } }
+  const action = normalizeAction(legacy)
+  expect(action).toEqual({ kind: "calls", calls: [{ callId: "a", name: "read", arguments: {} }], text: "Reading", usage: { promptTokens: 12, completionTokens: 2 } })
+  expect(normalizeAction(action)).toBe(action)
+})

--- a/packages/agent/src/inference/action-compat.ts
+++ b/packages/agent/src/inference/action-compat.ts
@@ -1,0 +1,12 @@
+import type { Action, ToolCall } from "../log/events"
+
+/** @deprecated Return Action with kind: "calls" instead. */
+export type LegacyCallAction = Omit<Extract<Action, { readonly kind: "calls" }>, "kind" | "calls"> & ToolCall & { readonly kind: "call" }
+
+// normalizeAction confines legacy single-call responses to the inference boundary.
+// TODO: Remove legacy call support in the next breaking release.
+export const normalizeAction = (action: Action | LegacyCallAction): Action => {
+  if (action.kind !== "call") return action
+  const { callId, name, arguments: args, kind: _kind, ...response } = action
+  return { ...response, kind: "calls", calls: [{ callId, name, arguments: args }] }
+}

--- a/packages/agent/src/inference/contract.ts
+++ b/packages/agent/src/inference/contract.ts
@@ -1,5 +1,6 @@
 import { Context, Effect } from "effect"
 import type { Event } from "@clavia/tardigrade-core/log/event"
+import type { LegacyCallAction } from "./action-compat"
 import type { Action } from "../log/events"
 import type { ContextPolicy } from "../component/compaction"
 import type { OutputFallback } from "../output/contract"
@@ -42,7 +43,7 @@ export class Infer extends Context.Service<
       key?: string,
       signal?: AbortSignal,
       onDelta?: (delta: InferDelta) => void
-    ) => Effect.Effect<Action>
+    ) => Effect.Effect<Action | LegacyCallAction>
     readonly resolve?: (reference?: ModelRef) => ModelResolution
   }
 >()("agent/Infer") {}

--- a/packages/agent/src/inference/machine.ts
+++ b/packages/agent/src/inference/machine.ts
@@ -1,3 +1,4 @@
+import { returnedAttemptCount } from "../log/response"
 import { bindTransitionContext } from "@clavia/tardigrade-core/transition/transition"
 import { eventAt, eventPositionOf } from "@clavia/tardigrade-core/event"
 import { Cause, Clock, Effect } from "effect"
@@ -5,7 +6,8 @@ import { EventLog } from "@clavia/tardigrade-core/log"
 import { HashMap, Option } from "effect"
 import { Self } from "@clavia/tardigrade-core/runtime"
 import { transitionProjection, type CompleteTransitionDerivation, type TransitionProjection } from "@clavia/tardigrade-core/transition"
-import { modelCalled, outputRejected, outputRepaired, textReturned, turnFailed } from "../log/events"
+import { normalizeAction } from "./action-compat"
+import { modelCalled, modelReturned, outputRejected, outputRepaired, textReturned, turnFailed } from "../log/events"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import type { Machine } from "@clavia/tardigrade-core/machine"
 import type { Action } from "../log/events"
@@ -100,12 +102,11 @@ const stampOf = (action: Action): { readonly endpoint?: unknown } =>
 // strict binding is checked rather than trusted (../turn.test.ts, "a turn that declares an output
 // contract"). What a mismatch means belongs to the implementation: a terminal under native or
 // local, and a recorded rejection under the two that carry on (src/output/contract.ts, mismatchCauseOf).
-const completionOf = (action: Action & { readonly kind: "complete" }, usage: unknown, ctx: Consequence): Event => {
+const completionOf = (action: Action & { readonly kind: "complete" }, ctx: Consequence): Event => {
   const mode = action.mode
   const completed = {
     type: "TurnCompleted",
     output: action.output,
-    usage,
     attemptKey: ctx.attempt,
     ...(mode === undefined ? {} : { mode }),
     ...stampOf(action),
@@ -122,7 +123,6 @@ const completionOf = (action: Action & { readonly kind: "complete" }, usage: unk
     return {
       type: "TurnFailed",
       error: `the model binding answered a turn declaring "${ctx.contract.name}" without stating the output mode it ran in`,
-      usage,
       turn: ctx.turn,
       ...epochStamp(ctx.epoch),
       cause: "inference_error",
@@ -142,7 +142,6 @@ const completionOf = (action: Action & { readonly kind: "complete" }, usage: unk
       text: action.output,
       errors: decoded.errors,
       mode,
-      usage,
       ...stampOf(action),
       turn: ctx.turn,
       ...epochStamp(ctx.epoch),
@@ -155,7 +154,6 @@ const completionOf = (action: Action & { readonly kind: "complete" }, usage: unk
     error:
       `the response missed the declared output contract "${ctx.contract.name}" in ${mode.name} mode:\n` +
       decoded.errors.map((e) => `- ${e}`).join("\n"),
-    usage,
     turn: ctx.turn,
     ...epochStamp(ctx.epoch),
     cause,
@@ -167,74 +165,26 @@ const completionOf = (action: Action & { readonly kind: "complete" }, usage: unk
   } as Event
 }
 
-// consequenceOf returns the action's recorded answer: the model responds by acting. Every
-// consequence carries the turn it serves, the attempt's spend, and who served it: `usage` is
-// always stamped, and an attempt whose binding reported nothing stamps an empty object, so
-// usageIn reads the spend as unknown rather than absent (usage.test.ts, "unknown is sticky").
-// `endpoint` is separate from spend on purpose: an endpoint that reports no tokens still has to
-// be named in the log (events.ts, Endpoint).
-const consequenceOf = (action: Exclude<Action, { readonly kind: "calls" }>, ctx: Consequence): Event => {
-  const usage = action.usage ?? {}
-  if (action.kind === "call" && ctx.contract !== undefined && action.mode === undefined) {
-    return {
-      type: "TurnFailed",
-      error: `the model binding answered a turn declaring "${ctx.contract.name}" with a tool call but did not state the output mode it ran in`,
-      usage,
-      turn: ctx.turn,
-      ...epochStamp(ctx.epoch),
-      cause: "inference_error",
-      attempts: 1,
-      attemptKey: ctx.attempt,
-      ...stampOf(action),
-      at: ctx.at
-    } as Event
-  }
-  return action.kind === "call"
-    ? ({
-        type: "ToolCalled",
-        callId: action.callId,
-        name: action.name,
-        arguments: action.arguments,
-        usage,
-        ...(action.mode === undefined ? {} : { mode: action.mode }),
-        ...stampOf(action),
-        turn: ctx.turn,
-        ...epochStamp(ctx.epoch),
-        at: ctx.at
-      } as Event)
-    : action.kind === "complete"
-      ? completionOf(action, usage, ctx)
-      : ({
-          type: "TurnFailed",
-          error: action.error,
-          usage,
-          turn: ctx.turn,
-          ...epochStamp(ctx.epoch),
-          cause: action.failure?.cause ?? "model",
-          ...(action.mode === undefined ? {} : { mode: action.mode }),
-          ...(action.failure === undefined
-            ? {}
-            : {
-                attempts: action.failure.attempts,
-                attemptKey: ctx.attempt,
-                ...(action.failure.policy === undefined ? {} : { policy: action.failure.policy })
-              }),
-          ...stampOf(action),
-          at: ctx.at
-        } as Event)
-}
-
-// consequencesOf records a batch in provider order with one usage entry (runtime/batches.test.ts).
+// consequencesOf records each tool request separately under its model response (runtime/batches.test.ts).
 const consequencesOf = (action: Action, ctx: Consequence): ReadonlyArray<Event> => {
-  if (action.kind !== "calls") return [consequenceOf(action, ctx)]
-  if (ctx.contract !== undefined && action.mode === undefined) {
-    return [consequenceOf({ ...action, ...action.calls[0], kind: "call" }, ctx)]
-  }
-  return action.calls.map((call, index) => {
-    const event = consequenceOf({ ...action, ...call, kind: "call" }, ctx)
-    const { usage, ...rest } = event
-    return { ...rest, batchId: ctx.attempt, batchIndex: index, ...(index === 0 ? { usage } : {}) } as Event
-  })
+  if (action.kind === "complete") return [completionOf(action, ctx)]
+  if (action.kind === "fail") return [{
+    type: "TurnFailed", error: action.error, turn: ctx.turn, ...epochStamp(ctx.epoch),
+    cause: action.failure?.cause ?? "model", attemptKey: ctx.attempt,
+    ...(action.failure === undefined ? {} : { attempts: action.failure.attempts, policy: action.failure.policy }),
+    ...(action.mode === undefined ? {} : { mode: action.mode }), ...stampOf(action), at: ctx.at
+  } as Event]
+  if (ctx.contract !== undefined && action.mode === undefined) return [{
+    type: "TurnFailed",
+    error: `the model binding answered a turn declaring "${ctx.contract.name}" with a tool call but did not state the output mode it ran in`,
+    turn: ctx.turn, ...epochStamp(ctx.epoch), cause: "inference_error", attempts: 1,
+    attemptKey: ctx.attempt, ...stampOf(action), at: ctx.at
+  } as Event]
+  return action.calls.map((call) => ({
+    type: "ToolCalled", ...call, responseId: ctx.attempt,
+    ...(action.mode === undefined ? {} : { mode: action.mode }),
+    ...stampOf(action), turn: ctx.turn, ...epochStamp(ctx.epoch), at: ctx.at
+  } as Event))
 }
 
 const failureMessage = (cause: Cause.Cause<never>): string => {
@@ -320,8 +270,7 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
   const modelFailures = derived.modelFailures
   // A rejected response is a spent logical attempt: the next ask must not reuse the idempotency
   // key, or a deduping provider answers the correction with the response it just refused.
-  const rejected = rejectionsIn(slice).length
-  const logicalAttempt = slice.filter((e) => e.type === "ToolCalled" && (e.batchIndex === undefined || e.batchIndex === 0)).length + modelFailures + rejected
+  const logicalAttempt = returnedAttemptCount(slice) + modelFailures
   const attempt = `${turn}/infer/${logicalAttempt}`
   const rendered = derived.rendered
   const fallback = rendered.output?.fallback
@@ -393,7 +342,7 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
     }
   }
   // The attempt's identity, the same string its ModelCalled mark carries. A died attempt leaves
-  // its mark. The completed tool calls count logical attempts, so an operator resume keeps the
+  // its mark. Recorded responses count logical attempts, so an operator resume keeps the
   // failed inference's provider idempotency key. The mark ordinal remains unique per physical run.
   return [
     context.effect("infer", {
@@ -480,7 +429,7 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
               Effect.asVoid
             )
           }
-          const action = yield* binding
+          const action = normalizeAction(yield* binding
             .react(
               {
                 trajectory,
@@ -513,9 +462,9 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
               Effect.ensuring(
                 Effect.suspend(() => signal?.aborted === true ? persistPartialOutput() : Effect.void)
               )
-            )
+            ))
           const after = yield* Clock.currentTimeMillis
-          const calls = action.kind === "calls" ? action.calls : action.kind === "call" ? [action] : []
+          const calls = action.kind === "calls" ? action.calls : []
           const seen = new Set(trajectory.filter((event) => event.type === "ToolCalled" && event.turn === input.turn).map((event) => String(event.callId)))
           const duplicate = calls.find((call) => {
             if (seen.has(call.callId)) return true
@@ -548,7 +497,13 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
               })
             : []
           return [
-            ...((action.kind === "call" || action.kind === "calls") && action.text !== undefined && action.text !== ""
+            modelReturned({
+              callId: input.attempt, ordinal: input.ordinal, turn: input.turn, ...epochStamp(input.epoch),
+              outcome: action.kind === "fail" ? "failed" : "returned",
+              usage: action.usage ?? {}, ...stampOf(action),
+              ...(action.kind === "fail" ? { error: action.error } : {}), at: after
+            }),
+            ...(action.kind === "calls" && action.text !== undefined && action.text !== ""
               ? [textReturned({ text: action.text, turn: input.turn, at: after })]
               : []),
             ...repaired.map((event) => outputRepaired({

--- a/packages/agent/src/inference/machine.ts
+++ b/packages/agent/src/inference/machine.ts
@@ -1,4 +1,4 @@
-import { returnedAttemptCount } from "../log/response"
+import { responsesOf } from "../log/response"
 import { bindTransitionContext } from "@clavia/tardigrade-core/transition/transition"
 import { eventAt, eventPositionOf } from "@clavia/tardigrade-core/event"
 import { Cause, Clock, Effect } from "effect"
@@ -168,23 +168,30 @@ const completionOf = (action: Action & { readonly kind: "complete" }, ctx: Conse
 // consequencesOf records each tool request separately under its model response (runtime/batches.test.ts).
 const consequencesOf = (action: Action, ctx: Consequence): ReadonlyArray<Event> => {
   if (action.kind === "complete") return [completionOf(action, ctx)]
+  const stamp = {
+    turn: ctx.turn,
+    ...epochStamp(ctx.epoch),
+    ...(action.mode === undefined ? {} : { mode: action.mode }),
+    ...stampOf(action),
+    at: ctx.at
+  }
   if (action.kind === "fail") return [{
-    type: "TurnFailed", error: action.error, turn: ctx.turn, ...epochStamp(ctx.epoch),
-    cause: action.failure?.cause ?? "model", attemptKey: ctx.attempt,
-    ...(action.failure === undefined ? {} : { attempts: action.failure.attempts, policy: action.failure.policy }),
-    ...(action.mode === undefined ? {} : { mode: action.mode }), ...stampOf(action), at: ctx.at
-  } as Event]
+    ...stamp,
+    type: "TurnFailed",
+    error: action.error,
+    cause: action.failure?.cause ?? "model",
+    attemptKey: ctx.attempt,
+    ...(action.failure === undefined ? {} : { attempts: action.failure.attempts, policy: action.failure.policy })
+  }]
   if (ctx.contract !== undefined && action.mode === undefined) return [{
+    ...stamp,
     type: "TurnFailed",
     error: `the model binding answered a turn declaring "${ctx.contract.name}" with a tool call but did not state the output mode it ran in`,
-    turn: ctx.turn, ...epochStamp(ctx.epoch), cause: "inference_error", attempts: 1,
-    attemptKey: ctx.attempt, ...stampOf(action), at: ctx.at
-  } as Event]
-  return action.calls.map((call) => ({
-    type: "ToolCalled", ...call, responseId: ctx.attempt,
-    ...(action.mode === undefined ? {} : { mode: action.mode }),
-    ...stampOf(action), turn: ctx.turn, ...epochStamp(ctx.epoch), at: ctx.at
-  } as Event))
+    cause: "inference_error",
+    attempts: 1,
+    attemptKey: ctx.attempt
+  }]
+  return action.calls.map((call) => ({ type: "ToolCalled", ...call, ...stamp, responseId: ctx.attempt }))
 }
 
 const failureMessage = (cause: Cause.Cause<never>): string => {
@@ -270,7 +277,7 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
   const modelFailures = derived.modelFailures
   // A rejected response is a spent logical attempt: the next ask must not reuse the idempotency
   // key, or a deduping provider answers the correction with the response it just refused.
-  const logicalAttempt = returnedAttemptCount(slice) + modelFailures
+  const logicalAttempt = responsesOf(slice).returnedAttempts + modelFailures
   const attempt = `${turn}/infer/${logicalAttempt}`
   const rendered = derived.rendered
   const fallback = rendered.output?.fallback

--- a/packages/agent/src/inference/usage.ts
+++ b/packages/agent/src/inference/usage.ts
@@ -405,11 +405,8 @@ const ofTurn = (event: Event, turn: string): boolean => {
   return callId === turn || callId.startsWith(`${turn}/`)
 }
 
-// usageIn sums what one turn spent on the model. A live attempt's consequence carries the
-// spend as its `usage` field, so the sum reads fields, never event types. An empty usage is an
-// attempt with unreported spend, and it keeps the total unknown (usage.test.ts, "unknown is
-// sticky"). An event with no usage field is no attempt: a died ModelCalled and the give-up
-// TurnFailed invent nothing.
+// usageIn sums response usage and legacy consequence usage for one turn (usage.test.ts).
+// Missing usage is not spend; an empty usage object retains unknown spend.
 export const usageIn = (log: ReadonlyArray<Event>, turn: string): Usage =>
   sumUsage(
     log.flatMap((event) => {

--- a/packages/agent/src/log/budget.ts
+++ b/packages/agent/src/log/budget.ts
@@ -1,0 +1,10 @@
+import type { Event } from "@clavia/tardigrade-core/log/event"
+import { upcast } from "./upcast"
+
+// startingBudget resolves the allowance not represented by recorded grants (component/budget.test.ts).
+export const startingBudget = (events: ReadonlyArray<Event>, fallback: number): number =>
+  upcast(events).budget.startingAllowance ?? fallback
+
+// needsInitialBudget reports whether a turn needs its starting grant (runtime/batches.test.ts).
+export const needsInitialBudget = (events: ReadonlyArray<Event>): boolean =>
+  upcast(events).budget.needsInitialGrant

--- a/packages/agent/src/log/events.ts
+++ b/packages/agent/src/log/events.ts
@@ -49,15 +49,15 @@ export const ToolCalled = Schema.Struct({
   callId: Schema.String,
   name: Schema.String,
   arguments: Schema.Unknown,
+  responseId: Schema.optional(Schema.String),
   batchId: Schema.optional(Schema.String),
   batchIndex: Schema.optional(Schema.Finite),
-  // The spend of the attempt this call answered (packages/agent/src/inference/usage.ts). An empty object
-  // is an attempt with unreported spend; an absent field is an event no attempt produced.
+  // usage preserves historical response spend; new responses use ModelReturned (inference/usage.test.ts).
   usage: Schema.optional(Schema.Unknown),
   endpoint: Schema.optional(Endpoint),
   // A tool call may be one response in a turn that declares final output. Its effective mode is
   // recorded here so replay does not decide how this attempt ran from a current capability
-  // (inference/machine.ts, consequenceOf).
+  // (inference/machine.ts, consequencesOf).
   mode: Schema.optional(Schema.Unknown),
   epoch: Schema.optional(Schema.Finite),
   at: Schema.Finite
@@ -72,10 +72,7 @@ export const ToolReturned = Schema.Struct({
   at: Schema.Finite
 })
 
-// ModelCalled is the ask to the model and the attempt mark in one, appended before the inference
-// runs. A committed acting consequence after it is the answer, and that consequence's `usage`
-// field is the attempt's spend. Consecutive `ModelCalled` with nothing between them are
-// attempts that died, and the give-up guard reads that count.
+// ModelCalled records the attempt before inference; an interrupted attempt can remain unanswered (runtime/turn.test.ts).
 export const ModelCalled = Schema.Struct({
   type: Schema.Literal("ModelCalled"),
   callId: Schema.String,
@@ -89,6 +86,20 @@ export const ModelCalled = Schema.Struct({
   output: Schema.optional(OutputPolicy),
   epoch: Schema.optional(Schema.Finite),
   turn: Schema.optional(Schema.String),
+  at: Schema.Finite
+})
+
+// ModelReturned settles a model attempt and owns its response usage (runtime/batches.test.ts).
+export const ModelReturned = Schema.Struct({
+  type: Schema.Literal("ModelReturned"),
+  callId: Schema.String,
+  ordinal: Schema.Finite,
+  outcome: Schema.Literals(["returned", "failed"]),
+  usage: Schema.Unknown,
+  endpoint: Schema.optional(Endpoint),
+  error: Schema.optional(Schema.String),
+  epoch: Schema.optional(Schema.Finite),
+  turn: Schema.String,
   at: Schema.Finite
 })
 
@@ -316,6 +327,7 @@ export const PermissionRequestFailed = Schema.Struct({
 export const BudgetGranted = Schema.Struct({
   type: Schema.Literal("BudgetGranted"),
   amount: Schema.Finite, // the tool calls added to this turn's budget
+  initial: Schema.optional(Schema.Boolean),
   // The BudgetRequested this grant answers. The dedup key reads it: a grant is summed into the
   // ceiling (component/budget.ts), so a redelivered grant landing twice would silently
   // double the budget; keyed by the request it answers, the store absorbs the repeat.
@@ -336,6 +348,7 @@ export const BudgetDenied = Schema.Struct({
 export const AgentEvent = Schema.Union([
   MessageReceived,
   ModelCalled,
+  ModelReturned,
   TextReturned,
   ToolCalled,
   ToolReturned,
@@ -390,7 +403,6 @@ export interface ToolCall {
 }
 
 export type Action =
-  | ({ readonly kind: "call"; readonly callId: string; readonly name: string; readonly arguments: unknown; readonly text?: string } & Served)
   | ({ readonly kind: "calls"; readonly calls: readonly [ToolCall, ...ToolCall[]]; readonly text?: string } & Served)
   | ({ readonly kind: "complete"; readonly output: string } & Served)
   | ({
@@ -410,13 +422,14 @@ export type Action =
 const epochSuffix = (epoch: unknown): string => epoch === undefined || Number(epoch) === 0 ? "" : `/${String(epoch)}`
 
 export const agentKeys: KeyFragment = {
-  prefixes: ["tr:", "bdec:", "tn:", "rs:", "mr:", "mc:", "bw:", "br:", "cc:", "or:", "oq:", "op:"],
+  prefixes: ["tr:", "bdec:", "bi:", "tn:", "rs:", "mr:", "mc:", "bw:", "br:", "cc:", "or:", "oq:", "op:"],
   keyOf: (e) => {
     const v = e as Record<string, unknown>
     switch (e.type) {
       case "ToolReturned":
         return `tr:${String(v.callId)}`
       case "BudgetGranted":
+        if (v.initial === true) return `bi:${String(v.turn)}`
         return v.callId === undefined ? undefined : `bdec:${String(v.callId)}`
       case "BudgetDenied":
         return v.callId === undefined ? undefined : `bdec:${String(v.callId)}`
@@ -432,6 +445,8 @@ export const agentKeys: KeyFragment = {
         // repetition that evidences died attempts is preserved. A mark predating the ordinal
         // lands unkeyed, which the folds tolerate.
         return v.ordinal === undefined ? undefined : `mc:${String(v.turn)}/${String(v.ordinal)}`
+      case "ModelReturned":
+        return `mr:${String(v.turn)}/${String(v.ordinal)}`
       case "BudgetExhausted":
         // The wall's occurrence is the ceiling it fired at: a grant raises it, so a second
         // crossing keys anew.
@@ -486,6 +501,18 @@ export const modelCalled = (
     }
   } & EpochStamp
 ): Event => ({ type: "ModelCalled", ...fields }) as Event
+export const modelReturned = (
+  fields: {
+    readonly callId: string
+    readonly ordinal: number
+    readonly turn: string
+    readonly outcome: "returned" | "failed"
+    readonly usage: unknown
+    readonly endpoint?: unknown
+    readonly error?: string
+  } & EpochStamp
+): Event => ({ type: "ModelReturned", ...fields }) as Event
+
 export const textReturned = (
   fields: { readonly text: string } & EpochStamp
 ): Event => ({ type: "TextReturned", ...fields }) as Event
@@ -589,7 +616,7 @@ export const permissionRequestFailed = (
 ): Event => ({ type: "PermissionRequestFailed", ...fields }) as Event
 
 export const budgetGranted = (
-  fields: { readonly amount: number; readonly callId?: string } & Stamp
+  fields: { readonly amount: number; readonly callId?: string; readonly initial?: boolean } & Stamp
 ): Event => ({ type: "BudgetGranted", ...fields }) as Event
 
 export const budgetDenied = (

--- a/packages/agent/src/log/response.test.ts
+++ b/packages/agent/src/log/response.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test"
 import type { Event } from "@clavia/tardigrade-core/log/event"
-import { firstResponseCallIndex, returnedAttemptCount, toolResponseKey } from "./response"
+import { responsesOf } from "./response"
 
 test.each(["current", "legacy", "singleton"])("response readers preserve %s history", (format) => {
   const calls: Event[] = [0, 1].map((index) => ({
@@ -11,9 +11,10 @@ test.each(["current", "legacy", "singleton"])("response readers preserve %s hist
     ? [{ type: "ModelReturned", callId: "response", outcome: "returned", at: 1 }, ...calls]
     : calls
   const before = JSON.stringify(history)
-  expect(firstResponseCallIndex(history, calls[1]!)).toBe(format === "current" ? 1 : format === "legacy" ? 0 : 1)
-  expect(returnedAttemptCount(history)).toBe(format === "singleton" ? 2 : 1)
-  expect(toolResponseKey(calls[0]!)).toBe(toolResponseKey(calls[1]!))
+  const responses = responsesOf(history)
+  expect(responses.firstCalls.get(calls[1]!)).toBe(calls[format === "singleton" ? 1 : 0]!)
+  expect(responsesOf(history).returnedAttempts).toBe(format === "singleton" ? 2 : 1)
+  expect(responses.keys.get(calls[0]!)).toBe(responses.keys.get(calls[1]!))
   expect(JSON.stringify(history)).toBe(before)
 })
 
@@ -25,7 +26,9 @@ test("response counts distinguish retries, rejections and old consequences", () 
     { type: "OutputRejected", attempt: "retry", at: 2 },
     { type: "OutputRejected", attempt: "old", at: 3 }
   ]
-  expect(returnedAttemptCount(history)).toBe(2)
-  expect(toolResponseKey({ type: "ToolCalled", turn: "a", responseId: "same", at: 1 }))
-    .not.toBe(toolResponseKey({ type: "ToolCalled", turn: "b", responseId: "same", at: 1 }))
+  expect(responsesOf(history).returnedAttempts).toBe(2)
+  const calls: Event[] = ["a", "b"].map((turn) => ({ type: "ToolCalled", turn, responseId: "same", at: 1 }))
+  const responses = responsesOf(calls)
+  expect(responses.keys.get(calls[0]!)).not.toBe(responses.keys.get(calls[1]!))
+  expect(responses.firstCalls.get(calls[1]!)).toBe(calls[1]!)
 })

--- a/packages/agent/src/log/response.test.ts
+++ b/packages/agent/src/log/response.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test"
+import type { Event } from "@clavia/tardigrade-core/log/event"
+import { firstResponseCallIndex, returnedAttemptCount, toolResponseKey } from "./response"
+
+test.each(["current", "legacy", "singleton"])("response readers preserve %s history", (format) => {
+  const calls: Event[] = [0, 1].map((index) => ({
+    type: "ToolCalled", turn: "turn", callId: String(index), at: 1,
+    ...(format === "current" ? { responseId: "response" } : format === "legacy" ? { batchId: "response", batchIndex: index } : {})
+  }))
+  const history: Event[] = format === "current"
+    ? [{ type: "ModelReturned", callId: "response", outcome: "returned", at: 1 }, ...calls]
+    : calls
+  const before = JSON.stringify(history)
+  expect(firstResponseCallIndex(history, calls[1]!)).toBe(format === "current" ? 1 : format === "legacy" ? 0 : 1)
+  expect(returnedAttemptCount(history)).toBe(format === "singleton" ? 2 : 1)
+  expect(toolResponseKey(calls[0]!)).toBe(toolResponseKey(calls[1]!))
+  expect(JSON.stringify(history)).toBe(before)
+})
+
+test("response counts distinguish retries, rejections and old consequences", () => {
+  const history: Event[] = [
+    { type: "ModelCalled", callId: "retry", at: 0 },
+    { type: "ModelReturned", callId: "retry", outcome: "failed", at: 1 },
+    { type: "ModelReturned", callId: "retry", outcome: "returned", at: 2 },
+    { type: "OutputRejected", attempt: "retry", at: 2 },
+    { type: "OutputRejected", attempt: "old", at: 3 }
+  ]
+  expect(returnedAttemptCount(history)).toBe(2)
+  expect(toolResponseKey({ type: "ToolCalled", turn: "a", responseId: "same", at: 1 }))
+    .not.toBe(toolResponseKey({ type: "ToolCalled", turn: "b", responseId: "same", at: 1 }))
+})

--- a/packages/agent/src/log/response.ts
+++ b/packages/agent/src/log/response.ts
@@ -1,17 +1,27 @@
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import { upcast } from "./upcast"
 
-// toolResponseKey identifies grouped tool requests (response.test.ts).
-export const toolResponseKey = (event: Event): string | undefined => upcast([event]).entries[0]?.responseKey
-
-// firstResponseCallIndex locates the first request in a response (response.test.ts).
-export const firstResponseCallIndex = (events: ReadonlyArray<Event>, call: Event): number => {
-  const entries = upcast(events).entries
-  const index = events.indexOf(call)
-  const key = entries[index]?.responseKey
-  return key === undefined ? index : entries.findIndex((entry) => entry.responseKey === key)
+// responsesOf indexes response groups and counts completed attempts without changing event identity (response.test.ts).
+export const responsesOf = (events: ReadonlyArray<Event>): {
+  readonly keys: ReadonlyMap<Event, string>
+  readonly firstCalls: ReadonlyMap<Event, Event>
+  readonly returnedAttempts: number
+} => {
+  const keys = new Map<Event, string>()
+  const firstCalls = new Map<Event, Event>()
+  const groups = new Map<string, Event>()
+  let returnedAttempts = 0
+  for (const { event, responseKey, advancesInference } of upcast(events).entries) {
+    if (advancesInference) returnedAttempts += 1
+    if (event.type !== "ToolCalled") continue
+    if (responseKey === undefined) {
+      firstCalls.set(event, event)
+    } else {
+      const first = groups.get(responseKey) ?? event
+      groups.set(responseKey, first)
+      keys.set(event, responseKey)
+      firstCalls.set(event, first)
+    }
+  }
+  return { keys, firstCalls, returnedAttempts }
 }
-
-// returnedAttemptCount counts responses that advance inference (response.test.ts).
-export const returnedAttemptCount = (events: ReadonlyArray<Event>): number =>
-  upcast(events).entries.filter((entry) => entry.advancesInference).length

--- a/packages/agent/src/log/response.ts
+++ b/packages/agent/src/log/response.ts
@@ -1,0 +1,17 @@
+import type { Event } from "@clavia/tardigrade-core/log/event"
+import { upcast } from "./upcast"
+
+// toolResponseKey identifies grouped tool requests (response.test.ts).
+export const toolResponseKey = (event: Event): string | undefined => upcast([event]).entries[0]?.responseKey
+
+// firstResponseCallIndex locates the first request in a response (response.test.ts).
+export const firstResponseCallIndex = (events: ReadonlyArray<Event>, call: Event): number => {
+  const entries = upcast(events).entries
+  const index = events.indexOf(call)
+  const key = entries[index]?.responseKey
+  return key === undefined ? index : entries.findIndex((entry) => entry.responseKey === key)
+}
+
+// returnedAttemptCount counts responses that advance inference (response.test.ts).
+export const returnedAttemptCount = (events: ReadonlyArray<Event>): number =>
+  upcast(events).entries.filter((entry) => entry.advancesInference).length

--- a/packages/agent/src/log/upcast.test.ts
+++ b/packages/agent/src/log/upcast.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test"
+import type { Event } from "@clavia/tardigrade-core/log/event"
+import { upcast } from "./upcast"
+
+test.each(["current", "legacy"])("upcast reads %s batches without inventing response events", (format) => {
+  const calls: Event[] = [0, 1].map((index) => ({
+    type: "ToolCalled", turn: "turn", callId: String(index), at: 1,
+    ...(format === "current" ? { responseId: "response" } : { batchId: "response", batchIndex: index })
+  }))
+  const history: Event[] = format === "current"
+    ? [{ type: "ModelReturned", turn: "turn", callId: "response", outcome: "returned", at: 1 }, ...calls]
+    : calls
+  const before = JSON.stringify(history)
+  const view = upcast(history)
+  expect(view.entries.filter((entry) => entry.advancesInference)).toHaveLength(1)
+  expect(view.entries.filter((entry) => entry.event.type === "ToolCalled").map((entry) => entry.responseKey))
+    .toEqual(['["turn",0,"response"]', '["turn",0,"response"]'])
+  expect(view.entries.map((entry) => entry.event)).toEqual(history)
+  view.entries.forEach((entry, index) => expect(entry.event).toBe(history[index]!))
+  expect(JSON.stringify(history)).toBe(before)
+  expect(upcast(view.entries.map((entry) => entry.event))).toEqual(view)
+})
+
+test("upcast preserves unknown starting allowances and recognizes recorded grants", () => {
+  const head: Event = { type: "MessageReceived", id: "turn", at: 0 }
+  expect(upcast([head]).budget).toEqual({ startingAllowance: undefined, needsInitialGrant: true })
+  expect(upcast([{ ...head, budget: 3 }]).budget.startingAllowance).toBe(3)
+  expect(upcast([head, { type: "ModelCalled", turn: "turn", at: 1 }]).budget)
+    .toEqual({ startingAllowance: undefined, needsInitialGrant: false })
+  expect(upcast([head, { type: "BudgetGranted", initial: true, amount: 3, turn: "turn", at: 1 }]).budget)
+    .toEqual({ startingAllowance: 0, needsInitialGrant: false })
+})

--- a/packages/agent/src/log/upcast.ts
+++ b/packages/agent/src/log/upcast.ts
@@ -1,0 +1,45 @@
+import type { Event } from "@clavia/tardigrade-core/log/event"
+
+export interface ReadEvent {
+  readonly event: Event
+  readonly responseKey?: string
+  readonly advancesInference: boolean
+}
+
+export interface ReadHistory {
+  readonly entries: ReadonlyArray<ReadEvent>
+  readonly budget: {
+    readonly startingAllowance: number | undefined
+    readonly needsInitialGrant: boolean
+  }
+}
+
+// upcast normalizes a history into read metadata without changing or synthesizing stored events (upcast.test.ts).
+// Budget metadata describes a single turn. An undefined starting allowance requires the caller's fallback; an unrecorded historical default remains unknown.
+export const upcast = (events: ReadonlyArray<Event>): ReadHistory => {
+  const responses = events.filter((event) => event.type === "ModelReturned")
+  const head = events.find((event) => event.type === "MessageReceived")
+  const initial = events.some((event) => event.type === "BudgetGranted" && event.initial === true)
+  return {
+    entries: events.map((event) => {
+      const response = event.type === "ToolCalled" ? event.responseId ?? event.batchId : undefined
+      const advancesInference = event.type === "ModelReturned"
+        ? event.outcome === "returned"
+        : event.type === "ToolCalled"
+          ? event.responseId === undefined && (event.batchIndex === undefined || event.batchIndex === 0)
+          : event.type === "OutputRejected" && !responses.some((reply) =>
+              reply.callId === event.attempt && reply.turn === event.turn && (reply.epoch ?? 0) === (event.epoch ?? 0))
+      return {
+        event,
+        ...(response === undefined ? {} : { responseKey: JSON.stringify([event.turn ?? null, event.epoch ?? 0, response]) }),
+        advancesInference
+      }
+    }),
+    budget: {
+      startingAllowance: initial ? 0 : typeof head?.budget === "number" && head.budget > 0 ? Math.floor(head.budget) : undefined,
+      needsInitialGrant: head !== undefined && !events.some((event) =>
+        event.type === "BudgetGranted" || event.type === "ModelCalled" || event.type === "ToolCalled" ||
+        event.type === "TurnCompleted" || event.type === "TurnFailed" || event.type === "TurnCancelled")
+    }
+  }
+}

--- a/packages/agent/src/log/upcast.ts
+++ b/packages/agent/src/log/upcast.ts
@@ -17,7 +17,8 @@ export interface ReadHistory {
 // upcast normalizes a history into read metadata without changing or synthesizing stored events (upcast.test.ts).
 // Budget metadata describes a single turn. An undefined starting allowance requires the caller's fallback; an unrecorded historical default remains unknown.
 export const upcast = (events: ReadonlyArray<Event>): ReadHistory => {
-  const responses = events.filter((event) => event.type === "ModelReturned")
+  const responseKey = (event: Event, id: unknown) => JSON.stringify([event.turn ?? null, event.epoch ?? 0, id])
+  const responses = new Set(events.filter((event) => event.type === "ModelReturned").map((event) => responseKey(event, event.callId)))
   const head = events.find((event) => event.type === "MessageReceived")
   const initial = events.some((event) => event.type === "BudgetGranted" && event.initial === true)
   return {
@@ -27,11 +28,10 @@ export const upcast = (events: ReadonlyArray<Event>): ReadHistory => {
         ? event.outcome === "returned"
         : event.type === "ToolCalled"
           ? event.responseId === undefined && (event.batchIndex === undefined || event.batchIndex === 0)
-          : event.type === "OutputRejected" && !responses.some((reply) =>
-              reply.callId === event.attempt && reply.turn === event.turn && (reply.epoch ?? 0) === (event.epoch ?? 0))
+          : event.type === "OutputRejected" && !responses.has(responseKey(event, event.attempt))
       return {
         event,
-        ...(response === undefined ? {} : { responseKey: JSON.stringify([event.turn ?? null, event.epoch ?? 0, response]) }),
+        ...(response === undefined ? {} : { responseKey: responseKey(event, response) }),
         advancesInference
       }
     }),

--- a/packages/agent/src/projection/messages.ts
+++ b/packages/agent/src/projection/messages.ts
@@ -1,4 +1,4 @@
-import { toolResponseKey as batchKey } from "../log/response"
+import { responsesOf } from "../log/response"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import { replayProjection, type Projection } from "@clavia/tardigrade-core/projection"
 import { terminalReportOutcomeOf } from "@clavia/tardigrade-core/interaction/provider-message"
@@ -73,6 +73,7 @@ const messagesFrom = (
   )
   if (openHead !== -1 && openHead < from) messages.push(userMessageOf(projected[openHead]!, resolved))
   if (checkpoint.summary !== "") messages.push({ role: "user", content: `Summary of earlier work:\n${checkpoint.summary}` })
+  const responses = responsesOf(projected)
   const batches = new Map<string, AgentToolCall[]>()
   const callOf = (event: Event): AgentToolCall => ({
     id: String(event.callId),
@@ -80,7 +81,7 @@ const messagesFrom = (
     arguments: JSON.stringify(event.arguments ?? {})
   })
   for (const event of projected.slice(from)) {
-    const key = batchKey(event)
+    const key = responses.keys.get(event)
     if (event.type !== "ToolCalled" || key === undefined) continue
     const calls = batches.get(key) ?? []
     calls.push(callOf(event))
@@ -98,7 +99,7 @@ const messagesFrom = (
         pendingText = String(value.text ?? "")
         break
       case "ToolCalled": {
-        const key = batchKey(event)
+        const key = responses.keys.get(event)
         if (key !== undefined && emitted.has(key)) break
         if (key !== undefined) emitted.add(key)
         messages.push({

--- a/packages/agent/src/projection/messages.ts
+++ b/packages/agent/src/projection/messages.ts
@@ -1,3 +1,4 @@
+import { toolResponseKey as batchKey } from "../log/response"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import { replayProjection, type Projection } from "@clavia/tardigrade-core/projection"
 import { terminalReportOutcomeOf } from "@clavia/tardigrade-core/interaction/provider-message"
@@ -72,9 +73,6 @@ const messagesFrom = (
   )
   if (openHead !== -1 && openHead < from) messages.push(userMessageOf(projected[openHead]!, resolved))
   if (checkpoint.summary !== "") messages.push({ role: "user", content: `Summary of earlier work:\n${checkpoint.summary}` })
-  const batchKey = (event: Event): string | undefined => event.batchId === undefined
-    ? undefined
-    : JSON.stringify([event.turn ?? null, event.epoch ?? 0, event.batchId])
   const batches = new Map<string, AgentToolCall[]>()
   const callOf = (event: Event): AgentToolCall => ({
     id: String(event.callId),

--- a/packages/agent/src/runtime/batches.test.ts
+++ b/packages/agent/src/runtime/batches.test.ts
@@ -65,6 +65,7 @@ describe("tool batches", () => {
       })
       await original.start()
       const grantIndex = original.read().findIndex((event) => event.type === "BudgetGranted")
+      expect(grantIndex).toBeLessThan(original.read().findIndex((event) => event.type === "ModelCalled"))
       const pending = original.read().slice(0, grantIndex + 1)
       const resumed = setup(components(replacement), complete, {}, pending)
       await resumed.host.wake(ROOT)
@@ -244,26 +245,6 @@ describe("tool batches", () => {
       hold.resolve()
       await driving
     }
-  })
-
-  test("an initial grant fixes the allowance across restart and a changed default", async () => {
-    const initial = setup([budget([tool({ spec, run: () => Effect.succeed("read") })], { limit: 1 })],
-      (request) => request.trajectory.some((event) => event.type === "ToolCalled") ? complete() : batch(call("a"), call("b")))
-    await initial.start()
-    const history = initial.read()
-    expect(history.filter((event) => event.type !== "ThreadCreated").slice(0, 3).map((event) => event.type)).toEqual(["MessageReceived", "BudgetGranted", "ModelCalled"])
-    expect(history.filter((event) => event.type === "BudgetGranted")).toMatchObject([{ amount: 1, initial: true, turn: TURN }])
-    const pending = history.slice(0, history.findLastIndex((event) => event.type === "ToolCalled") + 1)
-    const ran: string[] = []
-    const recovered = setup([budget([tool({ spec, run: (_input, context) => Effect.sync(() => {
-      ran.push(context.callId)
-      return context.callId
-    }) })], { limit: 2 })], complete, {}, pending)
-    await recovered.host.wake(ROOT)
-    await recovered.host.drive()
-    expect(ran).toEqual(["a"])
-    expect(recovered.read().filter((event) => event.type === "BudgetGranted")).toHaveLength(1)
-    expect(recovered.read().find((event) => event.type === "ToolReturned" && event.callId === "b")?.result).toMatchObject({ error: expect.stringContaining("Tool budget reached") })
   })
 
   test.each([undefined, 1])("historical resume with a changed default and recorded budget %s", async (recordedBudget) => {

--- a/packages/agent/src/runtime/batches.test.ts
+++ b/packages/agent/src/runtime/batches.test.ts
@@ -1,8 +1,10 @@
+import fc from "fast-check"
 import { describe, expect, test } from "bun:test"
 import { Effect, Layer } from "effect"
 import { KeyValueStore } from "effect/unstable/persistence"
 import { actor } from "@clavia/tardigrade-core/actor"
 import type { Event } from "@clavia/tardigrade-core/log/event"
+import { EventLog } from "@clavia/tardigrade-core/log"
 import { createHost } from "@clavia/tardigrade-host/host"
 import { agentMethods, budget, codeMode, infer, nativeOutput, tool } from "../index"
 import { jsSandboxFor } from "@clavia/tardigrade-code/sandbox/defaults"
@@ -54,6 +56,84 @@ const setup = (
 const complete = (): Action => ({ kind: "complete", output: "done", usage: { promptTokens: 50, completionTokens: 5, costUsd: 0.005 } })
 
 describe("tool batches", () => {
+  test("generated starting allowances are recorded once before inference and survive restart", async () => {
+    await fc.assert(fc.asyncProperty(fc.integer({ min: 1, max: 20 }), fc.integer({ min: 1, max: 20 }), async (limit, replacement) => {
+      const components = (amount: number) => [budget([tool({ spec, run: () => Effect.void })], { limit: amount })]
+      const original = setup(components(limit), (request) => {
+        expect(request.trajectory.filter((event) => event.type === "BudgetGranted")).toMatchObject([{ initial: true, amount: limit }])
+        return complete()
+      })
+      await original.start()
+      const grantIndex = original.read().findIndex((event) => event.type === "BudgetGranted")
+      const pending = original.read().slice(0, grantIndex + 1)
+      const resumed = setup(components(replacement), complete, {}, pending)
+      await resumed.host.wake(ROOT)
+      await resumed.host.drive()
+      expect(resumed.read().filter((event) => event.type === "BudgetGranted")).toMatchObject([{ initial: true, amount: limit }])
+      expect(resumed.read().filter((event) => event.type === "BudgetGranted")).toHaveLength(1)
+      expect(boundaryOf(resumed.read(), TURN)?.kind).toBe("completed")
+    }), { numRuns: 20 })
+  })
+
+  test("generated grants preserve admission and bounded progress across replay", async () => {
+    await fc.assert(fc.asyncProperty(
+      fc.integer({ min: 1, max: 5 }),
+      fc.array(fc.oneof(fc.constant("call" as const), fc.integer({ min: 1, max: 3 })), { minLength: 1, maxLength: 12 }),
+      fc.integer({ min: 1, max: 4 }), fc.nat(),
+      async (initial, operations, concurrency, restartSeed) => {
+        const tokens = Array.from({ length: initial }, () => true)
+        const admitted: string[] = []
+        const requested: string[] = []
+        const history: Event[] = [
+          { type: "MessageReceived", id: TURN, text: "work", at: 0 },
+          { type: "BudgetGranted", initial: true, amount: initial, turn: TURN, at: 1 },
+          { type: "ModelCalled", callId: "m1/infer/0", ordinal: 0, turn: TURN, at: 2 },
+          { type: "ModelReturned", callId: "m1/infer/0", ordinal: 0, turn: TURN, outcome: "returned", usage: {}, at: 3 }
+        ]
+        for (const operation of [...operations, "call"] as const) {
+          if (typeof operation === "number") {
+            tokens.push(...Array.from({ length: operation }, () => true))
+            history.push({ type: "BudgetGranted", amount: operation, turn: TURN, at: history.length })
+          } else {
+            const callId = `call-${requested.length}`
+            requested.push(callId)
+            if (tokens.shift() !== undefined) admitted.push(callId)
+            history.push({ type: "ToolCalled", ...call(callId), responseId: "m1/infer/0", turn: TURN, at: history.length })
+          }
+        }
+        const runFrom = async (saved: ReadonlyArray<Event>, limit: number) => {
+          const executions: string[] = []
+          const recovered = setup([budget([tool({ spec, run: (_input, context) => Effect.gen(function* () {
+            for (let step = 0; step < (Number(context.callId.split("-")[1]) + restartSeed) % 4; step++) yield* Effect.yieldNow
+            executions.push(context.callId)
+            return context.callId
+          }) })], { limit })], (request) => {
+            expect(request.trajectory.filter((event) => event.type === "ToolReturned")).toHaveLength(requested.length)
+            return complete()
+          }, { toolConcurrency: concurrency }, saved)
+          await recovered.host.wake(ROOT)
+          await recovered.host.drive()
+          expect(boundaryOf(recovered.read(), TURN)?.kind).toBe("completed")
+          const results = recovered.read().filter((event) => event.type === "ToolReturned")
+          expect(results).toHaveLength(requested.length)
+          expect(new Set(results.map((event) => event.callId)).size).toBe(requested.length)
+          for (const event of results) {
+            expect(event.result).toEqual(admitted.includes(String(event.callId)) ? event.callId : { error: expect.stringContaining("Tool budget reached") })
+          }
+          expect(recovered.read().filter((event) => event.type === "BudgetGranted" && event.initial === true)).toHaveLength(1)
+          return { events: recovered.read(), executions }
+        }
+        const first = await runFrom(history, 1)
+        expect([...first.executions].sort()).toEqual([...admitted].sort())
+        const cut = history.length + restartSeed % (first.events.length - history.length + 1)
+        const saved = first.events.slice(0, cut)
+        const done = new Set(saved.filter((event) => event.type === "ToolReturned").map((event) => event.callId))
+        const replay = await runFrom(saved, initial + 10)
+        expect([...replay.executions].sort()).toEqual(admitted.filter((id) => !done.has(id)).sort())
+      }
+    ), { numRuns: 60 })
+  }, 30_000)
+
   test("default dispatch overlaps calls and waits for every result before inference", async () => {
     const first = Promise.withResolvers<void>()
     const second = Promise.withResolvers<void>()
@@ -85,6 +165,14 @@ describe("tool batches", () => {
       await driving
     }
     expect(keys).toEqual(["m1/infer/0", "m1/infer/1"])
+    const responses = run.read().filter((event) => event.type === "ModelReturned")
+    expect(responses.map((event) => [event.callId, event.ordinal, event.outcome])).toEqual([
+      ["m1/infer/0", 0, "returned"], ["m1/infer/1", 1, "returned"]
+    ])
+    const requests = run.read().filter((event) => event.type === "ToolCalled")
+    expect(requests.map((event) => event.responseId)).toEqual(["m1/infer/0", "m1/infer/0"])
+    expect(requests.every((event) => event.usage === undefined && event.batchIndex === undefined)).toBe(true)
+    expect(run.read().find((event) => event.type === "TurnCompleted")?.usage).toBeUndefined()
     expect(usageIn(run.read(), TURN)).toMatchObject({ promptTokens: 150, completionTokens: 25, costUsd: 0.015 })
     expect(renderMessages(run.read()).filter((message) => message.role !== "user")).toEqual([
       { role: "assistant", content: "Reading both files.", toolCalls: [
@@ -158,6 +246,47 @@ describe("tool batches", () => {
     }
   })
 
+  test("an initial grant fixes the allowance across restart and a changed default", async () => {
+    const initial = setup([budget([tool({ spec, run: () => Effect.succeed("read") })], { limit: 1 })],
+      (request) => request.trajectory.some((event) => event.type === "ToolCalled") ? complete() : batch(call("a"), call("b")))
+    await initial.start()
+    const history = initial.read()
+    expect(history.filter((event) => event.type !== "ThreadCreated").slice(0, 3).map((event) => event.type)).toEqual(["MessageReceived", "BudgetGranted", "ModelCalled"])
+    expect(history.filter((event) => event.type === "BudgetGranted")).toMatchObject([{ amount: 1, initial: true, turn: TURN }])
+    const pending = history.slice(0, history.findLastIndex((event) => event.type === "ToolCalled") + 1)
+    const ran: string[] = []
+    const recovered = setup([budget([tool({ spec, run: (_input, context) => Effect.sync(() => {
+      ran.push(context.callId)
+      return context.callId
+    }) })], { limit: 2 })], complete, {}, pending)
+    await recovered.host.wake(ROOT)
+    await recovered.host.drive()
+    expect(ran).toEqual(["a"])
+    expect(recovered.read().filter((event) => event.type === "BudgetGranted")).toHaveLength(1)
+    expect(recovered.read().find((event) => event.type === "ToolReturned" && event.callId === "b")?.result).toMatchObject({ error: expect.stringContaining("Tool budget reached") })
+  })
+
+  test.each([undefined, 1])("historical resume with a changed default and recorded budget %s", async (recordedBudget) => {
+    const saved: Event[] = [
+      { type: "MessageReceived", id: TURN, text: "work", ...(recordedBudget === undefined ? {} : { budget: recordedBudget }), at: 0 },
+      { type: "ModelCalled", turn: TURN, callId: "m1/infer/0", ordinal: 0, at: 1 },
+      { type: "ModelReturned", turn: TURN, callId: "m1/infer/0", ordinal: 0, outcome: "returned", usage: {}, at: 2 },
+      ...["a", "b"].map((callId) => ({ type: "ToolCalled", turn: TURN, callId, name: "read", arguments: {}, responseId: "m1/infer/0", at: 2 }))
+    ]
+    const executions: string[][] = []
+    for (const limit of [1, 2]) {
+      const ran: string[] = []
+      const recovered = setup([budget([tool({ spec, run: (_input, context) => Effect.sync(() => {
+        ran.push(context.callId)
+        return context.callId
+      }) })], { limit })], complete, {}, saved)
+      await recovered.host.wake(ROOT)
+      await recovered.host.drive()
+      executions.push(ran)
+    }
+    expect(executions).toEqual(recordedBudget === undefined ? [["a"], ["a", "b"]] : [["a"], ["a"]])
+  })
+
   test("duplicate IDs reject the whole response before dispatch", async () => {
     let ran = 0
     const run = setup([tool({ spec, run: () => Effect.sync(() => ++ran) })], () => batch(call("same"), call("same")))
@@ -221,6 +350,25 @@ describe("tool batches", () => {
     expect(run.read().filter((event) => event.type === "BudgetExhausted")).toHaveLength(1)
   })
 
+  test.each([1, "unbounded"] as const)("a later grant cannot admit an earlier refused call at concurrency %s", async (toolConcurrency) => {
+    const ran: string[] = []
+    const run = setup([budget([tool({ spec, run: (_input, context) => Effect.gen(function*() {
+      ran.push(context.callId)
+      if (context.callId === "a") yield* (yield* EventLog).append([
+        { type: "BudgetGranted", turn: TURN, callId: "grant", amount: 1, at: 2 }
+      ])
+      return context.callId
+    }) })], { limit: 1 })], (request) => {
+      const results = request.trajectory.filter((event) => event.type === "ToolReturned")
+      if (results.length === 0) return batch(call("a"), call("b"))
+      if (results.length === 2) return batch(call("c"))
+      return complete()
+    }, { toolConcurrency })
+    await run.start()
+    expect(ran).toEqual(["a", "c"])
+    expect(run.read().find((event) => event.type === "ToolReturned" && event.callId === "b")?.result).toMatchObject({ error: expect.stringContaining("Tool budget reached") })
+  })
+
   test("code mode retains and settles every execute call", async () => {
     const run = setup([codeMode()], (request) => request.trajectory.some((event) => event.type === "ToolCalled") ? complete() : batch(
       { callId: "code-1", name: "execute", arguments: { code: "return 1" } },
@@ -240,11 +388,11 @@ describe("tool batches", () => {
     expect(run.read().filter((event) => event.type === "ToolReturned")).toHaveLength(2)
   })
 
-  test("compaction keeps a complete batch even when a checkpoint names a later call", () => {
+  test.each(["current", "legacy"])("compaction keeps a complete %s batch when a checkpoint names a later call", (format) => {
     const history: Event[] = [
       { type: "MessageReceived", id: TURN, text: "work", at: 0 },
-      { type: "ToolCalled", turn: TURN, callId: "a", name: "read", arguments: {}, batchId: "m1/infer/0", batchIndex: 0, at: 1 },
-      { type: "ToolCalled", turn: TURN, callId: "b", name: "read", arguments: {}, batchId: "m1/infer/0", batchIndex: 1, at: 1 },
+      { type: "ToolCalled", turn: TURN, callId: "a", name: "read", arguments: {}, ...(format === "current" ? { responseId: "m1/infer/0" } : { batchId: "m1/infer/0", batchIndex: 0 }), at: 1 },
+      { type: "ToolCalled", turn: TURN, callId: "b", name: "read", arguments: {}, ...(format === "current" ? { responseId: "m1/infer/0" } : { batchId: "m1/infer/0", batchIndex: 1 }), at: 1 },
       { type: "ToolReturned", turn: TURN, callId: "b", result: "x".repeat(500), at: 2 }
     ]
     const reactor = compactionReactor({ contextWindowTokens: 100, fireRatio: 0.5, keepRatio: 0.1 })

--- a/packages/agent/src/runtime/composition.test.ts
+++ b/packages/agent/src/runtime/composition.test.ts
@@ -317,7 +317,7 @@ describe("infer component", () => {
         return Effect.succeed(
           returned
             ? { kind: "complete" as const, output: "done" }
-            : { kind: "call" as const, callId: "c1", name: "echo", arguments: { hi: 1 } }
+            : { kind: "calls" as const, calls: [{ callId: "c1", name: "echo", arguments: { hi: 1 } }] as const }
         )
       }
     })
@@ -343,7 +343,7 @@ describe("infer component", () => {
         const returned = request.trajectory.find((e) => e.type === "ToolReturned") as { result?: unknown } | undefined
         return Effect.succeed(
           returned === undefined
-            ? { kind: "call" as const, callId: "c9", name: "ghost", arguments: {} }
+            ? { kind: "calls" as const, calls: [{ callId: "c9", name: "ghost", arguments: {} }] as const }
             : { kind: "complete" as const, output: JSON.stringify(returned.result) }
         )
       }
@@ -367,7 +367,7 @@ describe("infer component", () => {
         const returned = request.trajectory.find((event) => event.type === "ToolReturned") as { result?: unknown } | undefined
         return Effect.succeed(
           returned === undefined
-            ? { kind: "call" as const, callId: "c10", name: "fetch.get", arguments: { url: "https://example.com" } }
+            ? { kind: "calls" as const, calls: [{ callId: "c10", name: "fetch.get", arguments: { url: "https://example.com" } }] as const }
             : { kind: "complete" as const, output: JSON.stringify(returned.result) }
         )
       }
@@ -429,7 +429,7 @@ describe("infer component", () => {
       react: (request: InferRequest) => Effect.succeed(
         request.trajectory.some((event) => event.type === "ToolReturned")
           ? { kind: "complete" as const, output: "done" }
-          : { kind: "call" as const, callId: "once-1", name: "once", arguments: {} }
+          : { kind: "calls" as const, calls: [{ callId: "once-1", name: "once", arguments: {} }] as const }
       )
     })
     const events = await run(

--- a/packages/agent/src/runtime/composition.ts
+++ b/packages/agent/src/runtime/composition.ts
@@ -249,13 +249,14 @@ export const infer = <
     output: (state) => {
       const children = childMachine.output(state.children)
       const inferred = incrementalInference.output(state.inference)
-      const resolvingModel = inferred.some((transition) => transition.key.startsWith("mr:"))
       return {
         view: children.view,
-        transitions: resolvingModel ? inferred : [
+        // Component intents commit policy decisions before inference or tool admission (batches.test.ts, "an initial grant fixes the allowance across restart and a changed default").
+        transitions: [
+          ...children.transitions.filter((transition) => transition.kind === "intent"),
           ...inferred,
           ...toolsMachine.output(state.tools).transitions,
-          ...children.transitions
+          ...children.transitions.filter((transition) => transition.kind !== "intent")
         ]
       }
     }

--- a/packages/agent/src/runtime/composition.ts
+++ b/packages/agent/src/runtime/composition.ts
@@ -251,7 +251,7 @@ export const infer = <
       const inferred = incrementalInference.output(state.inference)
       return {
         view: children.view,
-        // Component intents commit policy decisions before inference or tool admission (batches.test.ts, "an initial grant fixes the allowance across restart and a changed default").
+        // Component intents commit policy decisions before inference or tool admission (batches.test.ts, "generated starting allowances are recorded once before inference and survive restart").
         transitions: [
           ...children.transitions.filter((transition) => transition.kind === "intent"),
           ...inferred,

--- a/packages/agent/src/runtime/refinement.properties.test.ts
+++ b/packages/agent/src/runtime/refinement.properties.test.ts
@@ -157,12 +157,9 @@ const completeAgent = (
     derive: (log) => {
       const children = deriveComponent(combined, log)
       const inferred = inference(log)
-      const resolvingModel = inferred.some((transition) => transition.key.startsWith("mr:"))
       return {
         view: children.view,
-        transitions: resolvingModel
-          ? inferred
-          : [...inferred, ...deriveComponent(tools, log).transitions, ...children.transitions]
+        transitions: [...children.transitions.filter((transition) => transition.kind === "intent"), ...inferred, ...deriveComponent(tools, log).transitions, ...children.transitions.filter((transition) => transition.kind !== "intent")]
       }
     },
     cancel: (log, cancellation) => [

--- a/packages/agent/src/runtime/turn.test.ts
+++ b/packages/agent/src/runtime/turn.test.ts
@@ -130,10 +130,41 @@ const codeThenComplete = (count: { calls: number }) =>
       return Effect.succeed(
         returned
           ? { kind: "complete" as const, output: "created jd-91, 3 candidates found" }
-          : { kind: "call" as const, callId: "t1", name: "execute", arguments: { code: CODE } }
+          : { kind: "calls" as const, calls: [{ callId: "t1", name: "execute", arguments: { code: CODE } }] as const }
       )
     }
   })
+
+test("a model response and its consequences share one append", async () => {
+  const history: Event[] = []
+  const appends: ReadonlyArray<Event>[] = []
+  const agent = assembled(infer([
+    tool({ spec: { name: "read", description: "Read", inputSchema: {} }, run: () => Effect.succeed("read") }),
+    nativeOutput
+  ], TEST_MODEL))
+  await run(receive(agent, { id: "m1", text: "read both" }), Layer.mergeAll(
+    noRouter,
+    KeyValueStore.layerMemory,
+    Layer.succeed(EventLog, withWatermark({
+      read: Effect.succeed(history),
+      append: (events) => Effect.sync(() => { appends.push(events); history.push(...events) })
+    })),
+    Layer.succeed(Infer, { react: () => Effect.succeed(history.some((event) => event.type === "ToolCalled")
+      ? { kind: "complete" as const, output: "done" }
+      : { kind: "calls" as const, text: "Reading both", calls: [
+          { callId: "a", name: "read", arguments: {} },
+          { callId: "b", name: "read", arguments: {} }
+        ] as const }) })
+  ))
+  const responses = appends.filter((events) => events.some((event) => event.type === "ModelReturned"))
+  expect(responses.map((events) => events.map((event) => event.type))).toEqual([
+    ["ModelReturned", "TextReturned", "ToolCalled", "ToolCalled"],
+    ["ModelReturned", "TurnCompleted"]
+  ])
+  expect(responses[0]!.filter((event) => event.type === "ToolCalled").map((event) => event.callId)).toEqual(["a", "b"])
+  expect(appends.filter((events) => events.some((event) => event.type === "ModelCalled")))
+    .toHaveLength(2)
+})
 
 describe("the agent with execute as the only tool", () => {
   test("the model's code runs with every package call recorded", async () => {
@@ -156,7 +187,9 @@ describe("the agent with execute as the only tool", () => {
     )
     expect(events.map((e) => e.type)).toEqual([
       "MessageReceived",
+      "BudgetGranted",
       "ModelCalled",
+      "ModelReturned",
       "ToolCalled",
       "CodeDispatched",
       "PackageCalled",
@@ -166,10 +199,11 @@ describe("the agent with execute as the only tool", () => {
       "CodeSettled",
       "ToolReturned",
       "ModelCalled",
+      "ModelReturned",
       "TurnCompleted"
     ])
-    expect(events[4]).toMatchObject({ callId: `${String(events[3]!.execId)}.0`, name: "zohorecruit.insert_record" })
-    expect(events[8]).toMatchObject({ result: { jd_record_id: "jd-91", hits: 3 } })
+    expect(events[6]).toMatchObject({ callId: `${String(events[5]!.execId)}.0`, name: "zohorecruit.insert_record" })
+    expect(events[10]).toMatchObject({ result: { jd_record_id: "jd-91", hits: 3 } })
     expect(spies).toEqual({ insert: 1, search: 1 })
     expect(count.calls).toBe(2)
     expect(rootReactor(events)).toHaveLength(0)
@@ -250,7 +284,7 @@ describe("the agent with execute as the only tool", () => {
           return Effect.succeed(
             returned
               ? { kind: "fail" as const, error: "the body is broken" }
-              : { kind: "call" as const, callId: "t1", name: "execute", arguments: { code: "throw new Error('boom')" } }
+              : { kind: "calls" as const, calls: [{ callId: "t1", name: "execute", arguments: { code: "throw new Error('boom')" } }] as const }
           )
         }
       }),
@@ -350,7 +384,7 @@ describe("the agent with execute as the only tool", () => {
     expect(count.calls).toBe(1)
   })
 
-  test("the consequence records the action's spend and who was called", async () => {
+  test("the model return records response spend and who was called", async () => {
     const spent = {
       promptTokens: 10,
       completionTokens: 4,
@@ -377,10 +411,12 @@ describe("the agent with execute as the only tool", () => {
     )
     expect(events.map((e) => e.type)).toEqual([
       "MessageReceived",
+      "BudgetGranted",
       "ModelCalled",
+      "ModelReturned",
       "TurnCompleted"
     ])
-    expect(events.find((e) => e.type === "TurnCompleted")).toMatchObject({
+    expect(events.find((e) => e.type === "ModelReturned")).toMatchObject({
       turn: "m1",
       usage: spent
     })
@@ -415,9 +451,9 @@ describe("the agent with execute as the only tool", () => {
       cause: "inference_attempts_exhausted",
       attempts: 2,
       attemptKey: "m1/infer/0",
-      policy: retry,
-      usage: {}
+      policy: retry
     })
+    expect(events.find((event) => event.type === "ModelReturned")).toMatchObject({ outcome: "failed", usage: {}, callId: "m1/infer/0" })
   })
 })
 
@@ -501,13 +537,7 @@ describe("a turn that declares an output contract", () => {
           Effect.succeed(
             trajectory.some((e) => e.type === "ToolReturned")
               ? { kind: "complete" as const, output: JSON.stringify(GOOD_ANSWER), mode: NATIVE_MODE }
-              : {
-                  kind: "call" as const,
-                  callId: "c1",
-                  name: "execute",
-                  arguments: { code: "return 1" },
-                  mode: NATIVE_MODE
-                }
+              : { kind: "calls" as const, calls: [{ callId: "c1", name: "execute", arguments: { code: "return 1" } }] as const, mode: NATIVE_MODE }
           )
       }),
       jsSandbox,
@@ -532,7 +562,7 @@ describe("a turn that declares an output contract", () => {
       KeyValueStore.layerMemory,
       Layer.succeed(Infer, {
         react: () =>
-          Effect.succeed({ kind: "call" as const, callId: "c1", name: "execute", arguments: { code: "return 1" } })
+          Effect.succeed({ kind: "calls" as const, calls: [{ callId: "c1", name: "execute", arguments: { code: "return 1" } }] as const })
       }),
       jsSandbox,
       noRouter
@@ -930,7 +960,7 @@ describe("the mind on a native surface", () => {
           return Effect.succeed(
             returned !== undefined
               ? { kind: "complete" as const, output: String(returned.result) }
-              : { kind: "call" as const, callId: "n1", name: "read", arguments: { path: "/contract.md" } }
+              : { kind: "calls" as const, calls: [{ callId: "n1", name: "read", arguments: { path: "/contract.md" } }] as const }
           )
         }
       })
@@ -945,9 +975,11 @@ describe("the mind on a native surface", () => {
     expect(events.map((e) => e.type)).toEqual([
       "MessageReceived",
       "ModelCalled",
+      "ModelReturned",
       "ToolCalled",
       "ToolReturned",
       "ModelCalled",
+      "ModelReturned",
       "TurnCompleted"
     ])
     expect(reads).toEqual(["/contract.md"])

--- a/packages/model/src/model.test.ts
+++ b/packages/model/src/model.test.ts
@@ -81,7 +81,7 @@ describe("actionOf", () => {
       content: "let me check",
       toolCalls: [{ id: "call_9", type: "function", function: { name: "execute", arguments: '{"code":"return 2"}' } }]
     } as never)
-    expect(action).toMatchObject({ kind: "call", callId: "call_9", name: "execute", arguments: { code: "return 2" }, text: "let me check" })
+    expect(action).toMatchObject({ kind: "calls", calls: [{ callId: "call_9", name: "execute", arguments: { code: "return 2" } }], text: "let me check" })
   })
 
   test("plain text completes; nothing throws", () => {
@@ -335,7 +335,7 @@ describe("infer end to end", () => {
         model.react(reqOf([{ type: "MessageReceived", id: "m1", text: "compute", at: 1 }]))
       ).pipe(Effect.provide(layer)) as Effect.Effect<unknown>
     )
-    expect(action).toMatchObject({ kind: "call", callId: "call_7", name: "execute", arguments: { code: "return 42" }, text: "on it" })
+    expect(action).toMatchObject({ kind: "calls", calls: [{ callId: "call_7", name: "execute", arguments: { code: "return 42" } }], text: "on it" })
     const body = requested!.body as { messages: ReadonlyArray<{ role: string }>; tools: ReadonlyArray<unknown> }
     expect(requested!.url).toContain("model.test")
     expect(body.messages.some((m) => m.role === "system")).toBe(true)

--- a/packages/model/src/model.ts
+++ b/packages/model/src/model.ts
@@ -144,9 +144,7 @@ export const actionOf = (result: ProcessorResult): Action => {
   const first = decoded[0]
   if (first !== undefined) {
     const prose = text === "" ? {} : { text }
-    return decoded.length === 1
-      ? { kind: "call", ...first, ...prose }
-      : { kind: "calls", calls: [first, ...decoded.slice(1)], ...prose }
+    return { kind: "calls", calls: [first, ...decoded.slice(1)], ...prose }
   }
   if (text !== "") return { kind: "complete", output: text }
   // A provider that declined leaves neither: content_filter is the finish reason that says so,

--- a/platform/bun/package.json
+++ b/platform/bun/package.json
@@ -41,5 +41,8 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "bun test"
+  },
+  "devDependencies": {
+    "fast-check": "^4.9.0"
   }
 }

--- a/platform/bun/src/host.test.ts
+++ b/platform/bun/src/host.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, setDefaultTimeout, test } from "bun:test"
+import fc from "fast-check"
 import { Database } from "bun:sqlite"
 import { existsSync, mkdtempSync, readFileSync } from "node:fs"
 import { tmpdir } from "node:os"
@@ -595,6 +596,45 @@ describe("the bun host", () => {
     actor.close()
     thread.close()
   })
+
+  test("response append rollback preserves history at every generated failure position", async () => {
+    await fc.assert(fc.asyncProperty(
+      fc.integer({ min: 1, max: 8 }), fc.integer({ min: 0, max: 5 }), fc.nat(),
+      async (callCount, priorCount, failureSeed) => {
+        const path = freshPath()
+        const eventKey = (event: Event) => event.type === "ThreadCreated" ? undefined : `${event.type}:${String(event.callId ?? event.id)}`
+        const settings = { ...options(path), keyOf: eventKey, actorFor: () => ({ projections: [], keyOf: eventKey }) }
+        let host = await createBunHost(settings)
+        const previous = [created("echo"), ...Array.from({ length: priorCount }, (_, id) => ({ type: "Done", id, at: id + 1 }))]
+        const response: Event[] = [
+          { type: "ModelReturned", callId: "response", ordinal: 0, turn: "turn", outcome: "returned", usage: {}, at: 10 },
+          ...Array.from({ length: callCount }, (_, index) => ({ type: "ToolCalled", callId: `call-${index}`, responseId: "response", name: "read", arguments: {}, turn: "turn", at: 10 }))
+        ]
+        try {
+          await host.seed("echo", previous)
+          const saved = await host.read("echo")
+          const db = new Database(bunThreadDatabasePath(path, "echo"))
+          const failurePosition = failureSeed % response.length
+          db.exec(`CREATE TRIGGER fail_response BEFORE INSERT ON events WHEN NEW.seq = ${saved.length + failurePosition + 1} BEGIN SELECT RAISE(ABORT, 'injected response failure'); END`)
+          db.close()
+          await expect(host.seed("echo", response)).rejects.toThrow()
+          await host.close()
+          host = await createBunHost(settings)
+          expect(await host.read("echo")).toEqual(saved)
+          const repaired = new Database(bunThreadDatabasePath(path, "echo"))
+          repaired.exec("DROP TRIGGER fail_response")
+          repaired.close()
+          await host.seed("echo", response)
+          await host.seed("echo", response)
+          await host.close()
+          host = await createBunHost(settings)
+          expect(await host.read("echo")).toEqual([...saved, ...response])
+        } finally {
+          await host.close()
+        }
+      }
+    ), { numRuns: 25 })
+  }, 30_000)
 
   test("a batch appends atomically: a mid-batch key collision absorbs that row only", async () => {
     const h = await createBunHost(options(freshPath()))


### PR DESCRIPTION
## Problem

Model replies had separate single-call and batch shapes, and response usage was attached to a tool call or turn outcome. Budget admission could depend on grants recorded after a request or a host default changed during restart. Historical format checks were spread across readers.

## Change

Use a nonempty `calls` array for tool responses. Custom bindings returning `kind: "call"` remain supported through an isolated adapter marked for removal in the next breaking release.

Record response usage on `ModelReturned` and commit it with the response's consequences in one append. Validation failure remains separate from successful receipt of a model response.

```text
ModelCalled
atomic append
|-- ModelReturned           usage
|-- ToolCalled A            responseId
|-- ToolCalled B            responseId
`-- ToolCalled C            responseId

ToolReturned B              results settle independently
ToolReturned A
ToolReturned C
```

Record the initial allowance as `BudgetGranted`. Admission follows recorded call order, using only preceding grants. Component intents commit before inference so the starting allowance is durable before the first model request.

```text
Grant 2
|-- A: admitted
|-- B: admitted
`-- C: exhaustion result
Grant 1
`-- D: admitted
```

Centralize historical interpretation in `log/upcast.ts`; `log/response.ts` and `log/budget.ts` consume normalized read metadata. Stored events remain intact, and an unknown historical starting allowance still requires the caller's fallback.

Validation: `bun run gate`. Added a real SQLite rollback property with generated failure positions and retry deduplication, an agent test for the append boundary, and generated budget safety and bounded-progress tests across grants, concurrency, and restart points. Progress tests use terminating tools and finite restarts; they do not establish unconditional liveness. Mortyplicity e2e exercises escalation separately from the initial grant.
