### PR TITLE
fix(agent): preserve native prompt images

### DIFF
--- a/docs/references/sdk.mdx
+++ b/docs/references/sdk.mdx
@@ -41,3 +41,20 @@ import type { Machine } from "tardie/core/machine"
 import type { Projection } from "tardie/core/projection"
 import type { ComponentOutput } from "tardie/core/component"
 ```
+
+## Agent prompt images
+
+The `message` method in `agentMethods` and the public `receive` helper accept an optional ordered `images` array. Each image has a `mimeType` and base64 `data`. Pass an empty `text` string for an image-only prompt:
+
+```ts
+const input = {
+  text: "",
+  images: [
+    { mimeType: "image/png", data: pngBase64 },
+  ],
+}
+```
+
+Images are stored on `MessageReceived` and retained in model history through replay and later turns. Text-only messages keep string content. Images inside application-owned `input` are not model content, and child-agent dispatch does not inherit a parent's images. Use a model that supports images and observe its format and request-size limits.
+
+`compaction({ imageTokens: 4_784 })` sets the estimated token weight per image. The default is 4,784; it is an approximate heuristic and some providers can use more. Base64 length does not contribute to the text estimate. Summary briefs contain image counts and text, without image bytes. Completed prompts before a checkpoint leave model history, while an active turn retains its original prompt images. The durable log remains available.

--- a/packages/agent/src/actor/message.ts
+++ b/packages/agent/src/actor/message.ts
@@ -17,6 +17,7 @@ import { turnCancelled, turnFailed } from "../log/events"
 
 export const AgentMessageInput = Schema.Struct({
   text: Schema.String,
+  images: MessageReceived.fields.images,
   input: Schema.optionalKey(Schema.Unknown),
   model: Schema.optionalKey(ModelRef)
 }).annotate({ identifier: "AgentMessageInput" })
@@ -88,6 +89,7 @@ export const agentMessageMethod = actorMethod({
   event: ({ invocation, input, at }) => messageReceived({
     id: invocation.id,
     text: input.text,
+    ...(input.images === undefined ? {} : { images: input.images }),
     ...(invocation.epoch === 0 ? {} : { epoch: invocation.epoch }),
     ...(input.input === undefined ? {} : { input: input.input }),
     ...(input.model === undefined ? {} : { model: input.model }),

--- a/packages/agent/src/component/compaction.test.ts
+++ b/packages/agent/src/component/compaction.test.ts
@@ -45,6 +45,26 @@ const openTurn = (rounds: number): Event[] => {
 }
 
 describe("the compaction measure and guard", () => {
+  test("images use configured weight independently of bytes in both guard paths", () => {
+    const image = { mimeType: "image/png", data: "eA==" }
+    const policy = { contextWindowTokens: 1_000, imageTokens: 900 }
+    const events: Event[] = [
+      { ...head, text: "", images: [image] },
+      { type: "ToolCalled", callId: "c1", name: "read", arguments: {}, turn: "m0", at: 1 },
+      { type: "ToolReturned", callId: "c1", result: "ok", turn: "m0", at: 2 }
+    ]
+    expect(estimateTokens([events[0]!], policy)).toBe(900)
+    expect(estimateTokens([{ ...events[0]!, images: [{ ...image, data: image.data.repeat(10_000) }] }], policy)).toBe(900)
+    expect(compactionReactor(policy)(events)).toHaveLength(1)
+    expect(compactionReactor({ ...policy, imageTokens: 1 })(events)).toHaveLength(0)
+    const projection = compaction(policy).machine
+    let state = projection.initial()
+    for (let i = 0; i < events.length; i++) state = projection.step(state, eventAt(events[i]!, i + 1))
+    expect(projection.output(state).transitions.map((transition) => transition.key))
+      .toEqual(compactionReactor(policy)(events).map((transition) => transition.key))
+    expect(() => contextPolicyOf({ imageTokens: 0 })).toThrow("imageTokens")
+  })
+
   test("the incremental quotient agrees with complete replay at every prefix", () => {
     const component = compaction(TEST_POLICY)
     const projection = component.machine
@@ -149,6 +169,15 @@ describe("the compaction pass", () => {
     )
     return { log: await Effect.runPromise(Ref.get(ref)), briefed: () => briefed, model: () => model }
   }
+
+  test("summary briefs retain image counts without image bytes", async () => {
+    const data = "cHJpdmF0ZS1waXhlbHM="
+    const { briefed } = await run([{ ...head, images: [{ mimeType: "image/png", data }] }, ...openTurn(16).slice(1)])
+    expect(briefed()).toContain("[1 images omitted from summary]")
+    expect(briefed()).toContain("extract the covenants")
+    expect(briefed()).not.toContain(data)
+    expect(briefed()).not.toContain("data:image/")
+  })
 
   test("a fire summarizes and checkpoints down to a KEEP-token tail, mid-turn", async () => {
     const { log, briefed } = await run(openTurn(16))

--- a/packages/agent/src/component/compaction.ts
+++ b/packages/agent/src/component/compaction.ts
@@ -53,6 +53,8 @@ export interface ContextPolicy {
   readonly messageRenderCap: number
   // Chars of one tool result the render sends; past it the result truncates.
   readonly resultRenderCap: number
+  // imageTokens estimates each image's compaction weight independently of binary size.
+  readonly imageTokens: number
   // Selected model context window used to derive the hysteresis lines.
   readonly contextWindowTokens: number
   // Fraction of the selected model window that fires compaction.
@@ -73,6 +75,7 @@ export type ContextWindowTokens = number | ((model: ModelRef | undefined) => num
 export interface CompactionPolicy {
   readonly messageRenderCap: number
   readonly resultRenderCap: number
+  readonly imageTokens: number
   readonly contextWindowTokens: ContextWindowTokens
   readonly fireRatio: number
   readonly keepRatio: number
@@ -83,6 +86,8 @@ export interface CompactionPolicy {
 export const DEFAULT_COMPACTION_POLICY: CompactionPolicy = {
   messageRenderCap: 12_000,
   resultRenderCap: 6_000,
+  // imageTokens uses Claude's high-resolution estimate; other providers can exceed it.
+  imageTokens: 4_784,
   contextWindowTokens: 128_000,
   fireRatio: 0.8,
   keepRatio: 0.5,
@@ -131,6 +136,10 @@ export const contextPolicyOf = (
       policy.resultRenderCap ?? DEFAULT_COMPACTION_POLICY.resultRenderCap,
       "resultRenderCap"
     ),
+    imageTokens: positive(
+      policy.imageTokens ?? DEFAULT_COMPACTION_POLICY.imageTokens,
+      "imageTokens"
+    ),
     contextWindowTokens,
     fireRatio,
     keepRatio,
@@ -155,6 +164,7 @@ export const resolvedContextPolicyOf = (policy: Partial<ContextPolicy> = {}): Co
   return {
     messageRenderCap: policy.messageRenderCap ?? defaults.messageRenderCap,
     resultRenderCap: policy.resultRenderCap ?? defaults.resultRenderCap,
+    imageTokens: policy.imageTokens ?? defaults.imageTokens,
     contextWindowTokens: policy.contextWindowTokens ?? defaults.contextWindowTokens,
     fireRatio: policy.fireRatio ?? defaults.fireRatio,
     keepRatio: policy.keepRatio ?? defaults.keepRatio,
@@ -164,15 +174,15 @@ export const resolvedContextPolicyOf = (policy: Partial<ContextPolicy> = {}): Co
   }
 }
 
-// renderedChars counts the characters a render sends for one event: capped where the render
-// caps, zero for an event the render skips. The guard must measure the request the model sees;
-// a measure over raw event JSON counts tool results the render truncates and threads the render
-// never shows, and fires against a size no request ever reaches.
+const imageCount = (event: Event): number =>
+  event.type === "MessageReceived" && Array.isArray(event.images) ? event.images.length : 0
+
+// renderedChars shares character-equivalent text and image weights across replay and incremental projection.
 const renderedChars = (e: Event, policy: ContextPolicy): number => {
   const v = e as Record<string, unknown>
   switch (e.type) {
     case "MessageReceived":
-      return Math.min(String(v.text ?? "").length, policy.messageRenderCap)
+      return Math.min(String(v.text ?? "").length, policy.messageRenderCap) + imageCount(e) * policy.imageTokens * 4
     case "TextReturned":
       return String(v.text ?? "").length
     case "ToolCalled":
@@ -197,9 +207,7 @@ const renderedChars = (e: Event, policy: ContextPolicy): number => {
   }
 }
 
-// estimateTokens estimates the span's rendered tokens as chars over four. A real tokenizer would
-// be a dependency and an impure path, and every budget decision must fold the same on replay, so
-// the estimate is a pure function of the recorded events (compaction.test.ts, "the measure").
+// estimateTokens combines chars over four with the configured image weight, deterministically on replay (compaction.test.ts, "the measure").
 export const estimateTokens = (events: ReadonlyArray<Event>, policy: Partial<ContextPolicy> = {}): number => {
   const resolved = resolvedContextPolicyOf(policy)
   return Math.ceil(projectedOutput(events).reduce((n, e) => n + renderedChars(e, resolved), 0) / 4)
@@ -309,7 +317,7 @@ const lineOf = (e: Event, policy: ContextPolicy): string | null => {
   const v = e as Record<string, unknown>
   switch (e.type) {
     case "MessageReceived":
-      return `user: ${String(v.text ?? "")}`
+      return `user: ${imageCount(e) === 0 ? "" : `[${imageCount(e)} images omitted from summary] `}${String(v.text ?? "")}`
     case "TextReturned":
       return `agent (working): ${String(v.text ?? "")}`
     case "ToolCalled":

--- a/packages/agent/src/inference/request.test.ts
+++ b/packages/agent/src/inference/request.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test"
-import { Effect } from "effect"
+import { Effect, Schema } from "effect"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import { trajectoryOf } from "@clavia/tardigrade-code/execution/turns"
 import { modelRequest } from "./request"
 import { messagesProjection, renderMessages } from "../projection/messages"
 import { budget, canonicalOf, codeMode, nativeOutput, output, outputRepairFor, renderOf, tool } from "../index"
+import { AgentMessageInput, agentMessageMethod } from "../actor/message"
+import { AgentEvent } from "../log/events"
 
 // One declared contract, used wherever a turn needs one.
 const SCOUT = output({
@@ -24,6 +26,39 @@ const budgetedCode = (log: ReadonlyArray<Event>) => renderOf([budget([codeMode()
 // prompt policy. Both live in the domain, so they test without a provider.
 
 describe("renderMessages", () => {
+  test("native image input survives durable replay in order without mining consumer input", () => {
+    const images = [{ mimeType: "image/png", data: "cG5n" }, { mimeType: "image/jpeg", data: "anBlZw==" }]
+    const event = agentMessageMethod.event({
+      invocation: { method: "message", id: "pictures", epoch: 0 },
+      input: Schema.decodeSync(AgentMessageInput)({ text: "compare", images }),
+      at: 0
+    })
+    const replayed = Schema.decodeUnknownSync(AgentEvent)(JSON.parse(JSON.stringify(event)))
+    const parts = images.map((image) => ({ type: "image" as const, source: { type: "data" as const, value: image.data, mimeType: image.mimeType } }))
+    expect(renderMessages([replayed])[0]?.content).toEqual([{ type: "text", content: "compare" }, ...parts])
+    expect(renderMessages([{ ...replayed, text: "" }])[0]?.content).toEqual(parts)
+    expect(renderMessages([{ ...replayed, images: [] }])[0]?.content).toBe("compare")
+    expect(renderMessages([{ type: "MessageReceived", id: "child", text: "brief", input: { images }, at: 1 }])[0]?.content).toBe("brief")
+    expect(() => renderMessages([{ ...replayed, images: [{ mimeType: "image/png" }] }])).toThrow("invalid MessageReceived.images")
+  })
+
+  test("image bytes survive text caps and active-head checkpoints only while retained", () => {
+    const image = { mimeType: "image/png", data: "eA==".repeat(50) }
+    const head: Event = { type: "MessageReceived", id: "picture", text: "inspect this image", images: [image], at: 0 }
+    const round: Event[] = [
+      { type: "ToolCalled", callId: "c1", name: "read", arguments: {}, turn: "picture", at: 1 },
+      { type: "ToolReturned", callId: "c1", result: "read", turn: "picture", at: 2 },
+      { type: "CompactionCompleted", keepFrom: 'c:["picture","c1"]', summary: "earlier work", at: 3 }
+    ]
+    const messages = renderMessages([head, ...round], { messageRenderCap: 4 })
+    expect(messages[0]?.content).toEqual([
+      { type: "text", content: expect.stringContaining("truncated at 4 of 18 chars") },
+      { type: "image", source: { type: "data", value: image.data, mimeType: image.mimeType } }
+    ])
+    const completed = renderMessages([head, ...round, { type: "TurnCompleted", turn: "picture", output: "done", at: 4 }])
+    expect(JSON.stringify(completed)).not.toContain(image.data)
+  })
+
   test("the projection matches complete replay at every prefix", () => {
     const events: ReadonlyArray<Event> = [
       { type: "MessageReceived", id: "m1", text: "inspect it", at: 0 },

--- a/packages/agent/src/projection/messages.ts
+++ b/packages/agent/src/projection/messages.ts
@@ -1,7 +1,8 @@
+import { Schema } from "effect"
 import { responsesOf } from "../log/response"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import { replayProjection, type Projection } from "@clavia/tardigrade-core/projection"
-import { terminalReportOutcomeOf } from "@clavia/tardigrade-core/interaction/provider-message"
+import { MessageReceived, terminalReportOutcomeOf } from "@clavia/tardigrade-core/interaction/provider-message"
 import { checkpointOf, keepFromIndex, resolvedContextPolicyOf, type ContextPolicy } from "../component/compaction"
 import {
   correctionText,
@@ -17,7 +18,10 @@ export interface AgentToolCall {
 
 export interface AgentMessage {
   readonly role: "user" | "assistant" | "tool"
-  readonly content: string | null
+  readonly content: string | null | Array<
+    | { readonly type: "text"; readonly content: string }
+    | { readonly type: "image"; readonly source: { readonly type: "data"; readonly value: string; readonly mimeType: string } }
+  >
   readonly toolCalls?: ReadonlyArray<AgentToolCall>
   readonly toolCallId?: string
 }
@@ -33,6 +37,8 @@ const feedbackFor = (
   return correctionText((rejection["errors"] ?? []) as ReadonlyArray<string>)
 }
 
+const isMessageImages = Schema.is(MessageReceived.fields.images)
+
 const userMessageOf = (event: Event, policy: ContextPolicy): AgentMessage => {
   const value = event as Record<string, unknown>
   const text = String(value.text ?? "")
@@ -40,12 +46,18 @@ const userMessageOf = (event: Event, policy: ContextPolicy): AgentMessage => {
     ? `${text.slice(0, policy.messageRenderCap)}…[truncated at ${policy.messageRenderCap} of ${text.length} chars; read the full message with logs.events on this facet, id ${String(value.id)}]`
     : text
   const report = terminalReportOutcomeOf(value)
-  return {
-    role: "user",
-    content: report === undefined
-      ? rendered
-      : `[Terminal report: ${report}. Your answer to this report stays in this thread and is not sent back to its sender.]\n${rendered}`
+  const body = report === undefined
+    ? rendered
+    : `[Terminal report: ${report}. Your answer to this report stays in this thread and is not sent back to its sender.]\n${rendered}`
+  const images = value.images
+  if (!isMessageImages(images)) throw new Error("invalid MessageReceived.images")
+  if (images === undefined || images.length === 0) return { role: "user", content: body }
+  const content: Exclude<AgentMessage["content"], string | null> = []
+  if (body !== "") content.push({ type: "text", content: body })
+  for (const image of images) {
+    content.push({ type: "image", source: { type: "data", value: image.data, mimeType: image.mimeType } })
   }
+  return { role: "user", content }
 }
 
 const messagesFrom = (

--- a/packages/agent/src/runtime/turn.test.ts
+++ b/packages/agent/src/runtime/turn.test.ts
@@ -39,6 +39,7 @@ import {
   tool
 } from "../index"
 import { agentMethods } from "../actor/methods"
+import { renderMessages, type AgentMessage } from "../projection/messages"
 
 const TEST_MODEL = { models: { default: { provider: "test", model_id: "test-model" }, allow: "*" } } as const
 
@@ -134,6 +135,29 @@ const codeThenComplete = (count: { calls: number }) =>
       )
     }
   })
+
+test("public receive retains image-only input after fresh log replay and a later turn", async () => {
+  const images = [{ mimeType: "image/png", data: "cGl4ZWxz" }]
+  const observed: unknown[] = []
+  const inference = Layer.succeed(Infer, {
+    react: ({ trajectory }) => {
+      observed.push(renderMessages(trajectory))
+      return Effect.succeed({ kind: "complete" as const, output: "done" })
+    }
+  })
+  const actor = assembled(infer([nativeOutput], TEST_MODEL))
+  const first = await run(Effect.gen(function* () {
+    yield* receive(actor, { id: "picture", text: "", images })
+    return yield* readLog
+  }), Layer.mergeAll(memoryLog(), inference, noRouter, KeyValueStore.layerMemory))
+  const replayed: Event[] = JSON.parse(JSON.stringify(first))
+  await run(receive(actor, { id: "later", text: "look again" }), Layer.mergeAll(
+    memoryLog(replayed), inference, noRouter, KeyValueStore.layerMemory
+  ))
+  const expected = { role: "user", content: [{ type: "image", source: { type: "data", value: images[0]!.data, mimeType: "image/png" } }] }
+  expect(observed[0]).toEqual([expected])
+  expect(observed[1]).toEqual([expected, { role: "assistant", content: "done" }, { role: "user", content: "look again" }])
+})
 
 test("a model response and its consequences share one append", async () => {
   const history: Event[] = []
@@ -681,7 +705,7 @@ describe("the repair implementation", () => {
   })
 
   test("the correction is a rendered exchange, and a later turn reads the corrected value alone", async () => {
-    const rendered: Array<ReadonlyArray<{ readonly role: string; readonly content: string | null }>> = []
+    const rendered: Array<ReadonlyArray<AgentMessage>> = []
     const layers = Layer.mergeAll(
       memoryLog(),
       KeyValueStore.layerMemory,
@@ -1108,7 +1132,7 @@ const houseStyle = (options: { readonly asks: number }): AgentComponent => legac
 
 describe("a domain-specific implementation", () => {
   test("the core records the rejection and waits; the component decides the feedback", async () => {
-    const prompts: Array<ReadonlyArray<{ readonly role: string; readonly content: string | null }>> = []
+    const prompts: Array<ReadonlyArray<AgentMessage>> = []
     const layers = Layer.mergeAll(
       memoryLog(),
       KeyValueStore.layerMemory,

--- a/packages/agent/src/runtime/turn.ts
+++ b/packages/agent/src/runtime/turn.ts
@@ -1,5 +1,6 @@
 import { Clock, Effect } from "effect"
 import type { KeyValueStore } from "effect/unstable/persistence"
+import type { MessageReceived } from "@clavia/tardigrade-core/interaction/provider-message"
 import { EventLog } from "@clavia/tardigrade-core/log"
 import { send, type ActorSource as Actor } from "@clavia/tardigrade-core/runtime"
 import type { Router } from "@clavia/tardigrade-core/transport/router"
@@ -44,6 +45,7 @@ export const receive = <R, T = unknown>(
   message: {
     readonly id: string
     readonly text: string
+    readonly images?: MessageReceived["images"]
     readonly input?: unknown
     readonly model?: ModelRef
     readonly output?: OutputContract<T>
@@ -59,6 +61,7 @@ export const receive = <R, T = unknown>(
       type: "MessageReceived",
       id: message.id,
       text: message.text,
+      ...(message.images === undefined ? {} : { images: message.images }),
       ...(message.input === undefined ? {} : { input: message.input }),
       ...(message.model === undefined ? {} : { model: message.model }),
       ...(message.output === undefined ? {} : { output: { name: message.output.name, schema: message.output.schema } }),

--- a/packages/core/src/interaction/provider-message.ts
+++ b/packages/core/src/interaction/provider-message.ts
@@ -7,6 +7,11 @@ export const MessageReceived = Schema.Struct({
   type: Schema.Literal("MessageReceived"),
   id: Schema.String,
   text: Schema.String,
+  // images carries ordered message content separately from inheritable input.
+  images: Schema.optional(Schema.Array(Schema.Struct({
+    mimeType: Schema.String,
+    data: Schema.String
+  }))),
   source: Schema.optional(Schema.String),
   chat: Schema.optional(Schema.String),
   sender: Schema.optional(Schema.String),

--- a/packages/model/src/model.test.ts
+++ b/packages/model/src/model.test.ts
@@ -64,6 +64,33 @@ const testInfer = <const C extends Omit<ModelConfig, "protocol" | "provider" | "
 // endpoint. No real provider is touched. Request-building (renderMessages, modelRequest) is domain
 // and tested in agent/request.test.ts.
 
+test("native images reach each provider serializer after replay", async () => {
+  const images = [{ mimeType: "image/png", data: "cG5n" }, { mimeType: "image/jpeg", data: "anBlZw==" }]
+  const trajectory: Event[] = JSON.parse(JSON.stringify([
+    { type: "MessageReceived", id: "m1", text: "", images, at: 1 }
+  ]))
+  for (const protocol of ["anthropic-messages", "openai-responses", "openai-chat-completions"] as const) {
+    let requested: Record<string, unknown> = {}
+    const fetchImpl = (async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+      const request = input instanceof Request ? input : new Request(String(input), init)
+      requested = JSON.parse(await request.text())
+      return new Response(JSON.stringify({ error: { message: "local capture complete", type: "invalid_request_error" } }), {
+        status: 400, headers: { "content-type": "application/json" }
+      })
+    }) as typeof globalThis.fetch
+    await Effect.runPromise(Effect.exit(Effect.flatMap(Infer, (model) => model.react(reqOf(trajectory))).pipe(
+      Effect.provide(testInfer({ protocol, baseUrl: "https://model.test/v1", apiKey: "local-test-key", model: "test-model", fetch: fetchImpl }))
+    )))
+    const messages = (protocol === "openai-responses" ? requested.input : requested.messages) as Array<{ role: string; content: unknown }>
+    const content = messages.find((message) => message.role === "user")?.content
+    expect(content).toEqual(images.map((image) => protocol === "anthropic-messages"
+      ? { type: "image", source: { type: "base64", data: image.data, media_type: image.mimeType } }
+      : protocol === "openai-responses"
+        ? { type: "input_image", image_url: `data:${image.mimeType};base64,${image.data}`, detail: "auto" }
+        : { type: "image_url", image_url: { url: `data:${image.mimeType};base64,${image.data}`, detail: "auto" } }))
+  }
+})
+
 describe("actionOf", () => {
   test("multiple calls preserve provider order including calls beside execute", () => {
     expect(actionOf({ content: "Reading files", toolCalls: [

--- a/packages/model/src/model.ts
+++ b/packages/model/src/model.ts
@@ -110,7 +110,7 @@ const toMessage = (m: AgentMessage): ModelMessage =>
           )
         }),
     ...(m.toolCallId === undefined ? {} : { toolCallId: m.toolCallId })
-  }) as ModelMessage
+  })
 
 const toTool = (t: ToolSpec): Tool => ({
   name: t.name,


### PR DESCRIPTION
[👾 omp · openai-codex/gpt-6-astra · agency: delegated · intent: publish native prompt-image support]

> **TL;DR:** Preserve ordered prompt images from the public message entry points through durable replay, model history, and the existing provider serializers.

1. **Carry native images.** Add optional `MessageReceived.images` and forward it through `agentMessageMethod` and `receive`.
2. **Preserve model content.** Render image-only and mixed prompts as native parts, while text-only messages retain string content.
3. **Account for images.** Extend the existing compaction policy with a configurable image-token estimate and count-only summary metadata.

**Risk:** Model input and durable replay change. No new storage service, provider serializer, or child dispatch behavior.

## Why

The model projection currently emits user content as a string, so prompt images cannot reach the model as image parts. Putting images inside application-owned `input` would mix message content with inheritable execution context.

This change gives the inbound event an optional ordered image field and uses the existing TanStack serializers. Related #412 concerns reasoning carry; #414 concerns tool-result content. Neither is implemented here.

## What changed and how

- Six source files in `core`, `agent`, and `model` own the schema, both entry points, projection, typed model bridge, and compaction behavior.
- Each image retains its MIME type, base64 data, and array order. Image-only input adds no fabricated text part. Existing text caps and terminal-report prefixes apply only to text.
- Replay preserves retained images. A checkpoint drops completed old prompts from model history and keeps the active turn's original prompt. The durable log is unchanged.
- `imageTokens` defaults to 4,784 and accepts a positive override. It is an approximate heuristic; providers can exceed it. Both compaction paths ignore base64 length when estimating text weight.
- The SDK reference documents the input and policy. Four existing test files cover the changed behavior.

## Security and scope

Images remain in the owning durable message and provider request. Summary briefs contain text and image counts without image bytes. The projection does not mine application-owned `input`, and child dispatch does not inherit parent images.

Tool-result images, reasoning carry, model capability gates, and image admission limits remain outside this PR.

## How this was tested

Verified source: `a1e03579ee805d353bd12f755f82a51173a41c49`, based on `425848c90e59bf9a9b52ee4ccff7dfc09602079f` (2026-09-09).

- All six new regressions fail against the unmodified base and pass after clean application of the six-source patch. The four focused files pass 132 tests.
- Executed the repository gate tasks serially: 1,265 Bun tests and 45 worker Vitest tests pass. All non-test gate tasks pass after correcting test-only literal types and schema-decoder usage; the affected 56 tests pass again.
- Built the release-layout tarball with `tools/publish.ts --pack-only`. Its public-import smoke and three separate release-layout proofs pass, covering construction, public receive, JSON replay, text caps, open-head checkpoints, both compaction paths, and all three serializers.
- Anthropic Messages, OpenAI Responses, and OpenAI Chat Completions request bodies were captured through the real adapters with local fetch responses. No provider was contacted; these captures prove serialization, not visual understanding.

<details>
<summary>Serial verification commands</summary>

The upstream runner is Bun. `--max-concurrency=1` keeps Bun tests serial; worker Vitest commands use `--maxWorkers=1`.

```sh
bun run tools/gate.ts --jobs=1 --only=lint,typecheck,bundle,build,knip
# Run each package/platform/app/e2e test task separately:
bun test --max-concurrency=1
# Run each worker package separately:
bun run test:workers --maxWorkers=1
bun run tools/publish.ts --pack-only --output .context/release-pack
```

No npm publication, deployment, or provider smoke was performed.
</details>

## After merge

Consumers can remove equivalent local image patches only after a published compatible release contains this behavior and their dependency upgrade passes replay and serializer checks. A merge to `main` alone does not satisfy that condition. No package version is changed here.
