### PR TITLE
feat(model): preserve reasoning through tools

### DIFF
--- a/docs/how-to/server.md
+++ b/docs/how-to/server.md
@@ -109,13 +109,51 @@ OPENROUTER_API_KEY='your-deployment-secret'
 
 The generated `bun run dev` script reads local credentials from `.dev.vars`. A hosted process reads the same credential names from its platform secret store. The manifest contains names such as `OPENROUTER_API_KEY`, never their values.
 
+A provider can set request options per model ID under `models`. Put this field beside its `baseUrl`, `protocol`, and `env` fields. For an `openai-responses` connection:
+
+```jsonc
+"models": {
+  "gpt-5": {
+    "options": {
+      "reasoning": { "effort": "high" }
+    }
+  },
+  "gpt-5-mini": {
+    "options": {
+      "reasoning": { "effort": "low" }
+    }
+  }
+}
+```
+
+The model entries are optional request overrides. They do not add catalog metadata, select the default, or grant model access; `default` and `allow` retain those roles. Omitted entries, empty entries, and omitted options preserve provider reasoning defaults. Both Bun and Workers read this configuration; regenerate `models.lock.json` after changing it. Direct `infer` callers supply the same native fields in `config.options`.
+
+The protocol determines which options TypeScript accepts. JSON configuration validates the same fields at runtime. Supported options are currently limited to reasoning controls:
+
+| Protocol | Native options |
+| --- | --- |
+| `openai-responses` | `reasoning: { effort: "high" }` |
+| `openai-chat-completions` | `reasoning_effort: "high"` |
+| `anthropic-messages` | `thinking: { type: "adaptive" }`, `output_config: { effort: "high" }` |
+| `bedrock-converse` | Request options are unsupported |
+
+Anthropic thinking also accepts `disabled`, or `enabled` with a positive integer `budget_tokens`. Adaptive thinking accepts `display: "summarized"` or `display: "omitted"`. These fields use TanStack's native thinking types and pass through unchanged. OpenAI effort accepts `none`, `minimal`, `low`, `medium`, or `high`; Anthropic effort accepts `low`, `medium`, `high`, `xhigh`, `max`, or `null`, matching the installed TanStack types. The provider checks which controls the selected model supports. See [Anthropic thinking controls](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking) and [OpenAI reasoning](https://developers.openai.com/api/docs/guides/reasoning).
+
+Manual Anthropic thinking requires `budget_tokens` below the request output limit. The adapter rejects a budget that would make the SDK raise that limit. Direct `infer` callers can set `maxTokensLadder` and `maxOutputTokens` to accommodate their budget.
+
+Reasoning controls configure each request, including requests after tool results. Completed Anthropic Messages and OpenAI Responses outputs retain their native assistant response on `ModelReturned.continuation` when reasoning is present. The runtime commits that event atomically with its tool-call or completion events. Request reconstruction restores compatible responses, including signed thinking, redacted thinking, and encrypted reasoning items. Continuation stays with its original response through recovery and compaction; opaque blocks are never summarized or edited.
+
+Continuation compatibility requires the same configured provider, protocol, model, and endpoint fingerprint. A changed coordinate omits continuation from the outgoing request while retaining the durable record. The fingerprint hashes the complete configured endpoint, so the log contains no endpoint credentials or query values. OpenAI Responses requests use `store: false` and request encrypted reasoning for stateless replay. The adapter owns these continuation fields; user options cannot override them.
+
+`ModelReturned.reasoning` stores displayable reasoning text or summaries when returned by these providers. It is separate from the opaque continuation payload. Recursive Chat renders that text in a collapsible Reasoning block. A missing display field means no text was returned, even if encrypted continuation exists.
+
 The server refreshes the public model catalog when it starts, validates the complete provider and model listing, and replaces the cache atomically. A failed refresh serves the last valid snapshot for the configured source with `status: "cached"`. The server keeps the resolved snapshot in memory, so model resolution and catalog requests do not read the cache file on each request. With no valid source or cache, both catalog endpoints answer 503. Provider credentials never appear in either response.
 
 Catalog responses use cursor pagination. They include `revision`, `status`, `refreshed_at`, `total`, `limit`, `items`, and optional `next_cursor`. The default limit is `50` and callers can state another positive integer. Search is a case-insensitive substring over IDs and names. `GET /v1/models` also accepts an exact provider filter. Pass `next_cursor` with the same filters to continue. A cursor records the catalog revision and query, so a changed revision or filter returns 400 and the caller starts again without a cursor.
 
 ## Live inference output
 
-The server publishes normalized model text at `GET /v1/actors/{instance}/threads/{thread}/inference/stream`. The SSE connection carries output produced after it opens and does not replay. Each delta names the actor, instance, thread, turn, logical attempt, physical provider request, model, text block, and sequence. `makeActorClient().followInference(...)` opens the stream for a public thread ID.
+The server publishes normalized model text at `GET /v1/actors/{instance}/threads/{thread}/inference/stream`. The SSE connection carries output produced after it opens and does not replay. Each delta names the actor, instance, thread, turn, logical attempt, physical provider request, model, text block, and sequence. Reasoning deltas carry `kind: "reasoning"`; ordinary text retains an absent kind for compatibility. Consumers must separate reasoning from answer text while tracking the shared sequence across both kinds. `makeActorClient().followInference(...)` opens the stream for a public thread ID.
 
 For another WebSocket, Redis, pub/sub, or telemetry transport, supply an observer as the fourth argument to `modelLayer(config, snapshot, adapters, observer)` when composing model services:
 

--- a/examples/react-rlm-chat/web/src/components/Transcript.test.tsx
+++ b/examples/react-rlm-chat/web/src/components/Transcript.test.tsx
@@ -41,3 +41,14 @@ test("tool groups preserve child and answer boundaries and report pending work",
   events.push({ type: "ToolReturned", callId: "third" } as Event)
   expect(render()).not.toContain("1 of 2 steps completed")
 })
+
+test("reasoning display uses the recorded text and hides opaque continuation", () => {
+  const rows: EventRow[] = [{ seq: 1, event: {
+    type: "ModelReturned", reasoning: "Compare both sources", continuation: { payload: [{ signature: "secret-signature" }] }
+  } as Event }]
+  const html = renderToStaticMarkup(<Transcript empty="Empty" rows={rows} streamingText="" onOpenThread={() => {}} />)
+  expect(html).toContain("Reasoning")
+  expect(html).toContain("Compare both sources")
+  expect(html).not.toContain("secret-signature")
+  expect(html).not.toContain(" open=")
+})

--- a/examples/react-rlm-chat/web/src/components/Transcript.tsx
+++ b/examples/react-rlm-chat/web/src/components/Transcript.tsx
@@ -16,6 +16,7 @@ export const Transcript = ({ empty, onOpenThread, rows, streamingText }: {
   const messages = rows.filter(({ event }) =>
     event.type === "MessageReceived" || event.type === "ToolCalled" || event.type === "ChildCreated" ||
     (event.type === "PackageCalled" && !value(event, "name")?.startsWith("agents.")) ||
+    (event.type === "ModelReturned" && typeof event.reasoning === "string") ||
     event.type === "TurnCompleted" || event.type === "TurnFailed"
   )
   const toolsReturned = new Set(rows
@@ -54,6 +55,12 @@ export const Transcript = ({ empty, onOpenThread, rows, streamingText }: {
     <section className="messages" aria-live="polite">
       {messages.length === 0 ? <p className="empty">{empty}</p> : null}
       {visible.map(({ event, seq }, index) => {
+        if (event.type === "ModelReturned") return (
+          <details className="tool-call" key={seq}>
+            <summary>Reasoning</summary>
+            <MarkdownMessage>{String(event.reasoning)}</MarkdownMessage>
+          </details>
+        )
         if (event.type === "ChildCreated") {
           if (visible[index - 1]?.event.type === "ChildCreated") return null
           const group: Array<EventRow> = []

--- a/examples/react-rlm-chat/web/src/use-streaming-text.ts
+++ b/examples/react-rlm-chat/web/src/use-streaming-text.ts
@@ -24,13 +24,13 @@ export const useStreamingText = (id: string | undefined, rows: ReadonlyArray<Eve
           return {
             physicalAttempt: delta.physicalAttempt,
             nextSequence: delta.sequence + 1,
-            text: delta.sequence === 0 ? delta.text : "",
+            text: delta.sequence === 0 && delta.kind !== "reasoning" ? delta.text : "",
             complete: delta.sequence !== 0
           }
         }
         if (current.complete) return current
         if (delta.sequence !== current.nextSequence) return { ...current, text: "", complete: true }
-        return { ...current, nextSequence: delta.sequence + 1, text: current.text + delta.text }
+        return { ...current, nextSequence: delta.sequence + 1, text: current.text + (delta.kind === "reasoning" ? "" : delta.text) }
       })
     })
   }, [id, rows.length > 0])

--- a/packages/agent/src/component/compaction.test.ts
+++ b/packages/agent/src/component/compaction.test.ts
@@ -167,6 +167,21 @@ describe("the compaction pass", () => {
     expect(briefed()).toContain("run 1")
   })
 
+  test("continuation boundaries stay whole and repeated compaction advances", async () => {
+    const responseRound = (i: number): Event[] => [
+      { type: "ModelReturned", turn: "m0", callId: `response-${i}`, continuation: { payload: [{ signature: `opaque-${i}` }] }, at: i },
+      ...round(i).map((event) => event.type === "ToolCalled" ? { ...event, responseId: `response-${i}` } : event)
+    ]
+    const first = await run([head, ...Array.from({ length: 16 }, (_, i) => responseRound(i)).flat()])
+    const firstIndex = keepFromIndex(first.log, checkpointOf(first.log).keepFrom)
+    expect(first.log[firstIndex]?.type).toBe("ModelReturned")
+    expect(first.briefed()).not.toContain("opaque-")
+    const second = await run([...first.log, ...Array.from({ length: 16 }, (_, i) => responseRound(i + 16)).flat()])
+    const secondIndex = keepFromIndex(second.log, checkpointOf(second.log).keepFrom)
+    expect(secondIndex).toBeGreaterThan(firstIndex)
+    expect(second.log[secondIndex]?.type).toBe("ModelReturned")
+  })
+
   test("a pass can select its model", async () => {
     const selected = { provider: "test", model_id: "compact" } as const
     const { log, model } = await run(openTurn(16), { ...TEST_POLICY, model: selected })

--- a/packages/agent/src/component/compaction.ts
+++ b/packages/agent/src/component/compaction.ts
@@ -173,6 +173,8 @@ const renderedChars = (e: Event, policy: ContextPolicy): number => {
   switch (e.type) {
     case "MessageReceived":
       return Math.min(String(v.text ?? "").length, policy.messageRenderCap)
+    case "ModelReturned":
+      return v.continuation === undefined ? 0 : JSON.stringify(v.continuation).length
     case "TextReturned":
       return String(v.text ?? "").length
     case "ToolCalled":
@@ -228,7 +230,10 @@ export const keepFromIndex = (events: ReadonlyArray<Event>, keepFrom: string): n
     const e = events[i]!
     const v = e as { callId?: unknown; id?: unknown }
     if (keepFrom.startsWith("c:") && e.type === "ToolCalled" && JSON.stringify([e.turn ?? null, v.callId]) === keepFrom.slice(2)) {
-      return events.indexOf(responsesOf(events).firstCalls.get(e)!)
+      const first = responsesOf(events).firstCalls.get(e)!
+      const response = events.findIndex((event) => event.type === "ModelReturned" && event.continuation !== undefined &&
+        event.callId === first.responseId && event.turn === first.turn && (event.epoch ?? 0) === (first.epoch ?? 0))
+      return response < 0 ? events.indexOf(first) : response
     }
     if (keepFrom.startsWith("m:") && e.type === "MessageReceived" && String(v.id) === keepFrom.slice(2)) return i
   }
@@ -290,11 +295,17 @@ const cutOf = (
   }
   for (let i = Math.min(raw, log.length - 1); i > priorIndex; i--) {
     const id = boundaryIdOf(log[i]!, served, firstCalls)
-    if (id !== undefined) return { keepFrom: id, index: i }
+    if (id !== undefined) {
+      const index = keepFromIndex(log, id)
+      if (index > priorIndex) return { keepFrom: id, index }
+    }
   }
   for (let i = Math.max(raw + 1, priorIndex + 1); i < log.length; i++) {
     const id = boundaryIdOf(log[i]!, served, firstCalls)
-    if (id !== undefined) return { keepFrom: id, index: i }
+    if (id !== undefined) {
+      const index = keepFromIndex(log, id)
+      if (index > priorIndex) return { keepFrom: id, index }
+    }
   }
   return undefined
 }

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -280,6 +280,20 @@ describe("an assembled agent", () => {
     expect(textOutcomes(log, "m1")).toEqual([{ text: "second try", owner: 0, interrupted: true }])
   })
 
+  test("reasoning deltas never become partial answer text on cancellation", async () => {
+    const { promise: started, resolve: markStarted } = Promise.withResolvers<void>()
+    const mind = rlm(async (request, key, _signal, onDelta) => {
+      streamOf(request, key, "p1", ["private reasoning"], (delta) => onDelta?.({ ...delta, kind: "reasoning" }))
+      streamOf(request, key, "p1", ["visible answer"], onDelta)
+      markStarted()
+      await new Promise<void>(() => {})
+      return { kind: "complete", output: "late" }
+    })
+    const log = await cancelAfter(mind, started)
+    expect(log.filter((event) => event.type === "TextReturned"))
+      .toEqual([expect.objectContaining({ text: "visible answer", turn: "m1" })])
+  })
+
   test("a normally completing inference journals no partial", async () => {
     const mind = rlm(async (request, key, _signal, onDelta) => {
       streamOf(request, key, "p1", ["an ", "answer"], onDelta)

--- a/packages/agent/src/inference/continuation.ts
+++ b/packages/agent/src/inference/continuation.ts
@@ -1,0 +1,8 @@
+// ProviderContinuation preserves one native assistant response for compatible replay (packages/model/src/continuation.test.ts).
+export interface ProviderContinuation {
+  readonly protocol: string
+  readonly provider: string
+  readonly model: string
+  readonly endpoint: string
+  readonly payload: ReadonlyArray<unknown>
+}

--- a/packages/agent/src/inference/machine.ts
+++ b/packages/agent/src/inference/machine.ts
@@ -451,7 +451,7 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
                   physicalAttempt = delta.physicalAttempt
                   partialOutput = ""
                 }
-                partialOutput += delta.text
+                if (delta.kind !== "reasoning") partialOutput += delta.text
               }
             )
             .pipe(
@@ -508,6 +508,8 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
               callId: input.attempt, ordinal: input.ordinal, turn: input.turn, ...epochStamp(input.epoch),
               outcome: action.kind === "fail" ? "failed" : "returned",
               usage: action.usage ?? {}, ...stampOf(action),
+              ...(action.reasoning === undefined ? {} : { reasoning: action.reasoning }),
+              ...(action.continuation === undefined ? {} : { continuation: action.continuation }),
               ...(action.kind === "fail" ? { error: action.error } : {}), at: after
             }),
             ...(action.kind === "calls" && action.text !== undefined && action.text !== ""

--- a/packages/agent/src/inference/observer.ts
+++ b/packages/agent/src/inference/observer.ts
@@ -9,13 +9,14 @@ export interface InferenceIdentity {
   readonly turn: string
 }
 
-// InferDelta is ephemeral normalized text from one physical provider request. Sequence is zero-based within that request, so a consumer can detect a dropped delta (model.test.ts, "observes normalized text without changing the terminal action").
+// InferDelta is ephemeral answer or reasoning text from one physical provider request. Sequence is zero-based within that request, so a consumer can detect a dropped delta (model.test.ts, "observes normalized text without changing the terminal action").
 export interface InferDelta extends InferenceIdentity {
   readonly logicalAttempt: string
   readonly physicalAttempt: string
   readonly model: ModelRef
   readonly blockIndex: number
   readonly sequence: number
+  readonly kind?: "text" | "reasoning"
   readonly text: string
 }
 

--- a/packages/agent/src/log/events.ts
+++ b/packages/agent/src/log/events.ts
@@ -95,6 +95,11 @@ export const ModelReturned = Schema.Struct({
   callId: Schema.String,
   ordinal: Schema.Finite,
   outcome: Schema.Literals(["returned", "failed"]),
+  reasoning: Schema.optional(Schema.String),
+  continuation: Schema.optional(Schema.Struct({
+    protocol: Schema.String, provider: Schema.String, model: Schema.String, endpoint: Schema.String,
+    payload: Schema.Array(Schema.Unknown)
+  })),
   usage: Schema.Unknown,
   endpoint: Schema.optional(Endpoint),
   error: Schema.optional(Schema.String),
@@ -390,6 +395,8 @@ export interface AttemptEndpoint {
 // declared one must state it: the reactor records it and reads it back on replay, and it refuses
 // to invent one (inference/machine.ts, completionOf).
 type Served = {
+  readonly reasoning?: string
+  readonly continuation?: import("../inference/continuation").ProviderContinuation
   readonly usage?: Usage
   readonly endpoint?: AttemptEndpoint
   readonly mode?: import("../output/contract").OutputMode

--- a/packages/agent/src/projection/messages.ts
+++ b/packages/agent/src/projection/messages.ts
@@ -1,3 +1,4 @@
+import type { ProviderContinuation } from "../inference/continuation"
 import { responsesOf } from "../log/response"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 import { replayProjection, type Projection } from "@clavia/tardigrade-core/projection"
@@ -16,6 +17,7 @@ export interface AgentToolCall {
 }
 
 export interface AgentMessage {
+  readonly continuation?: ProviderContinuation
   readonly role: "user" | "assistant" | "tool"
   readonly content: string | null
   readonly toolCalls?: ReadonlyArray<AgentToolCall>
@@ -89,6 +91,13 @@ const messagesFrom = (
   }
   const emitted = new Set<string>()
   let pendingText: string | null = null
+  const responseKey = (event: Event, id: unknown) => JSON.stringify([event.turn ?? null, event.epoch ?? 0, id])
+  const continuations = new Map(projected.filter((event) => event.type === "ModelReturned" && event.continuation !== undefined)
+    .map((event) => [responseKey(event, event.callId), event.continuation as ProviderContinuation]))
+  const continuationOf = (event: Event, id: unknown) => {
+    const continuation = id === undefined ? undefined : continuations.get(responseKey(event, id))
+    return continuation === undefined ? {} : { continuation }
+  }
   for (const event of projected.slice(from)) {
     const value = event as Record<string, unknown>
     switch (event.type) {
@@ -105,6 +114,7 @@ const messagesFrom = (
         messages.push({
           role: "assistant",
           content: pendingText,
+          ...continuationOf(event, value.responseId),
           toolCalls: key === undefined ? [callOf(event)] : batches.get(key)!
         })
         pendingText = null
@@ -122,13 +132,13 @@ const messagesFrom = (
         break
       }
       case "OutputRejected": {
-        messages.push({ role: "assistant", content: String(value.text ?? "") })
+        messages.push({ role: "assistant", content: String(value.text ?? ""), ...continuationOf(event, value.attempt) })
         const feedback = feedbackFor(value, decided)
         if (feedback !== undefined) messages.push({ role: "user", content: feedback })
         break
       }
       case "TurnCompleted":
-        messages.push({ role: "assistant", content: String(value.output ?? "") })
+        messages.push({ role: "assistant", content: String(value.output ?? ""), ...continuationOf(event, value.attemptKey) })
         break
       case "TurnFailed":
         messages.push({ role: "assistant", content: `the turn failed: ${String(value.error ?? "")}` })

--- a/packages/agent/src/runtime/turn.test.ts
+++ b/packages/agent/src/runtime/turn.test.ts
@@ -136,6 +136,7 @@ const codeThenComplete = (count: { calls: number }) =>
   })
 
 test("a model response and its consequences share one append", async () => {
+  const continuation = { protocol: "test", provider: "test", model: "test", endpoint: "test", payload: [{ signature: "opaque" }] }
   const history: Event[] = []
   const appends: ReadonlyArray<Event>[] = []
   const agent = assembled(infer([
@@ -151,7 +152,7 @@ test("a model response and its consequences share one append", async () => {
     })),
     Layer.succeed(Infer, { react: () => Effect.succeed(history.some((event) => event.type === "ToolCalled")
       ? { kind: "complete" as const, output: "done" }
-      : { kind: "calls" as const, text: "Reading both", calls: [
+      : { kind: "calls" as const, text: "Reading both", reasoning: "Compare both", continuation, calls: [
           { callId: "a", name: "read", arguments: {} },
           { callId: "b", name: "read", arguments: {} }
         ] as const }) })
@@ -161,6 +162,7 @@ test("a model response and its consequences share one append", async () => {
     ["ModelReturned", "TextReturned", "ToolCalled", "ToolCalled"],
     ["ModelReturned", "TurnCompleted"]
   ])
+  expect(responses[0]![0]).toMatchObject({ continuation, reasoning: "Compare both" })
   expect(responses[0]!.filter((event) => event.type === "ToolCalled").map((event) => event.callId)).toEqual(["a", "b"])
   expect(appends.filter((events) => events.some((event) => event.type === "ModelCalled")))
     .toHaveLength(2)

--- a/packages/model/src/adapter.ts
+++ b/packages/model/src/adapter.ts
@@ -5,6 +5,9 @@ import type { OutputMode } from "@clavia/tardigrade-agent/output/contract"
 import type { ModelPricing } from "@clavia/tardigrade-agent/inference/usage"
 import type { ModelProtocol } from "./directory"
 import type { OutputCapability } from "./output"
+import type { ProtocolOptions } from "./reasoning"
+
+export type { ModelOptionsByProtocol, ThinkingConfig } from "./reasoning"
 
 export interface StreamBounds {
   readonly firstChunkMs: number
@@ -17,11 +20,12 @@ export type ModelFetch = (
   init?: Parameters<typeof globalThis.fetch>[1]
 ) => Promise<Response>
 
-export interface ModelConfig {
+export type ModelConfig = ModelConnection & ProtocolOptions
+
+interface ModelConnection {
   readonly baseUrl: string
   readonly apiKey: string
   readonly model: string
-  readonly protocol: ModelProtocol
   readonly provider: string
   // region selects the AWS region for a Bedrock Converse connection.
   readonly region?: string

--- a/packages/model/src/anthropic.ts
+++ b/packages/model/src/anthropic.ts
@@ -1,4 +1,5 @@
 import { createAnthropicChat } from "@tanstack/ai-anthropic"
+import { protocolOptionsOf } from "./reasoning"
 import { outputSchemaFor } from "./output"
 import type { ModelAdapter } from "./adapter"
 
@@ -6,7 +7,11 @@ import type { ModelAdapter } from "./adapter"
 export const anthropicAdapter: ModelAdapter = {
   id: "tanstack/anthropic",
   protocols: ["anthropic-messages"],
-  start: ({ config, request, mode, fetch, messages, tools, systemPrompts }) => {
+  start: ({ config, request, mode, maxTokens, fetch, messages, tools, systemPrompts }) => {
+    const options = protocolOptionsOf(config.protocol, config.options).options
+    if (options?.thinking?.type === "enabled" && options.thinking.budget_tokens >= maxTokens) {
+      throw new Error("options.thinking.budget_tokens must be less than the request output token limit; set maxTokensLadder and maxOutputTokens accordingly")
+    }
     const outputSchema = request.output?.kind === "contract" && mode.kind === "native"
       ? outputSchemaFor(request.output, mode)
       : undefined
@@ -21,6 +26,10 @@ export const anthropicAdapter: ModelAdapter = {
         messages: messages as never,
         tools: tools as never,
         systemPrompts,
+        modelOptions: {
+          max_tokens: maxTokens,
+          ...options
+        },
         ...(outputSchema === undefined ? {} : { outputSchema }),
         logger: new Proxy({}, { get: () => () => {} }) as never
       } as never)

--- a/packages/model/src/bedrock.ts
+++ b/packages/model/src/bedrock.ts
@@ -1,3 +1,4 @@
+import { protocolOptionsOf } from "./reasoning"
 import * as BedrockRuntime from "@aws-sdk/client-bedrock-runtime"
 import { FetchHttpHandler } from "@smithy/fetch-http-handler"
 import { BedrockConverseTextAdapter, type BEDROCK_CONVERSE_MODELS } from "@tanstack/ai-bedrock"
@@ -132,6 +133,7 @@ export const bedrockAdapter: ModelAdapter = {
   id: "tanstack/bedrock-converse",
   protocols: ["bedrock-converse"],
   start: ({ config, request, mode, maxTokens, bounds, messages, tools, systemPrompts }) => {
+    protocolOptionsOf(config.protocol, config.options)
     const stops: { stopReason?: string } = {}
     const reported: { usage?: unknown } = {}
     const adapter = bedrockConverseTextAdapter(config, maxTokens, bounds, request.output, mode, stops, reported)

--- a/packages/model/src/config.ts
+++ b/packages/model/src/config.ts
@@ -1,10 +1,14 @@
 import { modelRefOf } from "@clavia/tardigrade-agent/inference/reference"
 import { modelAllowedBy, modelPolicyOf, type ModelPolicy } from "@clavia/tardigrade-agent/inference/access"
 import { modelProtocolOf, type ModelProtocol } from "./directory"
+import { protocolOptionsOf, type ModelOptionsByProtocol } from "./reasoning"
 
-export interface ModelProviderConfig {
+export type ModelProviderConfig = ProviderConnection & ({
+  [P in ModelProtocol]: { readonly protocol: P; readonly models?: Readonly<Record<string, { readonly options?: ModelOptionsByProtocol[P] }>> }
+}[ModelProtocol] | { readonly protocol: ModelProtocol; readonly models?: never })
+
+interface ProviderConnection {
   readonly baseUrl: string
-  readonly protocol: ModelProtocol
   readonly env: ReadonlyArray<string>
   readonly region?: string
 }
@@ -56,7 +60,7 @@ export const modelConfigOf = (value: unknown): ModelConfig => {
     if (provider["apiKey"] !== undefined) {
       throw new Error(`provider ${JSON.stringify(name)} cannot contain apiKey; declare its secret environment variable in env`)
     }
-    const allowed = new Set(["baseUrl", "protocol", "env", "region"])
+    const allowed = new Set(["baseUrl", "protocol", "env", "region", "models"])
     const unknown = Object.keys(provider).filter((field) => !allowed.has(field))
     if (unknown.length > 0) throw new Error(`provider ${JSON.stringify(name)} contains unknown fields: ${unknown.join(", ")}`)
     const baseUrl = stringOf(provider["baseUrl"])
@@ -75,12 +79,27 @@ export const modelConfigOf = (value: unknown): ModelConfig => {
     if (selectedProtocol !== "bedrock-converse" && region !== undefined) {
       throw new Error(`provider ${JSON.stringify(name)} cannot declare region with protocol ${JSON.stringify(selectedProtocol)}`)
     }
+    let models: Record<string, { readonly options?: ModelOptionsByProtocol[ModelProtocol] }> | undefined
+    if (provider["models"] !== undefined) {
+      const entries = recordOf(provider["models"])
+      if (entries === undefined || Array.isArray(entries)) throw new Error(`provider ${JSON.stringify(name)} models must map model IDs to settings`)
+      models = {}
+      for (const [model, value] of Object.entries(entries)) {
+        if (model.trim().length === 0) throw new Error("model ID cannot be empty")
+        const settings = recordOf(value)
+        if (settings === undefined || Array.isArray(settings)) throw new Error(`model ${model} settings must be an object`)
+        if (Object.keys(settings).some((field) => field !== "options")) throw new Error(`model ${model} contains unsupported settings`)
+        const parsed = protocolOptionsOf(selectedProtocol, settings.options)
+        models[model] = parsed.options === undefined ? {} : { options: parsed.options }
+      }
+    }
     providers[name] = {
+      ...(models === undefined ? {} : { models }),
       baseUrl,
       protocol: selectedProtocol,
       env,
       ...(region === undefined ? {} : { region })
-    }
+    } as ModelProviderConfig
   }
   const selectedValue = source["default"]
   const selected = modelRefOf(selectedValue)

--- a/packages/model/src/continuation.test.ts
+++ b/packages/model/src/continuation.test.ts
@@ -1,0 +1,128 @@
+import { expect, test } from "bun:test"
+import { Effect } from "effect"
+import { Infer, type InferDelta } from "@clavia/tardigrade-agent"
+import type { Event } from "@clavia/tardigrade-core/log/event"
+import { renderMessages } from "@clavia/tardigrade-agent/projection/messages"
+import { modelAdapters, type ModelConfig } from "./adapter"
+import { infer } from "./model"
+import { anthropicAdapter } from "./anthropic"
+import { openAICompatibleAdapter } from "./openai"
+import { continuationScopeOf, responseStateOf, withContinuation } from "./continuation"
+
+interface CapturedBody {
+  messages: Array<{ role?: string; content: Array<Record<string, unknown>> }>
+  input: unknown[]
+  store?: boolean
+  include?: string[]
+}
+
+const configOf = (protocol: "anthropic-messages" | "openai-responses"): ModelConfig => ({ protocol, provider: "test", model: "test-model", baseUrl: "https://test.invalid/v1", apiKey: "key", contextWindowTokens: 128_000 })
+const thinking = { type: "thinking", thinking: "Compare the sources", signature: "signed opaque bytes" }
+const redacted = { type: "redacted_thinking", data: "encrypted redaction" }
+const reasoning = { type: "reasoning", id: "r1", summary: [{ type: "summary_text", text: "Compare the sources" }], encrypted_content: "encrypted opaque bytes" }
+const tool = { type: "tool_use", id: "a", name: "read", input: {} }
+const call = { type: "function_call", id: "fc_a", call_id: "a", name: "read", arguments: "{}", status: "completed" }
+const head: Event = { type: "MessageReceived", id: "m1", text: "Read both", at: 1 }
+const identity = { actor: "test", instance: "main", thread: "root", turn: "m1" }
+const sse = (events: readonly Record<string, unknown>[]) => new Response(events.map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join(""), { headers: { "content-type": "text/event-stream" } })
+const anthropicEvents = [
+  { type: "message_start", message: { id: "msg1", role: "assistant", model: "test-model", content: [], usage: { input_tokens: 5, output_tokens: 0 } } },
+  { type: "content_block_start", index: 0, content_block: { type: "thinking", thinking: "", signature: "" } },
+  { type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking: thinking.thinking } },
+  { type: "content_block_delta", index: 0, delta: { type: "signature_delta", signature: thinking.signature } },
+  { type: "content_block_stop", index: 0 },
+  { type: "content_block_start", index: 1, content_block: redacted },
+  { type: "content_block_stop", index: 1 },
+  { type: "content_block_start", index: 2, content_block: tool },
+  { type: "content_block_delta", index: 2, delta: { type: "input_json_delta", partial_json: "{}" } },
+  { type: "content_block_stop", index: 2 },
+  { type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 20 } },
+  { type: "message_stop" }
+]
+const openaiEvents = [
+  { type: "response.created", response: { id: "resp1", model: "test-model", status: "in_progress", output: [] } },
+  { type: "response.output_item.added", output_index: 0, item: { ...reasoning, summary: [] } },
+  { type: "response.reasoning_summary_text.delta", item_id: "r1", output_index: 0, summary_index: 0, delta: "Compare the sources" },
+  { type: "response.output_item.done", output_index: 0, item: reasoning },
+  { type: "response.output_item.added", output_index: 1, item: { ...call, arguments: "" } },
+  { type: "response.function_call_arguments.delta", item_id: "fc_a", output_index: 1, delta: "{}" },
+  { type: "response.function_call_arguments.done", item_id: "fc_a", output_index: 1, arguments: "{}" },
+  { type: "response.output_item.done", output_index: 1, item: call },
+  { type: "response.completed", response: { id: "resp1", model: "test-model", status: "completed", output: [reasoning, call], usage: { input_tokens: 5, output_tokens: 20 } } }
+]
+
+test.each(["anthropic-messages", "openai-responses"] as const)("%s preserves continuation through a serialized log and a fresh binding", async (protocol) => {
+  const config = configOf(protocol)
+  const bodies: CapturedBody[] = []
+  const deltas: InferDelta[] = []
+  const invoke = (trajectory: readonly Event[]) => Effect.runPromise(Effect.flatMap(Infer, (binding) => binding.react({ trajectory, identity, system: "", tools: [{ name: "read", description: "Read", inputSchema: { type: "object", properties: {} } }] }, "m1/infer/0", undefined, (delta) => deltas.push(delta))).pipe(Effect.provide(infer({ ...config, fetch: async (input, init) => {
+    const request = input instanceof Request ? input : new Request(String(input), init)
+    bodies.push(JSON.parse(typeof init?.body === "string" ? init.body : await request.text()))
+    return sse(protocol === "anthropic-messages" ? anthropicEvents : openaiEvents)
+  } }, modelAdapters(anthropicAdapter, openAICompatibleAdapter)))))
+  const action = await invoke([head])
+  expect(action).toMatchObject({ kind: "calls", calls: [{ callId: "a", name: "read", arguments: {} }], reasoning: "Compare the sources" })
+  const payload = protocol === "anthropic-messages" ? [thinking, redacted, tool] : [reasoning, call]
+  expect(action.continuation?.payload).toEqual(payload)
+  expect(deltas.filter((delta) => delta.kind === "reasoning").map((delta) => delta.text).join("")).toBe("Compare the sources")
+  const events: Event[] = JSON.parse(JSON.stringify([
+    head,
+    { type: "ModelReturned", callId: "response-1", ordinal: 0, outcome: "returned", usage: {}, turn: "m1", at: 2, continuation: action.continuation, reasoning: action.reasoning },
+    { type: "ToolCalled", callId: "a", name: "read", arguments: {}, responseId: "response-1", turn: "m1", at: 2 },
+    { type: "ToolReturned", callId: "a", result: "contents", turn: "m1", at: 3 }
+  ]))
+  await invoke(events)
+  const body = bodies[1]!
+  if (protocol === "anthropic-messages") expect(body.messages.find((message) => message.role === "assistant")?.content).toEqual(payload)
+  else {
+    expect(body.input.slice(1, 3)).toEqual(payload)
+    expect(body.store).toBe(false)
+    expect(body.include).toContain("reasoning.encrypted_content")
+  }
+  const compacted = [...events, { type: "CompactionCompleted", keepFrom: `c:${JSON.stringify(["m1", "a"])}`, summary: "Earlier work", at: 4 }]
+  expect(renderMessages(compacted).find((message) => message.role === "assistant")?.continuation?.payload).toEqual(payload)
+})
+
+test("continuation stays with each response and is omitted for incompatible requests", async () => {
+  const config = configOf("anthropic-messages")
+  const first = await responseStateOf([{ content: [thinking, tool] }], config)
+  const second = await responseStateOf([{ content: [{ ...thinking, signature: "second" }, { ...tool, id: "b" }] }], config)
+  const messages = [
+    { role: "assistant" as const, content: null, toolCalls: [{ id: "a", name: "read", arguments: "{}" }], continuation: first.continuation! },
+    { role: "assistant" as const, content: null, toolCalls: [{ id: "b", name: "read", arguments: "{}" }], continuation: second.continuation! }
+  ]
+  for (const changed of [config, { ...config, provider: "other" }, { ...config, model: "other" }, { ...config, baseUrl: "https://test.invalid/v1?tenant=other" }, configOf("openai-responses")]) {
+    let sent: CapturedBody = { messages: [], input: [] }
+    const fetch = withContinuation(async (_input, init) => { sent = JSON.parse(String(init?.body)); return new Response() }, changed, messages)
+    const body = { messages: [{ role: "assistant", content: [tool] }, { role: "assistant", content: [{ ...tool, id: "b" }] }] }
+    await fetch("https://test.invalid", { method: "POST", body: JSON.stringify(body) })
+    if (changed === config) expect(sent.messages.map((message) => message.content[0]?.signature)).toEqual(["signed opaque bytes", "second"])
+    else expect(sent as unknown).toEqual(body)
+  }
+  expect((await continuationScopeOf({ ...config, baseUrl: "https://secret:password@test.invalid/v1?key=secret" })).endpoint).not.toContain("secret")
+})
+
+test("encrypted-only responses retain state without fabricating display text", async () => {
+  const item = { ...reasoning, summary: [] }
+  const state = await responseStateOf([{ output: [item, call] }], configOf("openai-responses"))
+  expect(state.reasoning).toBeUndefined()
+  expect(state.continuation?.payload).toEqual([item, call])
+})
+
+test("Responses replays successive native outputs in conversation order", async () => {
+  const config = configOf("openai-responses")
+  const output1 = [reasoning, call]
+  const output2 = [{ ...reasoning, id: "r2", encrypted_content: "second" }, { ...call, id: "fc_b", call_id: "b" }]
+  const first = await responseStateOf([{ output: output1 }], config)
+  const second = await responseStateOf([{ output: output2 }], config)
+  const messages = [
+    { role: "assistant" as const, content: null, toolCalls: [{ id: "a", name: "read", arguments: "{}" }], continuation: first.continuation! },
+    { role: "tool" as const, content: "a result", toolCallId: "a" },
+    { role: "assistant" as const, content: null, toolCalls: [{ id: "b", name: "read", arguments: "{}" }], continuation: second.continuation! }
+  ]
+  let sent: CapturedBody = { messages: [], input: [] }
+  const fetch = withContinuation(async (_input, init) => { sent = JSON.parse(String(init?.body)); return new Response() }, config, messages)
+  const result = { type: "function_call_output", call_id: "a", output: "a result" }
+  await fetch(config.baseUrl, { method: "POST", body: JSON.stringify({ input: [call, result, { ...call, call_id: "b" }] }) })
+  expect(sent.input).toEqual([...output1, result, ...output2])
+})

--- a/packages/model/src/continuation.ts
+++ b/packages/model/src/continuation.ts
@@ -1,0 +1,94 @@
+import type { ProviderContinuation } from "@clavia/tardigrade-agent/inference/continuation"
+import type { AgentMessage } from "@clavia/tardigrade-agent/projection/messages"
+import type { ModelConfig, ModelFetch } from "./adapter"
+
+type Part = Record<string, unknown>
+const partOf = (value: unknown): Part | undefined => typeof value === "object" && value !== null && !Array.isArray(value) ? value as Part : undefined
+
+// continuationScopeOf fingerprints the complete endpoint without storing credentials or query values (continuation.test.ts).
+export const continuationScopeOf = async (config: ModelConfig) => {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(config.baseUrl))
+  const endpoint = `sha256:${Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("")}`
+  return { protocol: config.protocol, provider: config.provider, model: config.model, endpoint }
+}
+
+// responseStateOf retains native output, including redacted blocks, only when the response contains reasoning (continuation.test.ts).
+export const responseStateOf = async (events: readonly unknown[], config: ModelConfig): Promise<{ continuation?: ProviderContinuation; reasoning?: string }> => {
+  let payload: Part[] = []
+  const blocks = new Map<number, Part>()
+  const inputs = new Map<number, string>()
+  for (const value of events) {
+    const event = partOf(value)
+    if (event === undefined) continue
+    if (config.protocol === "anthropic-messages") {
+      if (Array.isArray(event.content)) payload = event.content as Part[]
+      if (event.type === "content_block_start") {
+        const block = partOf(event.content_block)
+        if (block !== undefined) blocks.set(Number(event.index), { ...block })
+      }
+      if (event.type === "content_block_delta") {
+        const block = blocks.get(Number(event.index))
+        const delta = partOf(event.delta)
+        if (block === undefined || delta === undefined) continue
+        for (const field of ["thinking", "signature", "text"] as const) if (typeof delta[field] === "string") block[field] = String(block[field] ?? "") + delta[field]
+        if (typeof delta.partial_json === "string") inputs.set(Number(event.index), (inputs.get(Number(event.index)) ?? "") + delta.partial_json)
+      }
+    } else if (config.protocol === "openai-responses") {
+      if (event.type === "response.output_item.done" && partOf(event.item) !== undefined) blocks.set(Number(event.output_index), event.item as Part)
+      const response = partOf(event.response) ?? event
+      if (Array.isArray(response.output)) payload = response.output as Part[]
+    }
+  }
+  if (payload.length === 0) payload = [...blocks.entries()].sort(([a], [b]) => a - b).map(([index, block]) => {
+    const input = inputs.get(index)
+    return input === undefined ? block : { ...block, input: JSON.parse(input) }
+  })
+  const reasoning = payload.filter((part) => part.type === "thinking" || part.type === "redacted_thinking" || part.type === "reasoning")
+  if (reasoning.length === 0) return {}
+  const text = reasoning.flatMap((part) => {
+    if (typeof part.thinking === "string") return [part.thinking]
+    return Array.isArray(part.summary) ? part.summary.flatMap((value) => {
+      const summary = partOf(value)
+      return typeof summary?.text === "string" ? [summary.text] : []
+    }) : []
+  }).filter((text) => text !== "").join("\n\n")
+  return { continuation: { ...await continuationScopeOf(config), payload }, ...(text === "" ? {} : { reasoning: text }) }
+}
+
+// withContinuation restores complete native assistant responses after TanStack's lossy conversion (continuation.test.ts).
+export const withContinuation = (fetch: ModelFetch, config: ModelConfig, messages: readonly AgentMessage[]): ModelFetch => async (input, init) => {
+  if (config.protocol !== "anthropic-messages" && config.protocol !== "openai-responses") return fetch(input, init)
+  if (!messages.some((message) => message.continuation !== undefined)) return fetch(input, init)
+  const scope = await continuationScopeOf(config)
+  const compatible = (continuation: ProviderContinuation | undefined) => continuation !== undefined &&
+    continuation.protocol === scope.protocol && continuation.provider === scope.provider &&
+    continuation.model === scope.model && continuation.endpoint === scope.endpoint
+  if (!messages.some((message) => compatible(message.continuation))) return fetch(input, init)
+  const request = input instanceof Request ? input : new Request(String(input), init)
+  const body = JSON.parse(typeof init?.body === "string" ? init.body : await request.clone().text()) as Part
+  const field = config.protocol === "anthropic-messages" ? "messages" : "input"
+  const items = body[field]
+  if (!Array.isArray(items)) throw new Error("provider request has no conversation for continuation replay")
+  let cursor = 0
+  for (const message of messages) {
+    if (message.role !== "assistant") continue
+    const call = message.toolCalls?.[0]?.id
+    const index = items.findIndex((item: Part, index: number) => index >= cursor && (config.protocol === "anthropic-messages"
+      ? item.role === "assistant"
+      : call === undefined ? item.role === "assistant" : item.type === "function_call" && item.call_id === call))
+    if (index < 0) {
+      if (compatible(message.continuation)) throw new Error("assistant response missing during continuation replay")
+      continue
+    }
+    const count = config.protocol === "anthropic-messages" ? 1 : (message.toolCalls?.length ?? 0) + (message.content ? 1 : 0)
+    if (compatible(message.continuation)) {
+      const payload = message.continuation!.payload
+      if (config.protocol === "anthropic-messages") items[index] = { ...items[index], content: payload }
+      else items.splice(index, count, ...payload)
+      cursor = index + (config.protocol === "anthropic-messages" ? 1 : payload.length)
+    } else cursor = index + count
+  }
+  const headers = new Headers(init?.headers ?? request.headers)
+  headers.delete("content-length")
+  return fetch(input, { ...init, headers, body: JSON.stringify(body) })
+}

--- a/packages/model/src/host.ts
+++ b/packages/model/src/host.ts
@@ -1,3 +1,4 @@
+import { protocolOptionsOf, type ProtocolOptions } from "./reasoning"
 import { Effect, Layer } from "effect"
 import { Infer, intersectModelPolicies, modelAllowedBy, type ModelPolicy, type ModelRef, type InferenceObserver } from "@clavia/tardigrade-agent"
 import type { Action } from "@clavia/tardigrade-agent/log/events"
@@ -18,12 +19,11 @@ export interface ModelHostConfig {
 // answers /healthz, and says why a turn cannot run (config.ts, ModelConfig).
 export const MISSING_MODEL = "no model provider is configured: run `tdg setup`"
 
-interface SelectedModel {
+type SelectedModel = ProtocolOptions & {
   readonly model_id: string
   readonly provider: string
   readonly baseUrl: string
   readonly apiKey: string
-  readonly protocol: ModelConfig["providers"][string]["protocol"]
   readonly region?: string
   readonly contextWindowTokens: number
   readonly maxOutputTokens?: number
@@ -59,8 +59,8 @@ const connectionFrom = (
   }
   return {
     baseUrl: provider.baseUrl,
-    apiKey,
     protocol: provider.protocol,
+    apiKey,
     ...(provider.region === undefined ? {} : { region: provider.region })
   }
 }
@@ -103,14 +103,15 @@ export const selectedModelFrom = (
   }
   const catalogModel = catalogModelFrom(catalog.snapshot, selected)
   const metadata = catalogModel.metadata
+  const options = config.providers[selected.provider]?.models?.[selected.model_id]?.options
   if (metadata.contextWindowTokens === undefined) {
     throw new Error(`model catalog has no context window for ${selected.provider}/${selected.model_id}`)
   }
   return {
     ...selected,
+    ...protocolOptionsOf(provider.protocol, options),
     baseUrl: provider.baseUrl,
     apiKey: provider.apiKey,
-    protocol: provider.protocol,
     ...(provider.region === undefined ? {} : { region: provider.region }),
     contextWindowTokens: metadata.contextWindowTokens,
     ...(metadata.maxOutputTokens === undefined ? {} : { maxOutputTokens: metadata.maxOutputTokens }),
@@ -183,10 +184,10 @@ export const modelLayer = (
         })
       }
       const binding = infer({
+        ...protocolOptionsOf(selected.protocol, selected.options),
         baseUrl: selected.baseUrl,
         apiKey: selected.apiKey,
         model: selected.model_id,
-        protocol: selected.protocol,
         provider: selected.provider,
         ...(selected.region === undefined ? {} : { region: selected.region }),
         contextWindowTokens: selected.contextWindowTokens,

--- a/packages/model/src/model.test.ts
+++ b/packages/model/src/model.test.ts
@@ -54,7 +54,7 @@ import type { Action } from "@clavia/tardigrade-agent/log/events"
 import type { Event } from "@clavia/tardigrade-core/log/event"
 
 const testAdapters = modelAdapters(openAICompatibleAdapter, anthropicAdapter, registeredBedrockAdapter)
-const testInfer = <const C extends Omit<ModelConfig, "protocol" | "provider" | "contextWindowTokens"> & { readonly protocol?: ModelProtocol }>(
+const testInfer = <const C extends Omit<ModelConfig, "protocol" | "provider" | "contextWindowTokens" | "options"> & { readonly protocol?: ModelProtocol }>(
   config: C,
   options: ModelInferOptions = {}
 ) => infer({ protocol: "openai-chat-completions", provider: "test", contextWindowTokens: 128_000, ...config }, testAdapters, options)

--- a/packages/model/src/model.ts
+++ b/packages/model/src/model.ts
@@ -1,3 +1,4 @@
+import { responseStateOf, withContinuation } from "./continuation"
 import { Cause, Clock, Effect, Fiber, Layer, Queue, Random, Stream } from "effect"
 import {
   StreamProcessor,
@@ -320,6 +321,7 @@ type BodyReader = {
 // stamps `provider` on each chunk; `model` is standard). Wire-reported provenance beats the
 // configured stamp: it is observed, never declared.
 interface Wire {
+  readonly events?: ReadonlyArray<unknown>
   readonly usage?: unknown
   readonly usageReports?: ReadonlyArray<unknown>
   readonly provider?: string
@@ -362,11 +364,14 @@ const captureWire = async (reader: BodyReader): Promise<Wire | undefined> => {
     }
   }
   let last: Wire = {}
+  const events: unknown[] = []
   for (const line of text.split(/\r?\n/)) {
     const payload = line.startsWith("data:") ? line.slice(5).trim() : ""
     if (payload === "" || payload === "[DONE]") continue
     try {
-      const next = wireOf(JSON.parse(payload) as never)
+      const parsed = JSON.parse(payload)
+      events.push(parsed)
+      const next = wireOf(parsed as never)
       const usageReports =
         next.usage === undefined ? last.usageReports : [...(last.usageReports ?? []), next.usage]
       // Refusal deltas arrive in pieces, like content: each chunk carries the next fragment.
@@ -380,9 +385,10 @@ const captureWire = async (reader: BodyReader): Promise<Wire | undefined> => {
       // a keep-alive or a malformed line is not usage
     }
   }
-  if (Object.keys(last).length > 0) return last
+  if (events.length > 0) return { ...last, events }
   try {
-    const wire = wireOf(JSON.parse(text) as never)
+    const parsed = JSON.parse(text)
+    const wire = { ...wireOf(parsed as never), events: [parsed] }
     if (Object.keys(wire).length === 0) return undefined
     return wire.usage === undefined ? wire : { ...wire, usageReports: [wire.usage] }
   } catch {
@@ -491,13 +497,22 @@ const observed = (
   if (logicalAttempt === undefined) throw new Error("an observed inference requires a logical attempt identity")
   let blockIndex = -1
   let sequence = 0
+  let modernReasoning = false
+  const thinkingSteps = new Set<string>()
   return Stream.fromAsyncIterable(stream, (cause) => cause).pipe(
     Stream.tap((chunk) => {
-      if (chunk.type === "TEXT_MESSAGE_START") {
+      if (chunk.type === "REASONING_MESSAGE_START") modernReasoning = true
+      if (chunk.type === "STEP_STARTED" && chunk.stepType === "thinking") {
+        thinkingSteps.add(chunk.stepId ?? chunk.stepName)
+        if (!modernReasoning) blockIndex += 1
+      }
+      if (chunk.type === "TEXT_MESSAGE_START" || chunk.type === "REASONING_MESSAGE_START") {
         blockIndex += 1
         return Effect.void
       }
-      if (chunk.type !== "TEXT_MESSAGE_CONTENT" || typeof chunk.delta !== "string" || chunk.delta === "") {
+      const reasoning = chunk.type === "REASONING_MESSAGE_CONTENT" ||
+        (!modernReasoning && chunk.type === "STEP_FINISHED" && thinkingSteps.has(chunk.stepId ?? chunk.stepName))
+      if ((chunk.type !== "TEXT_MESSAGE_CONTENT" && !reasoning) || !("delta" in chunk) || typeof chunk.delta !== "string" || chunk.delta === "") {
         return Effect.void
       }
       if (blockIndex < 0) blockIndex = 0
@@ -508,6 +523,7 @@ const observed = (
         model,
         blockIndex,
         sequence: sequence++,
+        ...(reasoning ? { kind: "reasoning" as const } : {}),
         text: chunk.delta
       }
       if (onDelta !== undefined) onDelta(delta)
@@ -626,7 +642,8 @@ export const infer = <const C extends ModelConfig>(
     const attemptSignal = signal === undefined
       ? attemptController.signal
       : AbortSignal.any([signal, attemptController.signal])
-    const fetcher = withCapture(config.fetch, keyForRung, sink, attemptSignal)
+    const capturedFetch = withCapture(config.fetch, keyForRung, sink, attemptSignal)
+    const fetcher = withContinuation(capturedFetch, config, req.messages)
     const fallbackSystem = fallbackSystemFor(req.output, mode)
     const attempt = selectedAdapter.start({
       config,
@@ -695,7 +712,7 @@ export const infer = <const C extends ModelConfig>(
       if (stopClass === "violation") {
         throw failed(new ViolatedError("the provider could not produce output matching the schema it was given"), usage, endpoint)
       }
-      return stamped(served(withSpend(actionOf(result), usage), endpoint))
+      return stamped(served(withSpend({ ...actionOf(result), ...await responseStateOf(wire?.events ?? [], config) }, usage), endpoint))
     } catch (e) {
       attemptController.abort()
       await sink.reader?.cancel().catch(() => undefined)

--- a/packages/model/src/openai.ts
+++ b/packages/model/src/openai.ts
@@ -1,4 +1,5 @@
 import { openaiCompatibleText } from "@tanstack/ai-openai/compatible"
+import { protocolOptionsOf } from "./reasoning"
 import { compatibleResponseFormat } from "./output"
 import type { ModelAdapter } from "./adapter"
 
@@ -7,6 +8,7 @@ export const openAICompatibleAdapter: ModelAdapter = {
   id: "tanstack/openai-compatible",
   protocols: ["openai-responses", "openai-chat-completions"],
   start: ({ config, request, mode, maxTokens, fetch, messages, tools, systemPrompts }) => {
+    const options = protocolOptionsOf(config.protocol, config.options).options
     const responseFormat = compatibleResponseFormat(request.output, mode)
     const adapter = openaiCompatibleText(config.model, {
       name: "tardigrade",
@@ -24,6 +26,8 @@ export const openAICompatibleAdapter: ModelAdapter = {
         systemPrompts,
         modelOptions: {
           max_tokens: maxTokens,
+          ...(config.protocol === "openai-responses" ? { store: false, include: ["reasoning.encrypted_content"] } : {}),
+          ...options,
           ...(responseFormat === undefined ? {} : { response_format: responseFormat })
         } as never,
         logger: new Proxy({}, { get: () => () => {} }) as never

--- a/packages/model/src/reasoning.test.ts
+++ b/packages/model/src/reasoning.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { Infer, renderOf, codeMode, nativeOutput, NATIVE_MODE } from "@clavia/tardigrade-agent"
+import { modelAdapters, type ModelAdapter, type ModelAdapterContext } from "./adapter"
+import { openAICompatibleAdapter } from "./openai"
+import { anthropicAdapter } from "./anthropic"
+import { bedrockAdapter } from "./bedrock"
+import { protocolOptionsOf, type ModelOptionsByProtocol } from "./reasoning"
+import { canonicalModelConfig, modelConfigOf } from "./config"
+import { modelLayer } from "./host"
+import type { ModelProtocol } from "./directory"
+
+const request = {
+  trajectory: [],
+  messages: [],
+  identity: { actor: "test", instance: "main", thread: "root", turn: "turn" },
+  ...renderOf([codeMode(), nativeOutput], [])
+}
+const contextOf = (protocol: ModelProtocol, options?: ModelOptionsByProtocol[ModelProtocol]): ModelAdapterContext => ({
+  config: { baseUrl: "https://model.test/v1", apiKey: "test", model: "test-model", provider: "test", contextWindowTokens: 128_000, ...protocolOptionsOf(protocol, options) },
+  request: { system: "", tools: [], messages: [] },
+  identity: request.identity,
+  mode: NATIVE_MODE,
+  maxTokens: 4096,
+  bounds: { firstChunkMs: 1000, idleMs: 1000, totalMs: 1000 },
+  messages: [{ role: "user", content: "Hello" }],
+  tools: [],
+  systemPrompts: [],
+  fetch: async () => new Response()
+})
+
+const bodyOf = async (protocol: ModelProtocol, options?: ModelOptionsByProtocol[ModelProtocol]) => {
+  let body: Record<string, unknown> | undefined
+  const context = contextOf(protocol, options)
+  const attempt = (protocol === "anthropic-messages" ? anthropicAdapter : openAICompatibleAdapter).start({
+    ...context,
+    fetch: async (input, init) => {
+      const outgoing = input instanceof Request ? input : new Request(String(input), init)
+      body = JSON.parse(await outgoing.text())
+      return new Response("", { headers: { "content-type": "text/event-stream" } })
+    }
+  })
+  for await (const _chunk of attempt.stream) {}
+  expect(body).toBeDefined()
+  return body!
+}
+
+describe("reasoning controls", () => {
+  test.each(["openai-responses", "openai-chat-completions", "anthropic-messages"] as const)("%s preserves provider defaults when omitted", async (protocol) => {
+    const body = await bodyOf(protocol)
+    for (const field of ["thinking", "reasoning", "reasoning_effort", "output_config"]) expect(body).not.toHaveProperty(field)
+  })
+  test.each(["high", "none"] as const)("OpenAI sends explicit effort %s on each wire", async (effort) => {
+    const responses = await bodyOf("openai-responses", { reasoning: { effort } })
+    expect(responses.reasoning).toEqual({ effort })
+    expect(responses).not.toHaveProperty("reasoning_effort")
+    const chat = await bodyOf("openai-chat-completions", { reasoning_effort: effort })
+    expect(chat.reasoning_effort).toBe(effort)
+    expect(chat).not.toHaveProperty("reasoning")
+  })
+  test.each([
+    [{ type: "adaptive" }, { type: "adaptive" }],
+    [{ type: "disabled" }, { type: "disabled" }],
+    [{ type: "adaptive", display: "summarized" }, { type: "adaptive", display: "summarized" }],
+    [{ type: "adaptive", display: "omitted" }, { type: "adaptive", display: "omitted" }],
+    [{ type: "enabled", budget_tokens: 2048 }, { type: "enabled", budget_tokens: 2048 }]
+  ] as const)("Anthropic sends thinking %j and effort", async (thinking, wire) => {
+    const body = await bodyOf("anthropic-messages", { thinking, output_config: { effort: "high" } })
+    expect(body.thinking).toEqual(wire)
+    expect(body.output_config).toEqual({ effort: "high" })
+    expect(body.max_tokens).toBe(4096)
+  })
+  test("Anthropic rejects a thinking budget that would increase the output cap before fetching", () => {
+    expect(() => anthropicAdapter.start(contextOf("anthropic-messages", { thinking: { type: "enabled", budget_tokens: 4096 } }))).toThrow("request output token limit")
+  })
+  test.each([
+    null, [], { typo: "high" }, { output_config: { effort: "" } }, { output_config: { effort: 3 } }, { output_config: { effort: "none" } },
+    { thinking: { type: "adaptive", display: "unknown" } },
+    { thinking: { type: "enabled", budgetTokens: 2048 } },
+    { thinking: { type: "disabled", display: "omitted" } },
+    { thinking: { type: "unknown" } }, { thinking: { type: "enabled" } },
+    { thinking: { type: "adaptive", budget_tokens: 12 } },
+    { thinking: { type: "enabled", budget_tokens: -1 } },
+    { thinking: { type: "enabled", budget_tokens: 1.5 } }
+  ].map((value) => [value] as const))("rejects invalid controls %j", (value) => {
+    expect(() => protocolOptionsOf("anthropic-messages", value)).toThrow()
+  })
+  test("protocol effort values are checked for external configuration", async () => {
+    expect(() => protocolOptionsOf("openai-responses", { reasoning: { effort: "max" } })).toThrow("unsupported")
+    expect(() => protocolOptionsOf("openai-chat-completions", { reasoning_effort: "future-provider-level" })).toThrow("unsupported")
+    expect(() => protocolOptionsOf("openai-responses", { reasoning: { effort: null } })).toThrow("unsupported")
+    expect((await bodyOf("anthropic-messages", { output_config: { effort: null } })).output_config).toEqual({ effort: null })
+  })
+  test("unsupported protocol controls fail explicitly", () => {
+    expect(() => openAICompatibleAdapter.start(contextOf("openai-responses", { thinking: { type: "adaptive" } }))).toThrow("unsupported fields")
+    expect(() => bedrockAdapter.start(contextOf("bedrock-converse", { reasoning: { effort: "high" } }))).toThrow("not supported")
+  })
+  test.each([null, [], { "": { effort: "high" } }, { a: { typo: true } }, { a: null }, { a: { options: { thinking: { type: "adaptive" } } } }].map((value) => [value] as const))("host rejects invalid model maps %j", (models) => {
+    expect(() => modelConfigOf({
+      default: { provider: "test", model_id: "a" }, allow: "*",
+      providers: { test: { baseUrl: "https://model.test", protocol: "openai-responses", env: ["KEY"], models } }
+    })).toThrow()
+  })
+  test("host selects per-model controls and deployment digest includes them", async () => {
+    const config = modelConfigOf({
+      default: { provider: "test", model_id: "a" }, allow: "*",
+      providers: { test: { baseUrl: "https://model.test", protocol: "openai-responses", env: ["KEY"], models: { a: { options: { reasoning: { effort: "high" } } }, b: { options: { reasoning: { effort: "low" } } }, c: {} } } }
+    })
+    const seen: unknown[] = []
+    const adapter: ModelAdapter = { id: "capture", protocols: ["openai-responses"], start: (context) => {
+      seen.push(context.config.options)
+      return { stream: (async function* () { throw new Error("captured") } )() }
+    } }
+    const layer = modelLayer({ model: config, modelCredentials: { KEY: "test" } }, {
+      snapshot: { source: "models.dev", revision: "test", refreshedAt: 0, status: "fresh", providers: [{ id: "test", name: "Test", env: ["KEY"], models: ["a", "b", "c", "d"].map((id) => ({ id, metadata: { contextWindowTokens: 128_000 } })) }] }
+    }, modelAdapters(adapter))
+    for (const model_id of ["a", "b", "c", "d"]) await Effect.runPromise(Effect.flatMap(Infer, (binding) => binding.react({ ...request, model: { provider: "test", model_id } }, "key", new AbortController().signal)).pipe(Effect.provide(layer)))
+    expect(seen).toEqual([{ reasoning: { effort: "high" } }, { reasoning: { effort: "low" } }, undefined, undefined])
+    expect(modelConfigOf(JSON.parse(canonicalModelConfig(config)))).toEqual(config)
+    expect(canonicalModelConfig(config)).not.toBe(canonicalModelConfig({ ...config, providers: { test: { ...config.providers.test!, protocol: "openai-responses", models: { a: { options: { reasoning: { effort: "low" } } } } } } }))
+  })
+})

--- a/packages/model/src/reasoning.ts
+++ b/packages/model/src/reasoning.ts
@@ -1,0 +1,97 @@
+import type { OpenAITextProviderOptions } from "@tanstack/ai-openai"
+import type { AnthropicTextProviderOptions, AnthropicChatModelProviderOptionsByName } from "@tanstack/ai-anthropic"
+import type { ModelProtocol } from "./directory"
+
+// ThinkingConfig uses the model map because TanStack's broad options intersect adaptive thinking with the legacy modes (reasoning.test.ts).
+export type ThinkingConfig = NonNullable<
+  AnthropicChatModelProviderOptionsByName[keyof AnthropicChatModelProviderOptionsByName]["thinking"]
+>
+
+type OpenAIEffort = NonNullable<OpenAITextProviderOptions["reasoning"]>["effort"]
+
+export interface ModelOptionsByProtocol {
+  readonly "anthropic-messages": {
+    readonly thinking?: ThinkingConfig
+    readonly output_config?: AnthropicTextProviderOptions["output_config"]
+    readonly reasoning?: never
+    readonly reasoning_effort?: never
+  }
+  readonly "openai-responses": {
+    readonly reasoning?: Pick<NonNullable<OpenAITextProviderOptions["reasoning"]>, "effort">
+    readonly thinking?: never
+    readonly output_config?: never
+    readonly reasoning_effort?: never
+  }
+  readonly "openai-chat-completions": {
+    readonly reasoning_effort?: OpenAIEffort
+    readonly reasoning?: never
+    readonly thinking?: never
+    readonly output_config?: never
+  }
+  readonly "bedrock-converse": never
+}
+
+// ProtocolOptions ties native request options to their wire (reasoning.types.test.ts).
+export type ProtocolOptions = {
+  [P in ModelProtocol]: { readonly protocol: P; readonly options?: ModelOptionsByProtocol[P] }
+}[ModelProtocol] | { readonly protocol: ModelProtocol; readonly options?: never }
+
+const fieldsOf = (value: unknown, fields: readonly string[], label: string): Record<string, unknown> => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error(`${label} must be an object`)
+  const source = value as Record<string, unknown>
+  const unknown = Object.keys(source).filter((key) => !fields.includes(key))
+  if (unknown.length > 0) throw new Error(`${label} contains unsupported fields: ${unknown.join(", ")}`)
+  return source
+}
+
+const effortOf = <const T extends readonly (string | null)[]>(value: unknown, allowed: T): T[number] => {
+  if (!allowed.some((entry) => entry === value)) throw new Error("options effort is unsupported for this protocol")
+  return value as T[number]
+}
+
+const openAIEffortOf = (value: unknown) => effortOf(value, ["none", "minimal", "low", "medium", "high"] as const)
+
+const thinkingOf = (value: unknown): ThinkingConfig => {
+  const raw = fieldsOf(value, ["type", "budget_tokens", "display"], "options.thinking")
+  switch (raw.type) {
+    case "enabled": {
+      fieldsOf(raw, ["type", "budget_tokens"], "options.thinking")
+      if (typeof raw.budget_tokens !== "number" || !Number.isSafeInteger(raw.budget_tokens) || raw.budget_tokens <= 0) throw new Error("options.thinking.budget_tokens must be a positive safe integer")
+      return { type: raw.type, budget_tokens: raw.budget_tokens }
+    }
+    case "adaptive": {
+      fieldsOf(raw, ["type", "display"], "options.thinking")
+      if (raw.display !== undefined && raw.display !== "summarized" && raw.display !== "omitted") throw new Error("options.thinking.display must be summarized or omitted")
+      return { type: raw.type, ...(raw.display === undefined ? {} : { display: raw.display }) }
+    }
+    case "disabled":
+      fieldsOf(raw, ["type"], "options.thinking")
+      return { type: raw.type }
+    default: throw new Error("options.thinking.type must be adaptive, enabled, or disabled")
+  }
+}
+
+// protocolOptionsOf validates external request options and preserves their protocol discriminant (reasoning.test.ts).
+export const protocolOptionsOf = (protocol: ModelProtocol, value: unknown): ProtocolOptions => {
+  if (value === undefined) return { protocol }
+  switch (protocol) {
+    case "anthropic-messages": {
+      const source = fieldsOf(value, ["thinking", "output_config"], "options")
+      const output = source.output_config === undefined ? undefined : fieldsOf(source.output_config, ["effort"], "options.output_config")
+      return { protocol, options: {
+        ...(source.thinking === undefined ? {} : { thinking: thinkingOf(source.thinking) }),
+        ...(output === undefined ? {} : { output_config: output.effort === undefined ? {} : { effort: effortOf(output.effort, ["low", "medium", "high", "xhigh", "max", null] as const) } })
+      } }
+    }
+    case "openai-responses": {
+      const source = fieldsOf(value, ["reasoning"], "options")
+      const reasoning = source.reasoning === undefined ? undefined : fieldsOf(source.reasoning, ["effort"], "options.reasoning")
+      return { protocol, options: reasoning === undefined ? {} : { reasoning: reasoning.effort === undefined ? {} : { effort: openAIEffortOf(reasoning.effort) } } }
+    }
+    case "openai-chat-completions": {
+      const source = fieldsOf(value, ["reasoning_effort"], "options")
+      return { protocol, options: source.reasoning_effort === undefined ? {} : { reasoning_effort: openAIEffortOf(source.reasoning_effort) } }
+    }
+    case "bedrock-converse": throw new Error("request options are not supported for bedrock-converse")
+  }
+}

--- a/packages/model/src/reasoning.types.test.ts
+++ b/packages/model/src/reasoning.types.test.ts
@@ -1,0 +1,32 @@
+import { modelAdapters, type ModelConfig } from "./adapter"
+import { infer } from "./model"
+import type { ModelProviderConfig } from "./config"
+import type { ProtocolOptions } from "./reasoning"
+
+const connection = { baseUrl: "https://model.test", apiKey: "test", model: "test", provider: "test", contextWindowTokens: 128_000 }
+const provider = { baseUrl: "https://model.test", env: ["KEY"] }
+
+void ({ ...connection, protocol: "anthropic-messages", options: { thinking: { type: "adaptive" }, output_config: { effort: "max" } } } satisfies ModelConfig);
+void ({ ...connection, protocol: "openai-responses", options: { reasoning: { effort: "high" } } } satisfies ModelConfig);
+void ({ ...connection, protocol: "openai-chat-completions", options: { reasoning_effort: "none" } } satisfies ModelConfig);
+
+// @ts-expect-error OpenAI does not accept Anthropic thinking.
+void ({ ...connection, protocol: "openai-responses", options: { thinking: { type: "adaptive" } } } satisfies ModelConfig);
+// @ts-expect-error Chat Completions does not accept Anthropic effort levels.
+void ({ ...connection, protocol: "openai-chat-completions", options: { reasoning_effort: "max" } } satisfies ModelConfig);
+// @ts-expect-error Bedrock controls are unsupported, including an empty object.
+void ({ ...connection, protocol: "bedrock-converse", options: {} } satisfies ModelConfig);
+// @ts-expect-error Host model maps retain the provider protocol restriction.
+void ({ ...provider, protocol: "openai-responses", models: { model: { options: { thinking: { type: "adaptive" } } } } } satisfies ModelProviderConfig);
+// @ts-expect-error A Bedrock model cannot specify even empty request options.
+void ({ ...provider, protocol: "bedrock-converse", models: { model: { options: {} } } } satisfies ModelProviderConfig);
+
+const mismatched = { protocol: "openai-responses", options: { reasoning: { effort: "high" }, thinking: { type: "adaptive" } } } as const
+// @ts-expect-error Existing variables also reject mixed controls, beyond excess-property checks.
+void (mismatched satisfies ProtocolOptions);
+
+// inferRejectsMixedControls exercises the generic inference entry point without making a request.
+export const inferRejectsMixedControls = () => {
+  // @ts-expect-error Inference cannot widen the discriminant to admit mixed controls.
+  infer({ ...connection, ...mismatched }, modelAdapters())
+}

--- a/platform/cloudflare/src/assembly.ts
+++ b/platform/cloudflare/src/assembly.ts
@@ -110,7 +110,7 @@ export const DEFAULT_CLOUDFLARE_MODEL_CATALOG_LOAD_POLICY: ModelCatalogLoadPolic
 export const deployed = (name: string): boolean => mountedActor?.actor.name === name
 export const directory = cloudflareDirectory(deployed)
 
-interface CloudflareProvider extends ModelProviderConfig {
+type CloudflareProvider = ModelProviderConfig & {
   readonly apiKey: string
 }
 


### PR DESCRIPTION
## Problem

Models that require reasoning controls cannot opt in through host configuration. Provider reasoning state is also lost after tool calls, so the next request cannot carry the model's signed or encrypted continuation.

## Change

- Add typed, validated per-model options under `providers.<provider>.models.<model>.options`, using native OpenAI and Anthropic settings.
- Persist displayable reasoning and native continuation on `ModelReturned`, atomically with the response's consequences. Replay continuation when provider, protocol, model, and endpoint match.
- Preserve each response's continuation through recovery and compaction, and show durable reasoning in a collapsed Recursive Chat section. Stream reasoning separately from answer text.

```text
model response
  +-- ModelReturned
  |     +-- displayable reasoning -> chat
  |     +-- native continuation  -> compatible next request
  +-- ToolCalled A
  +-- ToolCalled B
        |
        v
  tool results -> next model request
```

Continuation replay supports Anthropic Messages and OpenAI Responses. The server guide documents configuration, replay compatibility, and reasoning stream events.

## Verification

Full gate passed, followed by targeted agent/model tests, agent typechecking, and lint after the final projection cleanup. Tests cover native adapter request bodies, continuation recovery, compatibility switches, atomic persistence, cancellation, compaction progress, and chat rendering. Live provider calls were not run.

Closes #412.
