### PR TITLE
fix(agent): preserve inclusive token totals

### DIFF
--- a/packages/agent/src/inference/usage.test.ts
+++ b/packages/agent/src/inference/usage.test.ts
@@ -144,10 +144,10 @@ describe("priced and usageFrom", () => {
       providerReports: [{ providerSpecific: raw }]
     })
 
-    const converse = { inputTokens: 10, outputTokens: 2, totalTokens: 12, cacheReadInputTokens: 4 }
+    const converse = { inputTokens: 10, outputTokens: 2, totalTokens: 16, cacheReadInputTokens: 4 }
     expect(
       usageFrom(
-        [converse, { promptTokens: 10, completionTokens: 2, totalTokens: 12 }],
+        [converse, { promptTokens: 10, completionTokens: 2, totalTokens: 16 }],
         { ...table, cachedPromptUsdPerToken: 0.0002 },
         { provider: "bedrock", model: "m" },
         converse
@@ -160,6 +160,43 @@ describe("priced and usageFrom", () => {
       estimatedCostUsd: 10 * 0.001 + 4 * 0.0002 + 2 * 0.002
     })
     expect(usageFrom({ promptTokens: 3, completionTokens: 2, totalTokens: 0 })).not.toHaveProperty("totalTokens")
+  })
+
+  test("cache-exclusive input does not increase a provider's inclusive total", () => {
+    const raw = { inputTokens: 4, cacheWriteInputTokens: 20, outputTokens: 3, totalTokens: 27 }
+    const usage = usageFrom(raw)
+    expect(usage).toMatchObject({ promptTokens: 24, completionTokens: 3, cacheWritePromptTokens: 20, totalTokens: 27 })
+    expect(usage?.providerReports?.[0]?.providerSpecific).toEqual(raw)
+    expect(sumUsage([usage!, usage!]).totalTokens).toBe(54)
+  })
+
+  test("inclusive prompt fields take precedence over cache-exclusive aliases", () => {
+    const raw = {
+      prompt_tokens: 100,
+      completion_tokens: 10,
+      total_tokens: 110,
+      cache_read_input_tokens: 40,
+      prompt_tokens_details: { cached_tokens: 40 }
+    }
+    expect(usageFrom(raw, { ...table, cachedPromptUsdPerToken: 0.0002 })).toMatchObject({
+      promptTokens: 100,
+      completionTokens: 10,
+      totalTokens: 110,
+      cachedPromptTokens: 40,
+      estimatedCostUsd: 60 * 0.001 + 40 * 0.0002 + 10 * 0.002
+    })
+  })
+
+  test("an adapter declares inclusive raw input accounting", () => {
+    const raw = { input_tokens: 100, output_tokens: 10, total_tokens: 110, cache_read_input_tokens: 40 }
+    const usage = usageFrom(raw, undefined, { provider: "gateway", inputTokensIncludeCache: true })
+    expect(usage).toMatchObject({ promptTokens: 100, completionTokens: 10, totalTokens: 110, cachedPromptTokens: 40 })
+    expect(usage?.providerReports).toEqual([{ provider: "gateway", providerSpecific: raw }])
+    expect(usageFrom({ input_tokens: 60, output_tokens: 10, cache_read_input_tokens: 40 }, undefined, {
+      inputTokensIncludeCache: false
+    })).toMatchObject({ promptTokens: 100, completionTokens: 10, cachedPromptTokens: 40 })
+    expect(usageFrom({ inputTokens: 4, outputTokens: 3, cacheWriteInputTokens: 20 })).not.toHaveProperty("totalTokens")
+    expect(usageFrom(usage)).toMatchObject({ promptTokens: 100, totalTokens: 110, cachedPromptTokens: 40 })
   })
 
   test("costNumber reads the seats a gateway actually writes", () => {
@@ -208,12 +245,12 @@ describe("sumUsage", () => {
 
   test("raw provider metrics survive normalization and aggregation", () => {
     const first = usageFrom(
-      { inputTokens: 10, outputTokens: 2, totalTokens: 12, cacheReadInputTokens: 4 },
+      { inputTokens: 10, outputTokens: 2, totalTokens: 16, cacheReadInputTokens: 4 },
       undefined,
       { provider: "bedrock", model: "m" }
     )!
     const second = usageFrom(
-      { inputTokens: 12, outputTokens: 3, totalTokens: 15, cacheReadInputTokens: 5 },
+      { inputTokens: 12, outputTokens: 3, totalTokens: 20, cacheReadInputTokens: 5 },
       undefined,
       { provider: "bedrock", model: "m" }
     )!

--- a/packages/agent/src/inference/usage.ts
+++ b/packages/agent/src/inference/usage.ts
@@ -14,6 +14,15 @@ export interface ProviderUsageReport {
   readonly providerSpecific: unknown
 }
 
+// UsageContext supplies serving coordinates and the input accounting declared by an adapter.
+export interface UsageContext {
+  readonly provider?: string
+  readonly model?: string
+  // inputTokensIncludeCache marks raw inputTokens/input_tokens as inclusive (usage.test.ts, "an adapter declares inclusive raw input accounting").
+  // Prompt fields are inclusive; raw input fields otherwise exclude separately reported cache buckets.
+  readonly inputTokensIncludeCache?: boolean
+}
+
 export interface Usage {
   readonly promptTokens: number
   readonly completionTokens: number
@@ -99,10 +108,11 @@ interface TokenMetrics {
   readonly cacheBucketsWereExclusive?: true
 }
 
-const tokensOf = (value: unknown): TokenMetrics | undefined => {
+const tokensOf = (value: unknown, context: UsageContext | undefined): TokenMetrics | undefined => {
   const rec = asRecord(value)
   if (rec === undefined) return undefined
-  const prompt = firstNumber(rec, ["promptTokens", "prompt_tokens", "inputTokens", "input_tokens"])
+  const inclusivePrompt = firstNumber(rec, ["promptTokens", "prompt_tokens"])
+  const prompt = inclusivePrompt ?? firstNumber(rec, ["inputTokens", "input_tokens"])
   const completion = firstNumber(rec, ["completionTokens", "completion_tokens", "outputTokens", "output_tokens"])
   if (prompt === undefined && completion === undefined) return undefined
   const total = firstNumber(rec, ["totalTokens", "total_tokens"])
@@ -136,12 +146,13 @@ const tokensOf = (value: unknown): TokenMetrics | undefined => {
       ["completion_tokens_details", ["reasoningTokens", "reasoning_tokens"]],
       ["output_tokens_details", ["reasoningTokens", "reasoning_tokens"]]
     ])
-  const cacheBucketsWereExclusive = exclusiveCached !== undefined || exclusiveCacheWrite !== undefined
-  const exclusivePromptTokens = (exclusiveCached ?? 0) + (exclusiveCacheWrite ?? 0)
+  const cacheBucketsWereExclusive = inclusivePrompt === undefined && context?.inputTokensIncludeCache !== true &&
+    (exclusiveCached !== undefined || exclusiveCacheWrite !== undefined)
+  const exclusivePromptTokens = cacheBucketsWereExclusive ? (exclusiveCached ?? 0) + (exclusiveCacheWrite ?? 0) : 0
   const normalizedTotal =
     total === undefined || (total === 0 && (prompt ?? 0) + (completion ?? 0) > 0)
       ? undefined
-      : total + exclusivePromptTokens
+      : total
   return {
     promptTokens: (prompt ?? 0) + exclusivePromptTokens,
     completionTokens: completion ?? 0,
@@ -218,7 +229,7 @@ export const priced = (usage: Usage, pricing?: ModelPricing): Usage => {
 export const usageFrom = (
   reported: unknown,
   pricing?: ModelPricing,
-  stamp?: { readonly provider?: string; readonly model?: string },
+  stamp?: UsageContext,
   providerMetrics?: unknown
 ): Usage | undefined => {
   const parts = Array.isArray(reported) ? reported : [reported]
@@ -227,7 +238,7 @@ export const usageFrom = (
   let raw: unknown = providerMetrics
   for (const part of parts) {
     if (raw === undefined && part !== undefined && part !== null) raw = part
-    const next = tokensOf(part)
+    const next = tokensOf(part, stamp)
     if (next !== undefined) {
       const keepExclusiveFold =
         tokens?.cacheBucketsWereExclusive === true &&


### PR DESCRIPTION
Usage normalization added cache buckets to provider totals that already included them. It also treated an inclusive `prompt_tokens` count as exclusive whenever a cache alias was present, inflating both input usage and table-based cost estimates.

- Preserve reported total tokens and normalize cache-exclusive input separately.
- Treat prompt fields as inclusive; allow adapters to declare inclusive raw input fields through `UsageContext.inputTokensIncludeCache`.
- Preserve raw provider metrics and missing totals, with regressions for normalization, repricing, and aggregation.

Validation: the regressions fail against the original implementation; all 13 usage tests and the full `bun run gate` pass.

Fixes #419.
