### PR TITLE
fix(model): preserve structured stream errors

### DIFF
--- a/packages/agent/src/inference/machine.ts
+++ b/packages/agent/src/inference/machine.ts
@@ -181,7 +181,10 @@ const consequencesOf = (action: Action, ctx: Consequence): ReadonlyArray<Event> 
     error: action.error,
     cause: action.failure?.cause ?? "model",
     attemptKey: ctx.attempt,
-    ...(action.failure === undefined ? {} : { attempts: action.failure.attempts, policy: action.failure.policy })
+    ...(action.failure === undefined ? {} : {
+      attempts: action.failure.attempts, policy: action.failure.policy,
+      ...(action.failure.errorDetails === undefined ? {} : { errorDetails: action.failure.errorDetails })
+    })
   }]
   if (ctx.contract !== undefined && action.mode === undefined) return [{
     ...stamp,

--- a/packages/agent/src/log/events.ts
+++ b/packages/agent/src/log/events.ts
@@ -208,6 +208,17 @@ export const OutputRepaired = Schema.Struct({
   at: Schema.Finite
 })
 
+// ModelErrorDetails retains provider failure metadata for retry decisions and terminal inspection (packages/model/src/model.test.ts, structured stream failures).
+export const ModelErrorDetails = Schema.Struct({
+  message: Schema.String,
+  code: Schema.optional(Schema.String),
+  statusCode: Schema.optional(Schema.Finite),
+  isRetryable: Schema.optional(Schema.Boolean),
+  details: Schema.optional(Schema.Unknown)
+})
+
+export type ModelErrorDetails = typeof ModelErrorDetails.Type
+
 // TurnFailed is the failure terminal for one execution epoch.
 export const TurnFailed = Schema.Struct({
   type: Schema.Literal("TurnFailed"),
@@ -219,6 +230,7 @@ export const TurnFailed = Schema.Struct({
   attempts: Schema.optional(Schema.Finite),
   attemptKey: Schema.optional(Schema.String),
   policy: Schema.optional(Schema.Unknown),
+  errorDetails: Schema.optional(ModelErrorDetails),
   mode: Schema.optional(Schema.Unknown),
   endpoint: Schema.optional(Endpoint),
   at: Schema.Finite
@@ -412,6 +424,7 @@ export type Action =
         readonly cause: TurnFailureCause
         readonly attempts: number
         readonly policy?: unknown
+        readonly errorDetails?: ModelErrorDetails
       }
     } & Served)
 
@@ -566,6 +579,7 @@ export const turnFailed = (
     readonly attempts?: number
     readonly attemptKey?: string
     readonly policy?: unknown
+    readonly errorDetails?: ModelErrorDetails
     readonly endpoint?: unknown
   } & EpochStamp
 ): Event =>

--- a/packages/agent/src/runtime/turn.test.ts
+++ b/packages/agent/src/runtime/turn.test.ts
@@ -424,6 +424,7 @@ describe("the agent with execute as the only tool", () => {
 
   test("provider retry exhaustion records a resumable failure with its policy", async () => {
     const retry = { throttleRetryDelaysMs: [100], stream: { firstChunkMs: 1, idleMs: 2, totalMs: 3 } }
+    const errorDetails = { message: "busy", code: "overloaded", statusCode: 503, isRetryable: true, details: { type: "RUN_ERROR", message: "busy" } }
     const layers = Layer.mergeAll(
       KeyValueStore.layerMemory,
       memoryLog(),
@@ -432,7 +433,7 @@ describe("the agent with execute as the only tool", () => {
           Effect.succeed({
             kind: "fail" as const,
             error: "model inference retries exhausted after 2 attempts: timeout",
-            failure: { cause: "inference_attempts_exhausted" as const, attempts: 2, policy: retry }
+            failure: { cause: "inference_attempts_exhausted" as const, attempts: 2, policy: retry, errorDetails }
           })
       }),
       jsSandbox,
@@ -451,7 +452,8 @@ describe("the agent with execute as the only tool", () => {
       cause: "inference_attempts_exhausted",
       attempts: 2,
       attemptKey: "m1/infer/0",
-      policy: retry
+      policy: retry,
+      errorDetails
     })
     expect(events.find((event) => event.type === "ModelReturned")).toMatchObject({ outcome: "failed", usage: {}, callId: "m1/infer/0" })
   })

--- a/packages/model/src/model.test.ts
+++ b/packages/model/src/model.test.ts
@@ -64,6 +64,61 @@ const testInfer = <const C extends Omit<ModelConfig, "protocol" | "provider" | "
 // endpoint. No real provider is touched. Request-building (renderMessages, modelRequest) is domain
 // and tested in agent/request.test.ts.
 
+describe("structured stream failures", () => {
+  test.each([
+    { message: "busy", statusCode: 503, code: "overloaded", isRetryable: true },
+    { error: { message: "busy", statusCode: 503, code: "overloaded", isRetryable: true } },
+    { cause: Object.assign(new Error("busy"), { status: 503, code: "overloaded", isRetryable: true }) }
+  ])("retains provider metadata through bounded retries: %j", async (fields) => {
+    let calls = 0
+    const waits: number[] = []
+    const chunk = { type: "RUN_ERROR", ...fields, headers: { "retry-after": "0" } }
+    const adapter: ModelAdapter = {
+      id: "structured-error", protocols: ["openai-chat-completions"],
+      start: () => {
+        calls += 1
+        return { stream: { async *[Symbol.asyncIterator]() { yield chunk as never } } }
+      }
+    }
+    const layer = infer({
+      baseUrl: "https://unused.test", apiKey: "unused", provider: "test", model: "fixture",
+      protocol: "openai-chat-completions", contextWindowTokens: 4096,
+      throttleRetryDelaysMs: [0], retryAfterJitterMs: 0,
+      sleep: async (ms) => { waits.push(ms) }
+    }, modelAdapters(adapter))
+    const action = await Effect.runPromise(Effect.flatMap(Infer, (service) => service.react(reqOf([]))).pipe(Effect.provide(layer)))
+    expect(calls).toBe(2)
+    expect(waits).toEqual([0])
+    expect(action).toMatchObject({ kind: "fail", failure: {
+      cause: "inference_attempts_exhausted", attempts: 2,
+      errorDetails: { message: "busy", statusCode: 503, code: "overloaded", isRetryable: true, details: chunk }
+    } })
+  })
+
+  test.each([
+    { statusCode: 503, isRetryable: false },
+    { statusCode: 400 }
+  ])("nonretryable metadata overrides message heuristics: %j", async (fields) => {
+    let calls = 0
+    const chunk = { type: "RUN_ERROR", message: "rate limit 503", ...fields }
+    const adapter: ModelAdapter = {
+      id: "permanent-error", protocols: ["openai-chat-completions"],
+      start: () => {
+        calls += 1
+        return { stream: { async *[Symbol.asyncIterator]() { yield chunk as never } } }
+      }
+    }
+    const action = await Effect.runPromise(Effect.flatMap(Infer, (service) => service.react(reqOf([]))).pipe(Effect.provide(infer({
+      baseUrl: "https://unused.test", apiKey: "unused", provider: "test", model: "fixture",
+      protocol: "openai-chat-completions", contextWindowTokens: 4096, throttleRetryDelaysMs: [0]
+    }, modelAdapters(adapter)))))
+    expect(calls).toBe(1)
+    expect(action).toMatchObject({ kind: "fail", failure: {
+      cause: "inference_error", attempts: 1, errorDetails: fields
+    } })
+  })
+})
+
 describe("actionOf", () => {
   test("multiple calls preserve provider order including calls beside execute", () => {
     expect(actionOf({ content: "Reading files", toolCalls: [

--- a/packages/model/src/model.ts
+++ b/packages/model/src/model.ts
@@ -17,7 +17,7 @@ import {
   type InferenceObserver,
   type InferenceObserverPolicy
 } from "@clavia/tardigrade-agent"
-import type { Action, AttemptEndpoint } from "@clavia/tardigrade-agent/log/events"
+import type { Action, AttemptEndpoint, ModelErrorDetails } from "@clavia/tardigrade-agent/log/events"
 import { modelRequest, type ModelRequest, type ToolSpec } from "@clavia/tardigrade-agent/inference/request"
 import type { AgentMessage } from "@clavia/tardigrade-agent/projection/messages"
 import {
@@ -63,6 +63,40 @@ export const DEFAULT_STREAM_BOUNDS: StreamBounds = {
 // (model.test.ts, "stream bounds").
 export const MAX_TIMER_DELAY_MS = 2_147_483_647
 
+const errorRecord = (value: unknown): Record<string, unknown> =>
+  typeof value === "object" && value !== null ? value as Record<string, unknown> : {}
+
+const errorField = (error: unknown, key: string): unknown => {
+  const outer = errorRecord(error)
+  return outer[key] ?? errorRecord(outer.error)[key] ?? errorRecord(outer.cause)[key]
+}
+
+const errorDetailsOf = (error: unknown): ModelErrorDetails => {
+  if (error instanceof ModelStreamError) return error.details
+  const status = errorField(error, "statusCode") ?? errorField(error, "status")
+  const message = errorField(error, "message")
+  const code = errorField(error, "code")
+  const isRetryable = errorField(error, "isRetryable")
+  return {
+    message: typeof message === "string" ? message : String(error),
+    ...(typeof code === "string" ? { code } : {}),
+    ...(typeof status === "number" && Number.isFinite(status) ? { statusCode: status } : {}),
+    ...(typeof isRetryable === "boolean" ? { isRetryable } : {})
+  }
+}
+
+// ModelStreamError carries a stream's structured error through retry classification and publication (model.test.ts, structured stream failures).
+class ModelStreamError extends Error {
+  readonly details: ModelErrorDetails
+  readonly headers: unknown
+  constructor(chunk: unknown) {
+    const details = errorDetailsOf(chunk)
+    super(`model stream error: ${details.message}${details.code === undefined ? "" : ` (${details.code})`}`, { cause: chunk })
+    this.details = { ...details, details: chunk }
+    this.headers = errorField(chunk, "headers") ?? errorField(chunk, "responseHeaders")
+  }
+}
+
 const bounded = (stream: AsyncIterable<StreamChunk>, bounds: StreamBounds): AsyncIterable<StreamChunk> => ({
   async *[Symbol.asyncIterator]() {
     const startedAt = Date.now()
@@ -81,11 +115,9 @@ const bounded = (stream: AsyncIterable<StreamChunk>, bounds: StreamBounds): Asyn
         first = false
         // A provider refusal arrives as a RUN_ERROR chunk the processor would silently absorb,
         // leaving an empty result that reads as "the model said nothing". Throw the real cause.
-        const chunk = next.value as { type?: unknown; message?: unknown; code?: unknown; error?: { message?: unknown } }
+        const chunk = next.value as { type?: unknown }
         if (String(chunk.type) === "RUN_ERROR") {
-          throw new Error(
-            `model stream error: ${String(chunk.message ?? chunk.error?.message ?? "unknown")}${chunk.code === undefined ? "" : ` (${String(chunk.code)})`}`
-          )
+          throw new ModelStreamError(next.value)
         }
         yield next.value
       } finally {
@@ -190,10 +222,10 @@ export const DEFAULT_RETRY_AFTER_JITTER_MS = 1_000
 // isRetryableFailure recognizes status-bearing provider failures and flattened transport errors.
 // The latter have no HTTP response metadata (model.test.ts, "infer: transient retry").
 const isRetryableFailure = (e: unknown): boolean => {
-  const err = e as { status?: unknown; statusCode?: unknown; message?: unknown }
-  const status = typeof err.status === "number" ? err.status : typeof err.statusCode === "number" ? err.statusCode : undefined
-  if (status === 429 || (status !== undefined && status >= 500)) return true
-  const message = String(err.message ?? e)
+  const details = errorDetailsOf(e)
+  if (details.isRetryable !== undefined) return details.isRetryable
+  if (details.statusCode !== undefined) return details.statusCode === 429 || details.statusCode >= 500
+  const message = [details.message, details.code].filter((part) => part !== undefined).join(" ")
   return /\b429\b|rate.?limit|too many requests|\b5\d\d\b|timeout|timed?\s*out|idle beyond bound|exceeded its total bound|no first chunk within bound|connection (?:error|failed|failure|reset|refused|closed|lost)|network.?error|network request failed|network connection (?:was )?lost|fetch failed|failed to fetch|load failed|socket (?:hang up|closed|disconnected)|dns(?: lookup)? (?:error|failed|failure)|getaddrinfo|ECONN(?:RESET|REFUSED|ABORTED)|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|EHOSTUNREACH|ENETUNREACH|UND_ERR_(?:CONNECT_TIMEOUT|HEADERS_TIMEOUT|BODY_TIMEOUT|SOCKET)/i.test(
     message
   )
@@ -797,7 +829,10 @@ export const infer = <const C extends ModelConfig>(
             const usage = isTruncated(e) ? e.usage : usageOn(e)
             const endpoint = endpointOn(e) ?? endpointOf(config, undefined)
             const ends = (action: Action): Action => {
-              const billed = served(withSpend(action, spentOf(parts, missed)), endpoint)
+              const detailed = action.kind === "fail" && action.failure !== undefined
+                ? { ...action, failure: { ...action.failure, errorDetails: errorDetailsOf(e) } }
+                : action
+              const billed = served(withSpend(detailed, spentOf(parts, missed)), endpoint)
               return req.output === undefined ? billed : { ...billed, mode }
             }
             remember(usage, isTruncated(e) || usage !== undefined)


### PR DESCRIPTION
Structured `RUN_ERROR` chunks lost their status, retryability, and original payload when inference converted them to a plain error. That made retry decisions depend on message text and left terminal logs without the evidence needed to explain the decision.

- Preserve structured stream metadata through retry classification and publish it as optional `errorDetails` on the failure action and `TurnFailed` event, alongside the existing readable error.
- Honor explicit retryability first, then HTTP status, with text matching reserved for errors without structured classification. Retain provider Retry-After headers through stream wrapping.
- Cover top-level, nested, and caused errors, explicit nonretryable failures, bounded retry exhaustion, and terminal event propagation with offline tests.

Validation: `bun run gate` passes, including 74 model tests. No provider credentials or network inference are required by the regressions.

Fixes #418.
