### PR TITLE
fix(model): require provider stream completion

### DIFF
--- a/packages/model/src/model.test.ts
+++ b/packages/model/src/model.test.ts
@@ -280,6 +280,56 @@ const sse = (events: ReadonlyArray<unknown>): Response => {
 }
 
 describe("infer end to end", () => {
+  test.each([
+    { content: "partial text" },
+    { tool_calls: [{ index: 0, id: "call_1", type: "function", function: { name: "execute", arguments: '{"code":"partial' } }] }
+  ])("an unfinished Chat Completions stream cannot commit output: %j", async (delta) => {
+    let calls = 0
+    const layer = testInfer({
+      baseUrl: "https://model.test/v1", apiKey: "unused", model: "fixture",
+      throttleRetryDelaysMs: [0], retryAfterJitterMs: 0,
+      fetch: async () => {
+        calls += 1
+        const body = `data: ${JSON.stringify({ choices: [{ index: 0, delta, finish_reason: null }] })}\n\n`
+        return new Response(body + (calls === 1 ? "" : "data: [DONE]\n\n"), { headers: { "content-type": "text/event-stream" } })
+      }
+    })
+    const action = await Effect.runPromise(Effect.flatMap(Infer, (model) => model.react(reqOf([]))).pipe(Effect.provide(layer)))
+    expect(action).toMatchObject({ kind: "fail", failure: { cause: "inference_attempts_exhausted", attempts: 2 } })
+    expect(calls).toBe(2)
+    if (action.kind === "fail") expect(action.error).toContain("before provider completion")
+  })
+
+  test("a raw length stop prevents execution of a normalized tool call", async () => {
+    const layer = testInfer({
+      baseUrl: "https://model.test/v1", apiKey: "unused", model: "fixture", maxTokensLadder: [17],
+      fetch: async () => sse([
+        { choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: "call_1", type: "function", function: { name: "execute", arguments: '{"code":"partial' } }] } }] },
+        { choices: [{ index: 0, delta: {}, finish_reason: "length" }] },
+        { choices: [], usage: { prompt_tokens: 10, completion_tokens: 17, total_tokens: 27 } }
+      ])
+    })
+    const action = await Effect.runPromise(Effect.flatMap(Infer, (model) => model.react(reqOf([]))).pipe(Effect.provide(layer)))
+    expect(action).toMatchObject({ kind: "fail", failure: { cause: "truncated", policy: { maxTokensLadder: [17] } }, usage: { totalTokens: 27 } })
+    if (action.kind === "fail") expect(action.error).toContain("17-token")
+  })
+
+  test.each([false, true])("Responses requires its provider completion event: %s", async (completed) => {
+    const response = { id: "r1", model: "fixture", output: [] }
+    const layer = testInfer({
+      baseUrl: "https://model.test/v1", apiKey: "unused", model: "fixture", protocol: "openai-responses", throttleRetryDelaysMs: [],
+      fetch: async () => sse([
+        { type: "response.created", response },
+        { type: "response.output_text.delta", item_id: "m1", output_index: 0, content_index: 0, delta: "answer" },
+        ...(completed ? [{ type: "response.completed", response }] : [])
+      ])
+    })
+    const action = await Effect.runPromise(Effect.flatMap(Infer, (model) => model.react(reqOf([]))).pipe(Effect.provide(layer)))
+    expect(action).toMatchObject(completed
+      ? { kind: "complete", output: "answer" }
+      : { kind: "fail", failure: { cause: "inference_attempts_exhausted", attempts: 1 } })
+  })
+
   test("interleaved streamed calls become one complete batch", async () => {
     const fetchImpl = (async () => sse([
       { id: "r1", choices: [{ index: 0, delta: { role: "assistant", tool_calls: [

--- a/packages/model/src/model.ts
+++ b/packages/model/src/model.ts
@@ -324,6 +324,9 @@ interface Wire {
   readonly usageReports?: ReadonlyArray<unknown>
   readonly provider?: string
   readonly model?: string
+  // completed distinguishes an observed provider terminal from a synthesized adapter finish (model.test.ts, "infer end to end").
+  readonly completed?: boolean
+  readonly finishReason?: string
   // A structured-output refusal arrives as `choices[].delta.refusal` with an ordinary `stop`
   // finish reason, and the adapter's processor keeps neither. The raw body is the only place it
   // survives, so it is read here (model.test.ts, "a refusal on the wire").
@@ -352,12 +355,21 @@ const captureWire = async (reader: BodyReader): Promise<Wire | undefined> => {
     }
     return undefined
   }
-  const wireOf = (parsed: { usage?: unknown; provider?: unknown; model?: unknown }): Wire => {
+  const wireOf = (parsed: { type?: unknown; usage?: unknown; provider?: unknown; model?: unknown; choices?: ReadonlyArray<{ finish_reason?: unknown }> }): Wire => {
     const refusal = refusalOf(parsed as never)
+    const rawFinish = parsed.choices?.[0]?.finish_reason
+    const finishReason = typeof rawFinish === "string" && rawFinish !== "" ? rawFinish : undefined
+    const completed = Array.isArray(parsed.choices)
+      ? finishReason !== undefined
+      : typeof parsed.type === "string" && parsed.type.startsWith("response.")
+        ? parsed.type === "response.completed"
+        : undefined
     return {
       ...(parsed.usage === undefined || parsed.usage === null ? {} : { usage: parsed.usage }),
       ...(typeof parsed.provider === "string" ? { provider: parsed.provider } : {}),
       ...(typeof parsed.model === "string" ? { model: parsed.model } : {}),
+      ...(finishReason === undefined ? {} : { finishReason }),
+      ...(completed === undefined ? {} : { completed }),
       ...(refusal === undefined ? {} : { refusal })
     }
   }
@@ -373,6 +385,7 @@ const captureWire = async (reader: BodyReader): Promise<Wire | undefined> => {
       last = {
         ...last,
         ...next,
+        ...(last.completed === true ? { completed: true } : {}),
         ...(usageReports === undefined ? {} : { usageReports }),
         ...(next.refusal === undefined ? {} : { refusal: `${last.refusal ?? ""}${next.refusal}` })
       }
@@ -684,9 +697,9 @@ export const infer = <const C extends ModelConfig>(
       )
       const result = await new StreamProcessor().process(normalized)
       const { usage, endpoint, wire } = await settle()
-      stats.finish = attempt.finishReason?.() ?? result.finishReason ?? "stop"
+      stats.finish = wire?.finishReason ?? attempt.finishReason?.() ?? result.finishReason ?? "stop"
       const stopClass = attempt.stopClass?.() ?? "ok"
-      if (result.finishReason === "length" || stopClass === "truncated") throw new TruncatedError(maxTokens, usage)
+      if (stats.finish === "length" || stopClass === "truncated") throw new TruncatedError(maxTokens, usage)
       // A structured-output refusal reaches the compatible wire as a `refusal` delta under an
       // ordinary stop, and the Converse wire as its own stop reason. Neither survives the shared
       // processor, so both are read here rather than from the decoded result.
@@ -694,6 +707,9 @@ export const infer = <const C extends ModelConfig>(
       if (stopClass === "refused") throw failed(new RefusedError("the provider refused to answer this request"), usage, endpoint)
       if (stopClass === "violation") {
         throw failed(new ViolatedError("the provider could not produce output matching the schema it was given"), usage, endpoint)
+      }
+      if (wire?.completed === false) {
+        throw failed(new Error("model stream connection closed before provider completion"), usage, endpoint)
       }
       return stamped(served(withSpend(actionOf(result), usage), endpoint))
     } catch (e) {


### PR DESCRIPTION
The OpenAI adapter can synthesize a successful finish when an HTTP stream ends without a provider terminal. It can also normalize a Chat Completions `length` stop into `tool_calls`. Inference then accepts partial text or exposes a truncated tool call for execution.

- Retain provider completion evidence in the existing wire capture. Chat Completions requires a finish reason and Responses requires `response.completed`; a missing terminal enters the configured bounded transport retry policy.
- Use the raw Chat Completions finish reason for truncation classification, preserving the existing output-token ladder and usage evidence. A later usage-only chunk preserves the observed terminal.
- Add offline regressions for early EOF, a DONE sentinel without a finish reason, partial tool arguments, Responses completion, and a length-limited tool call. All four failure cases reproduce against main before the fix; valid completion remains accepted.

Validation: `bun run gate` passes, including 74 model tests. The change reuses the existing capture and retry policies without adding a public configuration surface.
