### PR TITLE
feat(agent): filter model trajectories

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -15,7 +15,8 @@ export {
   type InferPolicy,
   type InferRequest,
   type ModelResolution,
-  type Render
+  type Render,
+  type TrajectoryFilter
 } from "./inference/contract"
 export { inferenceFromHistory, inferenceMachine, type InferenceMachineProjection } from "./inference/machine"
 export { ModelRef, modelRefOf } from "./inference/reference"

--- a/packages/agent/src/inference/contract.ts
+++ b/packages/agent/src/inference/contract.ts
@@ -3,7 +3,7 @@ import type { Event } from "@clavia/tardigrade-core/log/event"
 import type { LegacyCallAction } from "./action-compat"
 import type { Action } from "../log/events"
 import type { ContextPolicy } from "../component/compaction"
-import type { OutputFallback } from "../output/contract"
+import type { DeclaredOutput, OutputFallback } from "../output/contract"
 import type { ModelRef } from "./reference"
 import { DEFAULT_MODEL_POLICY_OVERRIDE, type ModelPolicy, type ModelPolicyOverride } from "./access"
 import type { InferDelta, InferenceIdentity } from "./observer"
@@ -29,6 +29,11 @@ export interface InferRequest {
   readonly tools: ReadonlyArray<import("./request").ToolSpec>
   readonly context?: Partial<ContextPolicy>
   readonly output?: { readonly fallback: OutputFallback; readonly system?: string }
+  // The turn's declared output, decided by the actor from the unfiltered turn. A trajectory filter
+  // may remove the message that declared it from what the model reads, but the turn still owes the
+  // contract it declared, so the request carries the declaration beside the trajectory rather
+  // than deriving it from what the filters left (inference/machine.ts; request.ts, modelRequest).
+  readonly declaredOutput?: DeclaredOutput
 }
 
 export interface ModelResolution {

--- a/packages/agent/src/inference/contract.ts
+++ b/packages/agent/src/inference/contract.ts
@@ -17,6 +17,9 @@ export interface InferPolicy {
 // DEFAULT_INFER_POLICY is the inference machine policy used when a caller supplies no override.
 export const DEFAULT_INFER_POLICY: InferPolicy = { giveUpAfter: 3, models: DEFAULT_MODEL_POLICY_OVERRIDE }
 
+// TrajectoryFilter derives the read-only event trajectory supplied to one model attempt.
+export type TrajectoryFilter = (trajectory: ReadonlyArray<Event>) => ReadonlyArray<Event>
+
 // InferRequest is one attempt's trajectory and model-facing surface. The actor derives the surface so a binding holds no tool, context, or output policy.
 export interface InferRequest {
   readonly trajectory: ReadonlyArray<Event>

--- a/packages/agent/src/inference/machine.ts
+++ b/packages/agent/src/inference/machine.ts
@@ -45,7 +45,8 @@ import {
   Infer,
   type InferPolicy,
   type ModelResolution,
-  type Render
+  type Render,
+  type TrajectoryFilter
 } from "./contract"
 
 // The inference machine derives a model attempt when the current turn has no unanswered tool call or terminal.
@@ -241,12 +242,23 @@ const openRejection = (events: ReadonlyArray<Event>): Event | undefined => {
     .at(-1)
 }
 
+const filteredTrajectory = (
+  trajectory: ReadonlyArray<Event>,
+  filters: ReadonlyArray<TrajectoryFilter>
+): ReadonlyArray<Event> => {
+  if (filters.length === 0) return trajectory
+  let filtered = [...trajectory]
+  for (const filter of filters) filtered = [...filter(filtered)]
+  return filtered
+}
+
 // Render derives what the model is shown over this log: the assembly owns it (runtime/composition.ts,
 // renderOf).
 interface InferDerivation {
   readonly slice: ReadonlyArray<Event>
   readonly epoch: number
   readonly trajectory: () => ReadonlyArray<Event>
+  readonly trajectoryFiltersAfter: (event: Event) => ReadonlyArray<TrajectoryFilter>
   readonly modelFailures: number
   readonly rendered: ReturnType<Render>
   readonly renderAfter: (event: Event) => ReturnType<Render>
@@ -422,7 +434,7 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
           })
           yield* events.append([mark])
           const actualRender = derived.renderAfter(mark)
-          const trajectory = input.trajectory()
+          const trajectory = filteredTrajectory(input.trajectory(), derived.trajectoryFiltersAfter(mark))
           let partialOutput = ""
           let physicalAttempt = ""
           let partialPersisted = false
@@ -543,11 +555,14 @@ export const inferenceFromHistory = (policy: Partial<InferPolicy>, render: Rende
         String((event as { readonly cause?: unknown }).cause) === "model"
     ).length,
     rendered: render(log),
-    renderAfter: (event) => render([...log, event])
+    renderAfter: (event) => render([...log, event]),
+    trajectoryFiltersAfter: () => []
   })
 }
 
-export type InferenceMachineProjection<State> = Machine<Event, State, ReturnType<Render>>
+export type InferenceMachineProjection<State> = Machine<Event, State, ReturnType<Render>> & {
+  readonly trajectoryFilters?: (state: State) => ReadonlyArray<TrajectoryFilter>
+}
 
 interface IncrementalInferState<State> {
   readonly turns: TurnProjectionState
@@ -584,7 +599,8 @@ export const inferenceMachine = <State>(
       trajectory: () => trajectoryFrom(state.turns),
       modelFailures: Option.getOrElse(HashMap.get(state.modelFailures, turn), () => 0),
       rendered: projection.output(state.render),
-      renderAfter: (event) => projection.output(projection.step(state.render, event))
+      renderAfter: (event) => projection.output(projection.step(state.render, event)),
+      trajectoryFiltersAfter: (event) => projection.trajectoryFilters?.(projection.step(state.render, event)) ?? []
     })
   }
 })

--- a/packages/agent/src/inference/machine.ts
+++ b/packages/agent/src/inference/machine.ts
@@ -434,7 +434,15 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
           })
           yield* events.append([mark])
           const actualRender = derived.renderAfter(mark)
-          const trajectory = filteredTrajectory(input.trajectory(), derived.trajectoryFiltersAfter(mark))
+          // The filters decide what this one attempt reads, nothing else. Every framework check
+          // below, from the call IDs a turn has reserved to the repairs a completion releases,
+          // reads the complete trajectory, and the request carries the turn's declared output
+          // beside the filtered one, so no filter can remove what the turn still owes
+          // (contract.ts, InferRequest.declaredOutput; composition.test.ts, "a filter that hides
+          // a tool call keeps its call ID reserved" and "a trajectory filter cannot remove the
+          // turn's declared output").
+          const trajectory = input.trajectory()
+          const modelTrajectory = filteredTrajectory(trajectory, derived.trajectoryFiltersAfter(mark))
           let partialOutput = ""
           let physicalAttempt = ""
           let partialPersisted = false
@@ -451,10 +459,11 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
           const action = normalizeAction(yield* binding
             .react(
               {
-                trajectory,
+                trajectory: modelTrajectory,
                 identity: { ...self, turn: input.turn },
                 model: selected,
-                ...actualRender
+                ...actualRender,
+                declaredOutput: declared
               },
               input.attempt,
               signal,
@@ -539,8 +548,15 @@ const inferTransitionsFor = (policy: Partial<InferPolicy>, derived: InferDerivat
   ]
 }
 
-// inferenceFromHistory derives inference through complete replay.
-export const inferenceFromHistory = (policy: Partial<InferPolicy>, render: Render): CompleteTransitionDerivation<Infer | EventLog | Self> => (history) => {
+// inferenceFromHistory derives inference through complete replay. The optional filter hook derives
+// the trajectory filters a replayed attempt reads, from the replayed log stepped past the mark
+// the same after-the-mark read the incremental projection takes from its render state, so replay
+// and live inference can share one filtering policy. Absent means replay reads the log unfiltered.
+export const inferenceFromHistory = (
+  policy: Partial<InferPolicy>,
+  render: Render,
+  trajectoryFilters?: (log: ReadonlyArray<Event>) => ReadonlyArray<TrajectoryFilter>
+): CompleteTransitionDerivation<Infer | EventLog | Self> => (history) => {
   const log = history.map((event, index) => eventPositionOf(event) === undefined ? eventAt(event, index + 1) : event)
   const slice = turnView(log)
   const turn = String((slice[0] as { readonly id?: unknown } | undefined)?.id ?? "")
@@ -556,7 +572,7 @@ export const inferenceFromHistory = (policy: Partial<InferPolicy>, render: Rende
     ).length,
     rendered: render(log),
     renderAfter: (event) => render([...log, event]),
-    trajectoryFiltersAfter: () => []
+    trajectoryFiltersAfter: (event) => trajectoryFilters?.([...log, event]) ?? []
   })
 }
 

--- a/packages/agent/src/inference/request.test.ts
+++ b/packages/agent/src/inference/request.test.ts
@@ -203,6 +203,30 @@ describe("modelRequest tool and prompt policy", () => {
   })
 })
 
+describe("the declared output on the request", () => {
+  const head = (declared = false): Event[] => [
+    { type: "MessageReceived", id: "m1", text: "go", ...(declared ? { output: { name: SCOUT.name, schema: SCOUT.schema } } : {}), at: 0 }
+  ]
+
+  // A trajectory filter can remove the message that declared the contract from what the model
+  // reads; the actor still states the declaration on the request, so the binding serves the
+  // contract the turn owes (machine.ts; composition.test.ts, "a trajectory filter cannot remove
+  // the turn's declared output").
+  test("a stated declaration outranks a trajectory that no longer carries it", () => {
+    const req = modelRequest([], { ...CODE, declaredOutput: { kind: "contract", contract: SCOUT } })
+    expect(req.output?.kind).toBe("contract")
+    expect(req.output?.kind === "contract" && canonicalOf(req.output.contract)).toBe(canonicalOf(SCOUT))
+  })
+
+  test("a stated prose declaration stays prose over a stale trajectory declaration", () => {
+    // The earlier turn declared scout and the filter hid only the current head, so the
+    // trajectory's last message still carries the old contract. The stated declaration pins
+    // this turn as prose instead of inheriting it.
+    const req = modelRequest(head(true), { ...CODE, declaredOutput: { kind: "none" } })
+    expect(req.output).toBeUndefined()
+  })
+})
+
 describe("the repair exchange in the render", () => {
   const repair = (projectHistory: boolean) => ({
     kind: "repair" as const,

--- a/packages/agent/src/inference/request.ts
+++ b/packages/agent/src/inference/request.ts
@@ -3,6 +3,7 @@ import type { ContextPolicy } from "../component/compaction"
 import { renderMessages, type AgentMessage } from "../projection/messages"
 import {
   declaredOutputOf,
+  type DeclaredOutput,
   type OutputContract,
   type OutputFallback
 } from "../output/contract"
@@ -73,10 +74,16 @@ export const modelRequest = (
     readonly system: string
     readonly tools: ReadonlyArray<ToolSpec>
     readonly output?: { readonly fallback: OutputFallback; readonly system?: string }
+    readonly declaredOutput?: DeclaredOutput
   },
   context: Partial<ContextPolicy> = {}
 ): ModelRequest => {
-  const declared = declaredOutputOf(trajectory)
+  // The actor's declaration rides the request when it states one: a filtered trajectory may no
+  // longer carry the message that declared the contract, but the turn still owes that contract, so
+  // the stated declaration outranks the trajectory. A render that states none keeps the
+  // trajectory as the declaration's home (request.test.ts, "the stated declaration outranks the
+  // trajectory").
+  const declared = render.declaredOutput ?? declaredOutputOf(trajectory)
   const fallback = render.output
   const base = SYSTEM(render.system)
   return {

--- a/packages/agent/src/runtime/composition.test.ts
+++ b/packages/agent/src/runtime/composition.test.ts
@@ -337,6 +337,149 @@ describe("infer component", () => {
     expect(events.at(-1)?.type).toBe("TurnCompleted")
   })
 
+  test("no trajectory filters preserve the model trajectory", async () => {
+    const seen: InferRequest[] = []
+    const mind = Layer.succeed(Infer, {
+      react: (request: InferRequest) => {
+        seen.push(request)
+        return Effect.succeed({ kind: "complete" as const, output: "done" })
+      }
+    })
+    const agent = assembled(infer([nativeOutput], TEST_MODEL))
+    const events = await run(
+      Effect.gen(function* () {
+        yield* receive(agent, { id: "m1", text: "go" })
+        return yield* readLog
+      }),
+      Layer.mergeAll(memoryLog(), mind, noRouter, KeyValueStore.layerMemory)
+    )
+    expect(seen[0]?.trajectory).toMatchObject([{ type: "MessageReceived", id: "m1", text: "go" }])
+    expect(events.find((event) => event.type === "MessageReceived")).toMatchObject({ id: "m1", text: "go" })
+  })
+
+  test("one trajectory filter changes only the model input", async () => {
+    const seen: InferRequest[] = []
+    const projected = viewComponent("projected", (events) => ({
+      system: [events.some((event) => event.type === "MessageReceived") ? "message projected" : "waiting"],
+      tools: [],
+      context: [],
+      output: [],
+      trajectoryFilters: [
+        (trajectory) => trajectory.filter((event) => event.type !== "MessageReceived")
+      ]
+    }))
+    const mind = Layer.succeed(Infer, {
+      react: (request: InferRequest) => {
+        seen.push(request)
+        return Effect.succeed({ kind: "complete" as const, output: "done" })
+      }
+    })
+    const agent = assembled(infer([projected, nativeOutput], TEST_MODEL))
+    const events = await run(
+      Effect.gen(function* () {
+        yield* receive(agent, { id: "m1", text: "go" })
+        return yield* readLog
+      }),
+      Layer.mergeAll(memoryLog(), mind, noRouter, KeyValueStore.layerMemory)
+    )
+    expect(seen[0]?.trajectory).toEqual([])
+    expect(seen[0]?.system).toContain("message projected")
+    expect(events.find((event) => event.type === "MessageReceived")).toMatchObject({ id: "m1", text: "go" })
+    expect(renderOf([projected, nativeOutput], events).system).toContain("message projected")
+  })
+
+  test("trajectory filters compose in component order", async () => {
+    const order: string[] = []
+    const seen: InferRequest[] = []
+    const first = viewComponent("first-filter", {
+      system: [],
+      tools: [],
+      context: [],
+      output: [],
+      trajectoryFilters: [
+        (trajectory) => {
+          order.push("first")
+          return trajectory.slice(1)
+        }
+      ]
+    })
+    const second = viewComponent("second-filter", {
+      system: [],
+      tools: [],
+      context: [],
+      output: [],
+      trajectoryFilters: [
+        (trajectory) => {
+          order.push("second")
+          return trajectory
+        }
+      ]
+    })
+    const mind = Layer.succeed(Infer, {
+      react: (request: InferRequest) => {
+        seen.push(request)
+        return Effect.succeed({ kind: "complete" as const, output: "done" })
+      }
+    })
+    const agent = assembled(infer([first, second, nativeOutput], TEST_MODEL))
+    await run(
+      Effect.gen(function* () {
+        yield* receive(agent, { id: "m1", text: "go" })
+        return yield* readLog
+      }),
+      Layer.mergeAll(memoryLog(), mind, noRouter, KeyValueStore.layerMemory)
+    )
+    expect(order).toEqual(["first", "second"])
+    expect(seen[0]?.trajectory).toEqual([])
+  })
+
+  test("each trajectory filter receives an isolated event array", async () => {
+    let source: ReadonlyArray<Event> = []
+    const seen: InferRequest[] = []
+    const first = viewComponent("source-filter", {
+      system: [],
+      tools: [],
+      context: [],
+      output: [],
+      trajectoryFilters: [
+        (trajectory) => {
+          source = trajectory
+          return trajectory
+        }
+      ]
+    })
+    const second = viewComponent("mutating-filter", {
+      system: [],
+      tools: [],
+      context: [],
+      output: [],
+      trajectoryFilters: [
+        (trajectory) => {
+          const mutable = trajectory as Event[]
+          mutable.splice(0, mutable.length)
+          return mutable
+        }
+      ]
+    })
+    const mind = Layer.succeed(Infer, {
+      react: (request: InferRequest) => {
+        seen.push(request)
+        return Effect.succeed({ kind: "complete" as const, output: "done" })
+      }
+    })
+    const agent = assembled(infer([first, second, nativeOutput], TEST_MODEL))
+    const events = await run(
+      Effect.gen(function* () {
+        yield* receive(agent, { id: "m1", text: "go" })
+        return yield* readLog
+      }),
+      Layer.mergeAll(memoryLog(), mind, noRouter, KeyValueStore.layerMemory)
+    )
+    expect(source).toMatchObject([{ type: "MessageReceived", id: "m1", text: "go" }])
+    expect(seen[0]?.trajectory).toEqual([])
+    expect(events.find((event) => event.type === "MessageReceived")).toMatchObject({ id: "m1", text: "go" })
+  })
+
   test("a call outside the derived tools answers unknown-tool naming the composed tools", async () => {
     const mind = Layer.succeed(Infer, {
       react: (request: InferRequest) => {

--- a/packages/agent/src/runtime/composition.test.ts
+++ b/packages/agent/src/runtime/composition.test.ts
@@ -29,7 +29,9 @@ import { permissions } from "../component/permissions"
 import { requestPermissionMethod } from "../actor/permission"
 import { receive } from "./turn"
 import { Infer, NativeOutputSupport, type InferRequest } from "../inference/contract"
-import { selectedModelOf } from "../inference/machine"
+import type { ExternalEffect } from "@clavia/tardigrade-core/effect"
+import { inferenceFromHistory, selectedModelOf } from "../inference/machine"
+import { NATIVE_MODE, output } from "../index"
 
 const TEST_MODEL = { models: { default: { provider: "test", model_id: "test-model" }, allow: "*" } } as const
 
@@ -478,6 +480,114 @@ describe("infer component", () => {
     expect(source).toMatchObject([{ type: "MessageReceived", id: "m1", text: "go" }])
     expect(seen[0]?.trajectory).toEqual([])
     expect(events.find((event) => event.type === "MessageReceived")).toMatchObject({ id: "m1", text: "go" })
+  })
+
+  test("a trajectory filter cannot remove the turn's declared output", async () => {
+    const contract = output({
+      name: "scout",
+      schema: {
+        type: "object",
+        properties: { a: { type: "string" } },
+        required: ["a"],
+        additionalProperties: false
+      }
+    })
+    const seen: InferRequest[] = []
+    const projected = viewComponent("projected", {
+      system: [],
+      tools: [],
+      context: [],
+      output: [],
+      trajectoryFilters: [(trajectory) => trajectory.filter((event) => event.type !== "MessageReceived")]
+    })
+    const mind = Layer.succeed(Infer, {
+      react: (request: InferRequest) => {
+        seen.push(request)
+        return Effect.succeed({ kind: "complete" as const, output: JSON.stringify({ a: "aspects" }), mode: NATIVE_MODE })
+      }
+    })
+    const agent = assembled(infer([projected, nativeOutput], TEST_MODEL))
+    const events = await run(
+      Effect.gen(function* () {
+        yield* receive(agent, { id: "m1", text: "go", output: contract })
+        return yield* readLog
+      }),
+      Layer.mergeAll(memoryLog(), mind, noRouter, KeyValueStore.layerMemory)
+    )
+    // The filter removed the declaring message from what the model reads, and the request still
+    // carries the declaration, so the turn completes under the contract it declared.
+    expect(seen[0]?.trajectory).toEqual([])
+    expect(seen[0]?.declaredOutput?.kind).toBe("contract")
+    expect(seen[0]?.declaredOutput?.kind === "contract" && seen[0]?.declaredOutput.contract.name).toBe("scout")
+    expect(events.at(-1)?.type).toBe("TurnCompleted")
+  })
+
+  test("a filter that hides a tool call keeps its call ID reserved", async () => {
+    const seen: InferRequest[] = []
+    let asked = 0
+    const hiding = viewComponent("hiding", {
+      system: [],
+      tools: [],
+      context: [],
+      output: [],
+      trajectoryFilters: [(trajectory) => trajectory.filter((event) => event.type !== "ToolCalled")]
+    })
+    const mind = Layer.succeed(Infer, {
+      react: (request: InferRequest) => {
+        seen.push(request)
+        asked += 1
+        return Effect.succeed(asked === 1
+          ? { kind: "calls" as const, calls: [{ callId: "c1", name: "echo", arguments: { q: "first" } }] as const }
+          : { kind: "calls" as const, calls: [{ callId: "c1", name: "echo", arguments: { q: "again" } }] as const })
+      }
+    })
+    const agent = assembled(infer([echoTable, hiding, nativeOutput], TEST_MODEL))
+    const events = await run(
+      Effect.gen(function* () {
+        yield* receive(agent, { id: "m1", text: "go" })
+        return yield* readLog
+      }),
+      Layer.mergeAll(memoryLog(), mind, noRouter, KeyValueStore.layerMemory)
+    )
+    // The second attempt read a trajectory with the first call hidden, yet the ID stayed
+    // reserved: the reuse fails the turn instead of dispatching a second call under one ID.
+    expect(seen[1]?.trajectory.some((event) => event.type === "ToolCalled")).toBe(false)
+    expect(events.filter((event) => event.type === "ToolCalled")).toHaveLength(1)
+    const failed = events.find((event) => event.type === "TurnFailed") as { error?: string } | undefined
+    expect(failed).toMatchObject({ cause: "inference_error" })
+    expect(failed?.error).toContain('duplicate tool call ID "c1"')
+  })
+
+  test("inferenceFromHistory applies its trajectory-filter hook after the mark", async () => {
+    const seen: InferRequest[] = []
+    const stepped: string[][] = []
+    const mind = Layer.succeed(Infer, {
+      react: (request: InferRequest) => {
+        seen.push(request)
+        return Effect.succeed({ kind: "complete" as const, output: "done" })
+      }
+    })
+    const history = [{ type: "MessageReceived", id: "m1", text: "go", at: 0 }] as ReadonlyArray<Event>
+    const layers = Layer.mergeAll(memoryLog(history), mind, noRouter, KeyValueStore.layerMemory)
+    const actOf = (transitions: ReadonlyArray<{ readonly kind: string }>): ExternalEffect =>
+      transitions.find((transition) => transition.kind === "effect") as ExternalEffect
+    const hooked = actOf(inferenceFromHistory(
+      TEST_MODEL,
+      () => ({ system: "", tools: [] }),
+      (log) => {
+        stepped.push(log.map((event) => event.type))
+        return [(trajectory) => trajectory.filter((event) => event.type !== "MessageReceived")]
+      }
+    )(history))
+    await run(hooked.act(hooked.input, new AbortController().signal), layers)
+    const bare = actOf(inferenceFromHistory(TEST_MODEL, () => ({ system: "", tools: [] }))(history))
+    await run(bare.act(bare.input, new AbortController().signal), layers)
+    // The hook read the replayed log stepped past the mark, the same after-the-mark read the
+    // incremental projection takes, and its filters shaped the replayed request. Absent the hook,
+    // the replay reads the log unfiltered.
+    expect(stepped).toEqual([["MessageReceived", "ModelCalled"]])
+    expect(seen[0]?.trajectory).toEqual([])
+    expect(seen[1]?.trajectory).toMatchObject([{ type: "MessageReceived", id: "m1" }])
   })
 
   test("a call outside the derived tools answers unknown-tool naming the composed tools", async () => {

--- a/packages/agent/src/runtime/composition.ts
+++ b/packages/agent/src/runtime/composition.ts
@@ -7,7 +7,7 @@ import type { Event } from "@clavia/tardigrade-core/log/event"
 import type { ToolSpec } from "../inference/request"
 import { fallbackOf, type OutputFallback } from "../output/contract"
 import { agentKeys } from "../log/events"
-import type { InferPolicy } from "../inference/contract"
+import type { InferPolicy, TrajectoryFilter } from "../inference/contract"
 import { inferenceMachine } from "../inference/machine"
 import { modelPolicyOverrideOf, type ModelPolicyOverride } from "../inference/access"
 import { incrementalToolsComponentFrom, toolConcurrencyOf, toolConcurrencyInstruction, DEFAULT_TOOL_CONCURRENCY, type ToolConcurrency, type Answer, type PendingCall } from "./tools"
@@ -61,6 +61,7 @@ export interface AgentView {
   readonly tools: ReadonlyArray<AgentTool<unknown>>
   readonly context: ReadonlyArray<ContextFragment>
   readonly output: ReadonlyArray<OutputFragment>
+  readonly trajectoryFilters?: ReadonlyArray<TrajectoryFilter>
 }
 
 // AgentComponent is a core component whose view is interpreted by its infer root.
@@ -85,16 +86,26 @@ export const defineOutputFallback = <R>(component: AgentComponent<R>): OutputFal
   return { ...component, machine: { ...component.machine, output }, [OutputFallbackMarker]: true }
 }
 
+const combinedTrajectoryFilters = (
+  left: ReadonlyArray<TrajectoryFilter> | undefined,
+  right: ReadonlyArray<TrajectoryFilter> | undefined
+): ReadonlyArray<TrajectoryFilter> | undefined =>
+  left === undefined ? right : right === undefined ? left : [...left, ...right]
+
 // AGENT_VIEW_ALGEBRA preserves every view contribution in component order. renderOf
 // applies the agent-specific collision and rendering rules to the combined value.
 export const AGENT_VIEW_ALGEBRA: ViewAlgebra<AgentView> = {
   empty: { system: [], tools: [], context: [], output: [] },
-  combine: (left, right) => ({
-    system: [...left.system, ...right.system],
-    tools: [...left.tools, ...right.tools],
-    context: [...left.context, ...right.context],
-    output: [...left.output, ...right.output]
-  })
+  combine: (left, right) => {
+    const trajectoryFilters = combinedTrajectoryFilters(left.trajectoryFilters, right.trajectoryFilters)
+    return {
+      system: [...left.system, ...right.system],
+      tools: [...left.tools, ...right.tools],
+      context: [...left.context, ...right.context],
+      output: [...left.output, ...right.output],
+      ...(trajectoryFilters === undefined ? {} : { trajectoryFilters })
+    }
+  }
 }
 
 // outputFrom resolves the output strategy the assembly declares. A turn has one final response,
@@ -220,7 +231,8 @@ export const infer = <
   const incrementalInference = inferenceMachine(inferPolicy, {
     initial: childMachine.initial,
     step: childMachine.step,
-    output: (state) => renderView(childMachine.output(state).view, toolConcurrency)
+    output: (state) => renderView(childMachine.output(state).view, toolConcurrency),
+    trajectoryFilters: (state) => childMachine.output(state).view.trajectoryFilters ?? []
   }) as TransitionProjection<unknown, R>
   const incrementalTools = incrementalToolsComponentFrom(
     AGENT_VIEW_ALGEBRA.empty,


### PR DESCRIPTION
[👾 omp · openrouter/z-ai/glm-5.3 · agency: directed · intent: composable per-attempt trajectory filters for the agent infer root]

## What and why

A long-lived agent session accumulates trajectory entries the next model attempt does not need: per-attempt marks, retries, rejections, and repair records that keep arriving as model input after their turn has settled. We run a multi-tenant agent platform where customers keep sessions open across thousands of tool calls, and those entries grow the token cost of every later request, while the durable log and the render already hold the complete record.

Components already own what the model sees through `AgentView`. This change adds a filter over the event trajectory supplied to each model attempt, so a component can choose what the model reads without rewriting the log or the render.

## Implementation

- Added `TrajectoryFilter` to `packages/agent/src/inference/contract.ts` and exported it from the package index. A filter receives the read-only event trajectory and returns the trajectory that one model attempt reads.
- Added the optional `trajectoryFilters` field to `AgentView`. `AGENT_VIEW_ALGEBRA.combine` concatenates contributions in component order, so an assembly that declares no filters produces the same request it produces today.
- Extended `InferenceMachineProjection` with the optional `trajectoryFilters` hook. The incremental inference machine reads the filters after the model mark and applies them through `filteredTrajectory` at the infer act, so the binding receives the filtered trajectory. Every other derivation, from rendering to attempt accounting, keeps the full log.
- Wired `infer` to feed the composed child view's `trajectoryFilters` into the incremental inference projection, alongside the render it already derives from the same child state.
- The filters shape only what the model reads. The infer act keeps the complete trajectory for framework validation: the duplicate call-ID check and the repairs a completion releases read the unfiltered trajectory, and only the `Infer.react` request reads the filtered one, so a filter that hides an earlier tool call cannot free its ID for reuse.
- The request carries the turn's declared output beside the filtered trajectory, and `modelRequest` reads that stated declaration before its trajectory scan, so a filter that removes the declaring message cannot remove the contract the turn still owes. A stated prose declaration also stays prose beside a trajectory whose last message still carries an old turn's contract.
- `inferenceFromHistory` accepts an optional trajectory-filter hook that reads the replayed log stepped past the mark, the same after-the-mark read the incremental projection takes from its render state, so replay and live inference can share one filtering policy. Absent the hook, replay reads the log unfiltered.

## Limits

A replay derives filters only from the hook its caller passes; the history derivation holds no component state to read. Live inference derives the same filters from the composed view without caller wiring.

## Non-goals

- No change to the durable log, compaction, or the render. A filter changes what one model attempt reads. The log keeps every event.
- No built-in filter implementations. The contribution is the composition point, and assemblies own their filtering policies.

## Verification

At `e21afda710881197677658f1cc89502490c05caa`, on top of `main` at `d8321f2ff74b7d87f066aaf3b024ffed185e90da`:

- `bun test src/runtime/composition.test.ts` from `packages/agent`: 34 pass, 0 fail, 85 expect() calls. The tests cover identity without filters ("no trajectory filters preserve the model trajectory"), model-only behavior with the log and render intact ("one trajectory filter changes only the model input"), composition order ("trajectory filters compose in component order"), isolation between filter stages ("each trajectory filter receives an isolated event array"), the declared output surviving a filter that removes the declaring message ("a trajectory filter cannot remove the turn's declared output"), the reserved-ID check reading the complete trajectory ("a filter that hides a tool call keeps its call ID reserved"), and the replay hook ("inferenceFromHistory applies its trajectory-filter hook after the mark").
- `bun test packages/agent/src/inference`: 42 pass, 0 fail, 1009 expect() calls. The new cases pin that the stated declaration outranks the trajectory ("a stated declaration outranks a trajectory that no longer carries it") and that a stated prose declaration stays prose beside a stale trajectory declaration ("a stated prose declaration stays prose over a stale trajectory declaration").
- `bun run gate`: exit 0, 20.6s total.
