### PR TITLE
fix(host): harden the worker loader

### DIFF
--- a/packages/code/src/index.ts
+++ b/packages/code/src/index.ts
@@ -14,7 +14,8 @@ export {
   fetchPolicyOf,
   DEFAULT_FETCH_POLICY,
   DEFAULT_FETCH_BODY_CHARS,
-  type FetchPolicy
+  type FetchPolicy,
+  type FetchUrlPolicy
 } from "./package/fetch"
 export {
   CODE_VIEW_ALGEBRA,

--- a/packages/code/src/package/fetch.test.ts
+++ b/packages/code/src/package/fetch.test.ts
@@ -3,10 +3,12 @@ import { Effect } from "effect"
 import { FetchHttpClient, type HttpClient } from "effect/unstable/http"
 import type { Park } from "../execution/errors"
 
-import { DEFAULT_FETCH_BODY_CHARS, DEFAULT_FETCH_POLICY, fetchPackage, fetchPolicyOf } from "./fetch"
+import { DEFAULT_FETCH_BODY_CHARS, DEFAULT_FETCH_POLICY, fetchPackage, fetchPolicyOf, type FetchPolicy } from "./fetch"
 
 // The fetch package against a server this file boots. Nothing here reaches the network: the origin
 // is loopback on a port the runtime chose, so the test is the same on a laptop and in a sandbox.
+// The urlPolicy cases reach further hosts the same way, as refusals the server never sees, and the
+// public-host cases bind a fetch this file stubs, so no test opens a socket to a third party.
 
 interface Answer {
   readonly status?: number
@@ -17,22 +19,47 @@ interface Answer {
 }
 
 let origin = ""
+let hits = 0
 let server: ReturnType<typeof Bun.serve> | undefined
 
 const run = (effect: Effect.Effect<unknown, Park, HttpClient.HttpClient>) =>
   Effect.runPromise(Effect.provide(Effect.orDie(effect), FetchHttpClient.layer)) as Promise<Answer>
 
-const call = (method: string, args: unknown, policy: Partial<{ bodyChars: number }> = {}) => {
+const call = (method: string, args: unknown, policy: Partial<FetchPolicy> = {}) => {
   const pkg = fetchPackage({ policy })
   return run(pkg.methods[method]!(args, { callId: "c1" }))
+}
+
+// callThroughFetch runs one get through the real FetchHttpClient transport over a fetch this test
+// states, so the urlPolicy's transport behavior is observable without a public socket: the stub
+// reads the RequestInit the package pinned, and answers what the policy must handle.
+const callThroughFetch = (
+  respond: (init: RequestInit) => Promise<Response>,
+  args: unknown,
+  policy: Partial<FetchPolicy> = {}
+): Promise<Answer> => {
+  const pkg = fetchPackage({ policy })
+  const fetchImpl: typeof globalThis.fetch = Object.assign(
+    (input: string | URL | Request, init?: RequestInit) => respond(init ?? {}),
+    { preconnect: () => undefined }
+  )
+  return Effect.runPromise(Effect.provideService(
+    Effect.orDie(Effect.provide(pkg.methods["get"]!(args, { callId: "c1" }), FetchHttpClient.layer)),
+    FetchHttpClient.Fetch,
+    fetchImpl
+  )) as Promise<Answer>
 }
 
 beforeAll(() => {
   server = Bun.serve({
     port: 0,
     fetch: async (request) => {
+      hits++
       const url = new URL(request.url)
       if (url.pathname === "/long") return new Response("x".repeat(1000))
+      if (url.pathname === "/redirect") {
+        return new Response(null, { status: 302, headers: { location: "/" } })
+      }
       if (url.pathname === "/echo") {
         return new Response(`${request.method}:${await request.text()}`, {
           status: 201,
@@ -56,6 +83,81 @@ describe("the fetch policy", () => {
     expect(fetchPolicyOf().bodyChars).toBe(DEFAULT_FETCH_BODY_CHARS)
     expect(fetchPolicyOf({ bodyChars: 10 }).bodyChars).toBe(10)
   })
+
+  test("the urlPolicy is opt-in and off by default", () => {
+    expect(DEFAULT_FETCH_POLICY.urlPolicy).toBeUndefined()
+    expect(fetchPolicyOf().urlPolicy).toBeUndefined()
+    expect(fetchPolicyOf({ urlPolicy: "public-only" }).urlPolicy).toBe("public-only")
+  })
+})
+
+describe("the urlPolicy", () => {
+  test("refuses a loopback address, however it was written", async () => {
+    const before = hits
+    const answer = await call("get", { url: `${origin}/` }, { urlPolicy: "public-only" })
+    expect(answer.error).toContain("refuses the loopback address 127.0.0.1")
+    expect(answer.status).toBeUndefined()
+    const odd = await call("get", { url: "http://0x7f.1/" }, { urlPolicy: "public-only" })
+    expect(odd.error).toContain("refuses the loopback address 127.0.0.1")
+    expect(hits).toBe(before)
+  })
+
+  // One call per RFC 1918 range: the three ranges are three branches of the classifier, and each
+  // is a distinct address an operator's network may answer on.
+  test("refuses each private range", async () => {
+    for (const host of ["10.0.0.1", "172.16.0.9", "192.168.1.1"]) {
+      const answer = await call("get", { url: `http://${host}/` }, { urlPolicy: "public-only" })
+      expect(answer.error).toContain(`refuses the private address ${host}`)
+      expect(answer.status).toBeUndefined()
+    }
+  })
+
+  test("refuses the link-local range", async () => {
+    const answer = await call("get", { url: "http://169.254.169.254/latest/meta-data" }, { urlPolicy: "public-only" })
+    expect(answer.error).toContain("refuses the link-local address 169.254.169.254")
+    expect(answer.status).toBeUndefined()
+  })
+
+  test("refuses a literal IP address, public or IPv6", async () => {
+    const four = await call("get", { url: "https://8.8.8.8/" }, { urlPolicy: "public-only" })
+    expect(four.error).toContain("refuses the literal IP address 8.8.8.8")
+    const six = await call("get", { url: "http://[2001:db8::1]/" }, { urlPolicy: "public-only" })
+    expect(six.error).toContain("refuses the literal IP address [2001:db8::1]")
+  })
+
+  test("refuses the loopback name", async () => {
+    const answer = await call("get", { url: "http://localhost:1/x" }, { urlPolicy: "public-only" })
+    expect(answer.error).toContain("refuses the loopback name localhost")
+    expect(answer.status).toBeUndefined()
+  })
+
+  test("refuses a scheme other than http and https, and what it cannot parse", async () => {
+    const scheme = await call("get", { url: "ftp://example.com/" }, { urlPolicy: "public-only" })
+    expect(scheme.error).toContain("refuses the ftp: scheme")
+    const broken = await call("get", { url: "not a url" }, { urlPolicy: "public-only" })
+    expect(broken.error).toContain("needs an absolute http or https URL")
+  })
+
+  test("passes a public host to the transport with redirects pinned to error", async () => {
+    const seen: Array<RequestInit> = []
+    const answer = await callThroughFetch((init) => {
+      seen.push(init)
+      return Promise.resolve(new Response("hello", { status: 200, headers: { "content-type": "text/plain" } }))
+    }, { url: "https://example.com/" }, { urlPolicy: "public-only" })
+    expect(answer.status).toBe(200)
+    expect(answer.body).toBe("hello")
+    expect(seen[0]?.redirect).toBe("error")
+  })
+
+  // A transport that ignores the RequestInit pin still cannot land a redirect as an answer.
+  test("refuses a redirect the transport surfaces", async () => {
+    const answer = await callThroughFetch(() => Promise.resolve(new Response(null, {
+      status: 302,
+      headers: { location: "https://elsewhere.example/" }
+    })), { url: "https://example.com/" }, { urlPolicy: "public-only" })
+    expect(answer.error).toContain("refuses a redirect")
+    expect(answer.status).toBeUndefined()
+  })
 })
 
 describe("the fetch package", () => {
@@ -64,7 +166,6 @@ describe("the fetch package", () => {
     expect(answer.status).toBe(200)
     expect(answer.body).toBe("hello")
     expect(answer.headers?.["content-type"]).toContain("text/plain")
-    expect(answer.truncated).toBeUndefined()
   })
 
   // A status the caller did not want is still an answer: the model reads the number and decides,
@@ -104,6 +205,14 @@ describe("the fetch package", () => {
     const answer = await call("get", { url: "http://127.0.0.1:1/" })
     expect(answer.error).toContain("127.0.0.1:1")
     expect(answer.status).toBeUndefined()
+  })
+
+  // The default package stays the open one: without the urlPolicy a redirect is followed to its
+  // target, which is the behavior an opting-out host keeps.
+  test("a redirect is followed when no urlPolicy is set", async () => {
+    const answer = await call("get", { url: `${origin}/redirect` })
+    expect(answer.status).toBe(200)
+    expect(answer.body).toBe("hello")
   })
 
   test("get is read-only and request is not, and both are open world", () => {

--- a/packages/code/src/package/fetch.ts
+++ b/packages/code/src/package/fetch.ts
@@ -1,5 +1,5 @@
-import { Effect } from "effect"
-import { HttpClient, HttpClientRequest } from "effect/unstable/http"
+import { Effect, Option } from "effect"
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { definePackage, type Package } from "./definition"
 
 // The fetch package: one HTTP request, made through `HttpClient` rather than through a global
@@ -9,22 +9,35 @@ import { definePackage, type Package } from "./definition"
 //
 // The package holds no credential and pins no origin: whatever the code passes as headers is what
 // goes on the wire. A package that speaks to a credentialed provider is the other shape, a
-// `Connection` and its door (packages/code/src/package/definition.ts), and this one is the open one.
+// `Connection` and its door (packages/code/src/package/definition.ts), and this one is the open
+// one. A host that mounts it for bodies it does not trust opts into `urlPolicy`, which pins the
+// network a URL may name the way the credentialed doors pin an origin (#427).
 
 // FetchPolicy bounds what one answer can put in a turn's context. `bodyChars` is where the body is
 // cut; the answer says `truncated` when it was, so a model reading a cut body knows it read a
 // prefix. The cap bounds what the turn reads rather than what the network carried: the response is
-// received whole and cut before it becomes an answer.
+// received whole and cut before it becomes an answer. `urlPolicy` is the opt-in network
+// restriction; absent, the package stays the open one it was.
 export interface FetchPolicy {
   readonly bodyChars: number
+  readonly urlPolicy?: FetchUrlPolicy
 }
+
+// FetchUrlPolicy is the opt-in network restriction: a URL may name a public host only. Every
+// literal IPv4 or IPv6 address is refused, whichever range it sits in, which covers the private,
+// loopback, and link-local ranges a prompt-injected body reaches for (fetch.test.ts, "the
+// urlPolicy refuses a private address" and the refusals beside it). The loopback name localhost,
+// every scheme but http and https, and every redirect are refused too, so a public host cannot
+// pivot a request into a host the policy never saw.
+export type FetchUrlPolicy = "public-only"
 
 export const DEFAULT_FETCH_BODY_CHARS = 65_536
 
 export const DEFAULT_FETCH_POLICY: FetchPolicy = { bodyChars: DEFAULT_FETCH_BODY_CHARS }
 
 export const fetchPolicyOf = (policy: Partial<FetchPolicy> = {}): FetchPolicy => ({
-  bodyChars: policy.bodyChars ?? DEFAULT_FETCH_POLICY.bodyChars
+  bodyChars: policy.bodyChars ?? DEFAULT_FETCH_POLICY.bodyChars,
+  ...(policy.urlPolicy === undefined ? {} : { urlPolicy: policy.urlPolicy })
 })
 
 // The methods the model is offered. A GET is safe by the HTTP specification's own word, so it is
@@ -48,6 +61,68 @@ type Method = (typeof METHODS)[number]
 
 const failure = (error: unknown): string => (error instanceof Error ? error.message : String(error))
 
+// ipv4Category names the special-use range a literal IPv4 address sits in, or undefined when the
+// address is global unicast. The private, loopback, and link-local ranges are what the urlPolicy
+// was filed against (#427); the rest are IANA's special-purpose registry (RFC 6890) beside them,
+// and none of them is a host on the public internet.
+const ipv4Category = (a: number, b: number, c: number): string | undefined => {
+  if (a === 0) return "this network"
+  if (a === 10 || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168)) return "private"
+  if (a === 127) return "loopback"
+  if (a === 169 && b === 254) return "link-local"
+  if (a === 100 && b >= 64 && b <= 127) return "shared"
+  if (a === 192 && b === 0 && c === 0) return "special-purpose"
+  if ((a === 192 && b === 0 && c === 2) || (a === 198 && b === 51 && c === 100) || (a === 203 && b === 0 && c === 113)) {
+    return "documentation"
+  }
+  if (a === 198 && (b === 18 || b === 19)) return "benchmarking"
+  if (a >= 224) return "reserved"
+  return undefined
+}
+
+// refusalOf names why a URL cannot leave under the urlPolicy, or undefined when it may. The host
+// is read from the parsed URL, so the WHATWG parser has already canonicalized an IPv4 literal
+// written any odd way (0x7f.1 arrives as 127.0.0.1, fetch.test.ts, "the urlPolicy refuses a
+// loopback address") and rejected what it cannot parse. A refusal is an answer the model reads,
+// never a failed effect, like a transport failure beside it.
+const refusalOf = (url: string): string | undefined => {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return "the urlPolicy needs an absolute http or https URL"
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return `the urlPolicy refuses the ${parsed.protocol} scheme`
+  }
+  const host = parsed.hostname.replace(/\.$/, "")
+  if (host.includes(":")) return `refuses the literal IP address ${host}`
+  const octets = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host)
+  if (octets !== null) {
+    return `refuses the ${ipv4Category(Number(octets[1]), Number(octets[2]), Number(octets[3])) ?? "literal IP"} address ${host}`
+  }
+  if (host === "localhost" || host.endsWith(".localhost")) return `refuses the loopback name ${host}`
+  return undefined
+}
+
+// redirectRefused executes one request with the transport's redirect handling pinned to error,
+// merged over the defaults the host set. FetchHttpClient reads its RequestInit service per
+// request (effect/unstable/http/FetchHttpClient.ts), so the transport throws on a redirect instead
+// of following it. A transport that surfaces the redirect anyway is caught by the status check in
+// send (fetch.test.ts, "the urlPolicy refuses a redirect the transport surfaces").
+const redirectRefused = (
+  client: HttpClient.HttpClient,
+  request: HttpClientRequest.HttpClientRequest
+) =>
+  Effect.flatMap(Effect.serviceOption(FetchHttpClient.RequestInit), (defaults) =>
+    client.execute(request).pipe(
+      Effect.provideService(FetchHttpClient.RequestInit, {
+        ...Option.getOrElse(defaults, (): globalThis.RequestInit => ({})),
+        redirect: "error"
+      })
+    )
+  )
+
 const send = (
   policy: FetchPolicy,
   method: Method,
@@ -56,13 +131,22 @@ const send = (
   body: string | undefined
 ): Effect.Effect<Answer, never, HttpClient.HttpClient> =>
   Effect.gen(function* () {
+    const urlPolicy = policy.urlPolicy
+    if (urlPolicy !== undefined) {
+      const refusal = refusalOf(url)
+      if (refusal !== undefined) return { error: `${method} ${url}: ${refusal}` }
+    }
     const client = yield* HttpClient.HttpClient
     const request = HttpClientRequest.make(method)(url).pipe(
       HttpClientRequest.setHeaders(headers),
       (built) => (body === undefined ? built : HttpClientRequest.bodyText(built, body))
     )
     return yield* Effect.gen(function* () {
-      const response = yield* client.execute(request)
+      const response = yield* urlPolicy === undefined ? client.execute(request) : redirectRefused(client, request)
+      const location = response.headers["location"]
+      if (urlPolicy !== undefined && location !== undefined && response.status >= 301 && response.status <= 308) {
+        return { error: `${method} ${url}: the urlPolicy refuses a redirect to ${location}` }
+      }
       const text = yield* response.text
       const cut = text.slice(0, policy.bodyChars)
       return {
@@ -96,6 +180,12 @@ const headersOf = (raw: unknown): Readonly<Record<string, string>> => {
 // codeReactorFor).
 export const fetchPackage = (options: FetchOptions = {}): Package<HttpClient.HttpClient> => {
   const policy = fetchPolicyOf(options.policy)
+  // The sentence the method docs gain under the urlPolicy, so the model reads the restriction in
+  // the tool it is about to call rather than learning it from a refusal.
+  const hostRule =
+    policy.urlPolicy === undefined
+      ? ""
+      : " The urlPolicy is set: a URL may name a public host only, a literal IP address, a private, loopback, or link-local host, and the loopback name localhost are refused, and a redirect is refused."
   const answer = {
     type: "object",
     properties: {
@@ -119,7 +209,7 @@ export const fetchPackage = (options: FetchOptions = {}): Package<HttpClient.Htt
     },
     docs: {
       get: {
-        description: `GET one URL. The body comes back as text, cut at ${policy.bodyChars} characters, and the answer says truncated when it was cut. A transport failure is an \`error\` rather than a throw.`,
+        description: `GET one URL. The body comes back as text, cut at ${policy.bodyChars} characters, and the answer says truncated when it was cut. A transport failure is an \`error\` rather than a throw.${hostRule}`,
         input: {
           type: "object",
           properties: { url: { type: "string" }, headers: { type: "object" } },
@@ -128,7 +218,7 @@ export const fetchPackage = (options: FetchOptions = {}): Package<HttpClient.Htt
         output: answer
       },
       request: {
-        description: `Send one HTTP request. method is one of ${METHODS.join(", ")}. The body comes back as text, cut at ${policy.bodyChars} characters, and the answer says truncated when it was cut. A transport failure is an \`error\` rather than a throw.`,
+        description: `Send one HTTP request. method is one of ${METHODS.join(", ")}. The body comes back as text, cut at ${policy.bodyChars} characters, and the answer says truncated when it was cut. A transport failure is an \`error\` rather than a throw.${hostRule}`,
         input: {
           type: "object",
           properties: {
@@ -163,3 +253,4 @@ export const fetchPackage = (options: FetchOptions = {}): Package<HttpClient.Htt
     }
   })
 }
+

--- a/platform/worker-loader/README.md
+++ b/platform/worker-loader/README.md
@@ -2,6 +2,8 @@
 
 This binding runs the Sandbox port in a fresh Worker Loader isolate. Capability transport carries package calls through a Durable Object stub on workerd. Replay transport carries the same calls as JSON boundaries on Celld.
 
+The harness shadows the ambient identifiers the Bun sandbox blanks as well: `fetch`, `WebSocket`, `WebSocketPair`, `caches`, and the rest of the Bun sandbox's restricted list arrive in the body as `undefined` parameters and `globalThis` as an empty object, so an isolate meant to have no ambient network cannot name one, independent of the outbound policy. A host binding keeps its own name: a mounted package shadows the global for that name.
+
 ## Verify
 
 ```bash

--- a/platform/worker-loader/README.md
+++ b/platform/worker-loader/README.md
@@ -2,7 +2,7 @@
 
 This binding runs the Sandbox port in a fresh Worker Loader isolate. Capability transport carries package calls through a Durable Object stub on workerd. Replay transport carries the same calls as JSON boundaries on Celld.
 
-The harness shadows the ambient identifiers the Bun sandbox blanks as well: `fetch`, `WebSocket`, `WebSocketPair`, `caches`, and the rest of the Bun sandbox's restricted list arrive in the body as `undefined` parameters and `globalThis` as an empty object, so an isolate meant to have no ambient network cannot name one, independent of the outbound policy. A host binding keeps its own name: a mounted package shadows the global for that name.
+The harness shadows the ambient identifiers the Bun sandbox blanks as well: `fetch`, `WebSocket`, `WebSocketPair`, `caches`, `global`, and the rest of the Bun sandbox's restricted list arrive in the body as `undefined` parameters and `globalThis` as an empty object, so an isolate meant to have no ambient network cannot name one, independent of the outbound policy. `global` joins the list because `nodejs_compat` exposes it as an alias of the real global scope. A host binding keeps its own name: a mounted package shadows the global for that name.
 
 ## Verify
 

--- a/platform/worker-loader/src/sandbox.ts
+++ b/platform/worker-loader/src/sandbox.ts
@@ -287,9 +287,12 @@ const scopeNames = (bindings: Bindings, ambient: Ambient | undefined): ReadonlyA
 
 // bodySource wraps one body as a module whose parameter list is the scope: every scope name,
 // the restricted ones included, shadows the isolate's own global with the value the harness
-// passes for it.
+// passes for it. The body sits in a nested block of its own, so a const, let, or class
+// declaration of a scoped name in the body stays valid instead of colliding with its own
+// parameter at parse time (sandbox.workers.ts, "a local declaration of a scoped name stays
+// valid").
 const bodySource = (names: ReadonlyArray<string>, code: string): string =>
-  `export default async function(${names.join(",")}) {\n${code}\n}`
+  `export default async function(${names.join(",")}) {\n{\n${code}\n}\n}`
 
 const sandboxInput = (bindings: Bindings, ambient: Ambient | undefined, policy: WorkerLoaderSandboxPolicy) => {
   const names = scopeNames(bindings, ambient)

--- a/platform/worker-loader/src/sandbox.ts
+++ b/platform/worker-loader/src/sandbox.ts
@@ -33,6 +33,29 @@ export const DEFAULT_WORKER_LOADER_SANDBOX_POLICY: WorkerLoaderSandboxPolicy = {
   transport: "capability"
 }
 
+// RESTRICTED_NAMES are shadowed in the loaded isolate the same way the Bun sandbox shadows its
+// own (platform/bun/src/sandbox.ts): each name arrives as a parameter of the body, so the
+// identifier inside the body is undefined (or an empty globalThis) rather than the isolate's own
+// global, whatever egress the host mapped (#427). The Bun list is carried in full for the names
+// a compatibility flag can add, and the workerd-only network globals WebSocket, WebSocketPair,
+// and caches join it. A name the host bound itself stays the binding: a mounted package keeps
+// its own name, and a body that names it reaches the package, never the global (sandbox.workers.ts,
+// "a host binding keeps its own name").
+const RESTRICTED_NAMES = [
+  "globalThis",
+  "self",
+  "postMessage",
+  "fetch",
+  "WebSocket",
+  "WebSocketPair",
+  "caches",
+  "process",
+  "Bun",
+  "Worker",
+  "Function",
+  "require"
+] as const
+
 export interface SandboxBridgeBinding {
   readonly sandboxCallBatch: (
     execution: string,
@@ -254,11 +277,16 @@ const packageMethods = (binding: Bindings[string]): ReadonlyArray<string> | unde
   return entries.map(([method]) => method)
 }
 
+const scopeNames = (bindings: Bindings, ambient: Ambient | undefined): ReadonlyArray<string> => [
+  ...Object.keys({ ...bindings, console: undefined, ...(ambient === undefined ? {} : { Date: undefined, Math: undefined }) }),
+  ...RESTRICTED_NAMES.filter((name) => !Object.hasOwn(bindings, name))
+]
+
+// bodySource wraps one body as a module whose parameter list is the scope: every scope name,
+// the restricted ones included, shadows the isolate's own global with the value the harness
+// passes for it.
 const bodySource = (names: ReadonlyArray<string>, code: string): string =>
   `export default async function(${names.join(",")}) {\n${code}\n}`
-
-const scopeNames = (bindings: Bindings, ambient: Ambient | undefined): ReadonlyArray<string> =>
-  Object.keys({ ...bindings, console: undefined, ...(ambient === undefined ? {} : { Date: undefined, Math: undefined }) })
 
 const sandboxInput = (bindings: Bindings, ambient: Ambient | undefined, policy: WorkerLoaderSandboxPolicy) => {
   const names = scopeNames(bindings, ambient)
@@ -266,10 +294,15 @@ const sandboxInput = (bindings: Bindings, ambient: Ambient | undefined, policy: 
   const values: Record<string, unknown> = {}
   for (const name of names) {
     if (name === "console" || (ambient !== undefined && (name === "Date" || name === "Math"))) continue
-    const methods = packageMethods(bindings[name])
-    if (methods === undefined) values[name] = bindings[name]
+    const binding = bindings[name]
+    const methods = packageMethods(binding)
+    if (methods === undefined) values[name] = binding
     else packages[name] = methods
   }
+  // A restricted name arrives as an undefined value the harness hands the body, so the isolate
+  // cannot name its own global; globalThis is the one exception, an empty object, because the
+  // Bun sandbox blanks it that way (sandbox.workers.ts, "shadows the ambient network globals").
+  if (!Object.hasOwn(bindings, "globalThis")) values["globalThis"] = {}
   return { names, packages, values, logCapBytes: policy.logCapBytes, ...(ambient === undefined ? {} : { ambient }) }
 }
 

--- a/platform/worker-loader/src/sandbox.ts
+++ b/platform/worker-loader/src/sandbox.ts
@@ -38,9 +38,11 @@ export const DEFAULT_WORKER_LOADER_SANDBOX_POLICY: WorkerLoaderSandboxPolicy = {
 // identifier inside the body is undefined (or an empty globalThis) rather than the isolate's own
 // global, whatever egress the host mapped (#427). The Bun list is carried in full for the names
 // a compatibility flag can add, and the workerd-only network globals WebSocket, WebSocketPair,
-// and caches join it. A name the host bound itself stays the binding: a mounted package keeps
-// its own name, and a body that names it reaches the package, never the global (sandbox.workers.ts,
-// "a host binding keeps its own name").
+// and caches join it, and so does global, the Node alias nodejs_compat exposes to the real
+// global scope (sandbox.workers.ts, "shadows the Node global alias under nodejs_compat").
+// A name the host bound itself stays the binding: a mounted package keeps its own name, and a
+// body that names it reaches the package, never the global (sandbox.workers.ts, "a host binding
+// keeps its own name").
 const RESTRICTED_NAMES = [
   "globalThis",
   "self",
@@ -49,6 +51,7 @@ const RESTRICTED_NAMES = [
   "WebSocket",
   "WebSocketPair",
   "caches",
+  "global",
   "process",
   "Bun",
   "Worker",
@@ -301,7 +304,8 @@ const sandboxInput = (bindings: Bindings, ambient: Ambient | undefined, policy: 
   }
   // A restricted name arrives as an undefined value the harness hands the body, so the isolate
   // cannot name its own global; globalThis is the one exception, an empty object, because the
-  // Bun sandbox blanks it that way (sandbox.workers.ts, "shadows the ambient network globals").
+  // Bun sandbox blanks it that way (sandbox.workers.ts, "shadows the ambient network globals in
+  // the body scope").
   if (!Object.hasOwn(bindings, "globalThis")) values["globalThis"] = {}
   return { names, packages, values, logCapBytes: policy.logCapBytes, ...(ambient === undefined ? {} : { ambient }) }
 }

--- a/platform/worker-loader/test/sandbox.workers.ts
+++ b/platform/worker-loader/test/sandbox.workers.ts
@@ -87,6 +87,59 @@ describe("worker loader sandbox", () => {
     expect(result).toEqual({ result: "blocked" })
   })
 
+  // Shadowing is the harness's own defense, independent of the egress mapping the test fixture
+  // states: the identifiers a body could use to name an ambient network are parameters of the
+  // body, undefined (sandbox.ts, RESTRICTED_NAMES).
+  test("shadows the ambient network globals in the body scope", async () => {
+    const sandbox = workerLoaderSandboxServiceFor((env as Env).LOADER, bridgeFor)
+    const result = await Effect.runPromise(sandbox.run(
+      `return {
+        fetch: typeof fetch,
+        WebSocket: typeof WebSocket,
+        WebSocketPair: typeof WebSocketPair,
+        caches: typeof caches,
+        self: typeof self,
+        postMessage: typeof postMessage,
+        process: typeof process,
+        Bun: typeof Bun,
+        Worker: typeof Worker,
+        Function: typeof Function,
+        require: typeof require,
+        globalThis: typeof globalThis,
+        globalKeys: Object.keys(globalThis).length
+      }`,
+      {}
+    ))
+    expect(result).toEqual({
+      result: {
+        fetch: "undefined",
+        WebSocket: "undefined",
+        WebSocketPair: "undefined",
+        caches: "undefined",
+        self: "undefined",
+        postMessage: "undefined",
+        process: "undefined",
+        Bun: "undefined",
+        Worker: "undefined",
+        Function: "undefined",
+        require: "undefined",
+        globalThis: "object",
+        globalKeys: 0
+      }
+    })
+  })
+
+  test("a host binding keeps its own name", async () => {
+    const sandbox = workerLoaderSandboxServiceFor((env as Env).LOADER, () => {
+      throw new Error("replay transport must not open a capability")
+    }, { transport: "replay" })
+    const result = await Effect.runPromise(sandbox.run(
+      `return typeof fetch === "object" ? await fetch.hello() : "shadowed"`,
+      { fetch: { hello: async () => sandboxReturned("bound") } }
+    ))
+    expect(result).toEqual({ result: "bound" })
+  })
+
   test("replays sequential and concurrent package calls", async () => {
     const { result, observed } = await replaySequenceWith((env as Env).LOADER)
 

--- a/platform/worker-loader/test/sandbox.workers.ts
+++ b/platform/worker-loader/test/sandbox.workers.ts
@@ -148,6 +148,19 @@ describe("worker loader sandbox", () => {
     expect(result).toEqual({ result: { global: "undefined", globalFetch: "undefined" } })
   })
 
+  // The harness wraps the body in a nested block of the parameter-scoped function, so a body
+  // that declares a scoped name itself stays parseable and reaches its own binding, while the
+  // names it leaves alone keep the shadowed values (sandbox.ts, bodySource).
+  test("a local declaration of a scoped name stays valid", async () => {
+    const sandbox = workerLoaderSandboxServiceFor((env as Env).LOADER, bridgeFor)
+    const result = await Effect.runPromise(sandbox.run(
+      `const fetch = () => "local"
+      return { fetch: fetch(), require: typeof require, global: typeof global }`,
+      {}
+    ))
+    expect(result).toEqual({ result: { fetch: "local", require: "undefined", global: "undefined" } })
+  })
+
   test("a host binding keeps its own name", async () => {
     const sandbox = workerLoaderSandboxServiceFor((env as Env).LOADER, () => {
       throw new Error("replay transport must not open a capability")

--- a/platform/worker-loader/test/sandbox.workers.ts
+++ b/platform/worker-loader/test/sandbox.workers.ts
@@ -106,6 +106,7 @@ describe("worker loader sandbox", () => {
         Function: typeof Function,
         require: typeof require,
         globalThis: typeof globalThis,
+        global: typeof global,
         globalKeys: Object.keys(globalThis).length
       }`,
       {}
@@ -124,9 +125,27 @@ describe("worker loader sandbox", () => {
         Function: "undefined",
         require: "undefined",
         globalThis: "object",
+        global: "undefined",
         globalKeys: 0
       }
     })
+  })
+
+  // nodejs_compat exposes global, Node's alias for the real global scope, so a loaded isolate
+  // under that flag must not name the ambient network through it (sandbox.ts,
+  // RESTRICTED_NAMES).
+  test("shadows the Node global alias under nodejs_compat", async () => {
+    const sandbox = workerLoaderSandboxServiceFor((env as Env).LOADER, bridgeFor, {
+      compatibilityFlags: ["nodejs_compat"]
+    })
+    const result = await Effect.runPromise(sandbox.run(
+      `return {
+        global: typeof global,
+        globalFetch: typeof global === "undefined" ? "undefined" : typeof global.fetch
+      }`,
+      {}
+    ))
+    expect(result).toEqual({ result: { global: "undefined", globalFetch: "undefined" } })
   })
 
   test("a host binding keeps its own name", async () => {


### PR DESCRIPTION
[👾 omp · openrouter/z-ai/glm-5.3 · agency: directed · intent: add an opt-in fetch URL policy and shadow the network globals in the Worker Loader harness]

## Change and reason

Two defense-in-depth asks from #427, filed by a team running Code Mode on a self-hosted celld fleet. They unmount the `fetch` package from hostile-code cells today, but the Worker Loader path stays risky for anyone who keeps it mounted. This PR implements both asks as two independent changes, an opt-in `urlPolicy` on the fetch package and shadowing of the network globals in the Worker Loader harness.

- The fetch package pins no origin and accepts any method, host, and body. With unrestricted egress, a prompt-injected body can reach loopback, an operator port, cloud metadata, or in-cluster services, and follow a redirect into any of them.
- The Worker Loader harness shadows no global, so in the loaded isolate the identifier `fetch` exists and is inert only because the host maps `globalOutbound: null` to a deny policy. The safety of an isolate with no ambient network rests entirely on the host's egress mapping, with nothing behind it in the harness.

Both changes are opt-in or harness-internal. A host that mounts nothing new sees no behavior change.

## The urlPolicy on the fetch package

`FetchPolicy` gains an optional `urlPolicy: "public-only"`, opt-in beside the existing `bodyChars` cap. When it is set, a URL may name a public host only:

- every literal IPv4 or IPv6 address is refused, whichever range it sits in, which covers the private ranges the issue names, loopback, link-local, and the rest of IANA's special-purpose ranges the classifier names;
- the loopback name `localhost` (and any name under it) is refused;
- the scheme must be http or https;
- a redirect is refused two ways: the package pins the transport's redirect handling to error through `FetchHttpClient`'s per-request `RequestInit` service, merged over whatever defaults the host set, and a 3xx answer with a location is refused even if the transport surfaces it anyway.

A refusal is an answer with an `error`, never a thrown effect, like a transport failure. The refusal reads the parsed URL, so a literal written any odd way is canonicalized before the check (`0x7f.1` arrives as `127.0.0.1`).

The method docs gain the restriction sentence when the policy is on, so the model reads the rule in the tool it is about to call. Without the policy the package is the open one it was, and redirects are followed as before (fetch.test.ts, "a redirect is followed when no urlPolicy is set").

The boundary the issue draws is the URL itself. A public DNS name that resolves into a private range is not caught, because the policy never does a lookup. Redirect refusal closes the cheap pivot. Full DNS pinning stays with the credentialed doors.

## Shadowing the network globals in the Worker Loader harness

The Bun sandbox blanks `globalThis`, `self`, `postMessage`, `fetch`, `process`, `Bun`, `Worker`, `Function`, and `require` (platform/bun/src/sandbox.ts). The Worker Loader harness now shadows the same list, carried in full for the names a compatibility flag can add, plus the workerd-only network globals `WebSocket`, `WebSocketPair`, and `caches`, and `global`, the Node alias `nodejs_compat` exposes to the real global scope, so under that flag a body cannot name `global.fetch` (sandbox.workers.ts, "shadows the Node global alias under nodejs_compat").

Every restricted name becomes a parameter of the body, so the identifier inside the body is undefined, or an empty object for `globalThis`, whatever the host mapped. An isolate meant to have no ambient network cannot name one. The host's egress mapping stays the primary defense, and the shadowing is the layer behind it.

The body itself sits in a nested block of the parameter-scoped function, so a body that declares a scoped name with `const`, `let`, or `class` keeps its own binding and stays parseable instead of colliding with the shadowing parameter at module parse (sandbox.workers.ts, "a local declaration of a scoped name stays valid").

A host binding keeps its own name. A mounted package named `fetch` shadows the global for that name, and a body that names it reaches the package (sandbox.workers.ts, "a host binding keeps its own name").

## Non-goals

- The default fetch package is unchanged. Without a `urlPolicy`, the package accepts any host and any method, and follows redirects, exactly as before.
- The package still pins no origin. A credentialed provider keeps the other shape, a `Connection` and its door.
- The shadowing does not restrict dynamic `import`, which no harness here constrains.

## Verification

At `db34dc803f737eacb34d449cd8f4807bf9c1ade1` on `fix/harden-worker-loader`, based on `main` at `d8321f2ff74b7d87f066aaf3b024ffed185e90da`. This is the branch tip.

```
cd packages/code && bun test src/package/fetch.test.ts   # 18 pass, 0 fail (9 urlPolicy cases)
cd platform/worker-loader && bun test                   # 7 pass, 0 fail
cd platform/worker-loader && bun run test:workers       # 10 pass, 0 fail on workerd
```

```
bun run gate                                            # exit 0, all 154 tasks PASS (22.7s)
```
