### PR TITLE
feat(agent): typed durable Ask for schema HITL

### DIFF
--- a/docs/getting-started/concepts.mdx
+++ b/docs/getting-started/concepts.mdx
@@ -54,7 +54,7 @@ Tardigrade builds an agent harness from a small set of primitives. Events record
   <div className="concept-copy">
     <h2>Components</h2>
     <p>A component is a named projection. Its output contains a view for its parent and the transitions that are enabled in the current state.</p>
-    <p>Components are pure. Given the same state, they produce the same output without performing external work. Components can contain other components, which lets an actor combine inference, tools, budgets, compaction, permissions, and output policies.</p>
+    <p>Components are pure. Given the same state, they produce the same output without performing external work. Components can contain other components, which lets an actor combine inference, tools, budgets, compaction, permissions, human asks, and output policies.</p>
   </div>
 
   <ConceptInterface>

--- a/docs/how-to/human-asks.md
+++ b/docs/how-to/human-asks.md
@@ -1,0 +1,106 @@
+---
+title: Ask a human from a turn
+description: Park an agent turn on a schema-shaped question and resume when the answer is durable.
+route: /docs/human-asks
+section: How To
+order: 31
+---
+
+Mount `ask` when a turn must wait for a human fact or decision. The model calls the `ask` tool with a prompt and a JSON Schema. The component records `AskRequested` and parks until `AskAnswered` or `AskDenied` lands on the same thread. The answer is validated against the schema before the tool returns, so the model sees a value of that contract.
+
+The schema uses the same closed object profile as output contracts: every property is required, and `additionalProperties` is `false`. Pass a schema at assembly time when every ask on that actor uses one contract. Omit it when the model chooses a schema per question.
+
+```ts
+import { actor } from "tardie/core"
+import { agentMethods, ask, budget, codeMode, compaction, infer, nativeOutput } from "tardie/agent"
+
+const APPROVAL = {
+  type: "object",
+  properties: {
+    approved: { type: "boolean", description: "Whether the human accepts the proposed action." },
+    note: { type: "string", description: "Anything the agent should know before it continues." }
+  },
+  required: ["approved", "note"],
+  additionalProperties: false
+}
+
+export const analyst = actor({
+  name: "analyst",
+  methods: agentMethods,
+  components: [
+    infer([
+      ask([budget([codeMode()])], { schema: APPROVAL }),
+      compaction(),
+      nativeOutput
+    ])
+  ]
+})
+```
+
+`boundaryOf(log, turn)` reads `kind: "asking"` while the question is unanswered. `turnViewOf(log, turn)` is the client `TurnView`: `status` is `"parked"` and `ask` carries `{ kind: "schema", callId, prompt, schema }`. A budget wall still reads as `{ kind: "budget", callId, reason, amount }` on the same field. A terminal wins over a park, so a later `TurnCompleted` is completed.
+
+Append the human's reply through the thread log. `callId` is the parked ask's id. `answer` must satisfy the recorded schema. `AskDenied` unparks with `{ denied: true }` so the model can finish without that fact.
+
+```ts
+import { turnViewOf } from "tardie/agent"
+
+declare const log: ReadonlyArray<{ readonly type: string; readonly id?: string }>
+declare const append: (event: { readonly type: string; readonly callId: string; readonly answer?: unknown; readonly turn: string; readonly at: number }) => Promise<void>
+
+export const answerParkedAsk = async (turn: string, answer: { approved: boolean; note: string }, at: number) => {
+  const view = turnViewOf(log as never, turn)
+  if (view.status !== "parked" || view.ask?.kind !== "schema") return
+  await append({ type: "AskAnswered", callId: view.ask.callId, answer, turn, at })
+}
+```
+
+The HTTP client follows the same shape. `resume` refuses a parked epoch, because resume starts the next execution after a failure, and an unanswered ask is still the current epoch. Answer the ask, then wait for the turn to continue.
+
+```ts
+import { makeActorClient, turnViewOf } from "tardie/client"
+
+const client = makeActorClient({ baseUrl: "http://localhost:4242" })
+
+const events = await client.events("main", "root")
+const view = turnViewOf(events.map((row) => row.event), "m1")
+if (view.status === "parked" && view.ask?.kind === "schema") {
+  await client.append("main", "root", {
+    type: "AskAnswered",
+    callId: view.ask.callId,
+    answer: { approved: true, note: "ship it" },
+    turn: "m1"
+  })
+}
+```
+
+An optional `authority` sends `requestAsk` to another actor for the decision. `askCaller()` selects the actor that invoked the current message. `askAuthority({ decide })` decides locally. `askAuthority.manual()` leaves `requestAsk` pending so an external process can append `AskRequestDecided`. The agent records `AskRequested` / `AskAnswered` / `AskDenied` on its own log, so `boundaryOf` and `TurnView` remain readable without following the authority call.
+
+```ts
+import { actor } from "tardie/core"
+import { agentMethods, ask, askAuthority, budget, codeMode, compaction, infer, nativeOutput, requestAskMethod } from "tardie/agent"
+
+export const human = actor({
+  name: "human",
+  methods: { requestAsk: requestAskMethod },
+  components: [askAuthority.manual()]
+})
+
+export const worker = actor({
+  name: "worker",
+  methods: agentMethods,
+  components: [
+    infer([
+      ask([budget([codeMode()])], {
+        authority: { coordinate: { actor: "human", instance: "main", thread: "inbox" }, methods: { requestAsk: requestAskMethod } },
+        timeoutMs: 3_600_000
+      }),
+      compaction(),
+      nativeOutput
+    ])
+  ]
+})
+```
+
+`timeoutMs` bounds the authority call. When omitted, the call uses `DEFAULT_ACTOR_METHOD_TIMEOUT_MS` from the actor method. When set, it must be a positive safe integer. Same-thread answers have no timeout: the turn stays parked until `AskAnswered` or `AskDenied` is recorded.
+
+`requestAskMethod` uses Effect schemas `AskRequestInput` and `AskDecision`. The per-ask JSON Schema is the `schema` field on that input. A local authority validates `answered` against that schema before it records `AskRequestDecided`. An invalid same-thread `AskAnswered` becomes a tool error, so the model can ask again under a new `callId`.

--- a/docs/references/sdk.mdx
+++ b/docs/references/sdk.mdx
@@ -17,7 +17,7 @@ Most applications can import their actor definition, agent components, policies,
 
 ```ts
 import { actor } from "tardie/core"
-import { agentMethods, budget, codeMode, compaction, infer, nativeOutput, system, tool } from "tardie/agent"
+import { agentMethods, ask, budget, codeMode, compaction, infer, nativeOutput, system, tool } from "tardie/agent"
 ```
 
 ## Core primitives

--- a/packages/agent/src/actor/ask.test.ts
+++ b/packages/agent/src/actor/ask.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test"
+import { Schema } from "effect"
+import type { Event } from "@clavia/tardigrade-core/log/event"
+import { AgentEvent } from "../log/events"
+import { requestAskMethod } from "./ask"
+
+const request = requestAskMethod.event({
+  invocation: { method: "requestAsk", id: "ask-1", epoch: 0 },
+  input: {
+    request: "tool-1",
+    turn: "run-1",
+    prompt: "Approve the release?",
+    schema: {
+      type: "object",
+      properties: { approved: { type: "boolean" } },
+      required: ["approved"],
+      additionalProperties: false
+    }
+  },
+  at: 1
+})
+
+describe("requestAskMethod", () => {
+  test("projects one answer or denial terminal for its call", () => {
+    const invocation = { method: "requestAsk", id: "ask-1", epoch: 0 }
+    expect(requestAskMethod.state([], invocation)).toBeUndefined()
+    expect(requestAskMethod.state([request], invocation)).toEqual({ status: "pending" })
+    expect(requestAskMethod.state([
+      request,
+      { type: "AskRequestDecided", callId: "ask-1", denied: false, answer: { approved: true }, at: 2 } as Event
+    ], invocation)).toEqual({ status: "completed", output: { answered: { approved: true } } })
+    expect(requestAskMethod.state([
+      request,
+      { type: "AskRequestDecided", callId: "ask-1", denied: true, reason: "needs review", at: 2 } as Event
+    ], invocation)).toEqual({ status: "completed", output: { denied: true, reason: "needs review" } })
+    expect(requestAskMethod.state([
+      request,
+      { type: "AskRequestFailed", callId: "ask-1", error: "authority unavailable", at: 2 } as Event
+    ], invocation)).toEqual({ status: "failed", error: "authority unavailable" })
+  })
+
+  test("AskRequested is an AgentEvent", () => {
+    expect(Schema.decodeSync(AgentEvent)({
+      type: "AskRequested",
+      callId: "a1",
+      prompt: "Approve the release?",
+      schema: {
+        type: "object",
+        properties: { approved: { type: "boolean" } },
+        required: ["approved"],
+        additionalProperties: false
+      },
+      turn: "m1",
+      at: 1
+    })).toMatchObject({ type: "AskRequested", callId: "a1" })
+  })
+})

--- a/packages/agent/src/actor/ask.ts
+++ b/packages/agent/src/actor/ask.ts
@@ -1,0 +1,78 @@
+import { Schema } from "effect"
+import type { Event } from "@clavia/tardigrade-core/event"
+import { actorMethod } from "@clavia/tardigrade-core/actor/method"
+import { askRequestReceived } from "../log/events"
+
+export const AskRequestInput = Schema.Struct({
+  request: Schema.String,
+  turn: Schema.String,
+  prompt: Schema.String,
+  schema: Schema.Unknown
+}).annotate({ identifier: "AskRequestInput" })
+
+export type AskRequestInput = typeof AskRequestInput.Type
+
+export const AskDecision = Schema.Union([
+  Schema.Struct({ answered: Schema.Unknown }),
+  Schema.Struct({ denied: Schema.Literal(true), reason: Schema.optionalKey(Schema.String) })
+]).annotate({ identifier: "AskDecision" })
+
+export type AskDecision = typeof AskDecision.Type
+
+interface AskMethodProjection {
+  readonly received: ReadonlySet<string>
+  readonly decided: ReadonlyMap<string, { readonly denied?: unknown; readonly answer?: unknown; readonly reason?: unknown }>
+  readonly failed: ReadonlyMap<string, string>
+}
+
+const reduceAskMethod = (state: AskMethodProjection, event: Event): AskMethodProjection => {
+  const received = new Set(state.received)
+  const decided = new Map(state.decided)
+  const failed = new Map(state.failed)
+  if (event.type === "AskRequestReceived") received.add(String((event as { readonly id?: unknown }).id ?? ""))
+  if (event.type === "AskRequestDecided") {
+    decided.set(
+      String((event as { readonly callId?: unknown }).callId ?? ""),
+      event as { readonly denied?: unknown; readonly answer?: unknown; readonly reason?: unknown }
+    )
+  }
+  if (event.type === "AskRequestFailed") {
+    failed.set(
+      String((event as { readonly callId?: unknown }).callId ?? ""),
+      String((event as { readonly error?: unknown }).error ?? "ask authority failed")
+    )
+  }
+  return { received, decided, failed }
+}
+
+const askStateFrom = (state: AskMethodProjection, id: string) => {
+  if (!state.received.has(id)) return undefined
+  const failure = state.failed.get(id)
+  if (failure !== undefined) return { status: "failed" as const, error: failure }
+  const decision = state.decided.get(id)
+  if (decision === undefined) return { status: "pending" as const }
+  return decision.denied === true
+    ? {
+        status: "completed" as const,
+        output: {
+          denied: true as const,
+          ...(typeof decision.reason === "string" && decision.reason !== "" ? { reason: decision.reason } : {})
+        }
+      }
+    : { status: "completed" as const, output: { answered: decision.answer } }
+}
+
+// requestAskMethod exposes one schema-shaped human question as a unary actor call.
+export const requestAskMethod = actorMethod({
+  input: AskRequestInput,
+  output: AskDecision,
+  event: ({ invocation, input, at }) => askRequestReceived({ id: invocation.id, ...input, at }),
+  projection: {
+    initial: (): AskMethodProjection => ({ received: new Set(), decided: new Map(), failed: new Map() }),
+    step: reduceAskMethod,
+    output: (state) => ({
+      currentEpoch: () => 0,
+      invocationState: (invocation) => askStateFrom(state, invocation.id)
+    })
+  }
+})

--- a/packages/agent/src/component/ask-authority.test.ts
+++ b/packages/agent/src/component/ask-authority.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test"
+import { deriveComponent } from "@clavia/tardigrade-core/component"
+import { componentContractOf } from "@clavia/tardigrade-core/actor"
+import type { Event } from "@clavia/tardigrade-core/log/event"
+import { requestAskMethod } from "../actor/ask"
+import { askAuthority, askAuthorityKeys } from "./ask-authority"
+
+const schema = {
+  type: "object",
+  properties: { approved: { type: "boolean" } },
+  required: ["approved"],
+  additionalProperties: false
+}
+
+const received: Event = {
+  type: "AskRequestReceived",
+  id: "ask-1",
+  request: "tool-1",
+  turn: "run-1",
+  prompt: "Approve the release?",
+  schema,
+  at: 1
+}
+
+const eventsOf = (
+  component: ReturnType<typeof askAuthority> | ReturnType<typeof askAuthority.manual>,
+  log: ReadonlyArray<Event>
+): ReadonlyArray<Event> => {
+  const transition = deriveComponent(component, log).transitions[0]
+  if (transition === undefined) return []
+  expect(transition.kind).toBe("intent")
+  return transition.kind === "intent" ? transition.events(transition.input, 2) : []
+}
+
+describe("askAuthority", () => {
+  test("records a local answer and then rests", () => {
+    const component = askAuthority({ decide: (request) => request.answer({ approved: true }) })
+    const events = eventsOf(component, [received])
+
+    expect(events).toMatchObject([{
+      type: "AskRequestDecided",
+      callId: "ask-1",
+      denied: false,
+      answer: { approved: true },
+      at: 2
+    }])
+    expect(askAuthorityKeys.keyOf(events[0]!)).toBe("aa:ask-1")
+    expect(deriveComponent(component, [received, ...events]).transitions).toEqual([])
+    expect(componentContractOf(component).handles).toEqual([{
+      method: requestAskMethod,
+      handling: "local"
+    }])
+  })
+
+  test("records a local denial", () => {
+    const component = askAuthority({ decide: (request) => request.deny("needs review") })
+    const events = eventsOf(component, [received])
+
+    expect(events).toMatchObject([{
+      type: "AskRequestDecided",
+      callId: "ask-1",
+      denied: true,
+      reason: "needs review",
+      at: 2
+    }])
+  })
+
+  test("turns an invalid answer into a durable method failure", () => {
+    const component = askAuthority({ decide: (request) => request.answer({ approved: "yes" }) })
+    const events = eventsOf(component, [received])
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toEqual(expect.objectContaining({
+      type: "AskRequestFailed",
+      callId: "ask-1",
+      error: expect.stringContaining("ask answer misses the schema")
+    }))
+  })
+
+  test("a manual authority declares external handling and schedules no decision", () => {
+    const component = askAuthority.manual()
+
+    expect(deriveComponent(component, [received]).transitions).toEqual([])
+    expect(componentContractOf(component).handles).toEqual([{
+      method: requestAskMethod,
+      handling: "external"
+    }])
+  })
+})

--- a/packages/agent/src/component/ask-authority.ts
+++ b/packages/agent/src/component/ask-authority.ts
@@ -1,0 +1,149 @@
+import { bindTransitionContext } from "@clavia/tardigrade-core/transition/transition"
+import type { Event } from "@clavia/tardigrade-core/log/event"
+import { HashMap, HashSet, Schema } from "effect"
+import type { KeyFragment } from "@clavia/tardigrade-core/log"
+import { type Transition } from "@clavia/tardigrade-core/runtime"
+import { externallyHandled, handles, component as defineComponent, type Component } from "@clavia/tardigrade-core/actor"
+import { formatThreadAddress, isThreadAddress } from "@clavia/tardigrade-core/transport/endpoint"
+import { AskDecision, requestAskMethod } from "../actor/ask"
+import { askRequestDecided, askRequestFailed } from "../log/events"
+import { outputErrors, outputProfileErrors } from "../output/contract"
+
+// AskRequest describes one durable authority call and supplies its valid decisions.
+export interface AskRequest {
+  readonly id: string
+  readonly request: string
+  readonly turn: string
+  readonly prompt: string
+  readonly schema: unknown
+  readonly from?: string
+  readonly answer: (value: unknown) => AskDecision
+  readonly deny: (reason?: string) => AskDecision
+}
+
+// DecideAsk is the pure local policy implemented by askAuthority.
+export type DecideAsk = (request: AskRequest) => AskDecision
+
+export interface AskAuthorityOptions {
+  readonly decide: DecideAsk
+}
+
+// askAuthorityKeys owns ask authority calls and their terminal outcomes.
+export const askAuthorityKeys: KeyFragment = {
+  prefixes: ["aar:", "aa:"],
+  keyOf: (event) => {
+    const value = event as Record<string, unknown>
+    if (event.type === "AskRequestReceived") return `aar:${String(value.id)}`
+    return event.type === "AskRequestDecided" || event.type === "AskRequestFailed"
+      ? `aa:${String(value.callId)}`
+      : undefined
+  }
+}
+
+const failureMessage = (failure: unknown): string =>
+  failure instanceof Error ? failure.message : String(failure)
+
+type ReceivedAskRequest = Event & {
+  readonly id?: unknown
+  readonly request?: unknown
+  readonly turn?: unknown
+  readonly prompt?: unknown
+  readonly schema?: unknown
+  readonly link?: { readonly source?: unknown }
+}
+
+interface AskAuthorityState {
+  readonly next: number
+  readonly pending: HashMap.HashMap<string, { readonly order: number; readonly event: ReceivedAskRequest }>
+  readonly settled: HashSet.HashSet<string>
+}
+
+const reduceAuthority = (state: AskAuthorityState, event: Event): AskAuthorityState => {
+  if (event.type === "AskRequestDecided" || event.type === "AskRequestFailed") {
+    const id = String((event as { readonly callId?: unknown }).callId ?? "")
+    return {
+      ...state,
+      pending: HashMap.remove(state.pending, id),
+      settled: HashSet.add(state.settled, id)
+    }
+  }
+  if (event.type !== "AskRequestReceived") return state
+  const received = event as ReceivedAskRequest
+  const id = String(received.id ?? "")
+  return HashSet.has(state.settled, id) || HashMap.has(state.pending, id)
+    ? state
+    : {
+        ...state,
+        next: state.next + 1,
+        pending: HashMap.set(state.pending, id, { order: state.next, event: received })
+      }
+}
+
+const answerErrors = (schema: unknown, value: unknown): ReadonlyArray<string> => {
+  const profile = outputProfileErrors(schema)
+  return profile.length > 0 ? profile : outputErrors(schema, value)
+}
+
+const authorityTransition = (
+  received: ReceivedAskRequest | undefined,
+  decide: DecideAsk
+): Transition<never> | undefined => {
+  if (received === undefined) return undefined
+
+  const id = String(received.id ?? "")
+  const context = bindTransitionContext(received, "ask-authority")
+  const request: AskRequest = {
+    id,
+    request: String(received.request ?? ""),
+    turn: String(received.turn ?? ""),
+    prompt: String(received.prompt ?? ""),
+    schema: received.schema,
+    ...(isThreadAddress(received.link?.source) ? { from: formatThreadAddress(received.link.source) } : {}),
+    answer: (value) => ({ answered: value }),
+    deny: (reason) => ({ denied: true, ...(reason === undefined ? {} : { reason }) })
+  }
+
+  try {
+    const decision = Schema.decodeSync(AskDecision)(decide(request))
+    if ("answered" in decision) {
+      const errors = answerErrors(received.schema, decision.answered)
+      if (errors.length > 0) {
+        throw new Error(`ask answer misses the schema:\n${errors.map((error) => `- ${error}`).join("\n")}`)
+      }
+      return context.intent("decide", (at) => askRequestDecided({ callId: id, denied: false, answer: decision.answered, at }))
+    }
+    return context.intent("decide", (at) => askRequestDecided({
+      callId: id, denied: true, ...("denied" in decision && decision.reason !== undefined ? { reason: decision.reason } : {}), at
+    }))
+  } catch (failure) {
+    return context.intent("decide", (at) => askRequestFailed({ callId: id, error: failureMessage(failure), at }))
+  }
+}
+
+const authorityComponent = (decide?: DecideAsk): Component<undefined> => {
+  const component: Component<undefined> = defineComponent({
+    name: "ask-authority",
+    initial: (): AskAuthorityState => ({ next: 0, pending: HashMap.empty(), settled: HashSet.empty() }),
+    step: reduceAuthority,
+    output: (state) => {
+      if (decide === undefined) return { view: undefined, transitions: [] }
+      const received = Array.from(HashMap.values(state.pending))
+        .reduce((first, candidate) => first === undefined || candidate.order < first.order ? candidate : first, undefined as { readonly order: number; readonly event: ReceivedAskRequest } | undefined)
+        ?.event
+      const transition = authorityTransition(received, decide)
+      return { view: undefined, transitions: transition === undefined ? [] : [transition] }
+    }
+  })
+  return decide === undefined
+    ? externallyHandled(requestAskMethod, { ...component, keys: askAuthorityKeys })
+    : handles(requestAskMethod, { ...component, keys: askAuthorityKeys })
+}
+
+// askAuthority handles requestAsk with a pure local decision policy.
+export const askAuthority = Object.assign(
+  (options: AskAuthorityOptions): Component<undefined> => authorityComponent(options.decide),
+  {
+    // askAuthority.manual leaves requestAsk pending for an external decision.
+    manual: (): Component<undefined> => authorityComponent()
+  }
+)

--- a/packages/agent/src/component/ask.test.ts
+++ b/packages/agent/src/component/ask.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+import { KeyValueStore } from "effect/unstable/persistence"
+import type { Event } from "@clavia/tardigrade-core/log/event"
+import { EventLog, withWatermark } from "@clavia/tardigrade-core/log"
+import { actor, componentContractOf } from "@clavia/tardigrade-core/actor"
+import { Self, enabled } from "@clavia/tardigrade-core/runtime"
+import { Router } from "@clavia/tardigrade-core/transport/router"
+import { ThreadAllocator } from "@clavia/tardigrade-core/actor/allocation"
+import { parseThreadAddress, threadAddressOf } from "@clavia/tardigrade-core/transport/endpoint"
+import { linkOf } from "@clavia/tardigrade-core/transport/link"
+import { Infer } from "../runtime/turn"
+import { NativeOutputSupport } from "../inference/contract"
+import { infer, renderOf } from "../runtime/composition"
+import { nativeOutput } from "./native-output"
+import { tool } from "./tool"
+import { agentMethods } from "../actor/methods"
+import { agentKeys } from "../log/events"
+import { ask, askCaller, ASK_TOOL_NAME } from "./ask"
+import { requestAskMethod } from "../actor/ask"
+import { boundaryOf, turnViewOf } from "../output/boundary"
+import { createHost, type Host, type ThreadEnv } from "@clavia/tardigrade-host/host"
+import { actorRuntimeOf } from "@clavia/tardigrade-core/runtime/actor"
+import type { Action } from "../log/events"
+import type { InferRequest } from "../inference/contract"
+import type { AgentR } from "../runtime/turn"
+
+const TEST_MODEL = { models: { default: { provider: "test", model_id: "test-model" }, allow: "*" } } as const
+
+const APPROVAL = {
+  type: "object",
+  properties: { approved: { type: "boolean" } },
+  required: ["approved"],
+  additionalProperties: false
+} as const
+
+const assembled = <R>(component: import("../runtime/composition").AgentComponent<R>) => actor({
+  name: "test-agent",
+  methods: agentMethods,
+  components: [component]
+})
+
+const echo = tool({
+  spec: { name: "echo", description: "echo", inputSchema: { type: "object" } },
+  run: (input) => Effect.succeed(input)
+})
+
+const rootActor = assembled(infer([ask([echo]), nativeOutput], TEST_MODEL))
+const rootReactor = (events: ReadonlyArray<Event>) => enabled(rootActor, events)
+
+const rest = Layer.mergeAll(
+  Layer.succeed(ThreadAllocator, { allocate: () => Effect.die(new Error("unexpected child allocation")) }),
+  KeyValueStore.layerMemory,
+  Layer.succeed(Router, {
+    send: () => Effect.void
+  }),
+  Layer.succeed(Self, parseThreadAddress("test-agent:main:main")),
+  Layer.succeed(NativeOutputSupport, { withTools: true }),
+  Layer.succeed(Infer, { react: () => Effect.die("the ask guard never asks the model") })
+)
+
+const dispatch = async (log: ReadonlyArray<Event>): Promise<ReadonlyArray<Event>> => {
+  const events: Event[] = [...log]
+  const memory = Layer.succeed(EventLog, withWatermark({
+    append: (more: ReadonlyArray<Event>) => Effect.sync(() => void events.push(...more)),
+    read: Effect.sync(() => events as ReadonlyArray<Event>)
+  }))
+  const derived = rootReactor(events)
+  if (derived.length > 0) {
+    const transition = derived[0]!
+    const out = transition.kind === "intent"
+      ? transition.events(transition.input, 0)
+      : await Effect.runPromise(
+          transition.act(transition.input, new AbortController().signal).pipe(Effect.provide(Layer.mergeAll(memory, rest)))
+        )
+    events.push(...out)
+  }
+  return events.slice(log.length)
+}
+
+const asked = (extra: Event[] = []): Event[] => [
+  { type: "MessageReceived", id: "m1", text: "go", at: 0 },
+  { type: "ToolCalled", callId: "a1", name: ASK_TOOL_NAME, arguments: { prompt: "Approve the release?", schema: APPROVAL }, turn: "m1", at: 1 },
+  ...extra
+]
+
+describe("ask", () => {
+  test("the ask tool is offered beside child tools", () => {
+    const rendered = renderOf([ask([echo]), nativeOutput], [])
+    expect(rendered.tools.map((item) => item.name)).toEqual(["echo", ASK_TOOL_NAME])
+    expect(rendered.system).toContain("call ask with a prompt and a JSON Schema")
+  })
+
+  test("a mounted schema is the only ask argument and is validated at construction", () => {
+    const rendered = renderOf([ask([echo], { schema: APPROVAL }), nativeOutput], [])
+    expect(rendered.tools[1]?.inputSchema).toEqual({
+      type: "object",
+      properties: { prompt: expect.any(Object) },
+      required: ["prompt"],
+      additionalProperties: false
+    })
+    expect(rendered.system).toContain("the schema this assembly mounted")
+    expect(() => ask([echo], { schema: { type: "string" } })).toThrow("ask schema is not declarable")
+    expect(() => ask([echo], { timeoutMs: 0 })).toThrow("ask timeoutMs must be a positive safe integer")
+  })
+
+  test("calling ask records AskRequested and parks the turn", async () => {
+    const out = await dispatch(asked())
+    expect(out).toMatchObject([{ type: "AskRequested", callId: "a1", prompt: "Approve the release?", turn: "m1" }])
+    expect(agentKeys.keyOf(out[0]!)).toBe("ar:a1")
+    const parked = [...asked(), ...out]
+    expect(await dispatch(parked)).toEqual([])
+    expect(boundaryOf(parked, "m1")).toEqual({
+      kind: "asking",
+      callId: "a1",
+      prompt: "Approve the release?",
+      schema: APPROVAL
+    })
+    expect(turnViewOf(parked, "m1")).toEqual({
+      turn: "m1",
+      status: "parked",
+      epoch: 0,
+      ask: { kind: "schema", callId: "a1", prompt: "Approve the release?", schema: APPROVAL }
+    })
+  })
+
+  test("AskAnswered unparks with the typed value", async () => {
+    const parked = asked([{
+      type: "AskRequested",
+      callId: "a1",
+      prompt: "Approve the release?",
+      schema: APPROVAL,
+      turn: "m1",
+      at: 2
+    }])
+    const out = await dispatch([
+      ...parked,
+      { type: "AskAnswered", callId: "a1", answer: { approved: true }, turn: "m1", at: 3 }
+    ])
+    expect(out).toMatchObject([{ type: "ToolReturned", callId: "a1", result: { answered: { approved: true } } }])
+    expect(boundaryOf([...parked, { type: "AskAnswered", callId: "a1", answer: { approved: true }, turn: "m1", at: 3 }], "m1")).toBeUndefined()
+  })
+
+  test("AskDenied unparks with the denial", async () => {
+    const parked = asked([{
+      type: "AskRequested",
+      callId: "a1",
+      prompt: "Approve the release?",
+      schema: APPROVAL,
+      turn: "m1",
+      at: 2
+    }])
+    const out = await dispatch([
+      ...parked,
+      { type: "AskDenied", callId: "a1", reason: "needs review", turn: "m1", at: 3 }
+    ])
+    expect(out).toMatchObject([{ type: "ToolReturned", callId: "a1", result: { denied: true, reason: "needs review" } }])
+    expect(agentKeys.keyOf({ type: "AskDenied", callId: "a1", turn: "m1", at: 3 })).toBe("adec:a1")
+    expect(agentKeys.keyOf({ type: "AskAnswered", callId: "a1", answer: {}, turn: "m1", at: 3 })).toBe("adec:a1")
+  })
+
+  test("an invalid schema does not park", async () => {
+    const out = await dispatch([
+      { type: "MessageReceived", id: "m1", text: "go", at: 0 },
+      { type: "ToolCalled", callId: "a1", name: ASK_TOOL_NAME, arguments: { prompt: "Approve?", schema: { type: "string" } }, turn: "m1", at: 1 }
+    ])
+    expect(out[0]!.type).toBe("ToolReturned")
+    expect(String((out[0] as { result?: { error?: string } }).result?.error)).toContain("ask schema is not declarable")
+    expect(boundaryOf([
+      { type: "MessageReceived", id: "m1", text: "go", at: 0 },
+      { type: "ToolCalled", callId: "a1", name: ASK_TOOL_NAME, arguments: { prompt: "Approve?", schema: { type: "string" } }, turn: "m1", at: 1 },
+      ...out
+    ], "m1")).toBeUndefined()
+  })
+
+  test("an invalid answer is a tool error so the model can ask again", async () => {
+    const out = await dispatch(asked([
+      { type: "AskRequested", callId: "a1", prompt: "Approve the release?", schema: APPROVAL, turn: "m1", at: 2 },
+      { type: "AskAnswered", callId: "a1", answer: { approved: "yes" }, turn: "m1", at: 3 }
+    ]))
+    expect(out[0]!.type).toBe("ToolReturned")
+    expect(String((out[0] as { result?: { error?: string } }).result?.error)).toContain("ask answer misses the schema")
+  })
+
+  test("an empty prompt is refused", async () => {
+    const out = await dispatch([
+      { type: "MessageReceived", id: "m1", text: "go", at: 0 },
+      { type: "ToolCalled", callId: "a1", name: ASK_TOOL_NAME, arguments: { prompt: "  ", schema: APPROVAL }, turn: "m1", at: 1 }
+    ])
+    expect(String((out[0] as { result?: { error?: string } }).result?.error)).toContain("ask takes prompt as a nonempty string")
+  })
+
+  test("the authority option records an outgoing requestAsk call", () => {
+    const source = threadAddressOf("agent", "main", "parent")
+    const target = threadAddressOf("agent", "main", "child")
+    const log: Event[] = [
+      {
+        type: "MessageReceived",
+        id: "m1",
+        text: "go",
+        link: linkOf(source, target),
+        at: 0
+      },
+      { type: "ToolCalled", callId: "a1", name: ASK_TOOL_NAME, arguments: { prompt: "Approve?", schema: APPROVAL }, turn: "m1", at: 1 },
+      { type: "AskRequested", callId: "a1", prompt: "Approve the release?", schema: APPROVAL, turn: "m1", at: 2 }
+    ]
+    const definition = assembled(infer([ask([echo], { authority: askCaller() }), nativeOutput], TEST_MODEL))
+    const planned = enabled(definition, log).find((transition) => transition.key.includes("ask.plan"))
+    expect(planned?.kind).toBe("intent")
+    const events = planned?.kind === "intent" ? planned.events(planned.input, 3) : []
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: "CallPlanned",
+        method: "requestAsk",
+        input: expect.objectContaining({ request: "a1", turn: "m1", prompt: "Approve the release?" })
+      })
+    ]))
+    expect(componentContractOf(ask([echo], { authority: askCaller() })).calls).toEqual([{
+      target: { kind: "caller", methods: { requestAsk: requestAskMethod } },
+      method: requestAskMethod
+    }])
+  })
+})
+
+describe("ask park then answer then resume", () => {
+  const ROOT_THREAD = "ag.root"
+
+  const hosted = (mind: (request: InferRequest) => Promise<Action>) => {
+    const definition = assembled(infer([ask([echo]), nativeOutput], TEST_MODEL))
+    const layersFor = (_thread: string): ThreadEnv<AgentR | NativeOutputSupport> =>
+      Layer.mergeAll(
+        KeyValueStore.layerMemory,
+        Layer.succeed(Infer, {
+          react: (request: InferRequest) => Effect.promise(() => mind(request))
+        }),
+        Layer.succeed(NativeOutputSupport, { withTools: true })
+      )
+    const host: Host = createHost({
+      actorName: "mem",
+      actorInstance: "main",
+      actorFor: () => definition,
+      keyOf: actorRuntimeOf(definition).keyOf,
+      layersFor
+    })
+    return { host }
+  }
+
+  test("a typed answer resumes inference with the schema value", async () => {
+    const mind = async (request: InferRequest): Promise<Action> => {
+      const returned = request.trajectory.find((event) => event.type === "ToolReturned" && event.turn === request.identity.turn)
+      if (returned !== undefined) {
+        return { kind: "complete", output: JSON.stringify((returned as { result?: unknown }).result) }
+      }
+      return {
+        kind: "calls",
+        calls: [{ callId: "a1", name: ASK_TOOL_NAME, arguments: { prompt: "Approve the release?", schema: APPROVAL } }]
+      }
+    }
+    const { host } = hosted(mind)
+    await host.commitRoot(host.self(ROOT_THREAD), { type: "MessageReceived", id: "m1", text: "go", at: 1 } as Event)
+    await host.drive()
+    const parked = host.read(ROOT_THREAD)
+    expect(boundaryOf(parked, "m1")?.kind).toBe("asking")
+    expect(turnViewOf(parked, "m1").status).toBe("parked")
+    await host.commitRoot(host.self(ROOT_THREAD), {
+      type: "AskAnswered",
+      callId: "a1",
+      answer: { approved: true },
+      turn: "m1",
+      at: 50
+    } as Event)
+    await host.drive()
+    const done = host.read(ROOT_THREAD)
+    expect(boundaryOf(done, "m1")).toEqual({ kind: "completed", output: JSON.stringify({ answered: { approved: true } }) })
+    expect(turnViewOf(done, "m1")).toMatchObject({ turn: "m1", status: "completed" })
+  })
+})

--- a/packages/agent/src/component/ask.ts
+++ b/packages/agent/src/component/ask.ts
@@ -1,0 +1,271 @@
+import { actorCall } from "@clavia/tardigrade-core/interaction/invoke"
+import { actorInvocationContextOf } from "@clavia/tardigrade-core/interaction/invocation"
+import { calls, composeComponents, inheritComponentContract, component as defineComponent, type ThreadTarget, type ComponentRequirements } from "@clavia/tardigrade-core/actor"
+import { Router } from "@clavia/tardigrade-core/transport/router"
+import { Self } from "@clavia/tardigrade-core/runtime"
+import { AGENT_VIEW_ALGEBRA, type AgentComponent, type AgentTool } from "../runtime/composition"
+import { requestAskMethod } from "../actor/ask"
+import { askAnswered, askDenied, askRequested } from "../log/events"
+import type { Event } from "@clavia/tardigrade-core/log/event"
+import { turnEpochOf } from "@clavia/tardigrade-code/execution/turns"
+import { formatThreadAddress, isThreadAddress, type ThreadAddress } from "@clavia/tardigrade-core/transport/endpoint"
+import type { Link } from "@clavia/tardigrade-core/transport/link"
+import { threadCreatedOf } from "@clavia/tardigrade-core/interaction/relations"
+import { outputErrors, outputFrom } from "../output/contract"
+import type { ToolSpec } from "../inference/request"
+
+export type AskAuthorityMethods = {
+  readonly requestAsk: typeof requestAskMethod
+}
+
+export interface CallerAskAuthority {
+  readonly kind: "caller"
+  readonly methods: AskAuthorityMethods
+}
+
+export type AskAuthority = ThreadTarget<AskAuthorityMethods> | CallerAskAuthority
+
+// askCaller selects the actor that invoked the current message call as its ask authority.
+export const askCaller = (): CallerAskAuthority => ({
+  kind: "caller",
+  methods: { requestAsk: requestAskMethod }
+})
+
+export interface AskOptions {
+  readonly authority?: AskAuthority
+  // schema is the answer contract every ask on this assembly must satisfy. The model supplies only a prompt.
+  readonly schema?: unknown
+  // timeoutMs bounds the authority call. Omitted uses DEFAULT_ACTOR_METHOD_TIMEOUT_MS (packages/core/src/actor/method.ts).
+  readonly timeoutMs?: number
+}
+
+// ASK_TOOL_NAME is the model-visible tool the ask component mounts.
+export const ASK_TOOL_NAME = "ask"
+
+// ASK_SCHEMA_NAME is the output-contract identity used to validate an ask schema (output/contract.ts, OUTPUT_NAME_PATTERN).
+export const ASK_SCHEMA_NAME = "ask"
+
+const ASK_SYSTEM =
+  "When you need a fact or decision only a human can provide, call ask with a prompt and a JSON Schema for the answer. The turn waits until they reply. The schema must be a closed object: every property is required and additionalProperties is false."
+
+const ASK_SYSTEM_MOUNTED =
+  "When you need a fact or decision only a human can provide, call ask with a prompt. The answer must match the schema this assembly mounted. The turn waits until they reply."
+
+const ASK_TOOL_PROPERTIES = {
+  prompt: { type: "string", description: "The question to ask the human." },
+  schema: {
+    type: "object",
+    description: "JSON Schema for the expected answer. A closed object: every property required, additionalProperties false."
+  }
+} as const
+
+const askToolSpec = (mounted: boolean): ToolSpec => ({
+  name: ASK_TOOL_NAME,
+  description: mounted
+    ? "Ask a human a question and wait for a structured answer. The turn parks until they reply."
+    : "Ask a human a question and wait for a structured answer. The turn parks until they reply. Pass a closed object JSON Schema for the answer.",
+  inputSchema: mounted
+    ? {
+        type: "object",
+        properties: { prompt: ASK_TOOL_PROPERTIES.prompt },
+        required: ["prompt"],
+        additionalProperties: false
+      }
+    : {
+        type: "object",
+        properties: ASK_TOOL_PROPERTIES,
+        required: ["prompt", "schema"],
+        additionalProperties: false
+      }
+})
+
+const field = (event: Event, name: string): string => String((event as Record<string, unknown>)[name] ?? "")
+
+const schemaContract = (schema: unknown) => outputFrom(ASK_SCHEMA_NAME, schema)
+
+const schemaErrors = (schema: unknown): ReadonlyArray<string> => {
+  const built = schemaContract(schema)
+  return "errors" in built ? built.errors : []
+}
+
+const answerErrors = (schema: unknown, value: unknown): ReadonlyArray<string> => {
+  const built = schemaContract(schema)
+  return "errors" in built ? built.errors : outputErrors(schema, value)
+}
+
+const askCallId = (child: ThreadAddress, turn: string, request: string): string =>
+  `ask/${formatThreadAddress(child)}/${turn}/${request}`
+
+const authorityFor = (
+  log: ReadonlyArray<Event>,
+  turn: string,
+  authority: AskAuthority | undefined
+): ThreadTarget<AskAuthorityMethods> | undefined => {
+  if (authority === undefined) return undefined
+  if ("coordinate" in authority || "address" in authority) return authority
+  const head = log.find((event) =>
+    event.type === "MessageReceived" && String((event as { readonly id?: unknown }).id) === turn
+  ) as { readonly link?: Link<unknown, ThreadAddress> } | undefined
+  return isThreadAddress(head?.link?.source)
+    ? { coordinate: head.link.source, methods: { requestAsk: requestAskMethod } }
+    : undefined
+}
+
+const sourceFor = (log: ReadonlyArray<Event>, turn: string): ThreadAddress | undefined => {
+  const head = log.find((event) =>
+    event.type === "MessageReceived" && String((event as { readonly id?: unknown }).id) === turn
+  ) as { readonly link?: Link<unknown, unknown> } | undefined
+  if (isThreadAddress(head?.link?.target)) return head.link.target
+  return threadCreatedOf(log)?.address
+}
+
+const askTool = (options: AskOptions, mountedSchema: unknown | undefined): AgentTool<Router | Self> => ({
+  spec: askToolSpec(mountedSchema !== undefined),
+  serve: (call, log, answer) => {
+    const stamp = call.turn === undefined ? {} : { turn: call.turn }
+    const invocation = call.turn === undefined
+      ? {}
+      : { invocation: { method: "message", id: call.turn, epoch: call.epoch ?? 0 } }
+    const requested = log.find((event) =>
+      event.type === "AskRequested" && field(event, "callId") === call.callId && (event.turn ?? "") === (call.turn ?? "")
+    )
+    if (requested === undefined) {
+      const args = call.arguments as { prompt?: unknown; schema?: unknown } | undefined
+      const prompt = args?.prompt
+      if (typeof prompt !== "string" || prompt.trim() === "") {
+        return [answer({ error: `ask takes prompt as a nonempty string; got ${JSON.stringify(prompt)}` })]
+      }
+      const schema = mountedSchema ?? args?.schema
+      const errors = schemaErrors(schema)
+      if (errors.length > 0) {
+        return [answer({ error: `ask schema is not declarable:\n${errors.map((error) => `- ${error}`).join("\n")}` })]
+      }
+      const built = schemaContract(schema)
+      const recorded = "errors" in built ? schema : built.contract.schema
+      return [
+        call.context.intent("ask.request", (at) => askRequested({
+          callId: call.callId, prompt, schema: recorded, ...stamp, at
+        }), invocation)
+      ]
+    }
+    const decision = log.find((event) =>
+      (event.type === "AskAnswered" || event.type === "AskDenied") &&
+      field(event, "callId") === call.callId &&
+      (call.turn === undefined || field(event, "turn") === "" || field(event, "turn") === call.turn)
+    )
+    if (decision !== undefined) {
+      if (decision.type === "AskDenied") {
+        const reason = field(decision, "reason")
+        return [answer({
+          denied: true,
+          ...(reason === "" ? {} : { reason })
+        })]
+      }
+      const schema = (requested as { readonly schema?: unknown }).schema
+      const value = (decision as { readonly answer?: unknown }).answer
+      const errors = answerErrors(schema, value)
+      if (errors.length > 0) {
+        return [answer({ error: `ask answer misses the schema:\n${errors.map((error) => `- ${error}`).join("\n")}` })]
+      }
+      return [answer({ answered: value })]
+    }
+    const target = authorityFor(log, call.turn ?? "", options.authority)
+    const source = sourceFor(log, call.turn ?? "")
+    if (target === undefined || source === undefined) return []
+    const turn = call.turn ?? ""
+    const callId = askCallId(source, turn, call.callId)
+    const message = { method: "message", id: turn, epoch: call.epoch ?? (turn === "" ? 0 : turnEpochOf(log, turn)) }
+    const actor = actorCall(log, {
+      id: callId,
+      target,
+      method: "requestAsk",
+      ...(turn === "" ? {} : {
+        context: actorInvocationContextOf(log, message) ?? { invocation: message }
+      }),
+      input: {
+        request: call.callId,
+        turn,
+        prompt: String((requested as { readonly prompt?: unknown }).prompt ?? ""),
+        schema: (requested as { readonly schema?: unknown }).schema
+      },
+      ...(options.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs })
+    }, { context: call.context, tag: "ask" })
+    if (actor.transitions.length > 0) return actor.transitions
+    if (actor.state.status === "pending") return []
+    if (actor.state.status === "failed") {
+      const error = actor.state.error
+      return [call.context.intent("ask.decide", (at) => askDenied({
+        callId: call.callId, reason: `Ask authority failed: ${error}`, ...stamp, at
+      }), invocation)]
+    }
+    if (actor.state.status === "cancelled") {
+      const cancelled = actor.state.reason ?? actor.state.cause
+      return [call.context.intent("ask.decide", (at) => askDenied({
+        callId: call.callId,
+        reason: `Ask authority cancelled: ${cancelled}`,
+        ...stamp,
+        at
+      }), invocation)]
+    }
+    if (actor.state.status !== "completed") return []
+    const output = actor.state.output
+    if ("denied" in output) {
+      return [call.context.intent("ask.decide", (at) => askDenied({
+        callId: call.callId,
+        ...(typeof output.reason === "string" && output.reason !== "" ? { reason: output.reason } : {}),
+        ...stamp,
+        at
+      }), invocation)]
+    }
+    return [call.context.intent("ask.decide", (at) => askAnswered({
+      callId: call.callId, answer: output.answered, ...stamp, at
+    }), invocation)]
+  }
+})
+
+// ask mounts a schema-shaped human question tool. An unanswered ask parks the turn (component/ask.test.ts).
+export const ask = <
+  const Cs extends ReadonlyArray<AgentComponent<never> | AgentComponent<unknown>>
+>(
+  components: Cs,
+  options: AskOptions = {}
+): AgentComponent<ComponentRequirements<Cs[number]> | Router | Self> => {
+  type R = ComponentRequirements<Cs[number]>
+  const mounted = options.schema === undefined ? undefined : (() => {
+    const built = schemaContract(options.schema)
+    if ("errors" in built) {
+      throw new Error(`ask schema is not declarable:\n${built.errors.map((error) => `- ${error}`).join("\n")}`)
+    }
+    return built.contract.schema
+  })()
+  if (options.timeoutMs !== undefined && (!Number.isSafeInteger(options.timeoutMs) || options.timeoutMs < 1)) {
+    throw new Error(`ask timeoutMs must be a positive safe integer, got ${JSON.stringify(options.timeoutMs)}`)
+  }
+  const combined = composeComponents("ask.children", AGENT_VIEW_ALGEBRA, components) as AgentComponent<R>
+  const machine = combined.machine
+  const tool = askTool(options, mounted)
+  const system = mounted === undefined ? ASK_SYSTEM : ASK_SYSTEM_MOUNTED
+  const project = (children: ReturnType<typeof machine.output>) => ({
+    view: {
+      ...children.view,
+      system: [...children.view.system, system],
+      tools: [...children.view.tools, tool]
+    },
+    transitions: children.transitions
+  })
+  const common = {
+    name: "ask",
+    children: [combined]
+  }
+  const component: AgentComponent<R | Router | Self> = defineComponent({
+    ...common,
+    initial: machine.initial,
+    step: machine.step,
+    cancelState: (state, cancellation) => machine.cancel?.(state, cancellation) ?? [],
+    output: (state) => project(machine.output(state))
+  })
+  const inherited = inheritComponentContract(component, combined)
+  return options.authority === undefined
+    ? inherited
+    : calls(options.authority, requestAskMethod, inherited)
+}

--- a/packages/agent/src/index.test.ts
+++ b/packages/agent/src/index.test.ts
@@ -83,7 +83,7 @@ const hosted = (
     if (boundary === undefined) return { turn, error: "the root never settled" }
     if (boundary.kind === "completed") return { turn, output: boundary.output }
     if (boundary.kind === "failed") return { turn, error: boundary.error }
-    return { turn, error: "the root parked on a budget ask with nobody to answer" }
+    return { turn, error: "the root parked on an ask with nobody to answer" }
   }
   const run = async (brief: string): Promise<Settled> => {
     const id = `run-${n++}`

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -8,6 +8,7 @@ export { AgentMessageInput, agentMessageMethod } from "./actor/message"
 export { agentMethods } from "./actor/methods"
 export { BudgetRequestInput, BudgetDecision, requestBudgetMethod } from "./actor/budget"
 export { PermissionRequestInput, PermissionDecision, requestPermissionMethod } from "./actor/permission"
+export { AskRequestInput, AskDecision, requestAskMethod } from "./actor/ask"
 export {
   Infer,
   NativeOutputSupport,
@@ -129,7 +130,7 @@ export {
   type CostSource,
   type ModelPricing
 } from "./inference/usage"
-export { boundaryOf, outputOf, type Boundary } from "./output/boundary"
+export { boundaryOf, outputOf, parkedBoundary, turnsOf, turnViewOf, type Boundary, type BudgetAsk, type SchemaAsk, type TurnAsk, type TurnSnapshot, type TurnStatus } from "./output/boundary"
 export {
   agentsPackage,
   INLINE_OUTPUT_NAME,
@@ -195,4 +196,21 @@ export {
   type PermissionAuthorityOptions,
   type PermissionRequest
 } from "./component/permission-authority"
+export {
+  ask,
+  askCaller,
+  ASK_SCHEMA_NAME,
+  ASK_TOOL_NAME,
+  type AskAuthority,
+  type AskAuthorityMethods,
+  type AskOptions,
+  type CallerAskAuthority
+} from "./component/ask"
+export {
+  askAuthority,
+  askAuthorityKeys,
+  type AskAuthorityOptions,
+  type AskRequest,
+  type DecideAsk
+} from "./component/ask-authority"
 export { compaction } from "./component/compaction"

--- a/packages/agent/src/log/events.ts
+++ b/packages/agent/src/log/events.ts
@@ -345,6 +345,63 @@ export const BudgetDenied = Schema.Struct({
   at: Schema.Finite
 })
 
+// AskRequested parks a turn on one schema-shaped human question. `schema` is the answer contract the human must satisfy (component/ask.test.ts).
+export const AskRequested = Schema.Struct({
+  type: Schema.Literal("AskRequested"),
+  callId: Schema.String,
+  prompt: Schema.String,
+  schema: Schema.Unknown,
+  turn: Schema.optional(Schema.String),
+  at: Schema.Finite
+})
+
+// AskAnswered is the human's typed reply to one AskRequested. The recorded `answer` is the value that passed the request's schema.
+export const AskAnswered = Schema.Struct({
+  type: Schema.Literal("AskAnswered"),
+  callId: Schema.String,
+  answer: Schema.Unknown,
+  turn: Schema.optional(Schema.String),
+  at: Schema.Finite
+})
+
+// AskDenied closes one AskRequested without a value. The parked tool returns `{ denied: true }` so the model can finish without that fact (component/ask.test.ts).
+export const AskDenied = Schema.Struct({
+  type: Schema.Literal("AskDenied"),
+  reason: Schema.optional(Schema.String),
+  callId: Schema.String,
+  turn: Schema.optional(Schema.String),
+  at: Schema.Finite
+})
+
+// AskRequestReceived is the durable input of the requestAsk actor method.
+export const AskRequestReceived = Schema.Struct({
+  type: Schema.Literal("AskRequestReceived"),
+  id: Schema.String,
+  request: Schema.String,
+  turn: Schema.String,
+  prompt: Schema.String,
+  schema: Schema.Unknown,
+  at: Schema.Finite
+})
+
+// AskRequestDecided is the terminal decision produced by an ask authority.
+export const AskRequestDecided = Schema.Struct({
+  type: Schema.Literal("AskRequestDecided"),
+  callId: Schema.String,
+  denied: Schema.Boolean,
+  answer: Schema.optional(Schema.Unknown),
+  reason: Schema.optional(Schema.String),
+  at: Schema.Finite
+})
+
+// AskRequestFailed is the terminal failure produced when an ask authority cannot decide a request.
+export const AskRequestFailed = Schema.Struct({
+  type: Schema.Literal("AskRequestFailed"),
+  callId: Schema.String,
+  error: Schema.String,
+  at: Schema.Finite
+})
+
 export const AgentEvent = Schema.Union([
   MessageReceived,
   ModelCalled,
@@ -369,7 +426,13 @@ export const AgentEvent = Schema.Union([
   PermissionRequestDecided,
   PermissionRequestFailed,
   BudgetGranted,
-  BudgetDenied
+  BudgetDenied,
+  AskRequested,
+  AskAnswered,
+  AskDenied,
+  AskRequestReceived,
+  AskRequestDecided,
+  AskRequestFailed
 ])
 export type AgentEvent = typeof AgentEvent.Type
 
@@ -419,10 +482,11 @@ export type Action =
 // pair; bdec names the budget request a local decision answers, so a grant and denial for one request
 // cannot both commit. A grant is summed into the ceiling, so a redelivery must also absorb. A
 // decision that carries no callId predates the stamp and lands unkeyed; the fold tolerates it.
+// adec names the AskRequested a human answer or denial settles, so both cannot commit for one call.
 const epochSuffix = (epoch: unknown): string => epoch === undefined || Number(epoch) === 0 ? "" : `/${String(epoch)}`
 
 export const agentKeys: KeyFragment = {
-  prefixes: ["tr:", "bdec:", "bi:", "tn:", "rs:", "mr:", "mc:", "bw:", "br:", "cc:", "or:", "oq:", "op:"],
+  prefixes: ["tr:", "bdec:", "bi:", "tn:", "rs:", "mr:", "mc:", "bw:", "br:", "cc:", "or:", "oq:", "op:", "ar:", "adec:"],
   keyOf: (e) => {
     const v = e as Record<string, unknown>
     switch (e.type) {
@@ -453,6 +517,11 @@ export const agentKeys: KeyFragment = {
         return `bw:${String(v.turn)}/${String(v.budget)}`
       case "BudgetRequested":
         return `br:${String(v.callId)}`
+      case "AskRequested":
+        return `ar:${String(v.callId)}`
+      case "AskAnswered":
+      case "AskDenied":
+        return v.callId === undefined ? undefined : `adec:${String(v.callId)}`
       case "OutputRejected":
         // One rejection per logical attempt: a crashed attempt retried under the same key
         // records the same rejection, and the committed one binds.
@@ -622,6 +691,30 @@ export const budgetGranted = (
 export const budgetDenied = (
   fields: { readonly reason?: string; readonly callId?: string } & Stamp
 ): Event => ({ type: "BudgetDenied", ...fields }) as Event
+
+export const askRequested = (
+  fields: { readonly callId: string; readonly prompt: string; readonly schema: unknown } & Stamp
+): Event => ({ type: "AskRequested", ...fields }) as Event
+
+export const askAnswered = (
+  fields: { readonly callId: string; readonly answer: unknown } & Stamp
+): Event => ({ type: "AskAnswered", ...fields }) as Event
+
+export const askDenied = (
+  fields: { readonly reason?: string; readonly callId: string } & Stamp
+): Event => ({ type: "AskDenied", ...fields }) as Event
+
+export const askRequestReceived = (
+  fields: { readonly id: string; readonly request: string; readonly turn: string; readonly prompt: string; readonly schema: unknown; readonly at: number }
+): Event => ({ type: "AskRequestReceived", ...fields }) as Event
+
+export const askRequestDecided = (
+  fields: { readonly callId: string; readonly denied: boolean; readonly answer?: unknown; readonly reason?: string; readonly at: number }
+): Event => ({ type: "AskRequestDecided", ...fields }) as Event
+
+export const askRequestFailed = (
+  fields: { readonly callId: string; readonly error: string; readonly at: number }
+): Event => ({ type: "AskRequestFailed", ...fields }) as Event
 
 export const compactionCompleted = (
   fields: {

--- a/packages/agent/src/output/boundary.test.ts
+++ b/packages/agent/src/output/boundary.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { Event } from "@clavia/tardigrade-core/log/event"
-import { boundaryOf, outputOf } from "./boundary"
+import { boundaryOf, outputOf, turnViewOf, turnsOf } from "./boundary"
 import { output } from "./contract"
 
 const base: Event[] = [{ type: "MessageReceived", id: "m1", text: "go", at: 0 }]
@@ -23,6 +23,12 @@ describe("boundaryOf", () => {
   test("a turn parked on an ask returns the request", () => {
     const log = [...base, { type: "BudgetRequested", callId: "rb1", reason: "need more", amount: 5, turn: "m1", at: 1 } as Event]
     expect(boundaryOf(log, "m1")).toEqual({ kind: "requesting", callId: "rb1", reason: "need more", amount: 5 })
+    expect(turnViewOf(log, "m1")).toEqual({
+      turn: "m1",
+      status: "parked",
+      epoch: 0,
+      ask: { kind: "budget", callId: "rb1", reason: "need more", amount: 5 }
+    })
   })
 
   test("a grant clears the ask; the turn is running again, not requesting", () => {
@@ -52,6 +58,68 @@ describe("boundaryOf", () => {
       { type: "BudgetRequested", callId: "rb2", reason: "second", amount: 3, turn: "m1", at: 3 } as Event
     ]
     expect(boundaryOf(log, "m1")).toEqual({ kind: "requesting", callId: "rb2", reason: "second", amount: 3 })
+  })
+
+  test("a turn parked on a schema ask returns the prompt and schema", () => {
+    const schema = {
+      type: "object",
+      properties: { approved: { type: "boolean" } },
+      required: ["approved"],
+      additionalProperties: false
+    }
+    const log = [...base, { type: "AskRequested", callId: "a1", prompt: "Approve?", schema, turn: "m1", at: 1 } as Event]
+    expect(boundaryOf(log, "m1")).toEqual({ kind: "asking", callId: "a1", prompt: "Approve?", schema })
+    expect(turnViewOf(log, "m1")).toEqual({
+      turn: "m1",
+      status: "parked",
+      epoch: 0,
+      ask: { kind: "schema", callId: "a1", prompt: "Approve?", schema }
+    })
+  })
+
+  test("AskAnswered clears the schema ask", () => {
+    const schema = { type: "object", properties: { approved: { type: "boolean" } }, required: ["approved"], additionalProperties: false }
+    const log = [
+      ...base,
+      { type: "AskRequested", callId: "a1", prompt: "Approve?", schema, turn: "m1", at: 1 } as Event,
+      { type: "AskAnswered", callId: "a1", answer: { approved: true }, turn: "m1", at: 2 } as Event
+    ]
+    expect(boundaryOf(log, "m1")).toBeUndefined()
+    expect(turnViewOf(log, "m1")).toEqual({ turn: "m1", status: "pending", epoch: 0 })
+  })
+
+  test("AskDenied clears the schema ask", () => {
+    const schema = { type: "object", properties: { approved: { type: "boolean" } }, required: ["approved"], additionalProperties: false }
+    const log = [
+      ...base,
+      { type: "AskRequested", callId: "a1", prompt: "Approve?", schema, turn: "m1", at: 1 } as Event,
+      { type: "AskDenied", callId: "a1", reason: "needs review", turn: "m1", at: 2 } as Event
+    ]
+    expect(boundaryOf(log, "m1")).toBeUndefined()
+    expect(turnViewOf(log, "m1")).toEqual({ turn: "m1", status: "pending", epoch: 0 })
+  })
+
+  test("a budget grant does not clear a later schema ask", () => {
+    const schema = { type: "object", properties: { approved: { type: "boolean" } }, required: ["approved"], additionalProperties: false }
+    const log = [
+      ...base,
+      { type: "BudgetRequested", callId: "rb1", reason: "need more", amount: 5, turn: "m1", at: 1 } as Event,
+      { type: "BudgetGranted", amount: 5, turn: "m1", at: 2 } as Event,
+      { type: "AskRequested", callId: "a1", prompt: "Approve?", schema, turn: "m1", at: 3 } as Event
+    ]
+    expect(boundaryOf(log, "m1")).toEqual({ kind: "asking", callId: "a1", prompt: "Approve?", schema })
+  })
+
+  test("turnsOf lists every message as a TurnView", () => {
+    const log = [
+      ...base,
+      { type: "TurnCompleted", output: "done", turn: "m1", at: 1 } as Event,
+      { type: "MessageReceived", id: "m2", text: "next", at: 2 } as Event
+    ]
+    expect(turnsOf(log)).toEqual([
+      { turn: "m1", status: "completed", epoch: 0, output: "done" },
+      { turn: "m2", status: "pending", epoch: 0 }
+    ])
   })
 
   test("a resume request clears the failed boundary until the next terminal", () => {

--- a/packages/agent/src/output/boundary.ts
+++ b/packages/agent/src/output/boundary.ts
@@ -1,10 +1,26 @@
 import type { Event } from "@clavia/tardigrade-core/log/event"
-import { turnTerminalOf } from "@clavia/tardigrade-code/execution/turns"
+import { turnEpochOf, turnTerminalOf } from "@clavia/tardigrade-code/execution/turns"
 import { canonicalOf, declarationForTurn, type OutputContract } from "./contract"
 
-// Boundary is where a settle left a turn: a terminal, or a park on a budget ask. The
+// Boundary is where a settle left a turn: a terminal, a budget ask, or a schema-shaped human ask. The
 // platform's call and resume read it to answer the spawning code. Pure over the log, so a
 // re-driven settle reads the same boundary.
+
+export type BudgetAsk = {
+  readonly kind: "budget"
+  readonly callId: string
+  readonly reason: string
+  readonly amount: number
+}
+
+export type SchemaAsk = {
+  readonly kind: "schema"
+  readonly callId: string
+  readonly prompt: string
+  readonly schema: unknown
+}
+
+export type TurnAsk = BudgetAsk | SchemaAsk
 
 export type Boundary =
   | { readonly kind: "completed"; readonly output: string }
@@ -16,10 +32,43 @@ export type Boundary =
       readonly deadlineAt?: number
     }
   | { readonly kind: "requesting"; readonly callId: string; readonly reason: string; readonly amount: number }
+  | { readonly kind: "asking"; readonly callId: string; readonly prompt: string; readonly schema: unknown }
+
+export type TurnStatus = "pending" | "completed" | "failed" | "cancelled" | "parked"
+
+export type TurnSnapshot = {
+  readonly turn: string
+  readonly status: TurnStatus
+  readonly epoch: number
+  readonly output?: string
+  readonly error?: string
+  readonly reason?: string
+  readonly ask?: TurnAsk
+}
+
+const field = (event: Event, name: string): unknown => (event as Record<string, unknown>)[name]
+
+const pendingAskOf = (log: ReadonlyArray<Event>, turn: string): Event | undefined => {
+  let pending: Event | undefined
+  for (const e of log) {
+    if (String(field(e, "turn") ?? "") !== turn) continue
+    if (e.type === "BudgetRequested" || e.type === "AskRequested") pending = e
+    else if (e.type === "BudgetGranted" || e.type === "BudgetDenied") {
+      if (pending?.type === "BudgetRequested") pending = undefined
+    } else if (e.type === "AskAnswered" || e.type === "AskDenied") {
+      if (pending?.type === "AskRequested") pending = undefined
+    }
+  }
+  return pending
+}
+
+// parkedBoundary reports whether a boundary is an unanswered budget or human ask.
+export const parkedBoundary = (boundary: Boundary | undefined): boolean =>
+  boundary?.kind === "requesting" || boundary?.kind === "asking"
 
 // boundaryOf returns the turn's boundary, or undefined while it still runs. A terminal wins
 // over a park: a resumed turn that finished reads completed even though it once asked. A park
-// is the last BudgetRequested no grant or denial has answered.
+// is the last BudgetRequested or AskRequested that no BudgetGranted, BudgetDenied, AskAnswered, or AskDenied has closed.
 export const boundaryOf = (log: ReadonlyArray<Event>, turn: string): Boundary | undefined => {
   const terminal = turnTerminalOf(log, turn)
   if (terminal !== undefined) {
@@ -37,18 +86,50 @@ export const boundaryOf = (log: ReadonlyArray<Event>, turn: string): Boundary | 
     }
     return { kind: "failed", error: String((terminal as { error?: unknown }).error) }
   }
-  let pending: Event | undefined
-  for (const e of log) {
-    if (String((e as { turn?: unknown }).turn) !== turn) continue
-    if (e.type === "BudgetRequested") pending = e
-    else if (e.type === "BudgetGranted" || e.type === "BudgetDenied") pending = undefined
+  const pending = pendingAskOf(log, turn)
+  if (pending === undefined) return undefined
+  if (pending.type === "AskRequested") {
+    const p = pending as { callId?: unknown; prompt?: unknown; schema?: unknown }
+    return { kind: "asking", callId: String(p.callId), prompt: String(p.prompt ?? ""), schema: p.schema }
   }
-  if (pending !== undefined) {
-    const p = pending as { callId?: unknown; reason?: unknown; amount?: unknown }
-    return { kind: "requesting", callId: String(p.callId), reason: String(p.reason ?? ""), amount: Number(p.amount ?? 0) }
+  const p = pending as { callId?: unknown; reason?: unknown; amount?: unknown }
+  return { kind: "requesting", callId: String(p.callId), reason: String(p.reason ?? ""), amount: Number(p.amount ?? 0) }
+}
+
+const askOf = (boundary: Boundary): TurnAsk | undefined => {
+  if (boundary.kind === "requesting") {
+    return { kind: "budget", callId: boundary.callId, reason: boundary.reason, amount: boundary.amount }
+  }
+  if (boundary.kind === "asking") {
+    return { kind: "schema", callId: boundary.callId, prompt: boundary.prompt, schema: boundary.schema }
   }
   return undefined
 }
+
+// turnViewOf projects one turn into the client TurnView shape, including a parked ask (client/src/contract.ts, TurnView).
+export const turnViewOf = (log: ReadonlyArray<Event>, turn: string): TurnSnapshot => {
+  const epoch = turnEpochOf(log, turn)
+  const boundary = boundaryOf(log, turn)
+  if (boundary === undefined) return { turn, status: "pending", epoch }
+  if (boundary.kind === "completed") return { turn, status: "completed", epoch, output: boundary.output }
+  if (boundary.kind === "failed") return { turn, status: "failed", epoch, error: boundary.error }
+  if (boundary.kind === "cancelled") {
+    return {
+      turn,
+      status: "cancelled",
+      epoch,
+      ...(boundary.reason === undefined ? {} : { reason: boundary.reason })
+    }
+  }
+  const ask = askOf(boundary)
+  return { turn, status: "parked", epoch, ...(ask === undefined ? {} : { ask }) }
+}
+
+// turnsOf lists every MessageReceived as a TurnView in log order (boundary.test.ts).
+export const turnsOf = (log: ReadonlyArray<Event>): ReadonlyArray<TurnSnapshot> =>
+  log
+    .filter((event) => event.type === "MessageReceived")
+    .map((event) => turnViewOf(log, String((event as { readonly id?: unknown }).id ?? "")))
 
 // outputOf reads a completed turn's result under the contract that turn declared. It returns undefined for a pending or failed turn and throws when the declaration or stored result cannot satisfy the supplied contract (boundary.test.ts, "a turn that declared nothing is never reinterpreted"; inference/machine.ts, completionOf).
 export const outputOf = <T>(

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -449,7 +449,8 @@ describe("resuming a turn", () => {
     ["pending", []],
     ["pending", [failed, { type: "TurnResumed", turn: "m1", failedEpoch: 0, epoch: 1 }]],
     ["cancelled", [{ type: "TurnCancelled", turn: "m1", cause: "requested" }]],
-    ["parked", [{ type: "BudgetRequested", turn: "m1", callId: "budget", amount: 1 }]]
+    ["parked", [{ type: "BudgetRequested", turn: "m1", callId: "budget", amount: 1 }]],
+    ["parked", [{ type: "AskRequested", turn: "m1", callId: "ask", prompt: "Approve?", schema: { type: "object", properties: { approved: { type: "boolean" } }, required: ["approved"], additionalProperties: false } }]]
   ] as const)("refuses a %s active epoch", async (status, events) => {
     answer = accepting([message, ...events])
     const failure = await client().resume("main", "root", "m1").catch((error: unknown) => error)
@@ -475,5 +476,26 @@ describe("resuming a turn", () => {
     expect(failure).toBeInstanceOf(ProblemError)
     expect((failure as ProblemError).detail).toContain('No turn named "m9"')
     expect(calls).toHaveLength(1)
+  })
+})
+
+describe("turnViewOf", () => {
+  test("a schema ask is parked with the prompt and schema", async () => {
+    const { turnViewOf } = await import("./turns")
+    const schema = {
+      type: "object",
+      properties: { approved: { type: "boolean" } },
+      required: ["approved"],
+      additionalProperties: false
+    }
+    expect(turnViewOf([
+      { type: "MessageReceived", id: "m1", text: "go", at: 0 },
+      { type: "AskRequested", callId: "a1", prompt: "Approve?", schema, turn: "m1", at: 1 }
+    ], "m1")).toEqual({
+      turn: "m1",
+      status: "parked",
+      epoch: 0,
+      ask: { kind: "schema", callId: "a1", prompt: "Approve?", schema }
+    })
   })
 })

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,5 +1,5 @@
 import type { Event } from "@clavia/tardigrade-core/log/event"
-import { boundaryOf } from "@clavia/tardigrade-agent/output/boundary"
+import { boundaryOf, parkedBoundary } from "@clavia/tardigrade-agent/output/boundary"
 import { turnEpochOf } from "@clavia/tardigrade-code/execution/turns"
 import { Effect, type Schema } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientError, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
@@ -454,7 +454,7 @@ export const makeActorClient = <const P extends Projections = {}, const M extend
         })
       }
       const boundary = boundaryOf(log, turn)
-      const status = boundary?.kind === "requesting" ? "parked" : boundary?.kind ?? "pending"
+      const status = parkedBoundary(boundary) ? "parked" : boundary?.kind ?? "pending"
       if (status !== "failed") {
         throw new ProblemError({
           ...ResumeRefused.of(

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -168,6 +168,29 @@ export const TurnStatus = Schema.Literals(["pending", "completed", "failed", "ca
 
 export type TurnStatus = typeof TurnStatus.Type
 
+export const BudgetAskView = Schema.Struct({
+  kind: Schema.Literal("budget"),
+  callId: Schema.String,
+  reason: Schema.String,
+  amount: Schema.Finite
+}).annotate({ identifier: "BudgetAskView" })
+
+export type BudgetAskView = typeof BudgetAskView.Type
+
+export const SchemaAskView = Schema.Struct({
+  kind: Schema.Literal("schema"),
+  callId: Schema.String,
+  prompt: Schema.String,
+  schema: Schema.Unknown
+}).annotate({ identifier: "SchemaAskView" })
+
+export type SchemaAskView = typeof SchemaAskView.Type
+
+// AskView is the parked question a TurnView exposes so a client can render or answer it (packages/agent/src/output/boundary.ts, turnViewOf).
+export const AskView = Schema.Union([BudgetAskView, SchemaAskView]).annotate({ identifier: "AskView" })
+
+export type AskView = typeof AskView.Type
+
 // TurnView describes a turn and its current execution epoch.
 export const TurnView = Schema.Struct({
   turn: Schema.String,
@@ -175,7 +198,8 @@ export const TurnView = Schema.Struct({
   epoch: Schema.Finite,
   output: Schema.optionalKey(Schema.String),
   error: Schema.optionalKey(Schema.String),
-  reason: Schema.optionalKey(Schema.String)
+  reason: Schema.optionalKey(Schema.String),
+  ask: Schema.optionalKey(AskView)
 }).annotate({ identifier: "TurnView" })
 
 export type TurnView = typeof TurnView.Type

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -73,8 +73,12 @@ export type {
   ThreadStatus,
   ThreadSummary,
   TurnStatus,
-  TurnView
+  TurnView,
+  AskView,
+  BudgetAskView,
+  SchemaAskView
 } from "./contract"
+export { turnViewOf, turnsOf, turnsProjection } from "./turns"
 export type { Event } from "@clavia/tardigrade-core/log/event"
 export type { InferDelta } from "@clavia/tardigrade-agent"
 export { connect, DEFAULT_CALL_POLL_INTERVAL_MS, type ConnectOptions, type ConnectedActor, type ClientThread, type CallOptions } from "./connect"

--- a/packages/client/src/turns.ts
+++ b/packages/client/src/turns.ts
@@ -1,0 +1,22 @@
+import type { Event } from "@clavia/tardigrade-core/log/event"
+import { turnsOf as snapshotsOf, turnViewOf as snapshotOf, type TurnSnapshot } from "@clavia/tardigrade-agent/output/boundary"
+import { projection } from "./contract"
+import { Schema } from "effect"
+import { TurnView, type TurnView as TurnViewType } from "./contract"
+
+// turnViewOf projects one turn into the HTTP TurnView, including a parked budget or schema ask.
+export const turnViewOf = (log: ReadonlyArray<Event>, turn: string): TurnViewType =>
+  snapshotOf(log, turn) as TurnViewType
+
+// turnsOf lists every MessageReceived as a TurnView in log order.
+export const turnsOf = (log: ReadonlyArray<Event>): ReadonlyArray<TurnViewType> =>
+  snapshotsOf(log) as ReadonlyArray<TurnViewType>
+
+export type { TurnSnapshot }
+
+// turnsProjection is the ready-made turns read an actor can mount on the HTTP API.
+export const turnsProjection = projection({
+  params: {},
+  result: Schema.Array(TurnView),
+  run: (events) => turnsOf(events)
+})


### PR DESCRIPTION
## What and why

An agent turn can wait for a schema-shaped human fact and continue when that answer is durable. Related work in #128: `TurnView` had no field for a parked ask, and stuffing reason or amount into `error` would make a live turn look failed. This adds an opt-in `ask()` component, `requestAskMethod`, and a structured `ask` field on the client `TurnView`.

## Change

- Agent-lifecycle events `AskRequested`, `AskAnswered`, and `AskDenied` park and unpark a turn. Authority threads use `AskRequestReceived`, `AskRequestDecided`, and `AskRequestFailed`, matching budget and permission so the alphabets do not collide.
- `ask()` mounts a model-visible `ask` tool. An unanswered ask parks the turn. Pass `schema` at assembly time when every ask uses one contract; the tool then takes only `prompt`. An invalid model schema is a tool error and does not park. An invalid same-thread `AskAnswered` is a tool error so the model can ask again under a new `callId`.
- `requestAskMethod` uses Effect schemas `AskRequestInput` and `AskDecision`. `askAuthority({ decide })` decides locally. `askAuthority.manual()` leaves the call pending. `timeoutMs` bounds the authority call; when omitted, the call uses `DEFAULT_ACTOR_METHOD_TIMEOUT_MS` from `tardie/core`. Same-thread answers have no timeout.
- `boundaryOf` reads `kind: "asking"` for a schema ask and keeps `kind: "requesting"` for a budget wall. `turnViewOf` and `turnsOf` project `TurnView.ask` as `{ kind: "schema", callId, prompt, schema }` or `{ kind: "budget", callId, reason, amount }`. The HTTP client `resume` refuses a parked epoch, including a schema ask.
- How-to: [docs/how-to/human-asks.md](docs/how-to/human-asks.md).

`requestAsk` is not on default `agentMethods`. Consumers that want an authority add `{ requestAsk: requestAskMethod }` on that actor.

## Walkthrough

A 36s HyperFrames composition of park, typed answer, and resume:

![Ask park, answer, and resume](https://raw.githubusercontent.com/mvanhorn/tardigrade/walkthrough-assets/ask-park-answer-resume.gif)

<video src="https://cdn.jsdelivr.net/gh/mvanhorn/tardigrade@walkthrough-assets/ask-park-answer-resume.mp4" controls></video>

Full-resolution MP4: https://cdn.jsdelivr.net/gh/mvanhorn/tardigrade@walkthrough-assets/ask-park-answer-resume.mp4

## Verification

`bun run gate` passed locally: lint, docs lint, Effect lint, typecheck, tests, knip. `test:agent` 336 pass. `test:client` pass, including parked `AskRequested` resume refuse and `turnViewOf` for a schema ask.

Related: #128. `TurnView.ask` now carries budget and schema parks. AgentStatus parked vocabulary remains a list-level decision and is not part of this change.

This pull request was written with assistance from an AI coding agent.