### PR TITLE
test(e2e): bound generated scenarios

### DIFF
--- a/e2e/actor/mortyplicity.test.ts
+++ b/e2e/actor/mortyplicity.test.ts
@@ -294,7 +294,7 @@ const mindFor = (missions: ReadonlyMap<string, Mission>, jitter: ReadonlyArray<n
     return action({ kind: "complete", output: JSON.stringify({ key: mission.key, status: "escaped" }) })
   }
 
-test("Rick and Morty survive generated portal, budget, permission, human, and scheduling chaos", async () => {
+test.each([1, 2, 3, 4])("Rick and Morty survive generated portal, budget, permission, human, and scheduling chaos (batch %i)", async () => {
   await fc.assert(fc.asyncProperty(universe, async (generated) => {
     const missions = generated.missions.map((mission, index): Mission => ({
       ...mission,
@@ -506,7 +506,12 @@ test("Rick and Morty survive generated portal, budget, permission, human, and sc
       expect(created.parent).toEqual(threadAddressOf("mem", "main", ROOT_THREAD))
     }
     expect(scenario.host.resting()).toBe(true)
-  }), { numRuns: 40 })
+  }), {
+    numRuns: 10,
+    timeout: 10_000,
+    interruptAfterTimeLimit: 45_000,
+    markInterruptAsFailure: true
+  })
 }, 60_000)
 
 const cancelForegroundMortys = async ({ children, headroom, schedule }: {


### PR DESCRIPTION
The release gate timed out while Mortyplicity ran 40 generated universes inside one 60-second Bun test. That outer timeout discarded fast-check's seed and counterexample, so the run could not distinguish accumulated CI load from a stuck universe.

Run the same 40 cases in four batches of ten. Each universe has a 10-second fast-check timeout, and each batch has a 45-second interruption limit that counts as failure. The existing 60-second Bun timeout leaves room for reporting. Assertions and shrinking remain enabled.

Validation: full gate passed. The four batches took 15.4, 5.4, 5.3, and 5.0 seconds under concurrent gate load. A temporary stalled-model probe failed with a seed, replay path, and counterexample before Bun's deadline. A seeded run of the original 40 cases passed in 23 seconds; no runtime liveness defect was reproduced.
