### PR TITLE
feat(http): share API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ tdg thread create --name quickstart
 tdg call message '{"text":"What is the weather in Singapore?"}' --thread quickstart
 ```
 
-The API listens at [localhost:4242](http://localhost:4242) by default.
+The API listens at [localhost:4242](http://localhost:4242) by default. View the interactive API reference at [localhost:4242/docs](http://localhost:4242/docs).
 
 <img alt="An actor serving API requests from its generated Bun development server" src="docs/assets/dev-server.png">
 

--- a/docs/how-to/server.md
+++ b/docs/how-to/server.md
@@ -35,6 +35,8 @@ Base path `/v1`. Runtime routes address instances of the actor mounted at the se
 | `PUT /v1/definitions` | Push an actor artifact to a host with a writable definition registry |
 | `GET /healthz` `GET /openapi.json` `GET /docs` | Unversioned |
 
+Bun HTTP hosts and Cloudflare Worker HTTP handlers serve Scalar at `/docs` and the OpenAPI document at `/openapi.json`. Each document describes its host's declared routes. Method calls use a generic payload in OpenAPI; `GET /v1/methods` provides the mounted actor's input and output schemas. An actor used in-process exposes no HTTP routes until a host serves it.
+
 ```bash
 curl -X POST localhost:4242/v1/actors/main/threads \
   -H 'content-type: application/json' \

--- a/packages/http/src/docs.ts
+++ b/packages/http/src/docs.ts
@@ -1,0 +1,49 @@
+import { Layer } from "effect"
+import { HttpRouter, HttpServerResponse } from "effect/unstable/http"
+import { HttpApi, HttpApiGroup, HttpApiScalar, OpenApi } from "effect/unstable/httpapi"
+import { DOCS_PATH, OPENAPI_PATH } from "@clavia/tardigrade-client/contract"
+
+// UNAUTHENTICATED_PATHS names public discovery routes (apps/server/src/contract.test.ts, platform/cloudflare/test/actor.workers.ts).
+export const UNAUTHENTICATED_PATHS: ReadonlyArray<string> = ["/healthz", "/v1/providers", "/v1/models", OPENAPI_PATH, DOCS_PATH]
+
+const scalarCss = `
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&display=swap");
+
+:root {
+  --scalar-font: "IBM Plex Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --scalar-font-code: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --scalar-background-1: #f3f0e4;
+  --scalar-background-2: #faf8ef;
+  --scalar-background-3: #e9eadc;
+  --scalar-background-accent: #e2eadf;
+  --scalar-color-1: #243128;
+  --scalar-color-2: #556158;
+  --scalar-color-3: #879087;
+  --scalar-color-accent: #4f6f52;
+  --scalar-border-color: #d1d6c2;
+  --scalar-radius: 6px;
+  --scalar-radius-lg: 6px;
+}
+
+.dark-mode {
+  --scalar-background-1: #131514;
+  --scalar-background-2: #1b1d1c;
+  --scalar-background-3: #0e100f;
+  --scalar-background-accent: #22302a;
+  --scalar-color-1: #e8eae8;
+  --scalar-color-2: #a3a8a4;
+  --scalar-color-3: #6b706c;
+  --scalar-color-accent: #7fae8c;
+  --scalar-border-color: #2a2d2b;
+}
+`.trim()
+
+// layerApiDocs serves an API's OpenAPI document and Scalar reference (apps/server/src/contract.test.ts, platform/cloudflare/test/actor.workers.ts).
+export const layerApiDocs = <Id extends string, Groups extends HttpApiGroup.Constraint>(api: HttpApi.HttpApi<Id, Groups>) =>
+  Layer.mergeAll(
+    HttpRouter.add("GET", OPENAPI_PATH, HttpServerResponse.jsonUnsafe(OpenApi.fromApi(api))),
+    HttpApiScalar.layer(api, {
+      path: DOCS_PATH,
+      scalar: { customCss: scalarCss, theme: "none", withDefaultFonts: false }
+    })
+  )

--- a/packages/http/src/http.ts
+++ b/packages/http/src/http.ts
@@ -1,6 +1,6 @@
 import { Effect, Layer } from "effect"
 import { Headers, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
-import { HttpApiBuilder, HttpApiScalar } from "effect/unstable/httpapi"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
 
 import {
   layerActorsGroup,
@@ -14,9 +14,11 @@ import {
   layerUnknownProjection,
   type ApiOptions
 } from "./api"
-import { Api, apiOf, DOCS_PATH, OPENAPI_PATH, type Health } from "@clavia/tardigrade-client/contract"
+import { Api, apiOf, type Health } from "@clavia/tardigrade-client/contract"
 import { layerRequestProblems } from "./contract"
 import { DriverGauge } from "./driver-gauge"
+import { layerApiDocs, UNAUTHENTICATED_PATHS } from "./docs"
+export { UNAUTHENTICATED_PATHS } from "./docs"
 
 // The HTTP surface. The JSON routes are one declaration (contract.ts) implemented through
 // HttpApiBuilder, and everything around them is a layer over effect's own HttpRouter, so the server
@@ -27,9 +29,6 @@ import { DriverGauge } from "./driver-gauge"
 
 import { problem } from "./problem"
 export { problem, type Problem, PROBLEM_CONTENT_TYPE, PROBLEM_TYPE_BASE } from "./problem"
-
-// UNAUTHENTICATED_PATHS names process capabilities that expose no actor state.
-export const UNAUTHENTICATED_PATHS: ReadonlyArray<string> = ["/healthz", "/v1/providers", "/v1/models", OPENAPI_PATH, DOCS_PATH]
 
 const pathOf = (url: string): string => {
   const query = url.indexOf("?")
@@ -143,38 +142,6 @@ export const layerCors = HttpRouter.cors({
   exposedHeaders: ["content-type", "location"]
 })
 
-const scalarCss = `
-@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&display=swap");
-
-:root {
-  --scalar-font: "IBM Plex Sans", system-ui, -apple-system, "Segoe UI", sans-serif;
-  --scalar-font-code: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-  --scalar-background-1: #f3f0e4;
-  --scalar-background-2: #faf8ef;
-  --scalar-background-3: #e9eadc;
-  --scalar-background-accent: #e2eadf;
-  --scalar-color-1: #243128;
-  --scalar-color-2: #556158;
-  --scalar-color-3: #879087;
-  --scalar-color-accent: #4f6f52;
-  --scalar-border-color: #d1d6c2;
-  --scalar-radius: 6px;
-  --scalar-radius-lg: 6px;
-}
-
-.dark-mode {
-  --scalar-background-1: #131514;
-  --scalar-background-2: #1b1d1c;
-  --scalar-background-3: #0e100f;
-  --scalar-background-accent: #22302a;
-  --scalar-color-1: #e8eae8;
-  --scalar-color-2: #a3a8a4;
-  --scalar-color-3: #6b706c;
-  --scalar-color-accent: #7fae8c;
-  --scalar-border-color: #2a2d2b;
-}
-`.trim()
-
 // The application: the declared API, the stream beside it, the document and the page derived from
 // the same declaration, plus the conventions that wrap them all. A route inherits the gate and the
 // error shape by being part of the same router.
@@ -182,7 +149,7 @@ export const layerApp = (options: ApiOptions = {}) => {
   const api = apiOf(options.projections ?? {})
   return Layer.mergeAll(
     Layer.provide(
-      Layer.provide(HttpApiBuilder.layer(api, { openapiPath: OPENAPI_PATH }), [
+      Layer.provide(HttpApiBuilder.layer(api), [
         layerActorsGroup,
         layerDefinitionsGroup,
         layerModelsGroup(options),
@@ -194,14 +161,7 @@ export const layerApp = (options: ApiOptions = {}) => {
       ]),
       layerRequestProblems
     ),
-    HttpApiScalar.layer(api, {
-      path: DOCS_PATH,
-      scalar: {
-        customCss: scalarCss,
-        theme: "none",
-        withDefaultFonts: false
-      }
-    }),
+    layerApiDocs(api),
     layerStream(options),
     // layerUnknownProjection names the declared projections when a lookup misses.
     layerUnknownProjection(options.projections),

--- a/platform/cloudflare/README.md
+++ b/platform/cloudflare/README.md
@@ -56,7 +56,9 @@ Point `wrangler.jsonc` at your Worker entry point and declare these bindings:
 
 Declare `ActorDO` and `ThreadDO` as SQLite classes in the Durable Object migrations. The generated project includes the bindings and [catalog migration](migrations/0001_catalog.sql). Follow the [Cloudflare setup guide](../../docs/platforms/cloudflare.mdx#configure) to create the catalog database, apply its migration, and set provider secrets. The same guide covers [local verification](../../docs/platforms/cloudflare.mdx#verify-locally).
 
-`/healthz`, `/v1/providers`, and `/v1/models` are public. Other API routes require `Authorization: Bearer <TARDIGRADE_TOKEN>`. Missing server authentication returns `503`; an incorrect token returns `401`.
+`/healthz`, `/v1/providers`, `/v1/models`, `/openapi.json`, and `/docs` are public. Other API routes require `Authorization: Bearer <TARDIGRADE_TOKEN>`. Missing server authentication returns `503`; an incorrect token returns `401`.
+
+`workerHttp(host)` serves a Scalar API reference at `/docs` and its OpenAPI document at `/openapi.json`. The document describes the routes mounted by the Worker. `GET /v1/methods` supplies the actor methods' input and output schemas.
 
 See the [actor guide](../../docs/getting-started/actors.mdx) for thread allocation and method calls.
 

--- a/platform/cloudflare/src/transport/contract.ts
+++ b/platform/cloudflare/src/transport/contract.ts
@@ -14,10 +14,9 @@ const ThreadTree = Schema.Struct({
 const WorkerActor = Schema.Struct({ actor: Schema.String, definition: Schema.String })
 
 const WorkerError = Schema.Struct({ error: Schema.String })
-const errors = [400, 401, 404, 500, 503].map((status) => WorkerError.pipe(HttpApiSchema.status(status)))
 
 // workerEndpoint retains shared requests and replaces the manual transport's response declarations (test/actor.workers.ts).
-const workerEndpoint = (endpoint: Pick<HttpApiEndpoint.Top, "identifier" | "method" | "params" | "query" | "headers" | "payload" | "success"> & { readonly path: HttpRouter.PathInput }, success: ReadonlyArray<Schema.Top> = [...endpoint.success]) => {
+const workerEndpoint = <const Name extends string>(endpoint: Pick<HttpApiEndpoint.Top, "method" | "params" | "query" | "headers" | "payload" | "success"> & { readonly identifier: Name; readonly path: HttpRouter.PathInput }, errors: ReadonlyArray<number>, success: ReadonlyArray<Schema.Top> = [...endpoint.success]) => {
   const payload = [...endpoint.payload.values()].flatMap((entry) => entry.schemas)
   return HttpApiEndpoint.make(endpoint.method)(endpoint.identifier, endpoint.path, {
     params: endpoint.params,
@@ -25,27 +24,29 @@ const workerEndpoint = (endpoint: Pick<HttpApiEndpoint.Top, "identifier" | "meth
     headers: endpoint.headers,
     ...(payload.length === 0 ? {} : { payload }),
     success,
-    error: errors
+    error: [401, 503, ...errors].map((status) => WorkerError.pipe(HttpApiSchema.status(status)))
   })
 }
 
-// workerRoutes declares the manual Worker routes, including runtime-specific responses (test/actor.workers.ts).
-export const workerRoutes = {
-  healthz: HttpApiEndpoint.get("healthz", "/healthz", {
+const workerGroup = HttpApiGroup.make("worker").add(
+  HttpApiEndpoint.get("healthz", "/healthz", {
     success: Schema.Struct({ status: Schema.Literal("ready"), actor: Schema.String })
   }),
-  metadata: workerEndpoint(runtimeGroup.endpoints.metadata),
-  ensureActor: workerEndpoint(actorsGroup.endpoints.ensureActor, [WorkerActor]),
-  actor: workerEndpoint(actorsGroup.endpoints.actor, [WorkerActor]),
-  allocateRoot: workerEndpoint(threadsGroup.endpoints.allocateRoot),
-  list: workerEndpoint(threadsGroup.endpoints.list, [Schema.Array(ThreadTree)]),
-  append: workerEndpoint(threadsGroup.endpoints.append),
-  events: workerEndpoint(threadsGroup.endpoints.events)
-}
+  workerEndpoint(runtimeGroup.endpoints.metadata, []),
+  workerEndpoint(actorsGroup.endpoints.ensureActor, [400], [WorkerActor]),
+  workerEndpoint(actorsGroup.endpoints.actor, [400, 404], [WorkerActor]),
+  workerEndpoint(threadsGroup.endpoints.allocateRoot, [400, 404]),
+  workerEndpoint(threadsGroup.endpoints.list, [400, 404], [Schema.Array(ThreadTree)]),
+  workerEndpoint(threadsGroup.endpoints.append, [400, 404]),
+  workerEndpoint(threadsGroup.endpoints.events, [400, 404, 500])
+)
+
+// workerRoutes declares the manual Worker routes, including runtime-specific responses (test/actor.workers.ts).
+export const workerRoutes = workerGroup.endpoints
 
 // WorkerApi describes the routes mounted by cloudflareHttp (test/actor.workers.ts).
 export const WorkerApi = HttpApi.make("tardigrade-worker").add(
   modelsGroup,
   methodsGroup,
-  HttpApiGroup.make("worker").add(workerRoutes.healthz, workerRoutes.metadata, workerRoutes.ensureActor, workerRoutes.actor, workerRoutes.allocateRoot, workerRoutes.list, workerRoutes.append, workerRoutes.events)
+  workerGroup
 ).annotateMerge(OpenApi.annotations({ title: "Tardigrade", description: "Durable actor methods and thread logs on Cloudflare Workers." }))

--- a/platform/cloudflare/src/transport/contract.ts
+++ b/platform/cloudflare/src/transport/contract.ts
@@ -1,0 +1,51 @@
+import type { HttpRouter } from "effect/unstable/http"
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
+import { actorsGroup, methodsGroup, modelsGroup, runtimeGroup, threadsGroup, ActorThread } from "@clavia/tardigrade-client/contract"
+import { ChildPlacement } from "@clavia/tardigrade-core/interaction/relations"
+import type { ActorThreadNode } from "../actor"
+
+const ThreadTree = Schema.Struct({
+  ...ActorThread.fields,
+  placement: Schema.optionalKey(ChildPlacement),
+  children: Schema.Array(Schema.suspend((): Schema.Codec<ActorThreadNode> => ThreadTree))
+}).annotate({ identifier: "WorkerThreadTree" })
+
+const WorkerActor = Schema.Struct({ actor: Schema.String, definition: Schema.String })
+
+const WorkerError = Schema.Struct({ error: Schema.String })
+const errors = [400, 401, 404, 500, 503].map((status) => WorkerError.pipe(HttpApiSchema.status(status)))
+
+// workerEndpoint retains shared requests and replaces the manual transport's response declarations (test/actor.workers.ts).
+const workerEndpoint = (endpoint: Pick<HttpApiEndpoint.Top, "identifier" | "method" | "params" | "query" | "headers" | "payload" | "success"> & { readonly path: HttpRouter.PathInput }, success: ReadonlyArray<Schema.Top> = [...endpoint.success]) => {
+  const payload = [...endpoint.payload.values()].flatMap((entry) => entry.schemas)
+  return HttpApiEndpoint.make(endpoint.method)(endpoint.identifier, endpoint.path, {
+    params: endpoint.params,
+    query: endpoint.query,
+    headers: endpoint.headers,
+    ...(payload.length === 0 ? {} : { payload }),
+    success,
+    error: errors
+  })
+}
+
+// workerRoutes declares the manual Worker routes, including runtime-specific responses (test/actor.workers.ts).
+export const workerRoutes = {
+  healthz: HttpApiEndpoint.get("healthz", "/healthz", {
+    success: Schema.Struct({ status: Schema.Literal("ready"), actor: Schema.String })
+  }),
+  metadata: workerEndpoint(runtimeGroup.endpoints.metadata),
+  ensureActor: workerEndpoint(actorsGroup.endpoints.ensureActor, [WorkerActor]),
+  actor: workerEndpoint(actorsGroup.endpoints.actor, [WorkerActor]),
+  allocateRoot: workerEndpoint(threadsGroup.endpoints.allocateRoot),
+  list: workerEndpoint(threadsGroup.endpoints.list, [Schema.Array(ThreadTree)]),
+  append: workerEndpoint(threadsGroup.endpoints.append),
+  events: workerEndpoint(threadsGroup.endpoints.events)
+}
+
+// WorkerApi describes the routes mounted by cloudflareHttp (test/actor.workers.ts).
+export const WorkerApi = HttpApi.make("tardigrade-worker").add(
+  modelsGroup,
+  methodsGroup,
+  HttpApiGroup.make("worker").add(workerRoutes.healthz, workerRoutes.metadata, workerRoutes.ensureActor, workerRoutes.actor, workerRoutes.allocateRoot, workerRoutes.list, workerRoutes.append, workerRoutes.events)
+).annotateMerge(OpenApi.annotations({ title: "Tardigrade", description: "Durable actor methods and thread logs on Cloudflare Workers." }))

--- a/platform/cloudflare/src/transport/http.ts
+++ b/platform/cloudflare/src/transport/http.ts
@@ -11,6 +11,8 @@ import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { MethodApi, MethodRuntime, layerMethodHandlers } from "@clavia/tardigrade-http/methods"
 import { CatalogApi, CatalogDiscovery, layerCatalogHandlers } from "@clavia/tardigrade-http/models"
 import { layerRequestProblems } from "@clavia/tardigrade-http/contract"
+import { layerApiDocs, UNAUTHENTICATED_PATHS } from "@clavia/tardigrade-http/docs"
+import { WorkerApi, workerRoutes } from "./contract"
 import type { Env } from "../env"
 import type { CloudflareDirectory } from "./directory"
 
@@ -82,13 +84,13 @@ export const cloudflareHttp = ({
   })
 
   const routes = [
-    HttpRouter.route("GET", "/healthz", Effect.gen(function* () {
+    HttpRouter.route(workerRoutes.healthz.method, workerRoutes.healthz.path, Effect.gen(function* () {
       return json({ status: "ready", actor: actorName() })
     })),
-    HttpRouter.route("GET", "/v1/metadata", workerRoute((_request, _env) =>
+    HttpRouter.route(workerRoutes.metadata.method, workerRoutes.metadata.path, workerRoute((_request, _env) =>
       Effect.succeed(json({ name: actorName(), storage: { kind: "durable-object" } }))
     )),
-    HttpRouter.route("PUT", "/v1/actors/:id", workerRoute((_request, env) =>
+    HttpRouter.route(workerRoutes.ensureActor.method, workerRoutes.ensureActor.path, workerRoute((_request, env) =>
       Effect.gen(function* () {
         const params = yield* HttpRouter.params
         const instance = params.id ?? ""
@@ -98,7 +100,7 @@ export const cloudflareHttp = ({
         return json({ actor: instance, definition: actorName() })
       })
     )),
-    HttpRouter.route("GET", "/v1/actors/:id", workerRoute((_request, env) =>
+    HttpRouter.route(workerRoutes.actor.method, workerRoutes.actor.path, workerRoute((_request, env) =>
       Effect.gen(function* () {
         const params = yield* HttpRouter.params
         const instance = params.id ?? ""
@@ -109,7 +111,7 @@ export const cloudflareHttp = ({
           : json({ actor: instance, definition: actorName() })
       })
     )),
-    HttpRouter.route("POST", "/v1/actors/:id/threads", workerRoute((request, env) =>
+    HttpRouter.route(workerRoutes.allocateRoot.method, workerRoutes.allocateRoot.path, workerRoute((request, env) =>
       Effect.gen(function* () {
         const selection = invocationQueryOf(request)
         if ("error" in selection) return json({ error: selection.error }, 400)
@@ -124,7 +126,7 @@ export const cloudflareHttp = ({
         return json(coordinate)
       })
     )),
-    HttpRouter.route("GET", "/v1/actors/:id/threads", workerRoute((request, env) =>
+    HttpRouter.route(workerRoutes.list.method, workerRoutes.list.path, workerRoute((request, env) =>
       Effect.gen(function* () {
         const params = yield* HttpRouter.params
         const instance = params.id ?? ""
@@ -138,7 +140,7 @@ export const cloudflareHttp = ({
         return json(tree)
       })
     )),
-    HttpRouter.route("POST", "/v1/actors/:id/threads/:thread/events", workerRoute((request, env) =>
+    HttpRouter.route(workerRoutes.append.method, workerRoutes.append.path, workerRoute((request, env) =>
       Effect.gen(function* () {
         const params = yield* HttpRouter.params
         const actor = actorName()
@@ -156,7 +158,7 @@ export const cloudflareHttp = ({
         return json({ actor: instance, thread }, 202)
       })
     )),
-    HttpRouter.route("GET", "/v1/actors/:id/threads/:thread/events", workerRoute((request, env) =>
+    HttpRouter.route(workerRoutes.events.method, workerRoutes.events.path, workerRoute((request, env) =>
       Effect.gen(function* () {
         const params = yield* HttpRouter.params
         const actor = actorName()
@@ -185,12 +187,13 @@ export const cloudflareHttp = ({
 
   const { handler } = HttpRouter.toWebHandler(Layer.mergeAll(
     HttpRouter.addAll(routes),
+    layerApiDocs(WorkerApi),
     HttpApiBuilder.layer(CatalogApi).pipe(Layer.provide(layerCatalogHandlers), Layer.provide(layerRequestProblems)),
     HttpApiBuilder.layer(MethodApi).pipe(Layer.provide(layerMethodHandlers), Layer.provide(layerRequestProblems)),
     HttpRouter.middleware((effect) => Effect.gen(function* () {
       const request = yield* HttpServerRequest.HttpServerRequest
       const path = new URL(request.url, "http://worker").pathname
-      if (["/healthz", "/v1/providers", "/v1/models"].includes(path)) return yield* effect
+      if (UNAUTHENTICATED_PATHS.includes(path)) return yield* effect
       return guard(request, yield* WorkerEnv) ?? (yield* effect)
     }), { global: true })
   ).pipe(Layer.provide(HttpServer.layerServices)), { disableLogger: true })

--- a/platform/cloudflare/test/actor.workers.ts
+++ b/platform/cloudflare/test/actor.workers.ts
@@ -680,6 +680,34 @@ describe("cloudflare actor", () => {
     expect(catalogTables).toEqual([])
   })
 
+  test("public API docs describe only mounted Worker routes", async () => {
+    const page = await SELF.fetch("http://test/docs")
+    expect(page.status).toBe(200)
+    expect(page.headers.get("content-type")).toContain("text/html")
+    const html = await page.text()
+    expect(html).toContain("Scalar")
+    expect(html).toContain("--scalar-background-1: #f3f0e4")
+
+    const response = await SELF.fetch("http://test/openapi.json")
+    expect(response.status).toBe(200)
+    const spec = await response.json() as { paths: Record<string, Record<string, { responses: Record<string, unknown> }>>; components: { schemas: Record<string, unknown> } }
+    expect(Object.keys(spec.paths).sort()).toEqual([
+      "/healthz", "/v1/metadata", "/v1/providers", "/v1/models", "/v1/methods",
+      "/v1/actors/{id}", "/v1/actors/{id}/threads", "/v1/actors/{id}/threads/{thread}/events",
+      "/v1/actors/{id}/threads/{thread}/methods/{method}",
+      "/v1/actors/{id}/threads/{thread}/methods/{method}/calls/{call}",
+      "/v1/actors/{id}/threads/{thread}/methods/{method}/calls/{call}/cancellation"
+    ].sort())
+    expect(spec.paths["/healthz"]?.get?.responses["200"]).toMatchObject({
+      content: { "application/json": { schema: { properties: { status: { enum: ["ready"] }, actor: { type: "string" } } } } }
+    })
+    expect(spec.components.schemas.WorkerThreadTree).toMatchObject({
+      properties: { id: { type: "string" }, children: { type: "array" } }
+    })
+    expect(spec.paths["/v1/actors/{id}/threads/{thread}/events"]?.post?.responses).toHaveProperty("202")
+    expect((await SELF.fetch("http://test/v1/methods")).status).toBe(401)
+  })
+
   test("a mounted actor exposes durable methods", async () => {
     const refused = await SELF.fetch("http://test/v1/methods")
     expect(refused.status).toBe(401)

--- a/platform/cloudflare/test/actor.workers.ts
+++ b/platform/cloudflare/test/actor.workers.ts
@@ -705,6 +705,18 @@ describe("cloudflare actor", () => {
       properties: { id: { type: "string" }, children: { type: "array" } }
     })
     expect(spec.paths["/v1/actors/{id}/threads/{thread}/events"]?.post?.responses).toHaveProperty("202")
+    for (const [path, method, statuses] of [
+      ["/healthz", "get", ["200"]],
+      ["/v1/metadata", "get", ["200", "401", "503"]],
+      ["/v1/actors/{id}", "put", ["200", "400", "401", "503"]],
+      ["/v1/actors/{id}", "get", ["200", "400", "401", "404", "503"]],
+      ["/v1/actors/{id}/threads", "post", ["200", "400", "401", "404", "503"]],
+      ["/v1/actors/{id}/threads", "get", ["200", "400", "401", "404", "503"]],
+      ["/v1/actors/{id}/threads/{thread}/events", "post", ["202", "400", "401", "404", "503"]],
+      ["/v1/actors/{id}/threads/{thread}/events", "get", ["200", "400", "401", "404", "500", "503"]]
+    ] as const) {
+      expect(Object.keys(spec.paths[path]![method]!.responses).sort()).toEqual(statuses)
+    }
     expect((await SELF.fetch("http://test/v1/methods")).status).toBe(401)
   })
 


### PR DESCRIPTION
## Problem

Bun HTTP hosts expose Scalar and OpenAPI, while Cloudflare Worker hosts expose neither. Reusing the full Bun document would advertise routes the Worker does not serve and describe several Worker responses incorrectly.

## Change

Share the Scalar theme, OpenAPI route, and public discovery paths across both HTTP hosts. Worker routes reuse shared request schemas and declare their existing health, actor, and thread-tree responses. Their HTTP paths come from the same declarations used by the document.

Both hosts serve `/docs` and `/openapi.json` without authentication. Actor state and method routes retain their existing authentication. Actor-specific input and output schemas remain available through `/v1/methods`; the OpenAPI method payload remains generic.

## Validation

Real Bun HTTP contract tests and the workerd integration suite cover public docs, supported routes, response schemas, and protected actor methods. The full repository gate passes.
